### PR TITLE
Update readme and revert relative URL. 

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "FreeRTOS/Source"]
 	path = FreeRTOS/Source
-	url = ../FreeRTOS-Kernel.git
+	url = https://github.com/FreeRTOS/FreeRTOS-Kernel.git

--- a/README.md
+++ b/README.md
@@ -29,11 +29,11 @@ git submodule update --init --recursive
 This repository contains the FreeRTOS Kernel, a number of supplementary libraries, and a comprehensive set of example applications.
 
 ### Kernel sources
-The FreeRTOS Kernel Source is located under [FreeRTOS/Source](https://github.com/FreeRTOS/FreeRTOS/tree/master/FreeRTOS/Source)
+The FreeRTOS Kernel Source is in [FreeRTOS/FreeRTOS-Kernel repository](https://github.com/FreeRTOS/FreeRTOS-Kernel), and it is consumed as a submodule in this repository.
 
-Hardware specific ports can be found under [FreeRTOS/Source/portable](https://github.com/FreeRTOS/FreeRTOS/tree/master/FreeRTOS/Source/portable)
+The version of the FreeRTOS Kernel Source in use could be accessed at [```./FreeRTOS/Source```](https://github.com/FreeRTOS/FreeRTOS/tree/master/FreeRTOS/Source)
 
-A number of Demo projects can be found under [FreeRTOS/Demo](https://github.com/FreeRTOS/FreeRTOS/tree/master/FreeRTOS/Demo)
+A number of Demo projects can be found under [```./FreeRTOS/Demo```](https://github.com/FreeRTOS/FreeRTOS/tree/master/FreeRTOS/Demo)
 
 ### Supplementary library sources
 The [FreeRTOS-Plus/Source](https://github.com/FreeRTOS/FreeRTOS/tree/master/FreeRTOS-Plus/Source) directory contains source code for some of the FreeRTOS+ components, as well as select partner provided libraries. These subdirectories contain further readme files and links to documentation.

--- a/README.md
+++ b/README.md
@@ -6,22 +6,6 @@ Additionally, for FreeRTOS kernel feature information refer to the [Developer Do
 ### Getting help
 If you have any questions or need assistance troubleshooting your FreeRTOS project, we have an active community that can help on the [FreeRTOS Community Support Forum](https://forums.freertos.org).
 
-## Repository structure
-This repository contains the FreeRTOS Kernel, a number of supplementary libraries, and a comprehensive set of example applications.
-
-### Kernel sources
-The FreeRTOS Kernel Source is located under [FreeRTOS/Source](https://github.com/FreeRTOS/FreeRTOS/tree/master/FreeRTOS/Source)
-
-Hardware specific ports can be found under [FreeRTOS/Source/portable](https://github.com/FreeRTOS/FreeRTOS/tree/master/FreeRTOS/Source/portable)
-
-A number of Demo projects can be found under [FreeRTOS/Demo](https://github.com/FreeRTOS/FreeRTOS/tree/master/FreeRTOS/Demo)
-
-### Supplementary library sources
-The [FreeRTOS-Plus/Source](https://github.com/FreeRTOS/FreeRTOS/tree/master/FreeRTOS-Plus/Source) directory contains source code for some of the FreeRTOS+ components, as well as select partner provided libraries. These subdirectories contain further readme files and links to documentation.
-
-[FreeRTOS-Labs](https://github.com/FreeRTOS/FreeRTOS/tree/master/FreeRTOS-Labs) contains libraries and demos that are fully functional, but undergoing optimizations or refactorization to improve memory usage, modularity,
-documentation, demo usability, or test coverage.  At this time the projects ARE A WORK IN PROGRESS and will be released in the main FreeRTOS directories of the download following full review and completion of the documentation.
-
 ## Cloning this repository
 This repo uses [Git Submodules](https://git-scm.com/book/en/v2/Git-Tools-Submodules) to bring in dependent components.
 
@@ -40,6 +24,22 @@ If you have downloaded the repo without using the `--recurse-submodules` argumen
 ```
 git submodule update --init --recursive
 ```
+
+## Repository structure
+This repository contains the FreeRTOS Kernel, a number of supplementary libraries, and a comprehensive set of example applications.
+
+### Kernel sources
+The FreeRTOS Kernel Source is located under [FreeRTOS/Source](https://github.com/FreeRTOS/FreeRTOS/tree/master/FreeRTOS/Source)
+
+Hardware specific ports can be found under [FreeRTOS/Source/portable](https://github.com/FreeRTOS/FreeRTOS/tree/master/FreeRTOS/Source/portable)
+
+A number of Demo projects can be found under [FreeRTOS/Demo](https://github.com/FreeRTOS/FreeRTOS/tree/master/FreeRTOS/Demo)
+
+### Supplementary library sources
+The [FreeRTOS-Plus/Source](https://github.com/FreeRTOS/FreeRTOS/tree/master/FreeRTOS-Plus/Source) directory contains source code for some of the FreeRTOS+ components, as well as select partner provided libraries. These subdirectories contain further readme files and links to documentation.
+
+[FreeRTOS-Labs](https://github.com/FreeRTOS/FreeRTOS/tree/master/FreeRTOS-Labs) contains libraries and demos that are fully functional, but undergoing optimizations or refactorization to improve memory usage, modularity,
+documentation, demo usability, or test coverage.  At this time the projects ARE A WORK IN PROGRESS and will be released in the main FreeRTOS directories of the download following full review and completion of the documentation.
 
 ## Previous releases
 Previous releases are available for download under [releases](https://github.com/FreeRTOS/FreeRTOS/releases).


### PR DESCRIPTION
As seen in commit message, three commits in order:
- Moving clone instruction up. 
- Rewording README.md to state clearly kernel is a submodule.
- Reverting relative URL change ( PR #24 ). (The functionality of relative URL is correct --  user could clone as expected. But the link is dead in GitHub UI, that user cannot click through. See the attached snapshot.)
 
<img width="1022" alt="Screen Shot 2020-03-05 at 11 15 46 PM" src="https://user-images.githubusercontent.com/10982575/76061209-e3ecac00-5f37-11ea-8fa3-7c92c0195a77.png">


If any concern about the wording, please edit directly.