### PR TITLE
Queue proof clean up. (partial)

### DIFF
--- a/FreeRTOS/Test/CBMC/include/queue_init.h
+++ b/FreeRTOS/Test/CBMC/include/queue_init.h
@@ -69,21 +69,21 @@ QueueHandle_t xUnconstrainedQueueBoundedItemSize( UBaseType_t uxItemSizeBound ) 
 	__CPROVER_assume(uxQueueStorageSize < CBMC_OBJECT_MAX_SIZE);
 	__CPROVER_assume(uxItemSize < uxQueueStorageSize/uxQueueLength);
 
-	QueueHandle_t xQueue =
-		xQueueGenericCreate(uxQueueLength, uxItemSize, ucQueueType);
-	if(xQueue){
-		xQueue->cTxLock = nondet_int8_t();
-		xQueue->cRxLock = nondet_int8_t();
-		xQueue->uxMessagesWaiting = nondet_UBaseType_t();
-		/* This is an invariant checked with a couple of asserts in the code base.
-		   If it is false from the beginning, the CBMC proofs are not able to succeed*/
-		__CPROVER_assume(xQueue->uxMessagesWaiting < xQueue->uxLength);
-		xQueue->xTasksWaitingToReceive.uxNumberOfItems = nondet_UBaseType_t();
-		xQueue->xTasksWaitingToSend.uxNumberOfItems = nondet_UBaseType_t();
-		#if( configUSE_QUEUE_SETS == 1)
-			xQueueAddToSet(xQueue, xUnconstrainedQueueSet());
-		#endif
-	}
+	QueueHandle_t xQueue = xQueueGenericCreate(uxQueueLength, uxItemSize, ucQueueType);
+	__CPROVER_assume(xQueue);
+	
+	xQueue->cTxLock = nondet_int8_t();
+	xQueue->cRxLock = nondet_int8_t();
+	xQueue->uxMessagesWaiting = nondet_UBaseType_t();
+	/* This is an invariant checked with a couple of asserts in the code base.
+	If it is false from the beginning, the CBMC proofs are not able to succeed*/
+	__CPROVER_assume(xQueue->uxMessagesWaiting < xQueue->uxLength);
+	xQueue->xTasksWaitingToReceive.uxNumberOfItems = nondet_UBaseType_t();
+	xQueue->xTasksWaitingToSend.uxNumberOfItems = nondet_UBaseType_t();
+	#if( configUSE_QUEUE_SETS == 1)
+		xQueueAddToSet(xQueue, xUnconstrainedQueueSet());
+	#endif
+
 	return xQueue;
 }
 

