### PR TITLE
Removing writes to read-only PLIC interrupt pending registers.

### DIFF
--- a/FreeRTOS/Demo/RISC-V_RV32_SiFive_HiFive1-RevB_FreedomStudio/main.c
+++ b/FreeRTOS/Demo/RISC-V_RV32_SiFive_HiFive1-RevB_FreedomStudio/main.c
@@ -141,10 +141,6 @@ struct metal_interrupt *pxInterruptController;
 	/* Set all interrupt enable bits to 0. */
 	mainPLIC_ENABLE_0 = 0UL;
 	mainPLIC_ENABLE_1 = 0UL;
-
-	/* Clear all pending interrupts. */
-	mainPLIC_PENDING_0 = 0UL;
-	mainPLIC_PENDING_1 = 0UL;
 }
 /*-----------------------------------------------------------*/
 


### PR DESCRIPTION
Description
-----------
PLIC interrupt pending registers at address 0x0C00_1000 and 0x0C00_1004 are with attribute RO, thus writes to these locations are unnecessary. 

Test Steps
-----------
Tested the change with ```RISC-V_RV32_SiFive_HiFive1-RevB_FreedomStudio``` project. Register ```pending1``` and ```pending2``` are not changed with or without these two lines. Safe to remove. 

Related Issue
-----------
https://forums.freertos.org/t/freertos-demo-for-hifive1-write-to-read-only-address/9406


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
