### PR TITLE
Remove version number from kernel source files

### DIFF
--- a/FreeRTOS/Source/croutine.c
+++ b/FreeRTOS/Source/croutine.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/event_groups.c
+++ b/FreeRTOS/Source/event_groups.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/include/FreeRTOS.h
+++ b/FreeRTOS/Source/include/FreeRTOS.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/include/StackMacros.h
+++ b/FreeRTOS/Source/include/StackMacros.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/include/atomic.h
+++ b/FreeRTOS/Source/include/atomic.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/include/croutine.h
+++ b/FreeRTOS/Source/include/croutine.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/include/deprecated_definitions.h
+++ b/FreeRTOS/Source/include/deprecated_definitions.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/include/event_groups.h
+++ b/FreeRTOS/Source/include/event_groups.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/include/list.h
+++ b/FreeRTOS/Source/include/list.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/include/message_buffer.h
+++ b/FreeRTOS/Source/include/message_buffer.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/include/mpu_prototypes.h
+++ b/FreeRTOS/Source/include/mpu_prototypes.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/include/mpu_wrappers.h
+++ b/FreeRTOS/Source/include/mpu_wrappers.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/include/portable.h
+++ b/FreeRTOS/Source/include/portable.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/include/projdefs.h
+++ b/FreeRTOS/Source/include/projdefs.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/include/queue.h
+++ b/FreeRTOS/Source/include/queue.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/include/semphr.h
+++ b/FreeRTOS/Source/include/semphr.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/include/stack_macros.h
+++ b/FreeRTOS/Source/include/stack_macros.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/include/stream_buffer.h
+++ b/FreeRTOS/Source/include/stream_buffer.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/include/task.h
+++ b/FreeRTOS/Source/include/task.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/include/timers.h
+++ b/FreeRTOS/Source/include/timers.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/list.c
+++ b/FreeRTOS/Source/list.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/ARMv8M/copy_files.py
+++ b/FreeRTOS/Source/portable/ARMv8M/copy_files.py
@@ -1,5 +1,5 @@
 #/*
-# * FreeRTOS Kernel V10.3.0
+# * FreeRTOS Kernel
 # * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 # *
 # * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/ARMv8M/non_secure/port.c
