### PR TITLE
use relative path to point to bundled toolchain instead

### DIFF
--- a/FreeRTOS/Demo/RISC-V_RV32_SiFive_HiFive1-RevB_FreedomStudio/.cproject
+++ b/FreeRTOS/Demo/RISC-V_RV32_SiFive_HiFive1-RevB_FreedomStudio/.cproject
@@ -35,7 +35,7 @@
                         						
                         <toolChain id="cdt.managedbuild.toolchain.gnu.cross.exe.debug.1023181676" name="Cross GCC" superClass="cdt.managedbuild.toolchain.gnu.cross.exe.debug">
                             							
-                            <option id="cdt.managedbuild.option.gnu.cross.path.2116215758" name="Path" superClass="cdt.managedbuild.option.gnu.cross.path" value="C:\devtools\FreedomStudio-2019-08-2-win64\SiFive\riscv64-unknown-elf-gcc-8.3.0-2019.08.0\bin" valueType="string"/>
+                            <option id="cdt.managedbuild.option.gnu.cross.path.2116215758" name="Path" superClass="cdt.managedbuild.option.gnu.cross.path" useByScannerDiscovery="false" value="${eclipse_home}\SiFive\riscv64-unknown-elf-gcc-8.3.0-2019.08.0\bin" valueType="string"/>
                             							
                             <targetPlatform archList="all" binaryParser="org.eclipse.cdt.core.ELF" id="cdt.managedbuild.targetPlatform.gnu.cross.1119183919" isAbstract="false" osList="all" superClass="cdt.managedbuild.targetPlatform.gnu.cross"/>
                             							


### PR DESCRIPTION
FreedomStudio comes with a  bundled installation of the riscv cross compiler tools. 
However our project had a hardcoded path to said bundled toolchain. 
Updated to relative point to IDEs bundled toolchain