### PR TITLE
[CBMC]QueueGenericCreateStatic - Some assumptions did not match asserts in kernel source

### DIFF
--- a/FreeRTOS/Test/CBMC/proofs/Queue/QueueGenericCreateStatic/QueueGenericCreateStatic_harness.c
+++ b/FreeRTOS/Test/CBMC/proofs/Queue/QueueGenericCreateStatic/QueueGenericCreateStatic_harness.c
@@ -52,8 +52,10 @@ void harness(){
     __CPROVER_assume(uxQueueLength > ( UBaseType_t ) 0);
 
     // QueueGenericCreateStatic asserts the following equivalence
-    __CPROVER_assume( ( pucQueueStorage && uxItemSize ) ||
-                      ( !pucQueueStorage && !uxItemSize ) );
+    /* A queue storage area should be provided if the item size is not 0, and
+    should not be provided if the item size is 0. */
+    __CPROVER_assume( !( ( pucQueueStorage != NULL ) && ( uxItemSize == 0 ) ) );
+    __CPROVER_assume( !( ( pucQueueStorage == NULL ) && ( uxItemSize != 0 ) ) );
 
     // QueueGenericCreateStatic asserts nonnull pointer
     __CPROVER_assume(pxStaticQueue);


### PR DESCRIPTION
Description
-----------
See the related asserts in [queue.c:320](https://github.com/FreeRTOS/FreeRTOS-Kernel/blob/master/queue.c#L320)

Logically equal, but easier to visually verify with the code.


Test Steps
-----------
Run cbmc tests in FreeRTOS/Test/CBMC/proofs/Queue/QueueGenericCreateStatic

Related Issue
-----------



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
