### PR TITLE
Change cbmc-viewer invocation in CBMC makefile

### DIFF
--- a/FreeRTOS/Test/CBMC/proofs/Makefile.template
+++ b/FreeRTOS/Test/CBMC/proofs/Makefile.template
@@ -1,4 +1,4 @@
-default: cbmc
+default: report
 
 # ____________________________________________________________________
 # CBMC binaries
@@ -114,7 +114,7 @@ goto:
 	$(MAKE) $(ENTRY).goto
 
 cbmc.txt: $(ENTRY).goto
-	cbmc $(CBMCFLAGS) --unwinding-assertions --trace @RULE_INPUT@ > $@ 2>&1
+	- cbmc $(CBMCFLAGS) --unwinding-assertions --trace @RULE_INPUT@ > $@ 2>&1
 
 property.xml: $(ENTRY).goto
 	cbmc $(CBMCFLAGS) --unwinding-assertions --show-properties --xml-ui @RULE_INPUT@ \

--- a/FreeRTOS/Test/CBMC/proofs/Makefile.template
+++ b/FreeRTOS/Test/CBMC/proofs/Makefile.template
@@ -135,7 +135,7 @@ report: cbmc.txt property.xml coverage.xml
 	--srcdir $(FREERTOS) \
 	--blddir $(FREERTOS) \
 	--htmldir html \
-	--srcexclude "(.@FORWARD_SLASH@doc|.@FORWARD_SLASH@tests|.@FORWARD_SLASH@vendors)" \
+	--srcexclude "(.@FORWARD_SLASH@Demo)" \
 	--result cbmc.txt \
 	--property property.xml \
 	--block coverage.xml


### PR DESCRIPTION
Exclude FreeRTOS/Demo from CBMC proof reports.
    
The script cbmc-viewer generates the CBMC proof reports.  The script searches source files for symbol definitions and annotates source files with coverage information.  This patch causes cbmc-viewer to ignore the directory FreeRTOS/Demo containing 348M of data.  The script now terminates in a few seconds.

Also modify the makefile to build the full report by default (not just the property checking).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