+++ b/FreeRTOS/Source/portable/ARMv8M/non_secure/port.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/ARMv8M/non_secure/portable/GCC/ARM_CM23/portasm.c
+++ b/FreeRTOS/Source/portable/ARMv8M/non_secure/portable/GCC/ARM_CM23/portasm.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/ARMv8M/non_secure/portable/GCC/ARM_CM23/portmacro.h
+++ b/FreeRTOS/Source/portable/ARMv8M/non_secure/portable/GCC/ARM_CM23/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/ARMv8M/non_secure/portable/GCC/ARM_CM23_NTZ/portasm.c
+++ b/FreeRTOS/Source/portable/ARMv8M/non_secure/portable/GCC/ARM_CM23_NTZ/portasm.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/ARMv8M/non_secure/portable/GCC/ARM_CM23_NTZ/portmacro.h
+++ b/FreeRTOS/Source/portable/ARMv8M/non_secure/portable/GCC/ARM_CM23_NTZ/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/ARMv8M/non_secure/portable/GCC/ARM_CM33/portasm.c
+++ b/FreeRTOS/Source/portable/ARMv8M/non_secure/portable/GCC/ARM_CM33/portasm.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/ARMv8M/non_secure/portable/GCC/ARM_CM33/portmacro.h
+++ b/FreeRTOS/Source/portable/ARMv8M/non_secure/portable/GCC/ARM_CM33/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/ARMv8M/non_secure/portable/GCC/ARM_CM33_NTZ/portasm.c
+++ b/FreeRTOS/Source/portable/ARMv8M/non_secure/portable/GCC/ARM_CM33_NTZ/portasm.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/ARMv8M/non_secure/portable/GCC/ARM_CM33_NTZ/portmacro.h
+++ b/FreeRTOS/Source/portable/ARMv8M/non_secure/portable/GCC/ARM_CM33_NTZ/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/ARMv8M/non_secure/portable/IAR/ARM_CM23/portasm.s
+++ b/FreeRTOS/Source/portable/ARMv8M/non_secure/portable/IAR/ARM_CM23/portasm.s
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/ARMv8M/non_secure/portable/IAR/ARM_CM23/portmacro.h
+++ b/FreeRTOS/Source/portable/ARMv8M/non_secure/portable/IAR/ARM_CM23/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/ARMv8M/non_secure/portable/IAR/ARM_CM23_NTZ/portasm.s
+++ b/FreeRTOS/Source/portable/ARMv8M/non_secure/portable/IAR/ARM_CM23_NTZ/portasm.s
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/ARMv8M/non_secure/portable/IAR/ARM_CM23_NTZ/portmacro.h
+++ b/FreeRTOS/Source/portable/ARMv8M/non_secure/portable/IAR/ARM_CM23_NTZ/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/ARMv8M/non_secure/portable/IAR/ARM_CM33/portasm.s
+++ b/FreeRTOS/Source/portable/ARMv8M/non_secure/portable/IAR/ARM_CM33/portasm.s
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/ARMv8M/non_secure/portable/IAR/ARM_CM33/portmacro.h
+++ b/FreeRTOS/Source/portable/ARMv8M/non_secure/portable/IAR/ARM_CM33/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/ARMv8M/non_secure/portable/IAR/ARM_CM33_NTZ/portasm.s
+++ b/FreeRTOS/Source/portable/ARMv8M/non_secure/portable/IAR/ARM_CM33_NTZ/portasm.s
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/ARMv8M/non_secure/portable/IAR/ARM_CM33_NTZ/portmacro.h
+++ b/FreeRTOS/Source/portable/ARMv8M/non_secure/portable/IAR/ARM_CM33_NTZ/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/ARMv8M/non_secure/portasm.h
+++ b/FreeRTOS/Source/portable/ARMv8M/non_secure/portasm.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/ARMv8M/secure/context/portable/GCC/ARM_CM23/secure_context_port.c
+++ b/FreeRTOS/Source/portable/ARMv8M/secure/context/portable/GCC/ARM_CM23/secure_context_port.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/ARMv8M/secure/context/portable/GCC/ARM_CM33/secure_context_port.c
+++ b/FreeRTOS/Source/portable/ARMv8M/secure/context/portable/GCC/ARM_CM33/secure_context_port.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/ARMv8M/secure/context/portable/IAR/ARM_CM23/secure_context_port.c
+++ b/FreeRTOS/Source/portable/ARMv8M/secure/context/portable/IAR/ARM_CM23/secure_context_port.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/ARMv8M/secure/context/portable/IAR/ARM_CM23/secure_context_port_asm.s
+++ b/FreeRTOS/Source/portable/ARMv8M/secure/context/portable/IAR/ARM_CM23/secure_context_port_asm.s
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/ARMv8M/secure/context/portable/IAR/ARM_CM33/secure_context_port.c
+++ b/FreeRTOS/Source/portable/ARMv8M/secure/context/portable/IAR/ARM_CM33/secure_context_port.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/ARMv8M/secure/context/portable/IAR/ARM_CM33/secure_context_port_asm.s
+++ b/FreeRTOS/Source/portable/ARMv8M/secure/context/portable/IAR/ARM_CM33/secure_context_port_asm.s
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/ARMv8M/secure/context/secure_context.c
+++ b/FreeRTOS/Source/portable/ARMv8M/secure/context/secure_context.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/ARMv8M/secure/context/secure_context.h
+++ b/FreeRTOS/Source/portable/ARMv8M/secure/context/secure_context.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/ARMv8M/secure/heap/secure_heap.c
+++ b/FreeRTOS/Source/portable/ARMv8M/secure/heap/secure_heap.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/ARMv8M/secure/heap/secure_heap.h
+++ b/FreeRTOS/Source/portable/ARMv8M/secure/heap/secure_heap.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/ARMv8M/secure/init/secure_init.c
+++ b/FreeRTOS/Source/portable/ARMv8M/secure/init/secure_init.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/ARMv8M/secure/init/secure_init.h
+++ b/FreeRTOS/Source/portable/ARMv8M/secure/init/secure_init.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/ARMv8M/secure/macros/secure_port_macros.h
+++ b/FreeRTOS/Source/portable/ARMv8M/secure/macros/secure_port_macros.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/BCC/16BitDOS/Flsh186/port.c
+++ b/FreeRTOS/Source/portable/BCC/16BitDOS/Flsh186/port.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/BCC/16BitDOS/Flsh186/prtmacro.h
+++ b/FreeRTOS/Source/portable/BCC/16BitDOS/Flsh186/prtmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/BCC/16BitDOS/PC/port.c
+++ b/FreeRTOS/Source/portable/BCC/16BitDOS/PC/port.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/BCC/16BitDOS/PC/prtmacro.h
+++ b/FreeRTOS/Source/portable/BCC/16BitDOS/PC/prtmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/BCC/16BitDOS/common/portasm.h
+++ b/FreeRTOS/Source/portable/BCC/16BitDOS/common/portasm.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/BCC/16BitDOS/common/portcomn.c
+++ b/FreeRTOS/Source/portable/BCC/16BitDOS/common/portcomn.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/CCS/ARM_CM3/port.c
+++ b/FreeRTOS/Source/portable/CCS/ARM_CM3/port.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/CCS/ARM_CM3/portasm.asm
+++ b/FreeRTOS/Source/portable/CCS/ARM_CM3/portasm.asm
@@ -1,5 +1,5 @@
 ;/*
-; * FreeRTOS Kernel V10.3.0
+; * FreeRTOS Kernel
 ; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 ; *
 ; * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/CCS/ARM_CM3/portmacro.h
+++ b/FreeRTOS/Source/portable/CCS/ARM_CM3/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/CCS/ARM_CM4F/port.c
+++ b/FreeRTOS/Source/portable/CCS/ARM_CM4F/port.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/CCS/ARM_CM4F/portasm.asm
+++ b/FreeRTOS/Source/portable/CCS/ARM_CM4F/portasm.asm
@@ -1,5 +1,5 @@
 ;/*
-; * FreeRTOS Kernel V10.3.0
+; * FreeRTOS Kernel
 ; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 ; *
 ; * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/CCS/ARM_CM4F/portmacro.h
+++ b/FreeRTOS/Source/portable/CCS/ARM_CM4F/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/CCS/ARM_Cortex-R4/port.c
+++ b/FreeRTOS/Source/portable/CCS/ARM_Cortex-R4/port.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/CCS/ARM_Cortex-R4/portASM.asm
+++ b/FreeRTOS/Source/portable/CCS/ARM_Cortex-R4/portASM.asm
@@ -1,5 +1,5 @@
 ;/*
-; * FreeRTOS Kernel V10.3.0
+; * FreeRTOS Kernel
 ; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 ; *
 ; * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/CCS/ARM_Cortex-R4/portmacro.h
+++ b/FreeRTOS/Source/portable/CCS/ARM_Cortex-R4/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/CCS/MSP430X/data_model.h
+++ b/FreeRTOS/Source/portable/CCS/MSP430X/data_model.h
@@ -1,5 +1,5 @@
 ;/*
-; * FreeRTOS Kernel V10.3.0
+; * FreeRTOS Kernel
 ; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 ; *
 ; * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/CCS/MSP430X/port.c
+++ b/FreeRTOS/Source/portable/CCS/MSP430X/port.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/CCS/MSP430X/portext.asm
+++ b/FreeRTOS/Source/portable/CCS/MSP430X/portext.asm
@@ -1,5 +1,5 @@
 ;/*
-; * FreeRTOS Kernel V10.3.0
+; * FreeRTOS Kernel
 ; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 ; *
 ; * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/CCS/MSP430X/portmacro.h
+++ b/FreeRTOS/Source/portable/CCS/MSP430X/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/CodeWarrior/ColdFire_V1/port.c
+++ b/FreeRTOS/Source/portable/CodeWarrior/ColdFire_V1/port.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/CodeWarrior/ColdFire_V1/portasm.S
+++ b/FreeRTOS/Source/portable/CodeWarrior/ColdFire_V1/portasm.S
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/CodeWarrior/ColdFire_V1/portmacro.h
+++ b/FreeRTOS/Source/portable/CodeWarrior/ColdFire_V1/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/CodeWarrior/ColdFire_V2/port.c
+++ b/FreeRTOS/Source/portable/CodeWarrior/ColdFire_V2/port.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/CodeWarrior/ColdFire_V2/portasm.S
+++ b/FreeRTOS/Source/portable/CodeWarrior/ColdFire_V2/portasm.S
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/CodeWarrior/ColdFire_V2/portmacro.h
+++ b/FreeRTOS/Source/portable/CodeWarrior/ColdFire_V2/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/CodeWarrior/HCS12/port.c
+++ b/FreeRTOS/Source/portable/CodeWarrior/HCS12/port.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/CodeWarrior/HCS12/portmacro.h
+++ b/FreeRTOS/Source/portable/CodeWarrior/HCS12/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/Common/mpu_wrappers.c
+++ b/FreeRTOS/Source/portable/Common/mpu_wrappers.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/ARM7_AT91FR40008/port.c
+++ b/FreeRTOS/Source/portable/GCC/ARM7_AT91FR40008/port.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/ARM7_AT91FR40008/portISR.c
+++ b/FreeRTOS/Source/portable/GCC/ARM7_AT91FR40008/portISR.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/ARM7_AT91FR40008/portmacro.h
+++ b/FreeRTOS/Source/portable/GCC/ARM7_AT91FR40008/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/ARM7_AT91SAM7S/port.c
+++ b/FreeRTOS/Source/portable/GCC/ARM7_AT91SAM7S/port.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/ARM7_AT91SAM7S/portISR.c
+++ b/FreeRTOS/Source/portable/GCC/ARM7_AT91SAM7S/portISR.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/ARM7_AT91SAM7S/portmacro.h
+++ b/FreeRTOS/Source/portable/GCC/ARM7_AT91SAM7S/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/ARM7_LPC2000/port.c
+++ b/FreeRTOS/Source/portable/GCC/ARM7_LPC2000/port.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/ARM7_LPC2000/portISR.c
+++ b/FreeRTOS/Source/portable/GCC/ARM7_LPC2000/portISR.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/ARM7_LPC2000/portmacro.h
+++ b/FreeRTOS/Source/portable/GCC/ARM7_LPC2000/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/ARM7_LPC23xx/port.c
+++ b/FreeRTOS/Source/portable/GCC/ARM7_LPC23xx/port.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/ARM7_LPC23xx/portISR.c
+++ b/FreeRTOS/Source/portable/GCC/ARM7_LPC23xx/portISR.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/ARM7_LPC23xx/portmacro.h
+++ b/FreeRTOS/Source/portable/GCC/ARM7_LPC23xx/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/ARM_CA53_64_BIT/port.c
+++ b/FreeRTOS/Source/portable/GCC/ARM_CA53_64_BIT/port.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/ARM_CA53_64_BIT/portASM.S
+++ b/FreeRTOS/Source/portable/GCC/ARM_CA53_64_BIT/portASM.S
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/ARM_CA53_64_BIT/portmacro.h
+++ b/FreeRTOS/Source/portable/GCC/ARM_CA53_64_BIT/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/ARM_CA9/port.c
+++ b/FreeRTOS/Source/portable/GCC/ARM_CA9/port.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/ARM_CA9/portASM.S
+++ b/FreeRTOS/Source/portable/GCC/ARM_CA9/portASM.S
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/ARM_CA9/portmacro.h
+++ b/FreeRTOS/Source/portable/GCC/ARM_CA9/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/ARM_CM0/port.c
+++ b/FreeRTOS/Source/portable/GCC/ARM_CM0/port.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/ARM_CM0/portmacro.h
+++ b/FreeRTOS/Source/portable/GCC/ARM_CM0/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/ARM_CM23/non_secure/port.c
+++ b/FreeRTOS/Source/portable/GCC/ARM_CM23/non_secure/port.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/ARM_CM23/non_secure/portasm.c
+++ b/FreeRTOS/Source/portable/GCC/ARM_CM23/non_secure/portasm.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/ARM_CM23/non_secure/portasm.h
+++ b/FreeRTOS/Source/portable/GCC/ARM_CM23/non_secure/portasm.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/ARM_CM23/non_secure/portmacro.h
+++ b/FreeRTOS/Source/portable/GCC/ARM_CM23/non_secure/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/ARM_CM23/secure/secure_context.c
+++ b/FreeRTOS/Source/portable/GCC/ARM_CM23/secure/secure_context.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/ARM_CM23/secure/secure_context.h
+++ b/FreeRTOS/Source/portable/GCC/ARM_CM23/secure/secure_context.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/ARM_CM23/secure/secure_context_port.c
+++ b/FreeRTOS/Source/portable/GCC/ARM_CM23/secure/secure_context_port.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/ARM_CM23/secure/secure_heap.c
+++ b/FreeRTOS/Source/portable/GCC/ARM_CM23/secure/secure_heap.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/ARM_CM23/secure/secure_heap.h
+++ b/FreeRTOS/Source/portable/GCC/ARM_CM23/secure/secure_heap.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/ARM_CM23/secure/secure_init.c
+++ b/FreeRTOS/Source/portable/GCC/ARM_CM23/secure/secure_init.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/ARM_CM23/secure/secure_init.h
+++ b/FreeRTOS/Source/portable/GCC/ARM_CM23/secure/secure_init.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/ARM_CM23/secure/secure_port_macros.h
+++ b/FreeRTOS/Source/portable/GCC/ARM_CM23/secure/secure_port_macros.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/ARM_CM23_NTZ/non_secure/port.c
+++ b/FreeRTOS/Source/portable/GCC/ARM_CM23_NTZ/non_secure/port.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/ARM_CM23_NTZ/non_secure/portasm.c
+++ b/FreeRTOS/Source/portable/GCC/ARM_CM23_NTZ/non_secure/portasm.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/ARM_CM23_NTZ/non_secure/portasm.h
+++ b/FreeRTOS/Source/portable/GCC/ARM_CM23_NTZ/non_secure/portasm.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/ARM_CM23_NTZ/non_secure/portmacro.h
+++ b/FreeRTOS/Source/portable/GCC/ARM_CM23_NTZ/non_secure/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/ARM_CM3/port.c
+++ b/FreeRTOS/Source/portable/GCC/ARM_CM3/port.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/ARM_CM3/portmacro.h
+++ b/FreeRTOS/Source/portable/GCC/ARM_CM3/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/ARM_CM33/non_secure/port.c
+++ b/FreeRTOS/Source/portable/GCC/ARM_CM33/non_secure/port.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/ARM_CM33/non_secure/portasm.c
+++ b/FreeRTOS/Source/portable/GCC/ARM_CM33/non_secure/portasm.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/ARM_CM33/non_secure/portasm.h
+++ b/FreeRTOS/Source/portable/GCC/ARM_CM33/non_secure/portasm.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/ARM_CM33/non_secure/portmacro.h
+++ b/FreeRTOS/Source/portable/GCC/ARM_CM33/non_secure/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/ARM_CM33/secure/secure_context.c
+++ b/FreeRTOS/Source/portable/GCC/ARM_CM33/secure/secure_context.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/ARM_CM33/secure/secure_context.h
+++ b/FreeRTOS/Source/portable/GCC/ARM_CM33/secure/secure_context.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/ARM_CM33/secure/secure_context_port.c
+++ b/FreeRTOS/Source/portable/GCC/ARM_CM33/secure/secure_context_port.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/ARM_CM33/secure/secure_heap.c
+++ b/FreeRTOS/Source/portable/GCC/ARM_CM33/secure/secure_heap.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/ARM_CM33/secure/secure_heap.h
+++ b/FreeRTOS/Source/portable/GCC/ARM_CM33/secure/secure_heap.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/ARM_CM33/secure/secure_init.c
+++ b/FreeRTOS/Source/portable/GCC/ARM_CM33/secure/secure_init.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/ARM_CM33/secure/secure_init.h
+++ b/FreeRTOS/Source/portable/GCC/ARM_CM33/secure/secure_init.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/ARM_CM33/secure/secure_port_macros.h
+++ b/FreeRTOS/Source/portable/GCC/ARM_CM33/secure/secure_port_macros.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/ARM_CM33_NTZ/non_secure/port.c
+++ b/FreeRTOS/Source/portable/GCC/ARM_CM33_NTZ/non_secure/port.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/ARM_CM33_NTZ/non_secure/portasm.c
+++ b/FreeRTOS/Source/portable/GCC/ARM_CM33_NTZ/non_secure/portasm.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/ARM_CM33_NTZ/non_secure/portasm.h
+++ b/FreeRTOS/Source/portable/GCC/ARM_CM33_NTZ/non_secure/portasm.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/ARM_CM33_NTZ/non_secure/portmacro.h
+++ b/FreeRTOS/Source/portable/GCC/ARM_CM33_NTZ/non_secure/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/ARM_CM3_MPU/port.c
+++ b/FreeRTOS/Source/portable/GCC/ARM_CM3_MPU/port.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/ARM_CM3_MPU/portmacro.h
+++ b/FreeRTOS/Source/portable/GCC/ARM_CM3_MPU/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/ARM_CM4F/port.c
+++ b/FreeRTOS/Source/portable/GCC/ARM_CM4F/port.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/ARM_CM4F/portmacro.h
+++ b/FreeRTOS/Source/portable/GCC/ARM_CM4F/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/ARM_CM4_MPU/port.c
+++ b/FreeRTOS/Source/portable/GCC/ARM_CM4_MPU/port.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/ARM_CM4_MPU/portmacro.h
+++ b/FreeRTOS/Source/portable/GCC/ARM_CM4_MPU/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/ARM_CM7/r0p1/port.c
+++ b/FreeRTOS/Source/portable/GCC/ARM_CM7/r0p1/port.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/ARM_CM7/r0p1/portmacro.h
+++ b/FreeRTOS/Source/portable/GCC/ARM_CM7/r0p1/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/ARM_CR5/port.c
+++ b/FreeRTOS/Source/portable/GCC/ARM_CR5/port.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/ARM_CR5/portASM.S
+++ b/FreeRTOS/Source/portable/GCC/ARM_CR5/portASM.S
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/ARM_CR5/portmacro.h
+++ b/FreeRTOS/Source/portable/GCC/ARM_CR5/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/ARM_CRx_No_GIC/port.c
+++ b/FreeRTOS/Source/portable/GCC/ARM_CRx_No_GIC/port.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/ARM_CRx_No_GIC/portASM.S
+++ b/FreeRTOS/Source/portable/GCC/ARM_CRx_No_GIC/portASM.S
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/ARM_CRx_No_GIC/portmacro.h
+++ b/FreeRTOS/Source/portable/GCC/ARM_CRx_No_GIC/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/ATMega323/port.c
+++ b/FreeRTOS/Source/portable/GCC/ATMega323/port.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/ATMega323/portmacro.h
+++ b/FreeRTOS/Source/portable/GCC/ATMega323/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/AVR32_UC3/port.c
+++ b/FreeRTOS/Source/portable/GCC/AVR32_UC3/port.c
@@ -13,7 +13,7 @@
  *****************************************************************************/
 
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/AVR32_UC3/portmacro.h
+++ b/FreeRTOS/Source/portable/GCC/AVR32_UC3/portmacro.h
@@ -13,7 +13,7 @@
  *****************************************************************************/
 
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/CORTUS_APS3/port.c
+++ b/FreeRTOS/Source/portable/GCC/CORTUS_APS3/port.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/CORTUS_APS3/portmacro.h
+++ b/FreeRTOS/Source/portable/GCC/CORTUS_APS3/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/ColdFire_V2/port.c
+++ b/FreeRTOS/Source/portable/GCC/ColdFire_V2/port.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/ColdFire_V2/portasm.S
+++ b/FreeRTOS/Source/portable/GCC/ColdFire_V2/portasm.S
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/ColdFire_V2/portmacro.h
+++ b/FreeRTOS/Source/portable/GCC/ColdFire_V2/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/H8S2329/port.c
+++ b/FreeRTOS/Source/portable/GCC/H8S2329/port.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/H8S2329/portmacro.h
+++ b/FreeRTOS/Source/portable/GCC/H8S2329/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/HCS12/port.c
+++ b/FreeRTOS/Source/portable/GCC/HCS12/port.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/HCS12/portmacro.h
+++ b/FreeRTOS/Source/portable/GCC/HCS12/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/IA32_flat/ISR_Support.h
+++ b/FreeRTOS/Source/portable/GCC/IA32_flat/ISR_Support.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/IA32_flat/port.c
+++ b/FreeRTOS/Source/portable/GCC/IA32_flat/port.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/IA32_flat/portASM.S
+++ b/FreeRTOS/Source/portable/GCC/IA32_flat/portASM.S
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/IA32_flat/portmacro.h
+++ b/FreeRTOS/Source/portable/GCC/IA32_flat/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/MSP430F449/port.c
+++ b/FreeRTOS/Source/portable/GCC/MSP430F449/port.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/MSP430F449/portmacro.h
+++ b/FreeRTOS/Source/portable/GCC/MSP430F449/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/MicroBlaze/port.c
+++ b/FreeRTOS/Source/portable/GCC/MicroBlaze/port.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/MicroBlaze/portasm.s
+++ b/FreeRTOS/Source/portable/GCC/MicroBlaze/portasm.s
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/MicroBlaze/portmacro.h
+++ b/FreeRTOS/Source/portable/GCC/MicroBlaze/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/MicroBlazeV8/port.c
+++ b/FreeRTOS/Source/portable/GCC/MicroBlazeV8/port.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/MicroBlazeV8/port_exceptions.c
+++ b/FreeRTOS/Source/portable/GCC/MicroBlazeV8/port_exceptions.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/MicroBlazeV8/portasm.S
+++ b/FreeRTOS/Source/portable/GCC/MicroBlazeV8/portasm.S
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/MicroBlazeV8/portmacro.h
+++ b/FreeRTOS/Source/portable/GCC/MicroBlazeV8/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/MicroBlazeV9/port.c
+++ b/FreeRTOS/Source/portable/GCC/MicroBlazeV9/port.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/MicroBlazeV9/port_exceptions.c
+++ b/FreeRTOS/Source/portable/GCC/MicroBlazeV9/port_exceptions.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/MicroBlazeV9/portasm.S
+++ b/FreeRTOS/Source/portable/GCC/MicroBlazeV9/portasm.S
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/MicroBlazeV9/portmacro.h
+++ b/FreeRTOS/Source/portable/GCC/MicroBlazeV9/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/NiosII/port.c
+++ b/FreeRTOS/Source/portable/GCC/NiosII/port.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/NiosII/port_asm.S
+++ b/FreeRTOS/Source/portable/GCC/NiosII/port_asm.S
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/NiosII/portmacro.h
+++ b/FreeRTOS/Source/portable/GCC/NiosII/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/PPC405_Xilinx/FPU_Macros.h
+++ b/FreeRTOS/Source/portable/GCC/PPC405_Xilinx/FPU_Macros.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/PPC405_Xilinx/port.c
+++ b/FreeRTOS/Source/portable/GCC/PPC405_Xilinx/port.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/PPC405_Xilinx/portasm.S
+++ b/FreeRTOS/Source/portable/GCC/PPC405_Xilinx/portasm.S
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/PPC405_Xilinx/portmacro.h
+++ b/FreeRTOS/Source/portable/GCC/PPC405_Xilinx/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/PPC440_Xilinx/FPU_Macros.h
+++ b/FreeRTOS/Source/portable/GCC/PPC440_Xilinx/FPU_Macros.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/PPC440_Xilinx/port.c
+++ b/FreeRTOS/Source/portable/GCC/PPC440_Xilinx/port.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/PPC440_Xilinx/portasm.S
+++ b/FreeRTOS/Source/portable/GCC/PPC440_Xilinx/portasm.S
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/PPC440_Xilinx/portmacro.h
+++ b/FreeRTOS/Source/portable/GCC/PPC440_Xilinx/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/RISC-V/chip_specific_extensions/Pulpino_Vega_RV32M1RM/freertos_risc_v_chip_specific_extensions.h
+++ b/FreeRTOS/Source/portable/GCC/RISC-V/chip_specific_extensions/Pulpino_Vega_RV32M1RM/freertos_risc_v_chip_specific_extensions.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/RISC-V/chip_specific_extensions/RV32I_CLINT_no_extensions/freertos_risc_v_chip_specific_extensions.h
+++ b/FreeRTOS/Source/portable/GCC/RISC-V/chip_specific_extensions/RV32I_CLINT_no_extensions/freertos_risc_v_chip_specific_extensions.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/RISC-V/port.c
+++ b/FreeRTOS/Source/portable/GCC/RISC-V/port.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/RISC-V/portASM.S
+++ b/FreeRTOS/Source/portable/GCC/RISC-V/portASM.S
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/RISC-V/portmacro.h
+++ b/FreeRTOS/Source/portable/GCC/RISC-V/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/RL78/isr_support.h
+++ b/FreeRTOS/Source/portable/GCC/RL78/isr_support.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/RL78/port.c
+++ b/FreeRTOS/Source/portable/GCC/RL78/port.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/RL78/portasm.S
+++ b/FreeRTOS/Source/portable/GCC/RL78/portasm.S
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/RL78/portmacro.h
+++ b/FreeRTOS/Source/portable/GCC/RL78/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/RX100/port.c
+++ b/FreeRTOS/Source/portable/GCC/RX100/port.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/RX100/portmacro.h
+++ b/FreeRTOS/Source/portable/GCC/RX100/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/RX600/port.c
+++ b/FreeRTOS/Source/portable/GCC/RX600/port.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/RX600/portmacro.h
+++ b/FreeRTOS/Source/portable/GCC/RX600/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/RX600v2/port.c
+++ b/FreeRTOS/Source/portable/GCC/RX600v2/port.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/RX600v2/portmacro.h
+++ b/FreeRTOS/Source/portable/GCC/RX600v2/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/STR75x/port.c
+++ b/FreeRTOS/Source/portable/GCC/STR75x/port.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/STR75x/portISR.c
+++ b/FreeRTOS/Source/portable/GCC/STR75x/portISR.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/STR75x/portmacro.h
+++ b/FreeRTOS/Source/portable/GCC/STR75x/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/TriCore_1782/port.c
+++ b/FreeRTOS/Source/portable/GCC/TriCore_1782/port.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/TriCore_1782/portmacro.h
+++ b/FreeRTOS/Source/portable/GCC/TriCore_1782/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/GCC/TriCore_1782/porttrap.c
+++ b/FreeRTOS/Source/portable/GCC/TriCore_1782/porttrap.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/78K0R/ISR_Support.h
+++ b/FreeRTOS/Source/portable/IAR/78K0R/ISR_Support.h
@@ -1,5 +1,5 @@
 ;/*
-; * FreeRTOS Kernel V10.3.0
+; * FreeRTOS Kernel
 ; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 ; *
 ; * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/78K0R/port.c
+++ b/FreeRTOS/Source/portable/IAR/78K0R/port.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/78K0R/portasm.s26
+++ b/FreeRTOS/Source/portable/IAR/78K0R/portasm.s26
@@ -1,5 +1,5 @@
 ;/*
-; * FreeRTOS Kernel V10.3.0
+; * FreeRTOS Kernel
 ; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 ; *
 ; * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/78K0R/portmacro.h
+++ b/FreeRTOS/Source/portable/IAR/78K0R/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/ARM_CA5_No_GIC/port.c
+++ b/FreeRTOS/Source/portable/IAR/ARM_CA5_No_GIC/port.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/ARM_CA5_No_GIC/portASM.h
+++ b/FreeRTOS/Source/portable/IAR/ARM_CA5_No_GIC/portASM.h
@@ -1,5 +1,5 @@
 ;/*
-; * FreeRTOS Kernel V10.3.0
+; * FreeRTOS Kernel
 ; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 ; *
 ; * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/ARM_CA5_No_GIC/portASM.s
+++ b/FreeRTOS/Source/portable/IAR/ARM_CA5_No_GIC/portASM.s
@@ -1,5 +1,5 @@
 ;/*
-; * FreeRTOS Kernel V10.3.0
+; * FreeRTOS Kernel
 ; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 ; *
 ; * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/ARM_CA5_No_GIC/portmacro.h
+++ b/FreeRTOS/Source/portable/IAR/ARM_CA5_No_GIC/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/ARM_CA9/port.c
+++ b/FreeRTOS/Source/portable/IAR/ARM_CA9/port.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/ARM_CA9/portASM.h
+++ b/FreeRTOS/Source/portable/IAR/ARM_CA9/portASM.h
@@ -1,5 +1,5 @@
 ;/*
-; * FreeRTOS Kernel V10.3.0
+; * FreeRTOS Kernel
 ; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 ; *
 ; * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/ARM_CA9/portASM.s
+++ b/FreeRTOS/Source/portable/IAR/ARM_CA9/portASM.s
@@ -1,5 +1,5 @@
 ;/*
-; * FreeRTOS Kernel V10.3.0
+; * FreeRTOS Kernel
 ; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 ; *
 ; * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/ARM_CA9/portmacro.h
+++ b/FreeRTOS/Source/portable/IAR/ARM_CA9/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/ARM_CM0/port.c
+++ b/FreeRTOS/Source/portable/IAR/ARM_CM0/port.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/ARM_CM0/portasm.s
+++ b/FreeRTOS/Source/portable/IAR/ARM_CM0/portasm.s
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/ARM_CM0/portmacro.h
+++ b/FreeRTOS/Source/portable/IAR/ARM_CM0/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/ARM_CM23/non_secure/port.c
+++ b/FreeRTOS/Source/portable/IAR/ARM_CM23/non_secure/port.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/ARM_CM23/non_secure/portasm.h
+++ b/FreeRTOS/Source/portable/IAR/ARM_CM23/non_secure/portasm.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/ARM_CM23/non_secure/portasm.s
+++ b/FreeRTOS/Source/portable/IAR/ARM_CM23/non_secure/portasm.s
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/ARM_CM23/non_secure/portmacro.h
+++ b/FreeRTOS/Source/portable/IAR/ARM_CM23/non_secure/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/ARM_CM23/secure/secure_context.c
+++ b/FreeRTOS/Source/portable/IAR/ARM_CM23/secure/secure_context.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/ARM_CM23/secure/secure_context.h
+++ b/FreeRTOS/Source/portable/IAR/ARM_CM23/secure/secure_context.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/ARM_CM23/secure/secure_context_port.c
+++ b/FreeRTOS/Source/portable/IAR/ARM_CM23/secure/secure_context_port.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/ARM_CM23/secure/secure_context_port_asm.s
+++ b/FreeRTOS/Source/portable/IAR/ARM_CM23/secure/secure_context_port_asm.s
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/ARM_CM23/secure/secure_heap.c
+++ b/FreeRTOS/Source/portable/IAR/ARM_CM23/secure/secure_heap.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/ARM_CM23/secure/secure_heap.h
+++ b/FreeRTOS/Source/portable/IAR/ARM_CM23/secure/secure_heap.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/ARM_CM23/secure/secure_init.c
+++ b/FreeRTOS/Source/portable/IAR/ARM_CM23/secure/secure_init.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/ARM_CM23/secure/secure_init.h
+++ b/FreeRTOS/Source/portable/IAR/ARM_CM23/secure/secure_init.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/ARM_CM23/secure/secure_port_macros.h
+++ b/FreeRTOS/Source/portable/IAR/ARM_CM23/secure/secure_port_macros.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/ARM_CM23_NTZ/non_secure/port.c
+++ b/FreeRTOS/Source/portable/IAR/ARM_CM23_NTZ/non_secure/port.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/ARM_CM23_NTZ/non_secure/portasm.h
+++ b/FreeRTOS/Source/portable/IAR/ARM_CM23_NTZ/non_secure/portasm.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/ARM_CM23_NTZ/non_secure/portasm.s
+++ b/FreeRTOS/Source/portable/IAR/ARM_CM23_NTZ/non_secure/portasm.s
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/ARM_CM23_NTZ/non_secure/portmacro.h
+++ b/FreeRTOS/Source/portable/IAR/ARM_CM23_NTZ/non_secure/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/ARM_CM3/port.c
+++ b/FreeRTOS/Source/portable/IAR/ARM_CM3/port.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/ARM_CM3/portasm.s
+++ b/FreeRTOS/Source/portable/IAR/ARM_CM3/portasm.s
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/ARM_CM3/portmacro.h
+++ b/FreeRTOS/Source/portable/IAR/ARM_CM3/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/ARM_CM33/non_secure/port.c
+++ b/FreeRTOS/Source/portable/IAR/ARM_CM33/non_secure/port.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/ARM_CM33/non_secure/portasm.h
+++ b/FreeRTOS/Source/portable/IAR/ARM_CM33/non_secure/portasm.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/ARM_CM33/non_secure/portasm.s
+++ b/FreeRTOS/Source/portable/IAR/ARM_CM33/non_secure/portasm.s
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/ARM_CM33/non_secure/portmacro.h
+++ b/FreeRTOS/Source/portable/IAR/ARM_CM33/non_secure/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/ARM_CM33/secure/secure_context.c
+++ b/FreeRTOS/Source/portable/IAR/ARM_CM33/secure/secure_context.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/ARM_CM33/secure/secure_context.h
+++ b/FreeRTOS/Source/portable/IAR/ARM_CM33/secure/secure_context.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/ARM_CM33/secure/secure_context_port.c
+++ b/FreeRTOS/Source/portable/IAR/ARM_CM33/secure/secure_context_port.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/ARM_CM33/secure/secure_context_port_asm.s
+++ b/FreeRTOS/Source/portable/IAR/ARM_CM33/secure/secure_context_port_asm.s
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/ARM_CM33/secure/secure_heap.c
+++ b/FreeRTOS/Source/portable/IAR/ARM_CM33/secure/secure_heap.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/ARM_CM33/secure/secure_heap.h
+++ b/FreeRTOS/Source/portable/IAR/ARM_CM33/secure/secure_heap.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/ARM_CM33/secure/secure_init.c
+++ b/FreeRTOS/Source/portable/IAR/ARM_CM33/secure/secure_init.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/ARM_CM33/secure/secure_init.h
+++ b/FreeRTOS/Source/portable/IAR/ARM_CM33/secure/secure_init.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/ARM_CM33/secure/secure_port_macros.h
+++ b/FreeRTOS/Source/portable/IAR/ARM_CM33/secure/secure_port_macros.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/ARM_CM33_NTZ/non_secure/port.c
+++ b/FreeRTOS/Source/portable/IAR/ARM_CM33_NTZ/non_secure/port.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/ARM_CM33_NTZ/non_secure/portasm.h
+++ b/FreeRTOS/Source/portable/IAR/ARM_CM33_NTZ/non_secure/portasm.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/ARM_CM33_NTZ/non_secure/portasm.s
+++ b/FreeRTOS/Source/portable/IAR/ARM_CM33_NTZ/non_secure/portasm.s
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/ARM_CM33_NTZ/non_secure/portmacro.h
+++ b/FreeRTOS/Source/portable/IAR/ARM_CM33_NTZ/non_secure/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/ARM_CM4F/port.c
+++ b/FreeRTOS/Source/portable/IAR/ARM_CM4F/port.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/ARM_CM4F/portasm.s
+++ b/FreeRTOS/Source/portable/IAR/ARM_CM4F/portasm.s
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/ARM_CM4F/portmacro.h
+++ b/FreeRTOS/Source/portable/IAR/ARM_CM4F/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/ARM_CM4F_MPU/port.c
+++ b/FreeRTOS/Source/portable/IAR/ARM_CM4F_MPU/port.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/ARM_CM4F_MPU/portasm.s
+++ b/FreeRTOS/Source/portable/IAR/ARM_CM4F_MPU/portasm.s
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/ARM_CM4F_MPU/portmacro.h
+++ b/FreeRTOS/Source/portable/IAR/ARM_CM4F_MPU/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/ARM_CM7/r0p1/port.c
+++ b/FreeRTOS/Source/portable/IAR/ARM_CM7/r0p1/port.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/ARM_CM7/r0p1/portasm.s
+++ b/FreeRTOS/Source/portable/IAR/ARM_CM7/r0p1/portasm.s
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/ARM_CM7/r0p1/portmacro.h
+++ b/FreeRTOS/Source/portable/IAR/ARM_CM7/r0p1/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/ARM_CRx_No_GIC/port.c
+++ b/FreeRTOS/Source/portable/IAR/ARM_CRx_No_GIC/port.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/ARM_CRx_No_GIC/portASM.s
+++ b/FreeRTOS/Source/portable/IAR/ARM_CRx_No_GIC/portASM.s
@@ -1,5 +1,5 @@
 ;/*
-; * FreeRTOS Kernel V10.3.0
+; * FreeRTOS Kernel
 ; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 ; *
 ; * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/ARM_CRx_No_GIC/portmacro.h
+++ b/FreeRTOS/Source/portable/IAR/ARM_CRx_No_GIC/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/ATMega323/port.c
+++ b/FreeRTOS/Source/portable/IAR/ATMega323/port.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/ATMega323/portmacro.h
+++ b/FreeRTOS/Source/portable/IAR/ATMega323/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/ATMega323/portmacro.s90
+++ b/FreeRTOS/Source/portable/IAR/ATMega323/portmacro.s90
@@ -1,5 +1,5 @@
 ;/*
-; * FreeRTOS Kernel V10.3.0
+; * FreeRTOS Kernel
 ; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 ; *
 ; * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/AVR32_UC3/port.c
+++ b/FreeRTOS/Source/portable/IAR/AVR32_UC3/port.c
@@ -13,7 +13,7 @@
  *****************************************************************************/
 
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/AVR32_UC3/portmacro.h
+++ b/FreeRTOS/Source/portable/IAR/AVR32_UC3/portmacro.h
@@ -13,7 +13,7 @@
  *****************************************************************************/
 
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/AtmelSAM7S64/ISR_Support.h
+++ b/FreeRTOS/Source/portable/IAR/AtmelSAM7S64/ISR_Support.h
@@ -1,5 +1,5 @@
 ;/*
-; * FreeRTOS Kernel V10.3.0
+; * FreeRTOS Kernel
 ; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 ; *
 ; * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/AtmelSAM7S64/port.c
+++ b/FreeRTOS/Source/portable/IAR/AtmelSAM7S64/port.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/AtmelSAM7S64/portasm.s79
+++ b/FreeRTOS/Source/portable/IAR/AtmelSAM7S64/portasm.s79
@@ -1,5 +1,5 @@
 ;/*
-; * FreeRTOS Kernel V10.3.0
+; * FreeRTOS Kernel
 ; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 ; *
 ; * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/AtmelSAM7S64/portmacro.h
+++ b/FreeRTOS/Source/portable/IAR/AtmelSAM7S64/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/AtmelSAM9XE/port.c
+++ b/FreeRTOS/Source/portable/IAR/AtmelSAM9XE/port.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/AtmelSAM9XE/portmacro.h
+++ b/FreeRTOS/Source/portable/IAR/AtmelSAM9XE/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/LPC2000/ISR_Support.h
+++ b/FreeRTOS/Source/portable/IAR/LPC2000/ISR_Support.h
@@ -1,5 +1,5 @@
 ;/*
-; * FreeRTOS Kernel V10.3.0
+; * FreeRTOS Kernel
 ; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 ; *
 ; * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/LPC2000/port.c
+++ b/FreeRTOS/Source/portable/IAR/LPC2000/port.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/LPC2000/portasm.s79
+++ b/FreeRTOS/Source/portable/IAR/LPC2000/portasm.s79
@@ -1,5 +1,5 @@
 ;/*
-; * FreeRTOS Kernel V10.3.0
+; * FreeRTOS Kernel
 ; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 ; *
 ; * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/LPC2000/portmacro.h
+++ b/FreeRTOS/Source/portable/IAR/LPC2000/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/MSP430/port.c
+++ b/FreeRTOS/Source/portable/IAR/MSP430/port.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/MSP430/portasm.h
+++ b/FreeRTOS/Source/portable/IAR/MSP430/portasm.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/MSP430/portext.s43
+++ b/FreeRTOS/Source/portable/IAR/MSP430/portext.s43
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/MSP430/portmacro.h
+++ b/FreeRTOS/Source/portable/IAR/MSP430/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/MSP430X/data_model.h
+++ b/FreeRTOS/Source/portable/IAR/MSP430X/data_model.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/MSP430X/port.c
+++ b/FreeRTOS/Source/portable/IAR/MSP430X/port.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/MSP430X/portext.s43
+++ b/FreeRTOS/Source/portable/IAR/MSP430X/portext.s43
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/MSP430X/portmacro.h
+++ b/FreeRTOS/Source/portable/IAR/MSP430X/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/RISC-V/chip_specific_extensions/RV32I_CLINT_no_extensions/freertos_risc_v_chip_specific_extensions.h
+++ b/FreeRTOS/Source/portable/IAR/RISC-V/chip_specific_extensions/RV32I_CLINT_no_extensions/freertos_risc_v_chip_specific_extensions.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/RISC-V/port.c
+++ b/FreeRTOS/Source/portable/IAR/RISC-V/port.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/RISC-V/portASM.s
+++ b/FreeRTOS/Source/portable/IAR/RISC-V/portASM.s
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/RISC-V/portmacro.h
+++ b/FreeRTOS/Source/portable/IAR/RISC-V/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/RL78/ISR_Support.h
+++ b/FreeRTOS/Source/portable/IAR/RL78/ISR_Support.h
@@ -1,5 +1,5 @@
 ;/*
-; * FreeRTOS Kernel V10.3.0
+; * FreeRTOS Kernel
 ; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 ; *
 ; * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/RL78/port.c
+++ b/FreeRTOS/Source/portable/IAR/RL78/port.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/RL78/portasm.s87
+++ b/FreeRTOS/Source/portable/IAR/RL78/portasm.s87
@@ -1,5 +1,5 @@
 ;/*
-; * FreeRTOS Kernel V10.3.0
+; * FreeRTOS Kernel
 ; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 ; *
 ; * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/RL78/portmacro.h
+++ b/FreeRTOS/Source/portable/IAR/RL78/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/RX100/port.c
+++ b/FreeRTOS/Source/portable/IAR/RX100/port.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/RX100/port_asm.s
+++ b/FreeRTOS/Source/portable/IAR/RX100/port_asm.s
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/RX100/portmacro.h
+++ b/FreeRTOS/Source/portable/IAR/RX100/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/RX600/port.c
+++ b/FreeRTOS/Source/portable/IAR/RX600/port.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/RX600/port_asm.s
+++ b/FreeRTOS/Source/portable/IAR/RX600/port_asm.s
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/RX600/portmacro.h
+++ b/FreeRTOS/Source/portable/IAR/RX600/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/RXv2/port.c
+++ b/FreeRTOS/Source/portable/IAR/RXv2/port.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/RXv2/port_asm.s
+++ b/FreeRTOS/Source/portable/IAR/RXv2/port_asm.s
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/RXv2/portmacro.h
+++ b/FreeRTOS/Source/portable/IAR/RXv2/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/STR71x/ISR_Support.h
+++ b/FreeRTOS/Source/portable/IAR/STR71x/ISR_Support.h
@@ -1,5 +1,5 @@
 ;/*
-; * FreeRTOS Kernel V10.3.0
+; * FreeRTOS Kernel
 ; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 ; *
 ; * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/STR71x/port.c
+++ b/FreeRTOS/Source/portable/IAR/STR71x/port.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/STR71x/portasm.s79
+++ b/FreeRTOS/Source/portable/IAR/STR71x/portasm.s79
@@ -1,5 +1,5 @@
 ;/*
-; * FreeRTOS Kernel V10.3.0
+; * FreeRTOS Kernel
 ; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 ; *
 ; * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/STR71x/portmacro.h
+++ b/FreeRTOS/Source/portable/IAR/STR71x/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/STR75x/ISR_Support.h
+++ b/FreeRTOS/Source/portable/IAR/STR75x/ISR_Support.h
@@ -1,5 +1,5 @@
 ;/*
-; * FreeRTOS Kernel V10.3.0
+; * FreeRTOS Kernel
 ; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 ; *
 ; * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/STR75x/port.c
+++ b/FreeRTOS/Source/portable/IAR/STR75x/port.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/STR75x/portasm.s79
+++ b/FreeRTOS/Source/portable/IAR/STR75x/portasm.s79
@@ -1,5 +1,5 @@
 ;/*
-; * FreeRTOS Kernel V10.3.0
+; * FreeRTOS Kernel
 ; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 ; *
 ; * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/STR75x/portmacro.h
+++ b/FreeRTOS/Source/portable/IAR/STR75x/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/STR91x/ISR_Support.h
+++ b/FreeRTOS/Source/portable/IAR/STR91x/ISR_Support.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/STR91x/port.c
+++ b/FreeRTOS/Source/portable/IAR/STR91x/port.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/STR91x/portasm.s79
+++ b/FreeRTOS/Source/portable/IAR/STR91x/portasm.s79
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/STR91x/portmacro.h
+++ b/FreeRTOS/Source/portable/IAR/STR91x/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/V850ES/ISR_Support.h
+++ b/FreeRTOS/Source/portable/IAR/V850ES/ISR_Support.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/V850ES/port.c
+++ b/FreeRTOS/Source/portable/IAR/V850ES/port.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/V850ES/portasm.s85
+++ b/FreeRTOS/Source/portable/IAR/V850ES/portasm.s85
@@ -1,5 +1,5 @@
 ;/*
-; * FreeRTOS Kernel V10.3.0
+; * FreeRTOS Kernel
 ; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 ; *
 ; * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/V850ES/portasm_Fx3.s85
+++ b/FreeRTOS/Source/portable/IAR/V850ES/portasm_Fx3.s85
@@ -1,5 +1,5 @@
 ;/*
-; * FreeRTOS Kernel V10.3.0
+; * FreeRTOS Kernel
 ; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 ; *
 ; * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/V850ES/portasm_Hx2.s85
+++ b/FreeRTOS/Source/portable/IAR/V850ES/portasm_Hx2.s85
@@ -1,5 +1,5 @@
 ;/*
-; * FreeRTOS Kernel V10.3.0
+; * FreeRTOS Kernel
 ; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 ; *
 ; * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/IAR/V850ES/portmacro.h
+++ b/FreeRTOS/Source/portable/IAR/V850ES/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/MPLAB/PIC18F/port.c
+++ b/FreeRTOS/Source/portable/MPLAB/PIC18F/port.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/MPLAB/PIC18F/portmacro.h
+++ b/FreeRTOS/Source/portable/MPLAB/PIC18F/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/MPLAB/PIC24_dsPIC/port.c
+++ b/FreeRTOS/Source/portable/MPLAB/PIC24_dsPIC/port.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/MPLAB/PIC24_dsPIC/portasm_PIC24.S
+++ b/FreeRTOS/Source/portable/MPLAB/PIC24_dsPIC/portasm_PIC24.S
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/MPLAB/PIC24_dsPIC/portasm_dsPIC.S
+++ b/FreeRTOS/Source/portable/MPLAB/PIC24_dsPIC/portasm_dsPIC.S
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/MPLAB/PIC24_dsPIC/portmacro.h
+++ b/FreeRTOS/Source/portable/MPLAB/PIC24_dsPIC/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/MPLAB/PIC32MEC14xx/ISR_Support.h
+++ b/FreeRTOS/Source/portable/MPLAB/PIC32MEC14xx/ISR_Support.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/MPLAB/PIC32MEC14xx/port.c
+++ b/FreeRTOS/Source/portable/MPLAB/PIC32MEC14xx/port.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/MPLAB/PIC32MEC14xx/port_asm.S
+++ b/FreeRTOS/Source/portable/MPLAB/PIC32MEC14xx/port_asm.S
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/MPLAB/PIC32MEC14xx/portmacro.h
+++ b/FreeRTOS/Source/portable/MPLAB/PIC32MEC14xx/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/MPLAB/PIC32MX/ISR_Support.h
+++ b/FreeRTOS/Source/portable/MPLAB/PIC32MX/ISR_Support.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/MPLAB/PIC32MX/port.c
+++ b/FreeRTOS/Source/portable/MPLAB/PIC32MX/port.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/MPLAB/PIC32MX/port_asm.S
+++ b/FreeRTOS/Source/portable/MPLAB/PIC32MX/port_asm.S
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/MPLAB/PIC32MX/portmacro.h
+++ b/FreeRTOS/Source/portable/MPLAB/PIC32MX/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/MPLAB/PIC32MZ/ISR_Support.h
+++ b/FreeRTOS/Source/portable/MPLAB/PIC32MZ/ISR_Support.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/MPLAB/PIC32MZ/port.c
+++ b/FreeRTOS/Source/portable/MPLAB/PIC32MZ/port.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/MPLAB/PIC32MZ/port_asm.S
+++ b/FreeRTOS/Source/portable/MPLAB/PIC32MZ/port_asm.S
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/MPLAB/PIC32MZ/portmacro.h
+++ b/FreeRTOS/Source/portable/MPLAB/PIC32MZ/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/MSVC-MingW/port.c
+++ b/FreeRTOS/Source/portable/MSVC-MingW/port.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/MSVC-MingW/portmacro.h
+++ b/FreeRTOS/Source/portable/MSVC-MingW/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/MemMang/heap_1.c
+++ b/FreeRTOS/Source/portable/MemMang/heap_1.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/MemMang/heap_2.c
+++ b/FreeRTOS/Source/portable/MemMang/heap_2.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/MemMang/heap_3.c
+++ b/FreeRTOS/Source/portable/MemMang/heap_3.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/MemMang/heap_4.c
+++ b/FreeRTOS/Source/portable/MemMang/heap_4.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/MemMang/heap_5.c
+++ b/FreeRTOS/Source/portable/MemMang/heap_5.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/MikroC/ARM_CM4F/port.c
+++ b/FreeRTOS/Source/portable/MikroC/ARM_CM4F/port.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/MikroC/ARM_CM4F/portmacro.h
+++ b/FreeRTOS/Source/portable/MikroC/ARM_CM4F/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/Paradigm/Tern_EE/large_untested/port.c
+++ b/FreeRTOS/Source/portable/Paradigm/Tern_EE/large_untested/port.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/Paradigm/Tern_EE/large_untested/portasm.h
+++ b/FreeRTOS/Source/portable/Paradigm/Tern_EE/large_untested/portasm.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/Paradigm/Tern_EE/large_untested/portmacro.h
+++ b/FreeRTOS/Source/portable/Paradigm/Tern_EE/large_untested/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/Paradigm/Tern_EE/small/port.c
+++ b/FreeRTOS/Source/portable/Paradigm/Tern_EE/small/port.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/Paradigm/Tern_EE/small/portasm.h
+++ b/FreeRTOS/Source/portable/Paradigm/Tern_EE/small/portasm.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/Paradigm/Tern_EE/small/portmacro.h
+++ b/FreeRTOS/Source/portable/Paradigm/Tern_EE/small/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/RVDS/ARM7_LPC21xx/port.c
+++ b/FreeRTOS/Source/portable/RVDS/ARM7_LPC21xx/port.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/RVDS/ARM7_LPC21xx/portASM.s
+++ b/FreeRTOS/Source/portable/RVDS/ARM7_LPC21xx/portASM.s
@@ -1,5 +1,5 @@
 ;/*
-; * FreeRTOS Kernel V10.3.0
+; * FreeRTOS Kernel
 ; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 ; *
 ; * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/RVDS/ARM7_LPC21xx/portmacro.h
+++ b/FreeRTOS/Source/portable/RVDS/ARM7_LPC21xx/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/RVDS/ARM7_LPC21xx/portmacro.inc
+++ b/FreeRTOS/Source/portable/RVDS/ARM7_LPC21xx/portmacro.inc
@@ -1,5 +1,5 @@
 ;/*
-; * FreeRTOS Kernel V10.3.0
+; * FreeRTOS Kernel
 ; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 ; *
 ; * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/RVDS/ARM_CA9/port.c
+++ b/FreeRTOS/Source/portable/RVDS/ARM_CA9/port.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/RVDS/ARM_CA9/portASM.s
+++ b/FreeRTOS/Source/portable/RVDS/ARM_CA9/portASM.s
@@ -1,5 +1,5 @@
 ;/*
-; * FreeRTOS Kernel V10.3.0
+; * FreeRTOS Kernel
 ; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 ; *
 ; * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/RVDS/ARM_CA9/portmacro.h
+++ b/FreeRTOS/Source/portable/RVDS/ARM_CA9/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/RVDS/ARM_CA9/portmacro.inc
+++ b/FreeRTOS/Source/portable/RVDS/ARM_CA9/portmacro.inc
@@ -1,5 +1,5 @@
 ;/*
-; * FreeRTOS Kernel V10.3.0
+; * FreeRTOS Kernel
 ; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 ; *
 ; * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/RVDS/ARM_CM0/port.c
+++ b/FreeRTOS/Source/portable/RVDS/ARM_CM0/port.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/RVDS/ARM_CM0/portmacro.h
+++ b/FreeRTOS/Source/portable/RVDS/ARM_CM0/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/RVDS/ARM_CM3/port.c
+++ b/FreeRTOS/Source/portable/RVDS/ARM_CM3/port.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/RVDS/ARM_CM3/portmacro.h
+++ b/FreeRTOS/Source/portable/RVDS/ARM_CM3/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/RVDS/ARM_CM4F/port.c
+++ b/FreeRTOS/Source/portable/RVDS/ARM_CM4F/port.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/RVDS/ARM_CM4F/portmacro.h
+++ b/FreeRTOS/Source/portable/RVDS/ARM_CM4F/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/RVDS/ARM_CM4_MPU/port.c
+++ b/FreeRTOS/Source/portable/RVDS/ARM_CM4_MPU/port.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/RVDS/ARM_CM4_MPU/portmacro.h
+++ b/FreeRTOS/Source/portable/RVDS/ARM_CM4_MPU/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/RVDS/ARM_CM7/r0p1/port.c
+++ b/FreeRTOS/Source/portable/RVDS/ARM_CM7/r0p1/port.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/RVDS/ARM_CM7/r0p1/portmacro.h
+++ b/FreeRTOS/Source/portable/RVDS/ARM_CM7/r0p1/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/Renesas/RX100/port.c
+++ b/FreeRTOS/Source/portable/Renesas/RX100/port.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/Renesas/RX100/port_asm.src
+++ b/FreeRTOS/Source/portable/Renesas/RX100/port_asm.src
@@ -1,5 +1,5 @@
 ;/*
-; * FreeRTOS Kernel V10.3.0
+; * FreeRTOS Kernel
 ; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 ; *
 ; * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/Renesas/RX100/portmacro.h
+++ b/FreeRTOS/Source/portable/Renesas/RX100/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/Renesas/RX200/port.c
+++ b/FreeRTOS/Source/portable/Renesas/RX200/port.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/Renesas/RX200/port_asm.src
+++ b/FreeRTOS/Source/portable/Renesas/RX200/port_asm.src
@@ -1,5 +1,5 @@
 ;/*
-; * FreeRTOS Kernel V10.3.0
+; * FreeRTOS Kernel
 ; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 ; *
 ; * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/Renesas/RX200/portmacro.h
+++ b/FreeRTOS/Source/portable/Renesas/RX200/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/Renesas/RX600/port.c
+++ b/FreeRTOS/Source/portable/Renesas/RX600/port.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/Renesas/RX600/port_asm.src
+++ b/FreeRTOS/Source/portable/Renesas/RX600/port_asm.src
@@ -1,5 +1,5 @@
 ;/*
-; * FreeRTOS Kernel V10.3.0
+; * FreeRTOS Kernel
 ; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 ; *
 ; * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/Renesas/RX600/portmacro.h
+++ b/FreeRTOS/Source/portable/Renesas/RX600/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/Renesas/RX600v2/port.c
+++ b/FreeRTOS/Source/portable/Renesas/RX600v2/port.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/Renesas/RX600v2/port_asm.src
+++ b/FreeRTOS/Source/portable/Renesas/RX600v2/port_asm.src
@@ -1,5 +1,5 @@
 ;/*
-; * FreeRTOS Kernel V10.3.0
+; * FreeRTOS Kernel
 ; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 ; *
 ; * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/Renesas/RX600v2/portmacro.h
+++ b/FreeRTOS/Source/portable/Renesas/RX600v2/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/Renesas/SH2A_FPU/ISR_Support.inc
+++ b/FreeRTOS/Source/portable/Renesas/SH2A_FPU/ISR_Support.inc
@@ -1,5 +1,5 @@
 ;/*
-; * FreeRTOS Kernel V10.3.0
+; * FreeRTOS Kernel
 ; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 ; *
 ; * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/Renesas/SH2A_FPU/port.c
+++ b/FreeRTOS/Source/portable/Renesas/SH2A_FPU/port.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/Renesas/SH2A_FPU/portasm.src
+++ b/FreeRTOS/Source/portable/Renesas/SH2A_FPU/portasm.src
@@ -1,5 +1,5 @@
 ;/*
-; * FreeRTOS Kernel V10.3.0
+; * FreeRTOS Kernel
 ; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 ; *
 ; * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/Renesas/SH2A_FPU/portmacro.h
+++ b/FreeRTOS/Source/portable/Renesas/SH2A_FPU/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/Rowley/MSP430F449/port.c
+++ b/FreeRTOS/Source/portable/Rowley/MSP430F449/port.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/Rowley/MSP430F449/portasm.h
+++ b/FreeRTOS/Source/portable/Rowley/MSP430F449/portasm.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/Rowley/MSP430F449/portext.asm
+++ b/FreeRTOS/Source/portable/Rowley/MSP430F449/portext.asm
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/Rowley/MSP430F449/portmacro.h
+++ b/FreeRTOS/Source/portable/Rowley/MSP430F449/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/SDCC/Cygnal/port.c
+++ b/FreeRTOS/Source/portable/SDCC/Cygnal/port.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/SDCC/Cygnal/portmacro.h
+++ b/FreeRTOS/Source/portable/SDCC/Cygnal/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/Softune/MB91460/port.c
+++ b/FreeRTOS/Source/portable/Softune/MB91460/port.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/Softune/MB91460/portmacro.h
+++ b/FreeRTOS/Source/portable/Softune/MB91460/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/Softune/MB96340/port.c
+++ b/FreeRTOS/Source/portable/Softune/MB96340/port.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/Softune/MB96340/portmacro.h
+++ b/FreeRTOS/Source/portable/Softune/MB96340/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/Tasking/ARM_CM4F/port.c
+++ b/FreeRTOS/Source/portable/Tasking/ARM_CM4F/port.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/Tasking/ARM_CM4F/port_asm.asm
+++ b/FreeRTOS/Source/portable/Tasking/ARM_CM4F/port_asm.asm
@@ -1,5 +1,5 @@
 ;/*
-; * FreeRTOS Kernel V10.3.0
+; * FreeRTOS Kernel
 ; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 ; *
 ; * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/Tasking/ARM_CM4F/portmacro.h
+++ b/FreeRTOS/Source/portable/Tasking/ARM_CM4F/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/WizC/PIC18/Drivers/Tick/Tick.c
+++ b/FreeRTOS/Source/portable/WizC/PIC18/Drivers/Tick/Tick.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/WizC/PIC18/Drivers/Tick/isrTick.c
+++ b/FreeRTOS/Source/portable/WizC/PIC18/Drivers/Tick/isrTick.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/WizC/PIC18/addFreeRTOS.h
+++ b/FreeRTOS/Source/portable/WizC/PIC18/addFreeRTOS.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/WizC/PIC18/port.c
+++ b/FreeRTOS/Source/portable/WizC/PIC18/port.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/WizC/PIC18/portmacro.h
+++ b/FreeRTOS/Source/portable/WizC/PIC18/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/oWatcom/16BitDOS/Flsh186/port.c
+++ b/FreeRTOS/Source/portable/oWatcom/16BitDOS/Flsh186/port.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/oWatcom/16BitDOS/Flsh186/portmacro.h
+++ b/FreeRTOS/Source/portable/oWatcom/16BitDOS/Flsh186/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/oWatcom/16BitDOS/PC/port.c
+++ b/FreeRTOS/Source/portable/oWatcom/16BitDOS/PC/port.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/oWatcom/16BitDOS/PC/portmacro.h
+++ b/FreeRTOS/Source/portable/oWatcom/16BitDOS/PC/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/oWatcom/16BitDOS/common/portasm.h
+++ b/FreeRTOS/Source/portable/oWatcom/16BitDOS/common/portasm.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/portable/oWatcom/16BitDOS/common/portcomn.c
+++ b/FreeRTOS/Source/portable/oWatcom/16BitDOS/common/portcomn.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/queue.c
+++ b/FreeRTOS/Source/queue.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/stream_buffer.c
+++ b/FreeRTOS/Source/stream_buffer.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/tasks.c
+++ b/FreeRTOS/Source/tasks.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Source/timers.c
+++ b/FreeRTOS/Source/timers.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of


### PR DESCRIPTION
The only directory touched in this commit is ```FreeRTOS/Source```. 

A second PR will remove version number in other directories. 