### PR TITLE
Fixed wrong git clone SSH command in README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ git clone https://github.com/FreeRTOS/FreeRTOS
 ```
 Using SSH:
 ```
-git clone https://github.com/FreeRTOS/FreeRTOS.git
+git clone git@github.com:FreeRTOS/FreeRTOS.git
 ```
 
 


### PR DESCRIPTION
### What's wrong ?
git clone command for SSH listed in [README.md](https://github.com/FreeRTOS/FreeRTOS/blob/master/README.md) _([Cloning ](https://github.com/FreeRTOS/FreeRTOS/blob/master/README.md#cloning)section)_ file is not correct :

> ```
> Using SSH:
> ```
> git clone https://github.com/FreeRTOS/FreeRTOS.git

### What is the proposed change ?
Replaced bad https URL with proper SSH URL :

> ```
> Using SSH:
> ```
> **git clone git@github.com:FreeRTOS/FreeRTOS.git**
> ```