--- a/FreeRTOS/Test/CBMC/include/queue_init.h
+++ b/FreeRTOS/Test/CBMC/include/queue_init.h
@@ -124,20 +124,22 @@ QueueHandle_t xUnconstrainedQueue( void ) {
 /* Create a mostly unconstrained Mutex */
 QueueHandle_t xUnconstrainedMutex( void ) {
 	uint8_t ucQueueType;
-	QueueHandle_t xQueue =
-		xQueueCreateMutex(ucQueueType);
-	if(xQueue){
-		xQueue->cTxLock = nondet_int8_t();
-		xQueue->cRxLock = nondet_int8_t();
-		xQueue->uxMessagesWaiting = nondet_UBaseType_t();
-		/* This is an invariant checked with a couple of asserts in the code base.
-		   If it is false from the beginning, the CBMC proofs are not able to succeed*/
-		__CPROVER_assume(xQueue->uxMessagesWaiting < xQueue->uxLength);
-		xQueue->xTasksWaitingToReceive.uxNumberOfItems = nondet_UBaseType_t();
-		xQueue->xTasksWaitingToSend.uxNumberOfItems = nondet_UBaseType_t();
-		#if( configUSE_QUEUE_SETS == 1)
-			xQueueAddToSet(xQueue, xUnconstrainedQueueSet());
-		#endif
-	}
+	QueueHandle_t xQueue = xQueueCreateMutex(ucQueueType);
+	__CPROVER_assume(xQueue);
+
+	xQueue->cTxLock = nondet_int8_t();
+	xQueue->cRxLock = nondet_int8_t();
+	xQueue->uxLength = nondet_UBaseType_t();
+	xQueue->uxMessagesWaiting = nondet_UBaseType_t();
+
+	/* This is an invariant checked with a couple of asserts in the code base.
+	    If it is false from the beginning, the CBMC proofs are not able to succeed*/
+	__CPROVER_assume(xQueue->uxMessagesWaiting < xQueue->uxLength);
+	xQueue->xTasksWaitingToReceive.uxNumberOfItems = nondet_UBaseType_t();
+	xQueue->xTasksWaitingToSend.uxNumberOfItems = nondet_UBaseType_t();
+	#if( configUSE_QUEUE_SETS == 1)
+		xQueueAddToSet(xQueue, xUnconstrainedQueueSet());
+	#endif
+
 	return xQueue;
 }

--- a/FreeRTOS/Test/CBMC/include/queue_init.h
+++ b/FreeRTOS/Test/CBMC/include/queue_init.h
@@ -74,7 +74,9 @@ QueueHandle_t xUnconstrainedQueueBoundedItemSize( UBaseType_t uxItemSizeBound ) 
 	
 	xQueue->cTxLock = nondet_int8_t();
 	xQueue->cRxLock = nondet_int8_t();
+	xQueue->uxLength = nondet_UBaseType_t();
 	xQueue->uxMessagesWaiting = nondet_UBaseType_t();
+
 	/* This is an invariant checked with a couple of asserts in the code base.
 	If it is false from the beginning, the CBMC proofs are not able to succeed*/
 	__CPROVER_assume(xQueue->uxMessagesWaiting < xQueue->uxLength);

--- a/FreeRTOS/Test/CBMC/proofs/CBMCStubLibrary/tasksStubs.c
+++ b/FreeRTOS/Test/CBMC/proofs/CBMCStubLibrary/tasksStubs.c
@@ -32,16 +32,19 @@ void vInitTaskCheckForTimeOut(BaseType_t maxCounter, BaseType_t maxCounter_limit
 }
 
 /* This is mostly called in a loop. For CBMC, we have to bound the loop
-   to a max limits of calls. Therefore this Stub models a nondet timeout in
-   max TASK_STUB_COUNTER_LIMIT iterations.*/
+   to a max limits of calls. In this stub implementation, some randomization 
+   is provided by none fixed value of increment. In the worst case, function 
+   returns pdTRUE after 3 entries (increment = 1). */
 BaseType_t xTaskCheckForTimeOut( TimeOut_t * const pxTimeOut, TickType_t * const pxTicksToWait ) {
-	++xCounter;
-	if(xCounter == xCounterLimit)
-	{
-		return pdTRUE;
-	}
-	else
-	{
-		return nondet_basetype();
-	}
+	
+	(void *) pxTimeOut;
+	(void *) pxTicksToWait;
+
+	static uint8_t time = 0;
+	uint8_t increment;
+
+	__CPROVER_assume(increment > 0 && increment < 10);
+	time += increment;
+
+	return time > 2 ? pdTRUE : pdFALSE;
 }

--- a/FreeRTOS/Test/CBMC/proofs/Queue/QueueGenericSend/Configurations.json
+++ b/FreeRTOS/Test/CBMC/proofs/Queue/QueueGenericSend/Configurations.json
@@ -29,7 +29,7 @@
 {
   "ENTRY": "QueueGenericSend",
   "LOCK_BOUND": 2,
-  "QUEUE_SEND_BOUND":3,
+  "QUEUE_SEND_BOUND":4,
   "CBMCFLAGS": [
     "--unwind 1",
     "--signed-overflow-check",

--- a/FreeRTOS/Test/CBMC/proofs/Queue/QueuePeek/QueuePeek_harness.c
+++ b/FreeRTOS/Test/CBMC/proofs/Queue/QueuePeek/QueuePeek_harness.c
@@ -35,7 +35,6 @@
 
 void harness(){
 	QueueHandle_t xQueue = xUnconstrainedQueueBoundedItemSize(10);
-	__CPROVER_assume( xQueue );
 
 	void *pvItemToQueue = pvPortMalloc( xQueue->uxItemSize );
 	__CPROVER_assume( pvItemToQueue || xQueue->uxItemSize == 0 );

--- a/FreeRTOS/Test/CBMC/proofs/Queue/QueuePeek/QueuePeek_harness.c
+++ b/FreeRTOS/Test/CBMC/proofs/Queue/QueuePeek/QueuePeek_harness.c
@@ -33,47 +33,19 @@
 
 #include "cbmc.h"
 
-#ifndef LOCK_BOUND
-	#define LOCK_BOUND 4
-#endif
-
-#ifndef QUEUE_PEEK_BOUND
-	#define QUEUE_PEEK_BOUND 4
-#endif
-
-QueueHandle_t xQueue;
-
-
-/* This method is called to initialize pxTimeOut.
-   Setting up the data structure is not interesting for the proof,
-   but the harness uses it to model a release
-   on the queue after first check. */
-void vTaskInternalSetTimeOutState( TimeOut_t * const pxTimeOut ){
-	xQueue-> uxMessagesWaiting = nondet_BaseType_t();
-}
-
 void harness(){
-	xQueue = xUnconstrainedQueueBoundedItemSize(10);
+	QueueHandle_t xQueue = xUnconstrainedQueueBoundedItemSize(10);
+	__CPROVER_assume( xQueue );
 
-	//Initialise the tasksStubs
-	vInitTaskCheckForTimeOut(0, QUEUE_PEEK_BOUND - 1);
+	void *pvItemToQueue = pvPortMalloc( xQueue->uxItemSize );
+	__CPROVER_assume( pvItemToQueue || xQueue->uxItemSize == 0 );
 
 	TickType_t xTicksToWait;
-	if(xState == taskSCHEDULER_SUSPENDED){
-		xTicksToWait = 0;
-	}
+	__CPROVER_assume( xState != taskSCHEDULER_SUSPENDED || xTicksToWait == 0 );
 
-	if(xQueue){
-		__CPROVER_assume(xQueue->cTxLock < LOCK_BOUND - 1);
-		__CPROVER_assume(xQueue->cRxLock < LOCK_BOUND - 1);
+	/* This is for loop unwinding. */
+	__CPROVER_assume( xQueue->cTxLock < LOCK_BOUND - 1 );
+	__CPROVER_assume( xQueue->cRxLock < LOCK_BOUND - 1 );
 
-		void *pvItemToQueue = pvPortMalloc(xQueue->uxItemSize);
-
-		/* In case malloc fails as this is otherwise an invariant violation. */
-		if(!pvItemToQueue){
-			xQueue->uxItemSize = 0;
-		}
-
-		xQueuePeek( xQueue, pvItemToQueue, xTicksToWait );
-	}
+	xQueuePeek( xQueue, pvItemToQueue, xTicksToWait );
 }

--- a/FreeRTOS/Test/CBMC/proofs/Queue/QueueReceive/Makefile.json
+++ b/FreeRTOS/Test/CBMC/proofs/Queue/QueueReceive/Makefile.json
@@ -29,7 +29,7 @@
 {
   "ENTRY": "QueueReceive",
   "LOCK_BOUND": 2,
-  "QUEUE_RECEIVE_BOUND": 3,
+  "QUEUE_RECEIVE_BOUND": 4,
   "CBMCFLAGS": [
     "--unwind 1",
     "--signed-overflow-check",

--- a/FreeRTOS/Test/CBMC/proofs/Queue/QueueReceive/QueueReceive_harness.c
+++ b/FreeRTOS/Test/CBMC/proofs/Queue/QueueReceive/QueueReceive_harness.c
@@ -63,9 +63,7 @@ void vTaskInternalSetTimeOutState( TimeOut_t * const pxTimeOut ){
 }
 
 void harness(){
-
 	xQueue = xUnconstrainedQueueBoundedItemSize(MAX_ITEM_SIZE);
-	__CPROVER_assume( xQueue );
 
 	void *pvBuffer = pvPortMalloc( xQueue->uxItemSize );
 	__CPROVER_assume( pvBuffer || xQueue->uxItemSize == 0 );

--- a/FreeRTOS/Test/CBMC/proofs/Queue/QueueReceiveFromISR/QueueReceiveFromISR_harness.c
+++ b/FreeRTOS/Test/CBMC/proofs/Queue/QueueReceiveFromISR/QueueReceiveFromISR_harness.c
@@ -38,16 +38,12 @@
 #endif
 
 void harness(){
-	QueueHandle_t xQueue =
-	xUnconstrainedQueueBoundedItemSize(MAX_ITEM_SIZE);
+	QueueHandle_t xQueue = xUnconstrainedQueueBoundedItemSize(MAX_ITEM_SIZE);
 
 	BaseType_t *xHigherPriorityTaskWoken = pvPortMalloc(sizeof(BaseType_t));
+	void *pvBuffer = pvPortMalloc(xQueue->uxItemSize);
+	__CPROVER_assume( pvBuffer || xQueue->uxItemSize == 0 );
 
-	if(xQueue){
-		void *pvBuffer = pvPortMalloc(xQueue->uxItemSize);
-		if(!pvBuffer){
-			xQueue->uxItemSize = 0;
-		}
-		xQueueReceiveFromISR( xQueue, pvBuffer, xHigherPriorityTaskWoken );
-	}
+	xQueueReceiveFromISR( xQueue, pvBuffer, xHigherPriorityTaskWoken );
+
 }

--- a/FreeRTOS/Test/CBMC/proofs/Queue/QueueSemaphoreTake/Makefile.json
+++ b/FreeRTOS/Test/CBMC/proofs/Queue/QueueSemaphoreTake/Makefile.json
@@ -30,7 +30,8 @@
   "ENTRY": "QueueSemaphoreTake",
 
   # This bound on queue size is needed to bound a loop in prvUnlockQueue
-  "QUEUE_BOUND": 5,
+  "LOCK_BOUND":5,
+  "SEM_TAKE_BOUND" :4,
 
   "CBMCFLAGS": [
     "--unwind 2",
@@ -38,7 +39,7 @@
     "--pointer-overflow-check",
     "--unsigned-overflow-check",
     "--nondet-static",
-    "--unwindset prvUnlockQueue.0:{QUEUE_BOUND},prvUnlockQueue.1:{QUEUE_BOUND},xQueueSemaphoreTake.0:3"
+    "--unwindset prvUnlockQueue.0:{LOCK_BOUND},prvUnlockQueue.1:{LOCK_BOUND},xQueueSemaphoreTake.0:{SEM_TAKE_BOUND}"
   ],
   "OBJS": [
     "$(ENTRY)_harness.goto",
@@ -49,7 +50,7 @@
   "DEF": [
     "configUSE_TRACE_FACILITY=0",
     "configGENERATE_RUN_TIME_STATS=0",
-    "PRV_UNLOCK_QUEUE_BOUND={QUEUE_BOUND}"
+    "LOCK_BOUND={LOCK_BOUND}"
   ],
   "INC": [
     "."

--- a/FreeRTOS/Test/CBMC/proofs/Queue/QueueSemaphoreTake/QueueSemaphoreTake_harness.c
+++ b/FreeRTOS/Test/CBMC/proofs/Queue/QueueSemaphoreTake/QueueSemaphoreTake_harness.c
@@ -32,57 +32,26 @@
 #include "tasksStubs.h"
 #include "cbmc.h"
 
-BaseType_t state;
-QueueHandle_t xQueue;
-BaseType_t counter;
-
-BaseType_t xTaskGetSchedulerState(void)
-{
-	return state;
-}
-
-void vTaskInternalSetTimeOutState( TimeOut_t * const pxTimeOut )
-{
-	/* QueueSemaphoreTake might be blocked to wait for
-	   another process to release a token to the semaphore.
-	   This is currently not in the CBMC model. Anyhow,
-	   vTaskInternalSetTimeOutState is set a timeout for
-	   QueueSemaphoreTake operation. We use this to model a successful
-	   release during wait time. */
-	UBaseType_t bound;
-	__CPROVER_assume((bound >= 0 && xQueue->uxLength >= bound));
-	xQueue->uxMessagesWaiting = bound;
-}
-
 void harness()
 {
-	/* Init task stub to make sure that the third loop iteration
-	simulates a time out */
-	vInitTaskCheckForTimeOut(0, 3);
+	QueueHandle_t xQueue = xUnconstrainedMutex();
 
-	xQueue = xUnconstrainedMutex();
 	TickType_t xTicksToWait;
+	__CPROVER_assume( xState != taskSCHEDULER_SUSPENDED || xTicksToWait == 0 );
 
-	if(state == taskSCHEDULER_SUSPENDED){
-		xTicksToWait = 0;
-	}
-	if (xQueue) {
-		/* Bounding the loop in prvUnlockQueue to
-		   PRV_UNLOCK_QUEUE_BOUND. As the loop is not relevant
-		   in this proof the value might be set to any
-		   positive 8-bit integer value. We subtract one,
-		   because the bound must be one greater than the
-		   amount of loop iterations. */
-		__CPROVER_assert(LOCK_BOUND > 0, "Make sure, a valid macro value is chosen.");
-		xQueue->cTxLock = LOCK_BOUND - 1;
-		xQueue->cRxLock = LOCK_BOUND - 1;
-		((&(xQueue->xTasksWaitingToReceive))->xListEnd).pxNext->xItemValue = nondet_ticktype();
+	/* This is for loop unwinding. */
+	__CPROVER_assume( xQueue->cTxLock = LOCK_BOUND - 1 );
+	__CPROVER_assume( xQueue->cRxLock = LOCK_BOUND - 1 );
 
-		/* This assumptions is required to prevent an overflow in l. 2057 of queue.c
-		   in the prvGetDisinheritPriorityAfterTimeout() function. */
-		__CPROVER_assume( (
-		  ( UBaseType_t ) listGET_ITEM_VALUE_OF_HEAD_ENTRY( &( xQueue->xTasksWaitingToReceive ) )
-		   <= ( ( UBaseType_t ) configMAX_PRIORITIES)));
-		xQueueSemaphoreTake(xQueue, xTicksToWait);
-	}
+	/* Volatile member. */
+	((&(xQueue->xTasksWaitingToReceive))->xListEnd).pxNext->xItemValue = nondet_ticktype();
+
+	/* This assumptions is required to prevent an overflow in l. 2057 of queue.c
+		in the prvGetDisinheritPriorityAfterTimeout() function. */
+	__CPROVER_assume( (
+		( UBaseType_t ) listGET_ITEM_VALUE_OF_HEAD_ENTRY( &( xQueue->xTasksWaitingToReceive ) )
+		<= ( ( UBaseType_t ) configMAX_PRIORITIES)));
+	
+	xQueueSemaphoreTake(xQueue, xTicksToWait);
+	
 }

--- a/FreeRTOS/Test/CBMC/proofs/Queue/QueueSemaphoreTake/QueueSemaphoreTake_harness.c
+++ b/FreeRTOS/Test/CBMC/proofs/Queue/QueueSemaphoreTake/QueueSemaphoreTake_harness.c
@@ -73,9 +73,9 @@ void harness()
 		   positive 8-bit integer value. We subtract one,
 		   because the bound must be one greater than the
 		   amount of loop iterations. */
-		__CPROVER_assert(PRV_UNLOCK_QUEUE_BOUND > 0, "Make sure, a valid macro value is chosen.");
-		xQueue->cTxLock = PRV_UNLOCK_QUEUE_BOUND - 1;
-		xQueue->cRxLock = PRV_UNLOCK_QUEUE_BOUND - 1;
+		__CPROVER_assert(LOCK_BOUND > 0, "Make sure, a valid macro value is chosen.");
+		xQueue->cTxLock = LOCK_BOUND - 1;
+		xQueue->cRxLock = LOCK_BOUND - 1;
 		((&(xQueue->xTasksWaitingToReceive))->xListEnd).pxNext->xItemValue = nondet_ticktype();
 
 		/* This assumptions is required to prevent an overflow in l. 2057 of queue.c


### PR DESCRIPTION
Description
-----------
Clean up proofs for:
- QueuePeek
- QueueReceive
- QueueReceiveFromISR
- QueueSemaphoreTake

Clean up initialization function:
- xUnconstrainedMutex
- xUnconstrainedQueueBoundedItemSize

Need to clean up initialization a little bit more. For now, just to get things going. 

Test Steps
-----------
This is a draft PR which is trying to use CI to validate nothing's broken. Once CI finishes, will double check states are not reduced due to this PR. 

Please don't review yet. 

Related Issue
-----------
N/A

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
