### PR TITLE
Add ./lib directory to make sure Zynq project compiles.

### DIFF
--- a/FreeRTOS/Demo/CORTEX_A9_Zynq_ZC702/RTOSDemo_bsp/ps7_cortexa9_0/lib/README.md
+++ b/FreeRTOS/Demo/CORTEX_A9_Zynq_ZC702/RTOSDemo_bsp/ps7_cortexa9_0/lib/README.md
@@ -1,0 +1,4 @@
+The ./lib directory is needed to ensure that bsp project compiles.
+Refer to Makefile: ```./FreeRTOS/Demo/CORTEX_A9_Zynq_ZC702/RTOSDemo_bsp/Makefile```.
+
+In order to keep an empty directory in git, this README.md is created.  


### PR DESCRIPTION
Add ./lib directory to make sure Zynq project compiles.

Description
-----------
In ```CORTEX_A9_Zynq_ZC702``` demo, ```./RTOSDemo``` project has dependency on ```./RTOSDemo_bsp``` project, in which libxil.a is built and later linked as a static library in RTOSDemo. 

Without ```./lib``` directory, Xilinx generated Makefile for bsp project will not work. Makefile -- https://github.com/FreeRTOS/FreeRTOS/blob/master/FreeRTOS/Demo/CORTEX_A9_Zynq_ZC702/RTOSDemo_bsp/Makefile. 

Test Steps
-----------
Without this PR, ```CORTEX_A9_Zynq_ZC702/RTOSDemo``` doesn't build. With this PR it builds. 

Related Issue
-----------
<!-- If any, please provide issue ID. -->
N/A

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
