### PR TITLE
Feature/multiple direct to task notifications

### DIFF
--- a/FreeRTOS-Plus/Source/FreeRTOS-Plus-Trace/Include/trcKernelPort.h
+++ b/FreeRTOS-Plus/Source/FreeRTOS-Plus-Trace/Include/trcKernelPort.h
@@ -1253,8 +1253,8 @@ extern void vTraceStoreMemMangEvent(uint32_t ecode, uint32_t address, int32_t si
 		trcKERNEL_HOOKS_KERNEL_SERVICE_WITH_PARAM(TRACE_TASK_NOTIFY_TAKE_TRCFAILED, TASK, pxCurrentTCB, xTicksToWait); \
 	}
 #else /* TRC_CFG_FREERTOS_VERSION < TRC_FREERTOS_VERSION_9_0_0 */
-#define traceTASK_NOTIFY_TAKE() \
-	if (pxCurrentTCB->ucNotifyState == taskNOTIFICATION_RECEIVED){ \
+#define traceTASK_NOTIFY_TAKE( index ) \
+	if (pxCurrentTCB->ucNotifyState[ ( index ) ] == taskNOTIFICATION_RECEIVED){ \
 		trcKERNEL_HOOKS_KERNEL_SERVICE_WITH_PARAM(TRACE_TASK_NOTIFY_TAKE, TASK, pxCurrentTCB, xTicksToWait); \
 	}else{ \
 		trcKERNEL_HOOKS_KERNEL_SERVICE_WITH_PARAM(TRACE_TASK_NOTIFY_TAKE_TRCFAILED, TASK, pxCurrentTCB, xTicksToWait);}
@@ -1276,10 +1276,10 @@ extern void vTraceStoreMemMangEvent(uint32_t ecode, uint32_t address, int32_t si
 			prvTraceStoreKernelCallWithParam(TRACE_TASK_NOTIFY_WAIT_TRCFAILED, TRACE_CLASS_TASK, TRACE_GET_TASK_NUMBER(pxCurrentTCB), xTicksToWait); \
 	}
 #else /* TRC_CFG_FREERTOS_VERSION < TRC_FREERTOS_VERSION_9_0_0 */
-#define traceTASK_NOTIFY_WAIT() \
+#define traceTASK_NOTIFY_WAIT( index ) \
 	if (TRACE_GET_OBJECT_FILTER(TASK, pxCurrentTCB) & CurrentFilterMask) \
 	{ \
-		if (pxCurrentTCB->ucNotifyState == taskNOTIFICATION_RECEIVED) \
+		if (pxCurrentTCB->ucNotifyState[ ( index ) ] == taskNOTIFICATION_RECEIVED) \
 			prvTraceStoreKernelCallWithParam(TRACE_TASK_NOTIFY_WAIT, TRACE_CLASS_TASK, TRACE_GET_TASK_NUMBER(pxCurrentTCB), xTicksToWait); \
 		else \
 			prvTraceStoreKernelCallWithParam(TRACE_TASK_NOTIFY_WAIT_TRCFAILED, TRACE_CLASS_TASK, TRACE_GET_TASK_NUMBER(pxCurrentTCB), xTicksToWait); \

--- a/FreeRTOS/Demo/Common/Minimal/TaskNotifyArray.c
+++ b/FreeRTOS/Demo/Common/Minimal/TaskNotifyArray.c
@@ -27,8 +27,8 @@
 
 
 /*
- * Tests the behaviour of arrays of task notifications per task.  This file is
- * used in combination with TaskNotify.c.
+ * Tests the behaviour of arrays of task notifications per task.  The tests in this
+ * file are additive to those implemented in FreeRTOS/Demo/Common/Minimal/TaskNotify.c.
  */
 
 /* Standard includes. */
@@ -42,8 +42,8 @@
 /* Demo program include files. */
 #include "TaskNotifyArray.h"
 
-#if( configNUMBER_OF_TASK_NOTIFICATIONS < 2 )
-	#error This file is intended to test direct to task notification arrays but the array does not contain more than one index.
+#if( configTASK_NOTIFICATION_ARRAY_ENTRIES < 3 )
+	#error This file tests direct to task notification arrays and needs configTASK_NOTIFICATION_ARRAY_ENTRIES to be at leat 3.
 #endif
 
 /* Allow parameters to be overridden on a demo by demo basis. */
@@ -203,12 +203,12 @@ UBaseType_t uxIndexToTest, uxOtherIndexes;
 
 	/* ------------------------------------------------------------------------
 	Check blocking when there are no notifications. */
-	for( uxIndexToTest = 0; uxIndexToTest < configNUMBER_OF_TASK_NOTIFICATIONS; uxIndexToTest++ )
+	for( uxIndexToTest = 0; uxIndexToTest < configTASK_NOTIFICATION_ARRAY_ENTRIES; uxIndexToTest++ )
 	{
 		/* Send notifications to the task notification in each index of the
 		task notification array other than the one on which this task will
 		block. */
-		for( uxOtherIndexes = 0; uxOtherIndexes < configNUMBER_OF_TASK_NOTIFICATIONS; uxOtherIndexes++ )
+		for( uxOtherIndexes = 0; uxOtherIndexes < configTASK_NOTIFICATION_ARRAY_ENTRIES; uxOtherIndexes++ )
 		{
 			if( uxOtherIndexes != uxIndexToTest )
 			{
@@ -229,7 +229,7 @@ UBaseType_t uxIndexToTest, uxOtherIndexes;
 
 		/* Clear all the other notifications within the array of task
 		notifications again ready for the next round. */
-		for( uxOtherIndexes = 0; uxOtherIndexes < configNUMBER_OF_TASK_NOTIFICATIONS; uxOtherIndexes++ )
+		for( uxOtherIndexes = 0; uxOtherIndexes < configTASK_NOTIFICATION_ARRAY_ENTRIES; uxOtherIndexes++ )
 		{
 			if( uxOtherIndexes != uxIndexToTest )
 			{
@@ -247,7 +247,7 @@ UBaseType_t uxIndexToTest, uxOtherIndexes;
 
 	/* ------------------------------------------------------------------------
 	Check no blocking when notifications are pending. */
-	for( uxIndexToTest = 0; uxIndexToTest < configNUMBER_OF_TASK_NOTIFICATIONS; uxIndexToTest++ )
+	for( uxIndexToTest = 0; uxIndexToTest < configTASK_NOTIFICATION_ARRAY_ENTRIES; uxIndexToTest++ )
 	{
 		/* First notify the task notification at index uxIndexToTest within this
 		task's own array of task notifications - this would not be a normal
@@ -286,11 +286,11 @@ UBaseType_t uxIndexToTest, uxOtherIndexes;
 
 	/*-------------------------------------------------------------------------
 	Check the non-overwriting functionality. */
-	for( uxIndexToTest = 0; uxIndexToTest < configNUMBER_OF_TASK_NOTIFICATIONS; uxIndexToTest++ )
+	for( uxIndexToTest = 0; uxIndexToTest < configTASK_NOTIFICATION_ARRAY_ENTRIES; uxIndexToTest++ )
 	{
 		/* Send notifications to all indexes with the array of task
 		notificaitons other than the one on which this task will block. */
-		for( uxOtherIndexes = 0; uxOtherIndexes < configNUMBER_OF_TASK_NOTIFICATIONS; uxOtherIndexes++ )
+		for( uxOtherIndexes = 0; uxOtherIndexes < configTASK_NOTIFICATION_ARRAY_ENTRIES; uxOtherIndexes++ )
 		{
 			if( uxOtherIndexes != uxIndexToTest )
 			{
@@ -322,7 +322,7 @@ UBaseType_t uxIndexToTest, uxOtherIndexes;
 
 		/* Clear all the other task notifications within the array of task
 		notifications again ready for the next round. */
-		for( uxOtherIndexes = 0; uxOtherIndexes < configNUMBER_OF_TASK_NOTIFICATIONS; uxOtherIndexes++ )
+		for( uxOtherIndexes = 0; uxOtherIndexes < configTASK_NOTIFICATION_ARRAY_ENTRIES; uxOtherIndexes++ )
 		{
 			if( uxOtherIndexes != uxIndexToTest )
 			{
@@ -348,9 +348,9 @@ UBaseType_t uxIndexToTest, uxOtherIndexes;
 	both notifications should pass, and the value written the second time should
 	overwrite the value written the first time, and so be the value that is read
 	back. */
-	for( uxIndexToTest = 0; uxIndexToTest < configNUMBER_OF_TASK_NOTIFICATIONS; uxIndexToTest++ )
+	for( uxIndexToTest = 0; uxIndexToTest < configTASK_NOTIFICATION_ARRAY_ENTRIES; uxIndexToTest++ )
 	{
-		for( uxOtherIndexes = 0; uxOtherIndexes < configNUMBER_OF_TASK_NOTIFICATIONS; uxOtherIndexes++ )
+		for( uxOtherIndexes = 0; uxOtherIndexes < configTASK_NOTIFICATION_ARRAY_ENTRIES; uxOtherIndexes++ )
 		{
 			if( uxOtherIndexes != uxIndexToTest )
 			{
@@ -370,7 +370,7 @@ UBaseType_t uxIndexToTest, uxOtherIndexes;
 		configASSERT( ulNotifiedValue == ulSecondNotifiedValueConst );
 		( void ) ulNotifiedValue;
 
-		for( uxOtherIndexes = 0; uxOtherIndexes < configNUMBER_OF_TASK_NOTIFICATIONS; uxOtherIndexes++ )
+		for( uxOtherIndexes = 0; uxOtherIndexes < configTASK_NOTIFICATION_ARRAY_ENTRIES; uxOtherIndexes++ )
 		{
 			if( uxOtherIndexes != uxIndexToTest )
 			{
@@ -390,7 +390,7 @@ UBaseType_t uxIndexToTest, uxOtherIndexes;
 	/*-------------------------------------------------------------------------
 	For each task notification within the array of task notifications, check
 	notifications with no action pass without updating the value. */
-	for( uxIndexToTest = 0; uxIndexToTest < configNUMBER_OF_TASK_NOTIFICATIONS; uxIndexToTest++ )
+	for( uxIndexToTest = 0; uxIndexToTest < configTASK_NOTIFICATION_ARRAY_ENTRIES; uxIndexToTest++ )
 	{
 		/* First set the notification values of the task notification at index
 		uxIndexToTest of the array of task notification to
@@ -421,7 +421,7 @@ UBaseType_t uxIndexToTest, uxOtherIndexes;
 		uxIndexToTest should still contain 0 as they have not been set in this
 		loop yet.  This time use xTaskNotifyValueClear() instead of
 		xTaskNotifyWaitIndexed(), just for test coverage. */
-		for( uxOtherIndexes = uxIndexToTest + 1; uxOtherIndexes < configNUMBER_OF_TASK_NOTIFICATIONS; uxOtherIndexes++ )
+		for( uxOtherIndexes = uxIndexToTest + 1; uxOtherIndexes < configTASK_NOTIFICATION_ARRAY_ENTRIES; uxOtherIndexes++ )
 		{
 			/* This time 0 is the bits to clear parameter - so clearing no bits. */
 			ulNotifiedValue = ulTaskNotifyValueClearIndexed( NULL, uxOtherIndexes, 0 );
@@ -438,7 +438,7 @@ UBaseType_t uxIndexToTest, uxOtherIndexes;
 	notifications in turn, send ulMaxLoop increment notifications, then ensure
 	the received value is as expected - which should be
 	ulSecondNotificationValueConst plus how ever many times to loop iterated. */
-	for( uxIndexToTest = 0; uxIndexToTest < configNUMBER_OF_TASK_NOTIFICATIONS; uxIndexToTest++ )
+	for( uxIndexToTest = 0; uxIndexToTest < configTASK_NOTIFICATION_ARRAY_ENTRIES; uxIndexToTest++ )
 	{
 		for( ulLoop = 0; ulLoop < ulMaxLoops; ulLoop++ )
 		{
@@ -471,7 +471,7 @@ UBaseType_t uxIndexToTest, uxOtherIndexes;
 		ulSecondNotifiedValueConst as they have not been set in this loop yet.
 		This time use xTaskNotifyValueClear() instead of xTaskNotifyWaitIndexed(),
 		just for test coverage. */
-		for( uxOtherIndexes = uxIndexToTest + 1; uxOtherIndexes < configNUMBER_OF_TASK_NOTIFICATIONS; uxOtherIndexes++ )
+		for( uxOtherIndexes = uxIndexToTest + 1; uxOtherIndexes < configTASK_NOTIFICATION_ARRAY_ENTRIES; uxOtherIndexes++ )
 		{
 			/* This time 0 is the bits to clear parameter - so clearing no bits. */
 			ulNotifiedValue = ulTaskNotifyValueClearIndexed( NULL, uxOtherIndexes, 0 );
@@ -481,7 +481,7 @@ UBaseType_t uxIndexToTest, uxOtherIndexes;
 	}
 
 	/* Clear all bits ready for next test. */
-	for( uxIndexToTest = 0; uxIndexToTest < configNUMBER_OF_TASK_NOTIFICATIONS; uxIndexToTest++ )
+	for( uxIndexToTest = 0; uxIndexToTest < configTASK_NOTIFICATION_ARRAY_ENTRIES; uxIndexToTest++ )
 	{
 		/* Start with all bits clear. */
 		ulTaskNotifyValueClearIndexed( NULL, uxIndexToTest, notifyUINT32_MAX );
@@ -495,7 +495,7 @@ UBaseType_t uxIndexToTest, uxOtherIndexes;
 	one additional bit set on each notification, and exiting the loop when all
 	the bits are found to be set.  As there are 32-bits the loop should execute
 	32 times before all the bits are found to be set. */
-	for( uxIndexToTest = 0; uxIndexToTest < configNUMBER_OF_TASK_NOTIFICATIONS; uxIndexToTest++ )
+	for( uxIndexToTest = 0; uxIndexToTest < configTASK_NOTIFICATION_ARRAY_ENTRIES; uxIndexToTest++ )
 	{
 		ulNotifyingValue = 0x01;
 		ulLoop = 0;
@@ -540,7 +540,7 @@ UBaseType_t uxIndexToTest, uxOtherIndexes;
 		notifications after index uxIndexToTest should still contain 0 as they
 		have not been set in this loop yet.  This time use xTaskNotifyValueClear()
 		instead of xTaskNotifyWaitIndexed(), just for test coverage. */
-		for( uxOtherIndexes = uxIndexToTest + 1; uxOtherIndexes < configNUMBER_OF_TASK_NOTIFICATIONS; uxOtherIndexes++ )
+		for( uxOtherIndexes = uxIndexToTest + 1; uxOtherIndexes < configTASK_NOTIFICATION_ARRAY_ENTRIES; uxOtherIndexes++ )
 		{
 			/* This time 0 is the bits to clear parameter - so clearing no bits. */
 			ulNotifiedValue = ulTaskNotifyValueClearIndexed( NULL, uxOtherIndexes, 0 );
@@ -555,7 +555,7 @@ UBaseType_t uxIndexToTest, uxOtherIndexes;
 	For each task notification within the array of task notification sin turn,
 	check bits are cleared on entry but not on exit when a notification fails
 	to arrive before timing out - both with and without a timeout value. */
-	for( uxIndexToTest = 0; uxIndexToTest < configNUMBER_OF_TASK_NOTIFICATIONS; uxIndexToTest++ )
+	for( uxIndexToTest = 0; uxIndexToTest < configTASK_NOTIFICATION_ARRAY_ENTRIES; uxIndexToTest++ )
 	{
 		/* Wait for the notification - but this time it is not given by anything
 		and should return pdFAIL.  The parameters are set to clear bit zero on
@@ -598,7 +598,7 @@ UBaseType_t uxIndexToTest, uxOtherIndexes;
 		/* All array indexes after uxIndexToTest should still contain notifyUINT32_MAX
 		left over from the previous test.  This time use xTaskNotifyValueClear()
 		instead of xTaskNotifyWaitIndexed(), just for test coverage. */
-		for( uxOtherIndexes = uxIndexToTest + 1; uxOtherIndexes < configNUMBER_OF_TASK_NOTIFICATIONS; uxOtherIndexes++ )
+		for( uxOtherIndexes = uxIndexToTest + 1; uxOtherIndexes < configTASK_NOTIFICATION_ARRAY_ENTRIES; uxOtherIndexes++ )
 		{
 			/* This time 0 is the bits to clear parameter - so clearing no bits. */
 			ulNotifiedValue = ulTaskNotifyValueClearIndexed( NULL, uxOtherIndexes, 0 );
@@ -612,7 +612,7 @@ UBaseType_t uxIndexToTest, uxOtherIndexes;
 
 	/*-------------------------------------------------------------------------
 	Now try clearing the bit on exit. */
-	for( uxIndexToTest = 0; uxIndexToTest < configNUMBER_OF_TASK_NOTIFICATIONS; uxIndexToTest++ )
+	for( uxIndexToTest = 0; uxIndexToTest < configTASK_NOTIFICATION_ARRAY_ENTRIES; uxIndexToTest++ )
 	{
 		/* The task is notified first using the task notification at index
 		uxIndexToTest within the array of task notifications. */
@@ -633,7 +633,7 @@ UBaseType_t uxIndexToTest, uxOtherIndexes;
 		( void ) xReturned; /* Remove compiler warnings in case configASSERT() is not defined. */
 
 		/* No other indexes should have a notification pending. */
-		for( uxOtherIndexes = 0; uxOtherIndexes < configNUMBER_OF_TASK_NOTIFICATIONS; uxOtherIndexes++ )
+		for( uxOtherIndexes = 0; uxOtherIndexes < configTASK_NOTIFICATION_ARRAY_ENTRIES; uxOtherIndexes++ )
 		{
 			if( uxOtherIndexes != uxIndexToTest )
 			{
@@ -649,7 +649,7 @@ UBaseType_t uxIndexToTest, uxOtherIndexes;
 	/*-------------------------------------------------------------------------
 	For each task notification within the array of task notifications, try
 	querying the previous value while notifying a task. */
-	for( uxIndexToTest = 0; uxIndexToTest < configNUMBER_OF_TASK_NOTIFICATIONS; uxIndexToTest++ )
+	for( uxIndexToTest = 0; uxIndexToTest < configTASK_NOTIFICATION_ARRAY_ENTRIES; uxIndexToTest++ )
 	{
 		xTaskNotifyAndQueryIndexed( xTaskToNotify, uxIndexToTest, 0x00, eSetBits, &ulPreviousValue );
 		configASSERT( ulNotifiedValue == ( notifyUINT32_MAX & ~( ulBit0 | ulBit1 ) ) );
@@ -673,18 +673,18 @@ UBaseType_t uxIndexToTest, uxOtherIndexes;
 
 
 	/* ---------------------------------------------------------------------- */
-	for( uxIndexToTest = 0; uxIndexToTest < configNUMBER_OF_TASK_NOTIFICATIONS; uxIndexToTest++ )
+	for( uxIndexToTest = 0; uxIndexToTest < configTASK_NOTIFICATION_ARRAY_ENTRIES; uxIndexToTest++ )
 	{
 		/* Clear the previous notifications. */
 		xTaskNotifyWaitIndexed( uxIndexToTest, notifyUINT32_MAX, 0, &ulNotifiedValue, 0 );
 	}
 
-	for( uxIndexToTest = 0; uxIndexToTest < configNUMBER_OF_TASK_NOTIFICATIONS; uxIndexToTest++ )
+	for( uxIndexToTest = 0; uxIndexToTest < configTASK_NOTIFICATION_ARRAY_ENTRIES; uxIndexToTest++ )
 	{
 		/* No task notification within the array of task notifications should
 		not have any notifications pending, so an attempt to clear the
 		notification state should fail. */
-		for( uxOtherIndexes = 0; uxOtherIndexes < configNUMBER_OF_TASK_NOTIFICATIONS; uxOtherIndexes++ )
+		for( uxOtherIndexes = 0; uxOtherIndexes < configTASK_NOTIFICATION_ARRAY_ENTRIES; uxOtherIndexes++ )
 		{
 			configASSERT( xTaskNotifyStateClearIndexed( NULL, uxOtherIndexes ) == pdFALSE );
 		}
@@ -698,7 +698,7 @@ UBaseType_t uxIndexToTest, uxOtherIndexes;
 		possible to clear the notification state.  Other indexes should still
 		not have a notification pending - likewise uxIndexToTest should not have
 		a notification pending once it has been cleared. */
-		for( uxOtherIndexes = 0; uxOtherIndexes < configNUMBER_OF_TASK_NOTIFICATIONS; uxOtherIndexes++ )
+		for( uxOtherIndexes = 0; uxOtherIndexes < configTASK_NOTIFICATION_ARRAY_ENTRIES; uxOtherIndexes++ )
 		{
 			if( uxOtherIndexes == uxIndexToTest )
 			{
@@ -713,7 +713,7 @@ UBaseType_t uxIndexToTest, uxOtherIndexes;
 	/* ------------------------------------------------------------------------
 	For each task notification within the array of task notifications, clear
 	bits in the notification value. */
-	for( uxIndexToTest = 0; uxIndexToTest < configNUMBER_OF_TASK_NOTIFICATIONS; uxIndexToTest++ )
+	for( uxIndexToTest = 0; uxIndexToTest < configTASK_NOTIFICATION_ARRAY_ENTRIES; uxIndexToTest++ )
 	{
 		/* Get the task to set all bits in its task notification at index
 		uxIndexToTest within its array of task notifications.  This is not a
@@ -751,7 +751,7 @@ UBaseType_t uxIndexToTest, uxOtherIndexes;
 	ulFineCycleCount++;
 
 	/* Leave all bits cleared. */
-	for( uxIndexToTest = 0; uxIndexToTest < configNUMBER_OF_TASK_NOTIFICATIONS; uxIndexToTest++ )
+	for( uxIndexToTest = 0; uxIndexToTest < configTASK_NOTIFICATION_ARRAY_ENTRIES; uxIndexToTest++ )
 	{
 		xTaskNotifyWaitIndexed( uxIndexToTest, notifyUINT32_MAX, 0, NULL, 0 );
 	}
@@ -791,7 +791,7 @@ static UBaseType_t uxIndexToNotify = 0;
 		/* Use the next task notification within the array of task notifications
 		the next time around. */
 		uxIndexToNotify++;
-		if( uxIndexToNotify >= configNUMBER_OF_TASK_NOTIFICATIONS )
+		if( uxIndexToNotify >= configTASK_NOTIFICATION_ARRAY_ENTRIES )
 		{
 			uxIndexToNotify = 0;
 		}
@@ -820,7 +820,7 @@ static BaseType_t uxIndexToNotify = 0;
 	/* Use the next task notification within the array of task notifications the
 	next time around. */
 	uxIndexToNotify++;
-	if( uxIndexToNotify >= configNUMBER_OF_TASK_NOTIFICATIONS )
+	if( uxIndexToNotify >= configTASK_NOTIFICATION_ARRAY_ENTRIES )
 	{
 		uxIndexToNotify = 0;
 	}
@@ -839,14 +839,14 @@ uint32_t ulNotifiedValue;
 
 	/* Perform the test on each task notification within the array or task
 	notifications. */
-	for( uxIndexToTest = 0; uxIndexToTest < configNUMBER_OF_TASK_NOTIFICATIONS; uxIndexToTest++ )
+	for( uxIndexToTest = 0; uxIndexToTest < configTASK_NOTIFICATION_ARRAY_ENTRIES; uxIndexToTest++ )
 	{
 		/* Incremented to show the task is still running. */
 		ulFineCycleCount++;
 
 		/* Ensure no notifications within the array of task notifications are
 		pending. */
-		for( uxOtherIndexes = 0; uxOtherIndexes < configNUMBER_OF_TASK_NOTIFICATIONS; uxOtherIndexes++ )
+		for( uxOtherIndexes = 0; uxOtherIndexes < configTASK_NOTIFICATION_ARRAY_ENTRIES; uxOtherIndexes++ )
 		{
 			xReturned = xTaskNotifyWaitIndexed( uxOtherIndexes, 0, 0, NULL, 0 );
 			configASSERT( xReturned == pdFALSE );
@@ -869,7 +869,7 @@ uint32_t ulNotifiedValue;
 
 		/* Check none of the task notifications within the array of task
 		notifications as been notified. */
-		for( uxOtherIndexes = 0; uxOtherIndexes < configNUMBER_OF_TASK_NOTIFICATIONS; uxOtherIndexes++ )
+		for( uxOtherIndexes = 0; uxOtherIndexes < configTASK_NOTIFICATION_ARRAY_ENTRIES; uxOtherIndexes++ )
 		{
 			xReturned = xTaskNotifyWaitIndexed( uxOtherIndexes, 0, 0, &ulNotifiedValue, 0 );
 			configASSERT( xReturned == pdFALSE );
@@ -897,7 +897,7 @@ uint32_t ulNotifiedValue;
 		of task notifications at and below the index being tested have a notification
 		value, and that indexes above the index being tested to not have
 		notification values. */
-		for( uxOtherIndexes = 0; uxOtherIndexes < configNUMBER_OF_TASK_NOTIFICATIONS; uxOtherIndexes++ )
+		for( uxOtherIndexes = 0; uxOtherIndexes < configTASK_NOTIFICATION_ARRAY_ENTRIES; uxOtherIndexes++ )
 		{
 			xReturned = xTaskNotifyWaitIndexed( uxOtherIndexes, 0, 0, &ulNotifiedValue, 0 );
 			configASSERT( xReturned == pdFALSE );
@@ -922,7 +922,7 @@ uint32_t ulNotifiedValue;
 	ulFineCycleCount++;
 
 	/* Leave all bits cleared. */
-	for( uxIndexToTest = 0; uxIndexToTest < configNUMBER_OF_TASK_NOTIFICATIONS; uxIndexToTest++ )
+	for( uxIndexToTest = 0; uxIndexToTest < configTASK_NOTIFICATION_ARRAY_ENTRIES; uxIndexToTest++ )
 	{
 		xTaskNotifyWaitIndexed( uxIndexToTest, notifyUINT32_MAX, 0, NULL, 0 );
 	}
@@ -940,7 +940,7 @@ BaseType_t xReturned;
 	the value of its index position plus 1 so everything starts in a known
 	state, then clear the notification state ready for the next test.  Plus 1 is
 	used because the index under test will use 0. */
-	for( uxIndex = 0; uxIndex < configNUMBER_OF_TASK_NOTIFICATIONS; uxIndex++ )
+	for( uxIndex = 0; uxIndex < configTASK_NOTIFICATION_ARRAY_ENTRIES; uxIndex++ )
 	{
 		xTaskNotifyIndexed( xTaskToNotify, uxIndex, uxIndex + 1, eSetValueWithOverwrite );
 		xTaskNotifyStateClearIndexed( xTaskToNotify, uxIndex );
@@ -948,7 +948,7 @@ BaseType_t xReturned;
 
 	/* Peform the test on each task notification within the array of task
 	notifications. */
-	for( uxIndexToNotify = 0; uxIndexToNotify < configNUMBER_OF_TASK_NOTIFICATIONS; uxIndexToNotify++ )
+	for( uxIndexToNotify = 0; uxIndexToNotify < configTASK_NOTIFICATION_ARRAY_ENTRIES; uxIndexToNotify++ )
 	{
 		/* Set the notification value of the index being tested to 0 so the
 		notification value increment/decrement functions can be tested. */
@@ -971,7 +971,7 @@ BaseType_t xReturned;
 		/* No other notification indexes should have changed, and therefore should
 		still have their value set to their index plus 1 within the array of
 		notifications. */
-		for( uxIndex = 0; uxIndex < configNUMBER_OF_TASK_NOTIFICATIONS; uxIndex++ )
+		for( uxIndex = 0; uxIndex < configTASK_NOTIFICATION_ARRAY_ENTRIES; uxIndex++ )
 		{
 			if( uxIndex != uxIndexToNotify )
 			{
@@ -1004,14 +1004,14 @@ TickType_t xTimeBeforeBlocking;
 
 	/* Set all notify values within the array of tasks notifications to zero
 	ready for the next test. */
-	for( uxIndexToNotify = 0; uxIndexToNotify < configNUMBER_OF_TASK_NOTIFICATIONS; uxIndexToNotify++ )
+	for( uxIndexToNotify = 0; uxIndexToNotify < configTASK_NOTIFICATION_ARRAY_ENTRIES; uxIndexToNotify++ )
 	{
 		ulTaskNotifyValueClearIndexed( xTaskToNotify, uxIndexToNotify, notifyUINT32_MAX );
 	}
 
 	/* Perform the test for each notification within the array of task
 	notifications. */
-	for( uxIndexToNotify = 0; uxIndexToNotify < configNUMBER_OF_TASK_NOTIFICATIONS; uxIndexToNotify++ )
+	for( uxIndexToNotify = 0; uxIndexToNotify < configTASK_NOTIFICATION_ARRAY_ENTRIES; uxIndexToNotify++ )
 	{
 		/* Start the software timer then wait for it to notify this task.  Block
 		on a notification index that we do not expect to receive the notification
@@ -1020,9 +1020,9 @@ TickType_t xTimeBeforeBlocking;
 		xTimeBeforeBlocking = xTaskGetTickCount();
 
 
-		if( uxIndexToNotify == ( configNUMBER_OF_TASK_NOTIFICATIONS - 1 ) )
+		if( uxIndexToNotify == ( configTASK_NOTIFICATION_ARRAY_ENTRIES - 1 ) )
 		{
-			/* configNUMBER_OF_TASK_NOTIFICATIONS - 1 is to be notified, so
+			/* configTASK_NOTIFICATION_ARRAY_ENTRIES - 1 is to be notified, so
 			block on index 0. */
 			uxIndex = 0;
 		}
@@ -1047,7 +1047,7 @@ TickType_t xTimeBeforeBlocking;
 
 		/* Only the notification at index position uxIndexToNotify() should be
 		set.  Calling this function will clear it again. */
-		for( uxIndex = 0; uxIndex < configNUMBER_OF_TASK_NOTIFICATIONS; uxIndex++ )
+		for( uxIndex = 0; uxIndex < configTASK_NOTIFICATION_ARRAY_ENTRIES; uxIndex++ )
 		{
 			xReturned = xTaskNotifyWaitIndexed( uxIndex, 0, 0, &ulReceivedValue, xDontBlock );
 
@@ -1085,7 +1085,7 @@ const TickType_t xDontBlock = 0;
 
 	/* Set the value of each notification within the array of task notifications
 	to zero so the task can block on xTaskNotifyTake(). */
-	for( uxIndex = 0; uxIndex < configNUMBER_OF_TASK_NOTIFICATIONS; uxIndex++ )
+	for( uxIndex = 0; uxIndex < configTASK_NOTIFICATION_ARRAY_ENTRIES; uxIndex++ )
 	{
 		xTaskNotifyIndexed( xTaskToNotify, uxIndex, 0, eSetValueWithOverwrite );
 		xTaskNotifyStateClearIndexed( xTaskToNotify, uxIndex );
@@ -1093,7 +1093,7 @@ const TickType_t xDontBlock = 0;
 
 	/* Perform the test on each task notification within the array of task
 	notifications. */
-	for( uxIndexToNotify = 0; uxIndexToNotify < configNUMBER_OF_TASK_NOTIFICATIONS; uxIndexToNotify++ )
+	for( uxIndexToNotify = 0; uxIndexToNotify < configTASK_NOTIFICATION_ARRAY_ENTRIES; uxIndexToNotify++ )
 	{
 		/* Tell the interrupt to send the next notification. */
 		taskENTER_CRITICAL();
@@ -1123,7 +1123,7 @@ const TickType_t xDontBlock = 0;
 		still have their value set to 0.  The value in array index uxIndexToNotify
 		should also have been decremented back to zero by the call to
 		ulTaskNotifyTakeIndexed(). */
-		for( uxIndex = 0; uxIndex < configNUMBER_OF_TASK_NOTIFICATIONS; uxIndex++ )
+		for( uxIndex = 0; uxIndex < configTASK_NOTIFICATION_ARRAY_ENTRIES; uxIndex++ )
 		{
 			xReturned = xTaskNotifyWaitIndexed( uxIndexToNotify, 0, 0, &ulReceivedValue, xDontBlock );
 			configASSERT( xReturned == pdFALSE );
@@ -1185,7 +1185,7 @@ static UBaseType_t uxIndexToNotify = 0;
 		/* Use the next index in the array of task notifications the next time
 		around. */
 		uxIndexToNotify++;
-		if( uxIndexToNotify >= configNUMBER_OF_TASK_NOTIFICATIONS )
+		if( uxIndexToNotify >= configTASK_NOTIFICATION_ARRAY_ENTRIES )
 		{
 			uxIndexToNotify = 0;
 		}

--- a/FreeRTOS/Demo/Common/Minimal/TaskNotifyArray.c
+++ b/FreeRTOS/Demo/Common/Minimal/TaskNotifyArray.c
@@ -1,0 +1,963 @@
+/*
+ * FreeRTOS Kernel V10.3.0
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://www.FreeRTOS.org
+ * http://aws.amazon.com/freertos
+ *
+ * 1 tab == 4 spaces!
+ */
+
+
+/*
+ * Tests the behaviour of direct task notifications.
+ */
+
+/* Standard includes. */
+#include <limits.h>
+
+/* Scheduler include files. */
+#include "FreeRTOS.h"
+#include "task.h"
+#include "timers.h"
+
+/* Demo program include files. */
+#include "TaskNotifyArray.h"
+
+#if( configNUMBER_OF_TASK_NOTIFICATIONS < 2 )
+	#error This file is intended to test direct to task notification arrays but the array does not contain more than one index.
+#endif
+
+/* Allow parameters to be overridden on a demo by demo basis. */
+#ifndef notifyNOTIFY_ARRAY_TASK_STACK_SIZE
+	#define notifyNOTIFY_ARRAY_TASK_STACK_SIZE configMINIMAL_STACK_SIZE
+#endif
+
+#define notifyTASK_PRIORITY		( tskIDLE_PRIORITY )
+
+/* Constants used in tests when setting/clearing bits. */
+#define notifyUINT32_MAX		( ( uint32_t ) 0xffffffff )
+#define notifyUINT32_HIGH_BYTE	( ( uint32_t ) 0xff000000 )
+#define notifyUINT32_LOW_BYTE	( ( uint32_t ) 0x000000ff )
+
+#define notifySUSPENDED_TEST_TIMER_PERIOD pdMS_TO_TICKS( 50 )
+
+/*-----------------------------------------------------------*/
+
+/*
+ * Implementation of the task that gets notified.
+ */
+static void prvNotifiedTask( void *pvParameters );
+
+/*
+ * Performs a few initial tests that can be done prior to creating the second
+ * task.
+ */
+static void prvSingleTaskTests( void );
+
+/*
+ * Software timer callback function from which xTaskNotify() is called.
+ */
+static void prvNotifyingTimer( TimerHandle_t xTimer );
+
+/*
+ * Utility function to create pseudo random numbers.
+ */
+static UBaseType_t prvRand( void );
+
+/*
+ * Callback for a timer that is used during preliminary testing.  The timer
+ * tests the behaviour when 1: a task waiting for a notification is suspended
+ * and then resumed without ever receiving a notification, and 2: when a task
+ * waiting for a notification receives a notification while it is suspended.
+ */
+static void prvSuspendedTaskTimerTestCallback( TimerHandle_t xExpiredTimer );
+
+/*-----------------------------------------------------------*/
+
+/* Used to latch errors during the test's execution. */
+static BaseType_t xErrorStatus = pdPASS;
+
+/* Used to ensure the task has not stalled. */
+static volatile uint32_t ulNotifyCycleCount = 0;
+
+/* The handle of the task that receives the notifications. */
+static TaskHandle_t xTaskToNotify = NULL;
+
+/* Used to count the notifications sent to the task from a software timer and
+the number of notifications received by the task from the software timer.  The
+two should stay synchronised. */
+static uint32_t ulTimerNotificationsReceived = 0UL, ulTimerNotificationsSent = 0UL;
+
+/* The timer used to notify the task. */
+static TimerHandle_t xTimer = NULL;
+
+/* Used by the pseudo random number generating function. */
+static size_t uxNextRand = 0;
+
+/*-----------------------------------------------------------*/
+
+void vStartTaskNotifyArrayTask( void  )
+{
+	/* Create the task that performs some tests by itself, then loops around
+	being notified by both a software timer and an interrupt. */
+	xTaskCreate( prvNotifiedTask, /* Function that implements the task. */
+				 "ArrayNotifed", /* Text name for the task - for debugging only - not used by the kernel. */
+				 notifyNOTIFY_ARRAY_TASK_STACK_SIZE, /* Task's stack size in words, not bytes!. */
+				 NULL, /* Task parameter, not used in this case. */
+				 notifyTASK_PRIORITY, /* Task priority, 0 is the lowest. */
+				 &xTaskToNotify ); /* Used to pass a handle to the task out is needed, otherwise set to NULL. */
+
+	/* Pseudo seed the random number generator. */
+	uxNextRand = ( size_t ) prvRand;
+}
+/*-----------------------------------------------------------*/
+
+static void prvSingleTaskTests( void )
+{
+const TickType_t xTicksToWait = pdMS_TO_TICKS( 100UL );
+BaseType_t xReturned;
+uint32_t ulNotifiedValue, ulLoop, ulNotifyingValue, ulPreviousValue, ulExpectedValue;
+TickType_t xTimeOnEntering;
+const uint32_t ulFirstNotifiedConst = 100001UL, ulSecondNotifiedValueConst = 5555UL, ulMaxLoops = 5UL;
+const uint32_t ulBit0 = 0x01UL, ulBit1 = 0x02UL;
+TimerHandle_t xSingleTaskTimer;
+UBaseType_t uxIndexToTest, uxOtherIndexes;
+
+
+	/* ------------------------------------------------------------------------
+	Check blocking when there are no notifications. */
+	for( uxIndexToTest = 0; uxIndexToTest < configNUMBER_OF_TASK_NOTIFICATIONS; uxIndexToTest++ )
+	{
+		/* Send notifications to all array indexes other than the one on which
+		this task will block. */
+		for( uxOtherIndexes = 0; uxOtherIndexes < configNUMBER_OF_TASK_NOTIFICATIONS; uxOtherIndexes++ )
+		{
+			if( uxOtherIndexes != uxIndexToTest )
+			{
+				xTaskNotifyArray( xTaskToNotify, uxOtherIndexes, 0, eNoAction );
+			}
+		}
+
+		xTimeOnEntering = xTaskGetTickCount();
+		xReturned = xTaskNotifyArrayWait( uxIndexToTest, notifyUINT32_MAX, 0, &ulNotifiedValue, xTicksToWait );
+		( void ) xReturned; /* In case configASSERT() is not defined. */
+
+		/* Should have blocked for the entire block time. */
+		if( ( xTaskGetTickCount() - xTimeOnEntering ) < xTicksToWait )
+		{
+			xErrorStatus = pdFAIL;
+		}
+		configASSERT( xReturned == pdFAIL );
+		configASSERT( ulNotifiedValue == 0UL );
+		( void ) xReturned; /* In case configASSERT() is not defined. */
+		( void ) ulNotifiedValue;
+
+		/* Clear all the other notifications again ready for the next round. */
+		for( uxOtherIndexes = 0; uxOtherIndexes < configNUMBER_OF_TASK_NOTIFICATIONS; uxOtherIndexes++ )
+		{
+			if( uxOtherIndexes != uxIndexToTest )
+			{
+				xReturned = xTaskNotifyArrayStateClear( xTaskToNotify, uxOtherIndexes );
+
+				/* The notification state was set in the outer loop so expect
+				it to still be set. */
+				configASSERT( xReturned == pdTRUE );
+				( void ) xReturned; /* In case configASSERT() is not defined. */
+			}
+		}
+	}
+
+
+
+	/* ------------------------------------------------------------------------
+	Check no blocking when notifications are pending. */
+	for( uxIndexToTest = 0; uxIndexToTest < configNUMBER_OF_TASK_NOTIFICATIONS; uxIndexToTest++ )
+	{
+		/* First notify itself - this would not be a normal thing to do and is
+		done here for test purposes only. */
+		xReturned = xTaskNotifyArrayAndQuery( xTaskToNotify, uxIndexToTest, ulFirstNotifiedConst, eSetValueWithoutOverwrite, &ulPreviousValue );
+
+		/* Even through the 'without overwrite' action was used the update should
+		have been successful. */
+		configASSERT( xReturned == pdPASS );
+		( void ) xReturned; /* In case configASSERT() is not defined. */
+
+		/* No bits should have been pending previously. */
+		configASSERT( ulPreviousValue == 0 );
+		( void ) ulPreviousValue;
+
+		/* The task should now have a notification pending, and so not time out. */
+		xTimeOnEntering = xTaskGetTickCount();
+		xReturned = xTaskNotifyArrayWait( uxIndexToTest, notifyUINT32_MAX, 0, &ulNotifiedValue, xTicksToWait );
+
+		if( ( xTaskGetTickCount() - xTimeOnEntering ) >= xTicksToWait )
+		{
+			xErrorStatus = pdFAIL;
+		}
+
+		/* The task should have been notified, and the notified value should
+		be equal to ulFirstNotifiedConst. */
+		configASSERT( xReturned == pdPASS );
+		configASSERT( ulNotifiedValue == ulFirstNotifiedConst );
+		( void ) xReturned; /* In case configASSERT() is not defined. */
+		( void ) ulNotifiedValue;
+
+		/* Incremented to show the task is still running. */
+		ulNotifyCycleCount++;
+	}
+
+
+
+
+	/*-------------------------------------------------------------------------
+	Check the non-overwriting functionality. */
+	for( uxIndexToTest = 0; uxIndexToTest < configNUMBER_OF_TASK_NOTIFICATIONS; uxIndexToTest++ )
+	{
+		/* Send notifications to all array indexes other than the one on which
+		this task will block. */
+		for( uxOtherIndexes = 0; uxOtherIndexes < configNUMBER_OF_TASK_NOTIFICATIONS; uxOtherIndexes++ )
+		{
+			if( uxOtherIndexes != uxIndexToTest )
+			{
+				xTaskNotifyArray( xTaskToNotify, uxOtherIndexes, ulFirstNotifiedConst, eSetValueWithOverwrite );
+			}
+		}
+
+		/* The notification is done twice using two different notification
+		values.  The action says don't overwrite so only the first notification
+		should pass and the value read back should also be that used with the
+		first notification. */
+		xReturned = xTaskNotifyArray( xTaskToNotify, uxIndexToTest, ulFirstNotifiedConst, eSetValueWithoutOverwrite );
+		configASSERT( xReturned == pdPASS );
+		( void ) xReturned; /* In case configASSERT() is not defined. */
+
+		xReturned = xTaskNotifyArray( xTaskToNotify, uxIndexToTest, ulSecondNotifiedValueConst, eSetValueWithoutOverwrite );
+		configASSERT( xReturned == pdFAIL );
+		( void ) xReturned; /* In case configASSERT() is not defined. */
+
+		/* Waiting for the notification should now return immediately so a block
+		time of zero is used. */
+		xReturned = xTaskNotifyArrayWait( uxIndexToTest, notifyUINT32_MAX, 0, &ulNotifiedValue, 0 );
+
+		configASSERT( xReturned == pdPASS );
+		configASSERT( ulNotifiedValue == ulFirstNotifiedConst );
+		( void ) xReturned; /* In case configASSERT() is not defined. */
+		( void ) ulNotifiedValue;
+
+		/* Clear all the other notifications again ready for the next round. */
+		for( uxOtherIndexes = 0; uxOtherIndexes < configNUMBER_OF_TASK_NOTIFICATIONS; uxOtherIndexes++ )
+		{
+			if( uxOtherIndexes != uxIndexToTest )
+			{
+				xReturned = xTaskNotifyArrayStateClear( xTaskToNotify, uxOtherIndexes );
+
+				/* The notification state in all the other indexes was set at
+				the start of the outer loop, so expect it to still be set. */
+				configASSERT( xReturned == pdTRUE );
+				( void ) xReturned; /* In case configASSERT() is not defined. */
+
+				ulNotifiedValue = ulTaskNotifyArrayValueClear( xTaskToNotify, uxOtherIndexes, notifyUINT32_MAX );
+
+				/* The notification value was set to ulFirstNotifiedConst in all
+				the other indexes by the outer loop, so expect it to still have
+				that value. */
+				configASSERT( ulNotifiedValue == ulFirstNotifiedConst );
+				( void ) ulNotifiedValue; /* In case configASSERT() is not defined. */
+			}
+		}
+	}
+
+
+
+
+	/*-------------------------------------------------------------------------
+	Do the same again, only this time use the overwriting version.  This time
+	both notifications should pass, and the value written the second time should
+	overwrite the value written the first time, and so be the value that is read
+	back. */
+	for( uxIndexToTest = 0; uxIndexToTest < configNUMBER_OF_TASK_NOTIFICATIONS; uxIndexToTest++ )
+	{
+		for( uxOtherIndexes = 0; uxOtherIndexes < configNUMBER_OF_TASK_NOTIFICATIONS; uxOtherIndexes++ )
+		{
+			if( uxOtherIndexes != uxIndexToTest )
+			{
+				xTaskNotifyArray( xTaskToNotify, uxOtherIndexes, ulFirstNotifiedConst, eSetValueWithOverwrite );
+			}
+		}
+
+		xReturned = xTaskNotifyArray( xTaskToNotify, uxIndexToTest, ulFirstNotifiedConst, eSetValueWithOverwrite );
+		configASSERT( xReturned == pdPASS );
+		( void ) xReturned; /* In case configASSERT() is not defined. */
+		xReturned = xTaskNotifyArray( xTaskToNotify, uxIndexToTest, ulSecondNotifiedValueConst, eSetValueWithOverwrite );
+		configASSERT( xReturned == pdPASS );
+		( void ) xReturned; /* In case configASSERT() is not defined. */
+		xReturned = xTaskNotifyArrayWait( uxIndexToTest, 0, notifyUINT32_MAX, &ulNotifiedValue, 0 );
+		configASSERT( xReturned == pdPASS );
+		( void ) xReturned; /* In case configASSERT() is not defined. */
+		configASSERT( ulNotifiedValue == ulSecondNotifiedValueConst );
+		( void ) ulNotifiedValue;
+
+		for( uxOtherIndexes = 0; uxOtherIndexes < configNUMBER_OF_TASK_NOTIFICATIONS; uxOtherIndexes++ )
+		{
+			if( uxOtherIndexes != uxIndexToTest )
+			{
+				xReturned = xTaskNotifyArrayStateClear( xTaskToNotify, uxOtherIndexes );
+				configASSERT( xReturned == pdTRUE );
+				( void ) xReturned; /* In case configASSERT() is not defined. */
+				ulNotifiedValue = ulTaskNotifyArrayValueClear( xTaskToNotify, uxOtherIndexes, notifyUINT32_MAX );
+				configASSERT( ulNotifiedValue == ulFirstNotifiedConst );
+				( void ) ulNotifiedValue; /* In case configASSERT() is not defined. */
+			}
+		}
+	}
+
+
+
+
+	/*-------------------------------------------------------------------------
+	Check notifications with no action pass without updating the value. */
+	for( uxIndexToTest = 0; uxIndexToTest < configNUMBER_OF_TASK_NOTIFICATIONS; uxIndexToTest++ )
+	{
+		/* First the notification values to ulSecondNotifiedValueConst. */
+		xReturned = xTaskNotifyArray( xTaskToNotify, uxIndexToTest, ulSecondNotifiedValueConst, eSetValueWithOverwrite );
+		configASSERT( xReturned == pdPASS );
+		( void ) xReturned; /* In case configASSERT() is not defined. */
+
+		/* Even though ulFirstNotifiedConst is used as the value next the value
+		read back should remain at ulSecondNotifiedConst. */
+		xReturned = xTaskNotifyArray( xTaskToNotify, uxIndexToTest, ulFirstNotifiedConst, eNoAction );
+		configASSERT( xReturned == pdPASS );
+		( void ) xReturned; /* In case configASSERT() is not defined. */
+
+		/* All array indexes up to and including uxIndexToTest should still
+		contain the same value. */
+		for( uxOtherIndexes = 0; uxOtherIndexes <= uxIndexToTest; uxOtherIndexes++ )
+		{
+			/* First zero is bits to clear on entry, the second is bits to clear on
+			exist, the last 0 is the block time. */
+			xReturned = xTaskNotifyArrayWait( uxOtherIndexes, 0, 0, &ulNotifiedValue, 0 );
+			configASSERT( ulNotifiedValue == ulSecondNotifiedValueConst );
+			( void ) ulNotifiedValue; /* In case configASSERT() is not defined. */
+		}
+
+		/* All array indexes after uxIndexToTest should still contain 0 as they
+		have not been set in this loop yet.  This time use xTaskNotifyValueClear()
+		instead of xTaskNotifyArrayWait(), just for test coverage. */
+		for( uxOtherIndexes = uxIndexToTest + 1; uxOtherIndexes < configNUMBER_OF_TASK_NOTIFICATIONS; uxOtherIndexes++ )
+		{
+			/* This time 0 is the bits to clear parameter - so clearing no bits. */
+			ulNotifiedValue = ulTaskNotifyArrayValueClear( NULL, uxOtherIndexes, 0 );
+			configASSERT( ulNotifiedValue == 0 );
+			( void ) ulNotifiedValue; /* In case configASSERT() is not defined. */
+		}
+	}
+
+
+
+
+	/*-------------------------------------------------------------------------
+	Check incrementing values.  Send ulMaxLoop increment notifications, then
+	ensure the received value is as expected - which should be
+	ulSecondNotificationValueConst plus how ever many times to loop iterated. */
+	for( uxIndexToTest = 0; uxIndexToTest < configNUMBER_OF_TASK_NOTIFICATIONS; uxIndexToTest++ )
+	{
+		for( ulLoop = 0; ulLoop < ulMaxLoops; ulLoop++ )
+		{
+			xReturned = xTaskNotifyArray( xTaskToNotify, uxIndexToTest, 0, eIncrement );
+			configASSERT( xReturned == pdPASS );
+			( void ) xReturned; /* In case configASSERT() is not defined. */
+		}
+
+		/* All array indexes up to and including uxIndexToTest should still
+		contain the updated value. */
+		for( uxOtherIndexes = 0; uxOtherIndexes <= uxIndexToTest; uxOtherIndexes++ )
+		{
+			/* First zero is bits to clear on entry, the second is bits to clear on
+			exist, the last 0 is the block time. */
+			xReturned = xTaskNotifyArrayWait( uxOtherIndexes, 0, 0, &ulNotifiedValue, 0 );
+			configASSERT( ulNotifiedValue == ( ulSecondNotifiedValueConst + ulMaxLoops ) );
+			( void ) ulNotifiedValue; /* In case configASSERT() is not defined. */
+		}
+
+		/* Should not be any notifications pending now. */
+		xReturned = xTaskNotifyArrayWait( uxIndexToTest, 0, 0, &ulNotifiedValue, 0 );
+		configASSERT( xReturned == pdFAIL );
+		( void ) xReturned; /* In case configASSERT() is not defined. */
+		( void ) ulNotifiedValue;
+
+		/* All array indexes after uxIndexToTest should still contain the
+		un-incremented ulSecondNotifiedValueConst as they have not been set in
+		this loop yet.  This time use xTaskNotifyValueClear() instead of
+		xTaskNotifyArrayWait(), just for test coverage. */
+		for( uxOtherIndexes = uxIndexToTest + 1; uxOtherIndexes < configNUMBER_OF_TASK_NOTIFICATIONS; uxOtherIndexes++ )
+		{
+			/* This time 0 is the bits to clear parameter - so clearing no bits. */
+			ulNotifiedValue = ulTaskNotifyArrayValueClear( NULL, uxOtherIndexes, 0 );
+			configASSERT( ulNotifiedValue == ulSecondNotifiedValueConst );
+			( void ) ulNotifiedValue; /* In case configASSERT() is not defined. */
+		}
+	}
+
+	/* Clear all bits ready for next test. */
+	for( uxIndexToTest = 0; uxIndexToTest < configNUMBER_OF_TASK_NOTIFICATIONS; uxIndexToTest++ )
+	{
+		/* Start with all bits clear. */
+		ulTaskNotifyArrayValueClear( NULL, uxIndexToTest, notifyUINT32_MAX );
+	}
+
+
+
+	/*-------------------------------------------------------------------------
+	Check all bits can be set by notifying the task with one additional bit	set
+	on each notification, and exiting the loop when all the bits are found to be
+	set.  As there are 32-bits the loop should execute 32 times before all the
+	bits are found to be set. */
+	for( uxIndexToTest = 0; uxIndexToTest < configNUMBER_OF_TASK_NOTIFICATIONS; uxIndexToTest++ )
+	{
+		ulNotifyingValue = 0x01;
+		ulLoop = 0;
+
+		do
+		{
+			/* Set the next bit in the task's notified value. */
+			xTaskNotifyArray( xTaskToNotify, uxIndexToTest, ulNotifyingValue, eSetBits );
+
+			/* Wait for the notified value - which of course will already be
+			available.  Don't clear the bits on entry or exit as this loop is
+			exited when all the bits are set. */
+			xReturned = xTaskNotifyArrayWait( uxIndexToTest, 0, 0, &ulNotifiedValue, 0 );
+			configASSERT( xReturned == pdPASS );
+			( void ) xReturned; /* In case configASSERT() is not defined. */
+
+			ulLoop++;
+
+			/* Use the next bit on the next iteration around this loop. */
+			ulNotifyingValue <<= 1UL;
+
+		} while ( ulNotifiedValue != notifyUINT32_MAX );
+
+		/* As a 32-bit value was used the loop should have executed 32 times before
+		all the bits were set. */
+		configASSERT( ulLoop == 32 );
+
+		/* All array indexes up to and including uxIndexToTest should still
+		have all bits set. */
+		for( uxOtherIndexes = 0; uxOtherIndexes <= uxIndexToTest; uxOtherIndexes++ )
+		{
+			/* First zero is bits to clear on entry, the second is bits to clear on
+			exist, the last 0 is the block time. */
+			xReturned = xTaskNotifyArrayWait( uxOtherIndexes, 0, 0, &ulNotifiedValue, 0 );
+			configASSERT( ulNotifiedValue == notifyUINT32_MAX );
+			( void ) ulNotifiedValue; /* In case configASSERT() is not defined. */
+		}
+
+		/* All array indexes after uxIndexToTest should still contain 0 as they
+		have not been set in this loop yet.  This time use xTaskNotifyValueClear()
+		instead of xTaskNotifyArrayWait(), just for test coverage. */
+		for( uxOtherIndexes = uxIndexToTest + 1; uxOtherIndexes < configNUMBER_OF_TASK_NOTIFICATIONS; uxOtherIndexes++ )
+		{
+			/* This time 0 is the bits to clear parameter - so clearing no bits. */
+			ulNotifiedValue = ulTaskNotifyArrayValueClear( NULL, uxOtherIndexes, 0 );
+			configASSERT( ulNotifiedValue == 0 );
+			( void ) ulNotifiedValue; /* In case configASSERT() is not defined. */
+		}
+	}
+
+
+
+	/*-------------------------------------------------------------------------
+	Check bits are cleared on entry but not on exit when a notification fails
+	to arrive before timing out - both with and without a timeout value. */
+	for( uxIndexToTest = 0; uxIndexToTest < configNUMBER_OF_TASK_NOTIFICATIONS; uxIndexToTest++ )
+	{
+		/* Wait for the notification again - but this time it is not given by
+		anything and should return pdFAIL.  The parameters are set to clear bit zero
+		on entry and bit one on exit.  As no notification was received only the bit
+		cleared on entry should actually get cleared. */
+		xReturned = xTaskNotifyArrayWait( uxIndexToTest, ulBit0, ulBit1, &ulNotifiedValue, xTicksToWait );
+		configASSERT( xReturned == pdFAIL );
+		( void ) xReturned; /* In case configASSERT() is not defined. */
+
+		/* Notify the task with no action so as not to update the bits even though
+		notifyUINT32_MAX is used as the notification value. */
+		xTaskNotifyArray( xTaskToNotify, uxIndexToTest, notifyUINT32_MAX, eNoAction );
+
+		/* All array indexes up to and including uxIndexToTest should have the
+		modified value.  */
+		for( uxOtherIndexes = 0; uxOtherIndexes <= uxIndexToTest; uxOtherIndexes++ )
+		{
+			/* Reading back the value should find bit 0 is clear, as this was cleared
+			on entry, but bit 1 is not clear as it will not have been cleared on exit
+			as no notification was received. */
+			xReturned = xTaskNotifyArrayWait( uxOtherIndexes, 0x00UL, 0x00UL, &ulNotifiedValue, 0 );
+			if( uxOtherIndexes == uxIndexToTest )
+			{
+				/* This is the index being used this time round the loop and its
+				notification state was set immediately above. */
+				configASSERT( xReturned == pdPASS );
+			}
+			else
+			{
+				/* Nothing should have set this index's notification state again. */
+				configASSERT( xReturned == pdFAIL );
+			}
+
+			configASSERT( ulNotifiedValue == ( notifyUINT32_MAX & ~ulBit0 ) );
+			( void ) xReturned; /* In case configASSERT() is not defined. */
+		}
+
+		/* All array indexes after uxIndexToTest should still contain notifyUINT32_MAX
+		left over from the previous test.  This time use xTaskNotifyValueClear()
+		instead of xTaskNotifyArrayWait(), just for test coverage. */
+		for( uxOtherIndexes = uxIndexToTest + 1; uxOtherIndexes < configNUMBER_OF_TASK_NOTIFICATIONS; uxOtherIndexes++ )
+		{
+			/* This time 0 is the bits to clear parameter - so clearing no bits. */
+			ulNotifiedValue = ulTaskNotifyArrayValueClear( NULL, uxOtherIndexes, 0 );
+			configASSERT( ulNotifiedValue == notifyUINT32_MAX );
+			( void ) ulNotifiedValue; /* In case configASSERT() is not defined. */
+		}
+	}
+
+
+
+
+	/*-------------------------------------------------------------------------
+	Now try clearing the bit on exit. */
+	for( uxIndexToTest = 0; uxIndexToTest < configNUMBER_OF_TASK_NOTIFICATIONS; uxIndexToTest++ )
+	{
+		/* The task is notified first. */
+		xTaskNotifyArray( xTaskToNotify, uxIndexToTest, 0, eNoAction );
+		xTaskNotifyArrayWait( uxIndexToTest, 0x00, ulBit1, &ulNotifiedValue, 0 );
+
+		/* However as the bit is cleared on exit, after the returned notification
+		value is set, the returned notification value should not have the bit
+		cleared... */
+		configASSERT( ulNotifiedValue == ( notifyUINT32_MAX & ~ulBit0 ) );
+
+		/* ...but reading the value back again should find that the bit was indeed
+		cleared internally.  The returned value should be pdFAIL however as nothing
+		has notified the task in the mean time. */
+		xReturned = xTaskNotifyArrayWait( uxIndexToTest, 0x00, 0x00, &ulNotifiedValue, 0 );
+		configASSERT( xReturned == pdFAIL );
+		configASSERT( ulNotifiedValue == ( notifyUINT32_MAX & ~( ulBit0 | ulBit1 ) ) );
+		( void ) xReturned; /* In case configASSERT() is not defined. */
+
+		/* No other indexes should have a notification pending. */
+		for( uxOtherIndexes = 0; uxOtherIndexes < configNUMBER_OF_TASK_NOTIFICATIONS; uxOtherIndexes++ )
+		{
+			if( uxOtherIndexes != uxIndexToTest )
+			{
+				xReturned = xTaskNotifyArrayWait( uxOtherIndexes, 0x00UL, 0x00UL, &ulNotifiedValue, 0 );
+				configASSERT( xReturned == pdFAIL );
+				( void ) xReturned; /* In case configASSERT() is not defined. */
+			}
+		}
+	}
+
+
+
+	/*-------------------------------------------------------------------------
+	Now try querying the previous value while notifying a task. */
+	for( uxIndexToTest = 0; uxIndexToTest < configNUMBER_OF_TASK_NOTIFICATIONS; uxIndexToTest++ )
+	{
+		xTaskNotifyArrayAndQuery( xTaskToNotify, uxIndexToTest, 0x00, eSetBits, &ulPreviousValue );
+		configASSERT( ulNotifiedValue == ( notifyUINT32_MAX & ~( ulBit0 | ulBit1 ) ) );
+
+		/* Clear all bits. */
+		xTaskNotifyArrayWait( uxIndexToTest, 0x00, notifyUINT32_MAX, &ulNotifiedValue, 0 );
+		xTaskNotifyArrayAndQuery( xTaskToNotify, uxIndexToTest, 0x00, eSetBits, &ulPreviousValue );
+		configASSERT( ulPreviousValue == 0 );
+
+		ulExpectedValue = 0;
+		for( ulLoop = 0x01; ulLoop < 0x80UL; ulLoop <<= 1UL )
+		{
+			/* Set the next bit up, and expect to receive the last bits set (so
+			the previous value will not yet have the bit being set this time
+			around). */
+			xTaskNotifyArrayAndQuery( xTaskToNotify, uxIndexToTest, ulLoop, eSetBits, &ulPreviousValue );
+			configASSERT( ulExpectedValue == ulPreviousValue );
+			ulExpectedValue |= ulLoop;
+		}
+	}
+
+
+	/* ---------------------------------------------------------------------- */
+
+	for( uxIndexToTest = 0; uxIndexToTest < configNUMBER_OF_TASK_NOTIFICATIONS; uxIndexToTest++ )
+	{
+		/* Clear the previous notifications. */
+		xTaskNotifyArrayWait( uxIndexToTest, notifyUINT32_MAX, 0, &ulNotifiedValue, 0 );
+	}
+
+	for( uxIndexToTest = 0; uxIndexToTest < configNUMBER_OF_TASK_NOTIFICATIONS; uxIndexToTest++ )
+	{
+		/* No task should not have any notifications pending, so an attempt to
+		clear the notification state should fail. */
+		for( uxOtherIndexes = 0; uxOtherIndexes < configNUMBER_OF_TASK_NOTIFICATIONS; uxOtherIndexes++ )
+		{
+			configASSERT( xTaskNotifyArrayStateClear( NULL, uxOtherIndexes ) == pdFALSE );
+		}
+
+		/* Get the task to notify itself.  This is not a normal thing to do, and
+		is only done here for test purposes. */
+		xTaskNotifyArrayAndQuery( xTaskToNotify, uxIndexToTest, ulFirstNotifiedConst, eSetValueWithoutOverwrite, &ulPreviousValue );
+
+		/* Now the notification state should be eNotified, so it should now be
+		possible to clear the notification state.  Other indexes should still
+		not have a notification pending - likewise uxIndexToTest should not have
+		a notification pending once it has been cleared. */
+		for( uxOtherIndexes = 0; uxOtherIndexes < configNUMBER_OF_TASK_NOTIFICATIONS; uxOtherIndexes++ )
+		{
+			if( uxOtherIndexes == uxIndexToTest )
+			{
+				configASSERT( xTaskNotifyArrayStateClear( NULL, uxOtherIndexes ) == pdTRUE );
+			}
+
+			configASSERT( xTaskNotifyArrayStateClear( NULL, uxOtherIndexes ) == pdFALSE );
+		}
+	}
+
+
+	/* ------------------------------------------------------------------------
+	Clear bits in the notification value. */
+
+	for( uxIndexToTest = 0; uxIndexToTest < configNUMBER_OF_TASK_NOTIFICATIONS; uxIndexToTest++ )
+	{
+		/* Get the task to set all bits its own notification value.  This is not
+		a normal thing to do, and is only done here for test purposes. */
+		xTaskNotifyArray( xTaskToNotify, uxIndexToTest, notifyUINT32_MAX, eSetBits );
+
+		/* Now clear the top bytes - the returned value from the first call
+		should indicate that previously all bits were set. */
+		configASSERT( ulTaskNotifyArrayValueClear( xTaskToNotify, uxIndexToTest, notifyUINT32_HIGH_BYTE ) == notifyUINT32_MAX );
+
+		/* Next clear the bottom bytes - the returned value this time should
+		indicate that the top byte was clear (before the bottom byte was
+		cleared. */
+		configASSERT( ulTaskNotifyArrayValueClear( xTaskToNotify, uxIndexToTest, notifyUINT32_LOW_BYTE ) == ( notifyUINT32_MAX & ~notifyUINT32_HIGH_BYTE ) );
+
+		/* Next clear all bytes - the returned value should indicate that previously the
+		high and low bytes were clear. */
+		configASSERT( ulTaskNotifyArrayValueClear( xTaskToNotify, uxIndexToTest, notifyUINT32_MAX ) == ( notifyUINT32_MAX & ~notifyUINT32_HIGH_BYTE & ~notifyUINT32_LOW_BYTE ) );
+
+		/* Now all bits should be clear. */
+		configASSERT( ulTaskNotifyArrayValueClear( xTaskToNotify, uxIndexToTest, notifyUINT32_MAX ) == 0 );
+		configASSERT( ulTaskNotifyArrayValueClear( xTaskToNotify, uxIndexToTest, 0UL ) == 0 );
+		configASSERT( ulTaskNotifyArrayValueClear( xTaskToNotify, uxIndexToTest, notifyUINT32_MAX ) == 0 );
+
+		/* Now the notification state should be eNotified, so it should now be
+		possible to clear the notification state. */
+		configASSERT( xTaskNotifyArrayStateClear( NULL, uxIndexToTest ) == pdTRUE );
+		configASSERT( xTaskNotifyArrayStateClear( NULL, uxIndexToTest ) == pdFALSE );
+	}
+
+
+	/* ------------------------------------------------------------------------
+	Create a timer that will try notifying this task while it is suspended. */
+	xSingleTaskTimer = xTimerCreate( "SingleNotify", notifySUSPENDED_TEST_TIMER_PERIOD, pdFALSE, NULL, prvSuspendedTaskTimerTestCallback );
+	configASSERT( xSingleTaskTimer );
+
+	/* Incremented to show the task is still running. */
+	ulNotifyCycleCount++;
+
+	/* Ensure no notifications are pending. */
+	xTaskNotifyWait( notifyUINT32_MAX, 0, NULL, 0 );
+
+	/* Raise the task's priority so it can suspend itself before the timer
+	expires. */
+	vTaskPrioritySet( NULL, configMAX_PRIORITIES - 1 );
+
+	/* Start the timer that will try notifying this task while it is
+	suspended, then wait for a notification.  The first time the callback
+	executes the timer will suspend the task, then resume the task, without
+	ever sending a notification to the task. */
+	ulNotifiedValue = 0;
+	xTimerStart( xSingleTaskTimer, portMAX_DELAY );
+
+	/* Check a notification is not received. */
+	xReturned = xTaskNotifyWait( 0, 0, &ulNotifiedValue, portMAX_DELAY );
+	configASSERT( xReturned == pdFALSE );
+	configASSERT( ulNotifiedValue == 0 );
+	( void ) xReturned; /* In case configASSERT() is not defined. */
+
+	/* Incremented to show the task is still running. */
+	ulNotifyCycleCount++;
+
+	/* Start the timer that will try notifying this task while it is
+	suspended, then wait for a notification.  The second time the callback
+	executes the timer will suspend the task, notify the task, then resume the
+	task (previously it was suspended and resumed without being notified). */
+	xTimerStart( xSingleTaskTimer, portMAX_DELAY );
+
+	/* Check a notification is received. */
+	xReturned = xTaskNotifyWait( 0, 0, &ulNotifiedValue, portMAX_DELAY );
+	configASSERT( xReturned == pdPASS );
+	( void ) xReturned; /* In case configASSERT() is not defined. */
+	configASSERT( ulNotifiedValue != 0 );
+
+	/* Return the task to its proper priority and delete the timer as it is
+	not used again. */
+	vTaskPrioritySet( NULL, notifyTASK_PRIORITY );
+	xTimerDelete( xSingleTaskTimer, portMAX_DELAY );
+
+	/* Incremented to show the task is still running. */
+	ulNotifyCycleCount++;
+
+	/* Leave all bits cleared. */
+	xTaskNotifyWait( notifyUINT32_MAX, 0, NULL, 0 );
+}
+/*-----------------------------------------------------------*/
+
+static void prvSuspendedTaskTimerTestCallback( TimerHandle_t xExpiredTimer )
+{
+static uint32_t ulCallCount = 0;
+
+	/* Remove compiler warnings about unused parameters. */
+	( void ) xExpiredTimer;
+
+	/* Callback for a timer that is used during preliminary testing.  The timer
+	tests the behaviour when 1: a task waiting for a notification is suspended
+	and then resumed without ever receiving a notification, and 2: when a task
+	waiting for a notification receives a notification while it is suspended. */
+
+	if( ulCallCount == 0 )
+	{
+		vTaskSuspend( xTaskToNotify );
+		configASSERT( eTaskGetState( xTaskToNotify ) == eSuspended );
+		vTaskResume( xTaskToNotify );
+	}
+	else
+	{
+		vTaskSuspend( xTaskToNotify );
+
+		/* Sending a notification while the task is suspended should pass, but
+		not cause the task to resume.  ulCallCount is just used as a convenient
+		non-zero value. */
+		xTaskNotify( xTaskToNotify, ulCallCount, eSetValueWithOverwrite );
+
+		/* Make sure giving the notification didn't resume the task. */
+		configASSERT( eTaskGetState( xTaskToNotify ) == eSuspended );
+
+		vTaskResume( xTaskToNotify );
+	}
+
+	ulCallCount++;
+}
+/*-----------------------------------------------------------*/
+
+static void prvNotifyingTimer( TimerHandle_t xNotUsed )
+{
+	( void ) xNotUsed;
+
+	xTaskNotifyGive( xTaskToNotify );
+
+	/* This value is also incremented from an interrupt. */
+	taskENTER_CRITICAL();
+	{
+		ulTimerNotificationsSent++;
+	}
+	taskEXIT_CRITICAL();
+}
+/*-----------------------------------------------------------*/
+
+static void prvNotifiedTask( void *pvParameters )
+{
+const TickType_t xMaxPeriod = pdMS_TO_TICKS( 90 ), xMinPeriod = pdMS_TO_TICKS( 10 ), xDontBlock = 0;
+TickType_t xPeriod;
+const uint32_t ulCyclesToRaisePriority = 50UL;
+
+	/* Remove compiler warnings about unused parameters. */
+	( void ) pvParameters;
+
+	/* Run a few tests that can be done from a single task before entering the
+	main loop. */
+	prvSingleTaskTests();
+
+	/* Create the software timer that is used to send notifications to this
+	task.  Notifications are also received from an interrupt. */
+	xTimer = xTimerCreate( "Notifier", xMaxPeriod, pdFALSE, NULL, prvNotifyingTimer );
+
+	for( ;; )
+	{
+		/* Start the timer again with a different period.  Sometimes the period
+		will be higher than the task's block time, sometimes it will be lower
+		than the task's block time. */
+		xPeriod = prvRand() % xMaxPeriod;
+		if( xPeriod < xMinPeriod )
+		{
+			xPeriod = xMinPeriod;
+		}
+
+		/* Change the timer period and start the timer. */
+		xTimerChangePeriod( xTimer, xPeriod, portMAX_DELAY );
+
+		/* Block waiting for the notification again with a different period.
+		Sometimes the period will be higher than the task's block time,
+		sometimes it will be lower than the task's block time. */
+		xPeriod = prvRand() % xMaxPeriod;
+		if( xPeriod < xMinPeriod )
+		{
+			xPeriod = xMinPeriod;
+		}
+
+		/* Block to wait for a notification but without clearing the
+		notification count, so only add one to the count of received
+		notifications as any other notifications will remain pending. */
+		if( ulTaskNotifyTake( pdFALSE, xPeriod ) != 0 )
+		{
+			ulTimerNotificationsReceived++;
+		}
+
+
+		/* Take a notification without clearing again, but this time without a
+		block time specified. */
+		if( ulTaskNotifyTake( pdFALSE, xDontBlock ) != 0 )
+		{
+			ulTimerNotificationsReceived++;
+		}
+
+		/* Wait for the next notification from the timer, clearing all
+		notifications if one is received, so this time adding the total number
+		of notifications that were pending as none will be left pending after
+		the function call. */
+		ulTimerNotificationsReceived += ulTaskNotifyTake( pdTRUE, xPeriod );
+
+		/* Occasionally raise the priority of the task being notified to test
+		the path where the task is notified from an ISR and becomes the highest
+		priority ready state task, but the pxHigherPriorityTaskWoken parameter
+		is NULL (which it is in the tick hook that sends notifications to this
+		task). */
+		if( ( ulNotifyCycleCount % ulCyclesToRaisePriority ) == 0 )
+		{
+			vTaskPrioritySet( xTaskToNotify, configMAX_PRIORITIES - 1 );
+
+			/* Wait for the next notification again, clearing all notifications
+			if one is received, but this time blocking indefinitely. */
+			ulTimerNotificationsReceived += ulTaskNotifyTake( pdTRUE, portMAX_DELAY );
+
+			/* Reset the priority. */
+			vTaskPrioritySet( xTaskToNotify, notifyTASK_PRIORITY );
+		}
+		else
+		{
+			/* Wait for the next notification again, clearing all notifications
+			if one is received, but this time blocking indefinitely. */
+			ulTimerNotificationsReceived += ulTaskNotifyTake( pdTRUE, portMAX_DELAY );
+		}
+
+		/* Incremented to show the task is still running. */
+		ulNotifyCycleCount++;
+	}
+}
+/*-----------------------------------------------------------*/
+
+void xNotifyArrayTaskFromISR( void )
+{
+static BaseType_t xCallCount = 0, xAPIToUse = 0;
+const BaseType_t xCallInterval = pdMS_TO_TICKS( 50 );
+uint32_t ulPreviousValue;
+const uint32_t ulUnexpectedValue = 0xff;
+
+	/* Check the task notification demo tasks were actually created. */
+	configASSERT( xTaskToNotify );
+
+	/* The task performs some tests before starting the timer that gives the
+	notification from this interrupt.  If the timer has not been created yet
+	then the initial tests have not yet completed and the notification should
+	not be sent. */
+	if( xTimer != NULL )
+	{
+		xCallCount++;
+
+		if( xCallCount >= xCallInterval )
+		{
+			/* It is time to 'give' the notification again. */
+			xCallCount = 0;
+
+			/* Test using both vTaskNotifyGiveFromISR(), xTaskNotifyFromISR()
+			and xTaskNotifyAndQueryFromISR(). */
+			switch( xAPIToUse )
+			{
+				case 0:	vTaskNotifyGiveFromISR( xTaskToNotify, NULL );
+						xAPIToUse++;
+						break;
+
+				case 1:	xTaskNotifyFromISR( xTaskToNotify, 0, eIncrement, NULL );
+						xAPIToUse++;
+						break;
+
+				case 2: ulPreviousValue = ulUnexpectedValue;
+						xTaskNotifyAndQueryFromISR( xTaskToNotify, 0, eIncrement, &ulPreviousValue, NULL );
+						configASSERT( ulPreviousValue != ulUnexpectedValue );
+						xAPIToUse = 0;
+						break;
+
+				default:/* Should never get here!. */
+						break;
+			}
+
+			ulTimerNotificationsSent++;
+		}
+	}
+}
+/*-----------------------------------------------------------*/
+
+/* This is called to check the created tasks are still running and have not
+detected any errors. */
+BaseType_t xAreTaskNotificationArrayTasksStillRunning( void )
+{
+static uint32_t ulLastNotifyCycleCount = 0;
+const uint32_t ulMaxSendReceiveDeviation = 5UL;
+
+	/* Check the cycle count is still incrementing to ensure the task is still
+	actually running. */
+	if( ulLastNotifyCycleCount == ulNotifyCycleCount )
+	{
+		xErrorStatus = pdFAIL;
+	}
+	else
+	{
+		ulLastNotifyCycleCount = ulNotifyCycleCount;
+	}
+
+	/* Check the count of 'takes' from the software timer is keeping track with
+	the amount of 'gives'. */
+	if( ulTimerNotificationsSent > ulTimerNotificationsReceived )
+	{
+		if( ( ulTimerNotificationsSent - ulTimerNotificationsReceived ) > ulMaxSendReceiveDeviation )
+		{
+			xErrorStatus = pdFAIL;
+		}
+	}
+
+	return xErrorStatus;
+}
+/*-----------------------------------------------------------*/
+
+static UBaseType_t prvRand( void )
+{
+const size_t uxMultiplier = ( size_t ) 0x015a4e35, uxIncrement = ( size_t ) 1;
+
+	/* Utility function to generate a pseudo random number. */
+	uxNextRand = ( uxMultiplier * uxNextRand ) + uxIncrement;
+	return( ( uxNextRand >> 16 ) & ( ( size_t ) 0x7fff ) );
+}
+/*-----------------------------------------------------------*/

--- a/FreeRTOS/Demo/Common/Minimal/TaskNotifyArray.c
+++ b/FreeRTOS/Demo/Common/Minimal/TaskNotifyArray.c
@@ -85,26 +85,26 @@ static void prvTestNotifyTaskWhileSuspended( void );
  * the state of all the other task notifications within the array should remain
  * unchanged.
  */
-static void prvBlockOnTheNotifiedIndex( void );
+static void prvBlockOnTheNotifiedIndexed( void );
 
 /*
- * As per prvBlockOnTheNotifiedIndex(), but this time the notification comes from
+ * As per prvBlockOnTheNotifiedIndexed(), but this time the notification comes from
  * the tick hook function, so from an interrupt rather than from a software timer.
  */
 static void prvBlockOnNotificationsComingFromInterrupts( void );
 
 /*
- * As per prvBlockOnTheNotifiedIndex(), except this time the notification is
+ * As per prvBlockOnTheNotifiedIndexed(), except this time the notification is
  * sent to an index within the task notification array on which the task is not
  * blocked, so this time the task should not unblock and the state of all the
  * task notifications other than the one to which the notification was actually
  * sent should remain unchanged.
  */
-static void prvBlockOnANonNotifiedIndex( void );
+static void prvBlockOnANonNotifiedIndexed( void );
 
 /*
  * Callback of the software timer used to send notifications for the
- * prvBlockOnTheNotifiedIndex() and prvBlockOnANonNotifiedIndex() tests.
+ * prvBlockOnTheNotifiedIndexed() and prvBlockOnANonNotifiedIndexed() tests.
  */
 static void prvNotifyingTimerCallback( TimerHandle_t xTimer );
 
@@ -182,8 +182,8 @@ static void prvNotifiedTask( void *pvParameters )
 	{
 		prvSingleTaskTests();
 		prvTestNotifyTaskWhileSuspended();
-		prvBlockOnTheNotifiedIndex();
-		prvBlockOnANonNotifiedIndex();
+		prvBlockOnTheNotifiedIndexed();
+		prvBlockOnANonNotifiedIndexed();
 		prvBlockOnNotificationsComingFromInterrupts();
 		ulCourseCycleCounter++;
 	}
@@ -212,12 +212,12 @@ UBaseType_t uxIndexToTest, uxOtherIndexes;
 		{
 			if( uxOtherIndexes != uxIndexToTest )
 			{
-				xTaskNotifyArray( xTaskToNotify, uxOtherIndexes, 0, eNoAction );
+				xTaskNotifyIndexed( xTaskToNotify, uxOtherIndexes, 0, eNoAction );
 			}
 		}
 
 		xTimeOnEntering = xTaskGetTickCount();
-		xReturned = xTaskNotifyArrayWait( uxIndexToTest, notifyUINT32_MAX, 0, &ulNotifiedValue, xTicksToWait );
+		xReturned = xTaskNotifyWaitIndexed( uxIndexToTest, notifyUINT32_MAX, 0, &ulNotifiedValue, xTicksToWait );
 		( void ) xReturned; /* Remove compiler warnings in case configASSERT() is not defined. */
 
 		/* Should have blocked for the entire block time. */
@@ -233,7 +233,7 @@ UBaseType_t uxIndexToTest, uxOtherIndexes;
 		{
 			if( uxOtherIndexes != uxIndexToTest )
 			{
-				xReturned = xTaskNotifyArrayStateClear( xTaskToNotify, uxOtherIndexes );
+				xReturned = xTaskNotifyStateClearIndexed( xTaskToNotify, uxOtherIndexes );
 
 				/* The notification state was set above so expect it to still be
 				set. */
@@ -252,7 +252,7 @@ UBaseType_t uxIndexToTest, uxOtherIndexes;
 		/* First notify the task notification at index uxIndexToTest within this
 		task's own array of task notifications - this would not be a normal
 		thing to do and is done here for test purposes only. */
-		xReturned = xTaskNotifyArrayAndQuery( xTaskToNotify, uxIndexToTest, ulFirstNotifiedConst, eSetValueWithoutOverwrite, &ulPreviousValue );
+		xReturned = xTaskNotifyAndQueryIndexed( xTaskToNotify, uxIndexToTest, ulFirstNotifiedConst, eSetValueWithoutOverwrite, &ulPreviousValue );
 
 		/* Even through the 'without overwrite' action was used the update should
 		have been successful. */
@@ -267,7 +267,7 @@ UBaseType_t uxIndexToTest, uxOtherIndexes;
 		notification at index uxIndexToTest within the task notification array,
 		and so not time out. */
 		xTimeOnEntering = xTaskGetTickCount();
-		xReturned = xTaskNotifyArrayWait( uxIndexToTest, notifyUINT32_MAX, 0, &ulNotifiedValue, xTicksToWait );
+		xReturned = xTaskNotifyWaitIndexed( uxIndexToTest, notifyUINT32_MAX, 0, &ulNotifiedValue, xTicksToWait );
 		configASSERT( ( xTaskGetTickCount() - xTimeOnEntering ) < xTicksToWait );
 
 		/* The task should have been notified, and the notified value should
@@ -294,7 +294,7 @@ UBaseType_t uxIndexToTest, uxOtherIndexes;
 		{
 			if( uxOtherIndexes != uxIndexToTest )
 			{
-				xTaskNotifyArray( xTaskToNotify, uxOtherIndexes, ulFirstNotifiedConst, eSetValueWithOverwrite );
+				xTaskNotifyIndexed( xTaskToNotify, uxOtherIndexes, ulFirstNotifiedConst, eSetValueWithOverwrite );
 			}
 		}
 
@@ -303,17 +303,17 @@ UBaseType_t uxIndexToTest, uxOtherIndexes;
 		should pass and the value read back should also be that used with the
 		first notification. The notification is sent to the task notification at
 		index uxIndexToTest within the array of task notifications. */
-		xReturned = xTaskNotifyArray( xTaskToNotify, uxIndexToTest, ulFirstNotifiedConst, eSetValueWithoutOverwrite );
+		xReturned = xTaskNotifyIndexed( xTaskToNotify, uxIndexToTest, ulFirstNotifiedConst, eSetValueWithoutOverwrite );
 		configASSERT( xReturned == pdPASS );
 		( void ) xReturned; /* Remove compiler warnings in case configASSERT() is not defined. */
 
-		xReturned = xTaskNotifyArray( xTaskToNotify, uxIndexToTest, ulSecondNotifiedValueConst, eSetValueWithoutOverwrite );
+		xReturned = xTaskNotifyIndexed( xTaskToNotify, uxIndexToTest, ulSecondNotifiedValueConst, eSetValueWithoutOverwrite );
 		configASSERT( xReturned == pdFAIL );
 		( void ) xReturned; /* Remove compiler warnings in case configASSERT() is not defined. */
 
 		/* Waiting for the notification should now return immediately so a block
 		time of zero is used. */
-		xReturned = xTaskNotifyArrayWait( uxIndexToTest, notifyUINT32_MAX, 0, &ulNotifiedValue, 0 );
+		xReturned = xTaskNotifyWaitIndexed( uxIndexToTest, notifyUINT32_MAX, 0, &ulNotifiedValue, 0 );
 
 		configASSERT( xReturned == pdPASS );
 		configASSERT( ulNotifiedValue == ulFirstNotifiedConst );
@@ -326,11 +326,11 @@ UBaseType_t uxIndexToTest, uxOtherIndexes;
 		{
 			if( uxOtherIndexes != uxIndexToTest )
 			{
-				xReturned = xTaskNotifyArrayStateClear( xTaskToNotify, uxOtherIndexes );
+				xReturned = xTaskNotifyStateClearIndexed( xTaskToNotify, uxOtherIndexes );
 				configASSERT( xReturned == pdTRUE );
 				( void ) xReturned; /* Remove compiler warnings in case configASSERT() is not defined. */
 
-				ulNotifiedValue = ulTaskNotifyArrayValueClear( xTaskToNotify, uxOtherIndexes, notifyUINT32_MAX );
+				ulNotifiedValue = ulTaskNotifyValueClearIndexed( xTaskToNotify, uxOtherIndexes, notifyUINT32_MAX );
 
 				/* The notification value was set to ulFirstNotifiedConst in all
 				the other indexes, so expect it to still have that value. */
@@ -354,17 +354,17 @@ UBaseType_t uxIndexToTest, uxOtherIndexes;
 		{
 			if( uxOtherIndexes != uxIndexToTest )
 			{
-				xTaskNotifyArray( xTaskToNotify, uxOtherIndexes, ulFirstNotifiedConst, eSetValueWithOverwrite );
+				xTaskNotifyIndexed( xTaskToNotify, uxOtherIndexes, ulFirstNotifiedConst, eSetValueWithOverwrite );
 			}
 		}
 
-		xReturned = xTaskNotifyArray( xTaskToNotify, uxIndexToTest, ulFirstNotifiedConst, eSetValueWithOverwrite );
+		xReturned = xTaskNotifyIndexed( xTaskToNotify, uxIndexToTest, ulFirstNotifiedConst, eSetValueWithOverwrite );
 		configASSERT( xReturned == pdPASS );
 		( void ) xReturned; /* Remove compiler warnings in case configASSERT() is not defined. */
-		xReturned = xTaskNotifyArray( xTaskToNotify, uxIndexToTest, ulSecondNotifiedValueConst, eSetValueWithOverwrite );
+		xReturned = xTaskNotifyIndexed( xTaskToNotify, uxIndexToTest, ulSecondNotifiedValueConst, eSetValueWithOverwrite );
 		configASSERT( xReturned == pdPASS );
 		( void ) xReturned; /* Remove compiler warnings in case configASSERT() is not defined. */
-		xReturned = xTaskNotifyArrayWait( uxIndexToTest, 0, notifyUINT32_MAX, &ulNotifiedValue, 0 );
+		xReturned = xTaskNotifyWaitIndexed( uxIndexToTest, 0, notifyUINT32_MAX, &ulNotifiedValue, 0 );
 		configASSERT( xReturned == pdPASS );
 		( void ) xReturned; /* Remove compiler warnings in case configASSERT() is not defined. */
 		configASSERT( ulNotifiedValue == ulSecondNotifiedValueConst );
@@ -374,10 +374,10 @@ UBaseType_t uxIndexToTest, uxOtherIndexes;
 		{
 			if( uxOtherIndexes != uxIndexToTest )
 			{
-				xReturned = xTaskNotifyArrayStateClear( xTaskToNotify, uxOtherIndexes );
+				xReturned = xTaskNotifyStateClearIndexed( xTaskToNotify, uxOtherIndexes );
 				configASSERT( xReturned == pdTRUE );
 				( void ) xReturned; /* Remove compiler warnings in case configASSERT() is not defined. */
-				ulNotifiedValue = ulTaskNotifyArrayValueClear( xTaskToNotify, uxOtherIndexes, notifyUINT32_MAX );
+				ulNotifiedValue = ulTaskNotifyValueClearIndexed( xTaskToNotify, uxOtherIndexes, notifyUINT32_MAX );
 				configASSERT( ulNotifiedValue == ulFirstNotifiedConst );
 				( void ) ulNotifiedValue; /* Remove compiler warnings in case configASSERT() is not defined. */
 			}
@@ -395,14 +395,14 @@ UBaseType_t uxIndexToTest, uxOtherIndexes;
 		/* First set the notification values of the task notification at index
 		uxIndexToTest of the array of task notification to
 		ulSecondNotifiedValueConst. */
-		xReturned = xTaskNotifyArray( xTaskToNotify, uxIndexToTest, ulSecondNotifiedValueConst, eSetValueWithOverwrite );
+		xReturned = xTaskNotifyIndexed( xTaskToNotify, uxIndexToTest, ulSecondNotifiedValueConst, eSetValueWithOverwrite );
 		configASSERT( xReturned == pdPASS );
 		( void ) xReturned; /* Remove compiler warnings in case configASSERT() is not defined. */
 
 		/* Even though ulFirstNotifiedConst is used as the value next, the value
 		read back should remain at ulSecondNotifiedConst as the action is set
 		to eNoAction. */
-		xReturned = xTaskNotifyArray( xTaskToNotify, uxIndexToTest, ulFirstNotifiedConst, eNoAction );
+		xReturned = xTaskNotifyIndexed( xTaskToNotify, uxIndexToTest, ulFirstNotifiedConst, eNoAction );
 		configASSERT( xReturned == pdPASS );
 		( void ) xReturned; /* Remove compiler warnings in case configASSERT() is not defined. */
 
@@ -412,7 +412,7 @@ UBaseType_t uxIndexToTest, uxOtherIndexes;
 		{
 			/* First zero is bits to clear on entry, the second is bits to clear on
 			exist, the last 0 is the block time. */
-			xReturned = xTaskNotifyArrayWait( uxOtherIndexes, 0, 0, &ulNotifiedValue, 0 );
+			xReturned = xTaskNotifyWaitIndexed( uxOtherIndexes, 0, 0, &ulNotifiedValue, 0 );
 			configASSERT( ulNotifiedValue == ulSecondNotifiedValueConst );
 			( void ) ulNotifiedValue; /* Remove compiler warnings in case configASSERT() is not defined. */
 		}
@@ -420,11 +420,11 @@ UBaseType_t uxIndexToTest, uxOtherIndexes;
 		/* All array indexes in the array of task notifications after index
 		uxIndexToTest should still contain 0 as they have not been set in this
 		loop yet.  This time use xTaskNotifyValueClear() instead of
-		xTaskNotifyArrayWait(), just for test coverage. */
+		xTaskNotifyWaitIndexed(), just for test coverage. */
 		for( uxOtherIndexes = uxIndexToTest + 1; uxOtherIndexes < configNUMBER_OF_TASK_NOTIFICATIONS; uxOtherIndexes++ )
 		{
 			/* This time 0 is the bits to clear parameter - so clearing no bits. */
-			ulNotifiedValue = ulTaskNotifyArrayValueClear( NULL, uxOtherIndexes, 0 );
+			ulNotifiedValue = ulTaskNotifyValueClearIndexed( NULL, uxOtherIndexes, 0 );
 			configASSERT( ulNotifiedValue == 0 );
 			( void ) ulNotifiedValue; /* Remove compiler warnings in case configASSERT() is not defined. */
 		}
@@ -444,7 +444,7 @@ UBaseType_t uxIndexToTest, uxOtherIndexes;
 		{
 			/* Increment the value of the task notification at index
 			uxIndexToTest within the array of task notifications. */
-			xReturned = xTaskNotifyArray( xTaskToNotify, uxIndexToTest, 0, eIncrement );
+			xReturned = xTaskNotifyIndexed( xTaskToNotify, uxIndexToTest, 0, eIncrement );
 			configASSERT( xReturned == pdPASS );
 			( void ) xReturned; /* Remove compiler warnings in case configASSERT() is not defined. */
 		}
@@ -455,13 +455,13 @@ UBaseType_t uxIndexToTest, uxOtherIndexes;
 		{
 			/* First zero is bits to clear on entry, the second is bits to clear on
 			exist, the last 0 is the block time. */
-			xReturned = xTaskNotifyArrayWait( uxOtherIndexes, 0, 0, &ulNotifiedValue, 0 );
+			xReturned = xTaskNotifyWaitIndexed( uxOtherIndexes, 0, 0, &ulNotifiedValue, 0 );
 			configASSERT( ulNotifiedValue == ( ulSecondNotifiedValueConst + ulMaxLoops ) );
 			( void ) ulNotifiedValue; /* Remove compiler warnings in case configASSERT() is not defined. */
 		}
 
 		/* Should not be any notifications pending now. */
-		xReturned = xTaskNotifyArrayWait( uxIndexToTest, 0, 0, &ulNotifiedValue, 0 );
+		xReturned = xTaskNotifyWaitIndexed( uxIndexToTest, 0, 0, &ulNotifiedValue, 0 );
 		configASSERT( xReturned == pdFAIL );
 		( void ) xReturned; /* Remove compiler warnings in case configASSERT() is not defined. */
 		( void ) ulNotifiedValue;
@@ -469,12 +469,12 @@ UBaseType_t uxIndexToTest, uxOtherIndexes;
 		/* All notifications values in the array of task notifications after
 		index uxIndexToTest should still contain the un-incremented
 		ulSecondNotifiedValueConst as they have not been set in this loop yet.
-		This time use xTaskNotifyValueClear() instead of xTaskNotifyArrayWait(),
+		This time use xTaskNotifyValueClear() instead of xTaskNotifyWaitIndexed(),
 		just for test coverage. */
 		for( uxOtherIndexes = uxIndexToTest + 1; uxOtherIndexes < configNUMBER_OF_TASK_NOTIFICATIONS; uxOtherIndexes++ )
 		{
 			/* This time 0 is the bits to clear parameter - so clearing no bits. */
-			ulNotifiedValue = ulTaskNotifyArrayValueClear( NULL, uxOtherIndexes, 0 );
+			ulNotifiedValue = ulTaskNotifyValueClearIndexed( NULL, uxOtherIndexes, 0 );
 			configASSERT( ulNotifiedValue == ulSecondNotifiedValueConst );
 			( void ) ulNotifiedValue; /* Remove compiler warnings in case configASSERT() is not defined. */
 		}
@@ -484,7 +484,7 @@ UBaseType_t uxIndexToTest, uxOtherIndexes;
 	for( uxIndexToTest = 0; uxIndexToTest < configNUMBER_OF_TASK_NOTIFICATIONS; uxIndexToTest++ )
 	{
 		/* Start with all bits clear. */
-		ulTaskNotifyArrayValueClear( NULL, uxIndexToTest, notifyUINT32_MAX );
+		ulTaskNotifyValueClearIndexed( NULL, uxIndexToTest, notifyUINT32_MAX );
 	}
 
 
@@ -504,12 +504,12 @@ UBaseType_t uxIndexToTest, uxOtherIndexes;
 		{
 			/* Set the next bit in the value of the task notification at index
 			uxIndexToTest within the array of task notifications. */
-			xTaskNotifyArray( xTaskToNotify, uxIndexToTest, ulNotifyingValue, eSetBits );
+			xTaskNotifyIndexed( xTaskToNotify, uxIndexToTest, ulNotifyingValue, eSetBits );
 
 			/* Wait for the notified value - which of course will already be
 			available.  Don't clear the bits on entry or exit as this loop is
 			exited when all the bits are set. */
-			xReturned = xTaskNotifyArrayWait( uxIndexToTest, 0, 0, &ulNotifiedValue, 0 );
+			xReturned = xTaskNotifyWaitIndexed( uxIndexToTest, 0, 0, &ulNotifiedValue, 0 );
 			configASSERT( xReturned == pdPASS );
 			( void ) xReturned; /* Remove compiler warnings in case configASSERT() is not defined. */
 
@@ -531,7 +531,7 @@ UBaseType_t uxIndexToTest, uxOtherIndexes;
 		{
 			/* First zero is bits to clear on entry, the second is bits to clear on
 			exist, the last 0 is the block time. */
-			xReturned = xTaskNotifyArrayWait( uxOtherIndexes, 0, 0, &ulNotifiedValue, 0 );
+			xReturned = xTaskNotifyWaitIndexed( uxOtherIndexes, 0, 0, &ulNotifiedValue, 0 );
 			configASSERT( ulNotifiedValue == notifyUINT32_MAX );
 			( void ) ulNotifiedValue; /* Remove compiler warnings in case configASSERT() is not defined. */
 		}
@@ -539,11 +539,11 @@ UBaseType_t uxIndexToTest, uxOtherIndexes;
 		/* The value of each task notification within the array of task
 		notifications after index uxIndexToTest should still contain 0 as they
 		have not been set in this loop yet.  This time use xTaskNotifyValueClear()
-		instead of xTaskNotifyArrayWait(), just for test coverage. */
+		instead of xTaskNotifyWaitIndexed(), just for test coverage. */
 		for( uxOtherIndexes = uxIndexToTest + 1; uxOtherIndexes < configNUMBER_OF_TASK_NOTIFICATIONS; uxOtherIndexes++ )
 		{
 			/* This time 0 is the bits to clear parameter - so clearing no bits. */
-			ulNotifiedValue = ulTaskNotifyArrayValueClear( NULL, uxOtherIndexes, 0 );
+			ulNotifiedValue = ulTaskNotifyValueClearIndexed( NULL, uxOtherIndexes, 0 );
 			configASSERT( ulNotifiedValue == 0 );
 			( void ) ulNotifiedValue; /* Remove compiler warnings in case configASSERT() is not defined. */
 		}
@@ -561,7 +561,7 @@ UBaseType_t uxIndexToTest, uxOtherIndexes;
 		and should return pdFAIL.  The parameters are set to clear bit zero on
 		entry and bit one on exit.  As no notification was received only the bit
 		cleared on entry should actually get cleared. */
-		xReturned = xTaskNotifyArrayWait( uxIndexToTest, ulBit0, ulBit1, &ulNotifiedValue, xTicksToWait );
+		xReturned = xTaskNotifyWaitIndexed( uxIndexToTest, ulBit0, ulBit1, &ulNotifiedValue, xTicksToWait );
 		configASSERT( xReturned == pdFAIL );
 		( void ) xReturned; /* Remove compiler warnings in case configASSERT() is not defined. */
 
@@ -569,7 +569,7 @@ UBaseType_t uxIndexToTest, uxOtherIndexes;
 		uxIndexToTest within the array of task notifications.  This should not
 		update the bits even though notifyUINT32_MAX is used as the notification
 		value. */
-		xTaskNotifyArray( xTaskToNotify, uxIndexToTest, notifyUINT32_MAX, eNoAction );
+		xTaskNotifyIndexed( xTaskToNotify, uxIndexToTest, notifyUINT32_MAX, eNoAction );
 
 		/* All array indexes up to and including uxIndexToTest within the array
 		of task notifications should have the modified value.  */
@@ -578,7 +578,7 @@ UBaseType_t uxIndexToTest, uxOtherIndexes;
 			/* Reading back the value should find bit 0 is clear, as this was cleared
 			on entry, but bit 1 is not clear as it will not have been cleared on exit
 			as no notification was received. */
-			xReturned = xTaskNotifyArrayWait( uxOtherIndexes, 0x00UL, 0x00UL, &ulNotifiedValue, 0 );
+			xReturned = xTaskNotifyWaitIndexed( uxOtherIndexes, 0x00UL, 0x00UL, &ulNotifiedValue, 0 );
 			if( uxOtherIndexes == uxIndexToTest )
 			{
 				/* This is the index being used this time round the loop and its
@@ -597,11 +597,11 @@ UBaseType_t uxIndexToTest, uxOtherIndexes;
 
 		/* All array indexes after uxIndexToTest should still contain notifyUINT32_MAX
 		left over from the previous test.  This time use xTaskNotifyValueClear()
-		instead of xTaskNotifyArrayWait(), just for test coverage. */
+		instead of xTaskNotifyWaitIndexed(), just for test coverage. */
 		for( uxOtherIndexes = uxIndexToTest + 1; uxOtherIndexes < configNUMBER_OF_TASK_NOTIFICATIONS; uxOtherIndexes++ )
 		{
 			/* This time 0 is the bits to clear parameter - so clearing no bits. */
-			ulNotifiedValue = ulTaskNotifyArrayValueClear( NULL, uxOtherIndexes, 0 );
+			ulNotifiedValue = ulTaskNotifyValueClearIndexed( NULL, uxOtherIndexes, 0 );
 			configASSERT( ulNotifiedValue == notifyUINT32_MAX );
 			( void ) ulNotifiedValue; /* Remove compiler warnings in case configASSERT() is not defined. */
 		}
@@ -616,8 +616,8 @@ UBaseType_t uxIndexToTest, uxOtherIndexes;
 	{
 		/* The task is notified first using the task notification at index
 		uxIndexToTest within the array of task notifications. */
-		xTaskNotifyArray( xTaskToNotify, uxIndexToTest, 0, eNoAction );
-		xTaskNotifyArrayWait( uxIndexToTest, 0x00, ulBit1, &ulNotifiedValue, 0 );
+		xTaskNotifyIndexed( xTaskToNotify, uxIndexToTest, 0, eNoAction );
+		xTaskNotifyWaitIndexed( uxIndexToTest, 0x00, ulBit1, &ulNotifiedValue, 0 );
 
 		/* However as the bit is cleared on exit, after the returned notification
 		value is set, the returned notification value should not have the bit
@@ -627,7 +627,7 @@ UBaseType_t uxIndexToTest, uxOtherIndexes;
 		/* ...but reading the value back again should find that the bit was indeed
 		cleared internally.  The returned value should be pdFAIL however as nothing
 		has notified the task in the mean time. */
-		xReturned = xTaskNotifyArrayWait( uxIndexToTest, 0x00, 0x00, &ulNotifiedValue, 0 );
+		xReturned = xTaskNotifyWaitIndexed( uxIndexToTest, 0x00, 0x00, &ulNotifiedValue, 0 );
 		configASSERT( xReturned == pdFAIL );
 		configASSERT( ulNotifiedValue == ( notifyUINT32_MAX & ~( ulBit0 | ulBit1 ) ) );
 		( void ) xReturned; /* Remove compiler warnings in case configASSERT() is not defined. */
@@ -637,7 +637,7 @@ UBaseType_t uxIndexToTest, uxOtherIndexes;
 		{
 			if( uxOtherIndexes != uxIndexToTest )
 			{
-				xReturned = xTaskNotifyArrayWait( uxOtherIndexes, 0x00UL, 0x00UL, &ulNotifiedValue, 0 );
+				xReturned = xTaskNotifyWaitIndexed( uxOtherIndexes, 0x00UL, 0x00UL, &ulNotifiedValue, 0 );
 				configASSERT( xReturned == pdFAIL );
 				( void ) xReturned; /* Remove compiler warnings in case configASSERT() is not defined. */
 			}
@@ -651,12 +651,12 @@ UBaseType_t uxIndexToTest, uxOtherIndexes;
 	querying the previous value while notifying a task. */
 	for( uxIndexToTest = 0; uxIndexToTest < configNUMBER_OF_TASK_NOTIFICATIONS; uxIndexToTest++ )
 	{
-		xTaskNotifyArrayAndQuery( xTaskToNotify, uxIndexToTest, 0x00, eSetBits, &ulPreviousValue );
+		xTaskNotifyAndQueryIndexed( xTaskToNotify, uxIndexToTest, 0x00, eSetBits, &ulPreviousValue );
 		configASSERT( ulNotifiedValue == ( notifyUINT32_MAX & ~( ulBit0 | ulBit1 ) ) );
 
 		/* Clear all bits. */
-		xTaskNotifyArrayWait( uxIndexToTest, 0x00, notifyUINT32_MAX, &ulNotifiedValue, 0 );
-		xTaskNotifyArrayAndQuery( xTaskToNotify, uxIndexToTest, 0x00, eSetBits, &ulPreviousValue );
+		xTaskNotifyWaitIndexed( uxIndexToTest, 0x00, notifyUINT32_MAX, &ulNotifiedValue, 0 );
+		xTaskNotifyAndQueryIndexed( xTaskToNotify, uxIndexToTest, 0x00, eSetBits, &ulPreviousValue );
 		configASSERT( ulPreviousValue == 0 );
 
 		ulExpectedValue = 0;
@@ -665,7 +665,7 @@ UBaseType_t uxIndexToTest, uxOtherIndexes;
 			/* Set the next bit up, and expect to receive the last bits set (so
 			the previous value will not yet have the bit being set this time
 			around). */
-			xTaskNotifyArrayAndQuery( xTaskToNotify, uxIndexToTest, ulLoop, eSetBits, &ulPreviousValue );
+			xTaskNotifyAndQueryIndexed( xTaskToNotify, uxIndexToTest, ulLoop, eSetBits, &ulPreviousValue );
 			configASSERT( ulExpectedValue == ulPreviousValue );
 			ulExpectedValue |= ulLoop;
 		}
@@ -676,7 +676,7 @@ UBaseType_t uxIndexToTest, uxOtherIndexes;
 	for( uxIndexToTest = 0; uxIndexToTest < configNUMBER_OF_TASK_NOTIFICATIONS; uxIndexToTest++ )
 	{
 		/* Clear the previous notifications. */
-		xTaskNotifyArrayWait( uxIndexToTest, notifyUINT32_MAX, 0, &ulNotifiedValue, 0 );
+		xTaskNotifyWaitIndexed( uxIndexToTest, notifyUINT32_MAX, 0, &ulNotifiedValue, 0 );
 	}
 
 	for( uxIndexToTest = 0; uxIndexToTest < configNUMBER_OF_TASK_NOTIFICATIONS; uxIndexToTest++ )
@@ -686,13 +686,13 @@ UBaseType_t uxIndexToTest, uxOtherIndexes;
 		notification state should fail. */
 		for( uxOtherIndexes = 0; uxOtherIndexes < configNUMBER_OF_TASK_NOTIFICATIONS; uxOtherIndexes++ )
 		{
-			configASSERT( xTaskNotifyArrayStateClear( NULL, uxOtherIndexes ) == pdFALSE );
+			configASSERT( xTaskNotifyStateClearIndexed( NULL, uxOtherIndexes ) == pdFALSE );
 		}
 
 		/* Get the task to notify itself using the task notification at index
 		uxIndexToTest within the array of task notifications.  This is not a
 		normal thing to do, and is only done here for test purposes. */
-		xTaskNotifyArrayAndQuery( xTaskToNotify, uxIndexToTest, ulFirstNotifiedConst, eSetValueWithoutOverwrite, &ulPreviousValue );
+		xTaskNotifyAndQueryIndexed( xTaskToNotify, uxIndexToTest, ulFirstNotifiedConst, eSetValueWithoutOverwrite, &ulPreviousValue );
 
 		/* Now the notification state should be eNotified, so it should now be
 		possible to clear the notification state.  Other indexes should still
@@ -702,10 +702,10 @@ UBaseType_t uxIndexToTest, uxOtherIndexes;
 		{
 			if( uxOtherIndexes == uxIndexToTest )
 			{
-				configASSERT( xTaskNotifyArrayStateClear( NULL, uxOtherIndexes ) == pdTRUE );
+				configASSERT( xTaskNotifyStateClearIndexed( NULL, uxOtherIndexes ) == pdTRUE );
 			}
 
-			configASSERT( xTaskNotifyArrayStateClear( NULL, uxOtherIndexes ) == pdFALSE );
+			configASSERT( xTaskNotifyStateClearIndexed( NULL, uxOtherIndexes ) == pdFALSE );
 		}
 	}
 
@@ -718,30 +718,30 @@ UBaseType_t uxIndexToTest, uxOtherIndexes;
 		/* Get the task to set all bits in its task notification at index
 		uxIndexToTest within its array of task notifications.  This is not a
 		normal thing to do, and is only done here for test purposes. */
-		xTaskNotifyArray( xTaskToNotify, uxIndexToTest, notifyUINT32_MAX, eSetBits );
+		xTaskNotifyIndexed( xTaskToNotify, uxIndexToTest, notifyUINT32_MAX, eSetBits );
 
 		/* Now clear the top bytes - the returned value from the first call
 		should indicate that previously all bits were set. */
-		configASSERT( ulTaskNotifyArrayValueClear( xTaskToNotify, uxIndexToTest, notifyUINT32_HIGH_BYTE ) == notifyUINT32_MAX );
+		configASSERT( ulTaskNotifyValueClearIndexed( xTaskToNotify, uxIndexToTest, notifyUINT32_HIGH_BYTE ) == notifyUINT32_MAX );
 
 		/* Next clear the bottom bytes - the returned value this time should
 		indicate that the top byte was clear (before the bottom byte was
 		cleared. */
-		configASSERT( ulTaskNotifyArrayValueClear( xTaskToNotify, uxIndexToTest, notifyUINT32_LOW_BYTE ) == ( notifyUINT32_MAX & ~notifyUINT32_HIGH_BYTE ) );
+		configASSERT( ulTaskNotifyValueClearIndexed( xTaskToNotify, uxIndexToTest, notifyUINT32_LOW_BYTE ) == ( notifyUINT32_MAX & ~notifyUINT32_HIGH_BYTE ) );
 
 		/* Next clear all bytes - the returned value should indicate that previously the
 		high and low bytes were clear. */
-		configASSERT( ulTaskNotifyArrayValueClear( xTaskToNotify, uxIndexToTest, notifyUINT32_MAX ) == ( notifyUINT32_MAX & ~notifyUINT32_HIGH_BYTE & ~notifyUINT32_LOW_BYTE ) );
+		configASSERT( ulTaskNotifyValueClearIndexed( xTaskToNotify, uxIndexToTest, notifyUINT32_MAX ) == ( notifyUINT32_MAX & ~notifyUINT32_HIGH_BYTE & ~notifyUINT32_LOW_BYTE ) );
 
 		/* Now all bits should be clear. */
-		configASSERT( ulTaskNotifyArrayValueClear( xTaskToNotify, uxIndexToTest, notifyUINT32_MAX ) == 0 );
-		configASSERT( ulTaskNotifyArrayValueClear( xTaskToNotify, uxIndexToTest, 0UL ) == 0 );
-		configASSERT( ulTaskNotifyArrayValueClear( xTaskToNotify, uxIndexToTest, notifyUINT32_MAX ) == 0 );
+		configASSERT( ulTaskNotifyValueClearIndexed( xTaskToNotify, uxIndexToTest, notifyUINT32_MAX ) == 0 );
+		configASSERT( ulTaskNotifyValueClearIndexed( xTaskToNotify, uxIndexToTest, 0UL ) == 0 );
+		configASSERT( ulTaskNotifyValueClearIndexed( xTaskToNotify, uxIndexToTest, notifyUINT32_MAX ) == 0 );
 
 		/* Now the notification state should be eNotified, so it should now be
 		possible to clear the notification state. */
-		configASSERT( xTaskNotifyArrayStateClear( NULL, uxIndexToTest ) == pdTRUE );
-		configASSERT( xTaskNotifyArrayStateClear( NULL, uxIndexToTest ) == pdFALSE );
+		configASSERT( xTaskNotifyStateClearIndexed( NULL, uxIndexToTest ) == pdTRUE );
+		configASSERT( xTaskNotifyStateClearIndexed( NULL, uxIndexToTest ) == pdFALSE );
 	}
 
 
@@ -753,7 +753,7 @@ UBaseType_t uxIndexToTest, uxOtherIndexes;
 	/* Leave all bits cleared. */
 	for( uxIndexToTest = 0; uxIndexToTest < configNUMBER_OF_TASK_NOTIFICATIONS; uxIndexToTest++ )
 	{
-		xTaskNotifyArrayWait( uxIndexToTest, notifyUINT32_MAX, 0, NULL, 0 );
+		xTaskNotifyWaitIndexed( uxIndexToTest, notifyUINT32_MAX, 0, NULL, 0 );
 	}
 }
 /*-----------------------------------------------------------*/
@@ -786,7 +786,7 @@ static UBaseType_t uxIndexToNotify = 0;
 		/* Sending a notification while the task is suspended should pass, but
 		not cause the task to resume.  ulCallCount is just used as a convenient
 		non-zero value. */
-		xTaskNotifyArray( xTaskToNotify, uxIndexToNotify, 1, eSetValueWithOverwrite );
+		xTaskNotifyIndexed( xTaskToNotify, uxIndexToNotify, 1, eSetValueWithOverwrite );
 
 		/* Use the next task notification within the array of task notifications
 		the next time around. */
@@ -815,7 +815,7 @@ static BaseType_t uxIndexToNotify = 0;
 	/* "Give" the task notification (which increments the target task
 	notification value) at index uxIndexToNotify within the array of task
 	notifications. */
-	xTaskNotifyArrayGive( xTaskToNotify, uxIndexToNotify );
+	xTaskNotifyGiveIndexed( xTaskToNotify, uxIndexToNotify );
 
 	/* Use the next task notification within the array of task notifications the
 	next time around. */
@@ -848,7 +848,7 @@ uint32_t ulNotifiedValue;
 		pending. */
 		for( uxOtherIndexes = 0; uxOtherIndexes < configNUMBER_OF_TASK_NOTIFICATIONS; uxOtherIndexes++ )
 		{
-			xReturned = xTaskNotifyArrayWait( uxOtherIndexes, 0, 0, NULL, 0 );
+			xReturned = xTaskNotifyWaitIndexed( uxOtherIndexes, 0, 0, NULL, 0 );
 			configASSERT( xReturned == pdFALSE );
 			( void ) xReturned; /* Remove compiler warnings in case configASSERT() is not defined. */
 		}
@@ -862,7 +862,7 @@ uint32_t ulNotifiedValue;
 
 		/* Check a notification is not received on the task notification at
 		index uxIndexToTest within the array of task notifications. */
-		xReturned = xTaskNotifyArrayWait( uxIndexToTest, 0, 0, &ulNotifiedValue, portMAX_DELAY );
+		xReturned = xTaskNotifyWaitIndexed( uxIndexToTest, 0, 0, &ulNotifiedValue, portMAX_DELAY );
 		configASSERT( xReturned == pdFALSE );
 		configASSERT( ulNotifiedValue == 0 );
 		( void ) xReturned; /* Remove compiler warnings in case configASSERT() is not defined. */
@@ -871,7 +871,7 @@ uint32_t ulNotifiedValue;
 		notifications as been notified. */
 		for( uxOtherIndexes = 0; uxOtherIndexes < configNUMBER_OF_TASK_NOTIFICATIONS; uxOtherIndexes++ )
 		{
-			xReturned = xTaskNotifyArrayWait( uxOtherIndexes, 0, 0, &ulNotifiedValue, 0 );
+			xReturned = xTaskNotifyWaitIndexed( uxOtherIndexes, 0, 0, &ulNotifiedValue, 0 );
 			configASSERT( xReturned == pdFALSE );
 			( void ) xReturned; /* Remove compiler warnings in case configASSERT() is not defined. */
 		}
@@ -888,7 +888,7 @@ uint32_t ulNotifiedValue;
 
 		/* Check a notification is only received in the index within the array
 		of task notifications under test. */
-		xReturned = xTaskNotifyArrayWait( uxIndexToTest, 0, 0, &ulNotifiedValue, portMAX_DELAY );
+		xReturned = xTaskNotifyWaitIndexed( uxIndexToTest, 0, 0, &ulNotifiedValue, portMAX_DELAY );
 		configASSERT( xReturned == pdPASS );
 		( void ) xReturned; /* Remove compiler warnings in case configASSERT() is not defined. */
 		configASSERT( ulNotifiedValue != 0 );
@@ -899,7 +899,7 @@ uint32_t ulNotifiedValue;
 		notification values. */
 		for( uxOtherIndexes = 0; uxOtherIndexes < configNUMBER_OF_TASK_NOTIFICATIONS; uxOtherIndexes++ )
 		{
-			xReturned = xTaskNotifyArrayWait( uxOtherIndexes, 0, 0, &ulNotifiedValue, 0 );
+			xReturned = xTaskNotifyWaitIndexed( uxOtherIndexes, 0, 0, &ulNotifiedValue, 0 );
 			configASSERT( xReturned == pdFALSE );
 
 			if( uxOtherIndexes <= uxIndexToTest )
@@ -924,12 +924,12 @@ uint32_t ulNotifiedValue;
 	/* Leave all bits cleared. */
 	for( uxIndexToTest = 0; uxIndexToTest < configNUMBER_OF_TASK_NOTIFICATIONS; uxIndexToTest++ )
 	{
-		xTaskNotifyArrayWait( uxIndexToTest, notifyUINT32_MAX, 0, NULL, 0 );
+		xTaskNotifyWaitIndexed( uxIndexToTest, notifyUINT32_MAX, 0, NULL, 0 );
 	}
 }
 /* ------------------------------------------------------------------------ */
 
-static void prvBlockOnTheNotifiedIndex( void )
+static void prvBlockOnTheNotifiedIndexed( void )
 {
 const TickType_t xTimerPeriod = pdMS_TO_TICKS( 100 ), xMargin = pdMS_TO_TICKS( 50 ), xDontBlock = 0;
 UBaseType_t uxIndex, uxIndexToNotify;
@@ -942,8 +942,8 @@ BaseType_t xReturned;
 	used because the index under test will use 0. */
 	for( uxIndex = 0; uxIndex < configNUMBER_OF_TASK_NOTIFICATIONS; uxIndex++ )
 	{
-		xTaskNotifyArray( xTaskToNotify, uxIndex, uxIndex + 1, eSetValueWithOverwrite );
-		xTaskNotifyArrayStateClear( xTaskToNotify, uxIndex );
+		xTaskNotifyIndexed( xTaskToNotify, uxIndex, uxIndex + 1, eSetValueWithOverwrite );
+		xTaskNotifyStateClearIndexed( xTaskToNotify, uxIndex );
 	}
 
 	/* Peform the test on each task notification within the array of task
@@ -952,18 +952,18 @@ BaseType_t xReturned;
 	{
 		/* Set the notification value of the index being tested to 0 so the
 		notification value increment/decrement functions can be tested. */
-		xTaskNotifyArray( xTaskToNotify, uxIndexToNotify, 0, eSetValueWithOverwrite );
-		xTaskNotifyArrayStateClear( xTaskToNotify, uxIndexToNotify );
+		xTaskNotifyIndexed( xTaskToNotify, uxIndexToNotify, 0, eSetValueWithOverwrite );
+		xTaskNotifyStateClearIndexed( xTaskToNotify, uxIndexToNotify );
 
 		/* Start the software timer then wait for it to notify this task.  Block
 		on the notification index we expect to receive the notification on.  The
 		margin is to ensure the task blocks longer than the timer period. */
 		xTimerStart( xIncrementingIndexTimer, portMAX_DELAY );
-		ulReceivedValue = ulTaskNotifyArrayTake( uxIndexToNotify, pdFALSE, xTimerPeriod + xMargin );
+		ulReceivedValue = ulTaskNotifyTakeIndexed( uxIndexToNotify, pdFALSE, xTimerPeriod + xMargin );
 
 		/* The notification value was initially zero, and should have been
 		incremented by the software timer, so now one.  It will also have been
-		decremented again by the call to ulTaskNotifyArrayTake() so gone back
+		decremented again by the call to ulTaskNotifyTakeIndexed() so gone back
 		to 0. */
 		configASSERT( ulReceivedValue == 1UL );
 		( void ) ulReceivedValue; /* Remove compiler warnings in case configASSERT() is not defined. */
@@ -975,7 +975,7 @@ BaseType_t xReturned;
 		{
 			if( uxIndex != uxIndexToNotify )
 			{
-				xReturned = xTaskNotifyArrayWait( uxIndex, 0, 0, &ulReceivedValue, xDontBlock );
+				xReturned = xTaskNotifyWaitIndexed( uxIndex, 0, 0, &ulReceivedValue, xDontBlock );
 				configASSERT( xReturned == pdFALSE );
 				configASSERT( ulReceivedValue == ( uxIndex + 1 ) );
 				( void ) ulReceivedValue; /* Remove compiler warnings in case configASSERT() is not defined. */
@@ -985,8 +985,8 @@ BaseType_t xReturned;
 
 		/* Reset the notification value for the index just tested back to the
 		index value plus 1 ready for the next iteration around this loop. */
-		xTaskNotifyArray( xTaskToNotify, uxIndexToNotify, uxIndexToNotify + 1, eSetValueWithOverwrite );
-		xTaskNotifyArrayStateClear( xTaskToNotify, uxIndexToNotify );
+		xTaskNotifyIndexed( xTaskToNotify, uxIndexToNotify, uxIndexToNotify + 1, eSetValueWithOverwrite );
+		xTaskNotifyStateClearIndexed( xTaskToNotify, uxIndexToNotify );
 
 		/* Incremented to show the task is still running. */
 		ulFineCycleCount++;
@@ -994,7 +994,7 @@ BaseType_t xReturned;
 }
 /* ------------------------------------------------------------------------ */
 
-static void prvBlockOnANonNotifiedIndex( void )
+static void prvBlockOnANonNotifiedIndexed( void )
 {
 const TickType_t xTimerPeriod = pdMS_TO_TICKS( 100 ), xMargin = pdMS_TO_TICKS( 50 ), xDontBlock = 0;
 UBaseType_t uxIndex, uxIndexToNotify;
@@ -1006,7 +1006,7 @@ TickType_t xTimeBeforeBlocking;
 	ready for the next test. */
 	for( uxIndexToNotify = 0; uxIndexToNotify < configNUMBER_OF_TASK_NOTIFICATIONS; uxIndexToNotify++ )
 	{
-		ulTaskNotifyArrayValueClear( xTaskToNotify, uxIndexToNotify, notifyUINT32_MAX );
+		ulTaskNotifyValueClearIndexed( xTaskToNotify, uxIndexToNotify, notifyUINT32_MAX );
 	}
 
 	/* Perform the test for each notification within the array of task
@@ -1033,7 +1033,7 @@ TickType_t xTimeBeforeBlocking;
 			uxIndex = uxIndexToNotify + 1;
 		}
 
-		xReturned = xTaskNotifyArrayWait( uxIndex, 0, 0, &ulReceivedValue, xTimerPeriod + xMargin );
+		xReturned = xTaskNotifyWaitIndexed( uxIndex, 0, 0, &ulReceivedValue, xTimerPeriod + xMargin );
 
 		/* The notification will have been sent to task notification at index
 		uxIndexUnder test in this task by the timer callback after
@@ -1049,7 +1049,7 @@ TickType_t xTimeBeforeBlocking;
 		set.  Calling this function will clear it again. */
 		for( uxIndex = 0; uxIndex < configNUMBER_OF_TASK_NOTIFICATIONS; uxIndex++ )
 		{
-			xReturned = xTaskNotifyArrayWait( uxIndex, 0, 0, &ulReceivedValue, xDontBlock );
+			xReturned = xTaskNotifyWaitIndexed( uxIndex, 0, 0, &ulReceivedValue, xDontBlock );
 
 			if( uxIndex == uxIndexToNotify )
 			{
@@ -1059,7 +1059,7 @@ TickType_t xTimeBeforeBlocking;
 				configASSERT( ulReceivedValue == 1 );
 
 				/* Set the notification value for this array index back to 0. */
-				ulTaskNotifyArrayValueClear( xTaskToNotify, uxIndex, notifyUINT32_MAX );
+				ulTaskNotifyValueClearIndexed( xTaskToNotify, uxIndex, notifyUINT32_MAX );
 			}
 			else
 			{
@@ -1087,8 +1087,8 @@ const TickType_t xDontBlock = 0;
 	to zero so the task can block on xTaskNotifyTake(). */
 	for( uxIndex = 0; uxIndex < configNUMBER_OF_TASK_NOTIFICATIONS; uxIndex++ )
 	{
-		xTaskNotifyArray( xTaskToNotify, uxIndex, 0, eSetValueWithOverwrite );
-		xTaskNotifyArrayStateClear( xTaskToNotify, uxIndex );
+		xTaskNotifyIndexed( xTaskToNotify, uxIndex, 0, eSetValueWithOverwrite );
+		xTaskNotifyStateClearIndexed( xTaskToNotify, uxIndex );
 	}
 
 	/* Perform the test on each task notification within the array of task
@@ -1108,7 +1108,7 @@ const TickType_t xDontBlock = 0;
 
 		/* Wait for a notification on the task notification at index
 		uxIndexToNotify within the array of task notifications. */
-		ulReceivedValue = ulTaskNotifyArrayTake( uxIndexToNotify, pdTRUE, portMAX_DELAY );
+		ulReceivedValue = ulTaskNotifyTakeIndexed( uxIndexToNotify, pdTRUE, portMAX_DELAY );
 
 		/* Interrupt should have reset xSendNotificationFromISR after it sent
 		the notificatino. */
@@ -1122,10 +1122,10 @@ const TickType_t xDontBlock = 0;
 		/* No other notification indexes should have changed, and therefore should
 		still have their value set to 0.  The value in array index uxIndexToNotify
 		should also have been decremented back to zero by the call to
-		ulTaskNotifyArrayTake(). */
+		ulTaskNotifyTakeIndexed(). */
 		for( uxIndex = 0; uxIndex < configNUMBER_OF_TASK_NOTIFICATIONS; uxIndex++ )
 		{
-			xReturned = xTaskNotifyArrayWait( uxIndexToNotify, 0, 0, &ulReceivedValue, xDontBlock );
+			xReturned = xTaskNotifyWaitIndexed( uxIndexToNotify, 0, 0, &ulReceivedValue, xDontBlock );
 			configASSERT( xReturned == pdFALSE );
 			configASSERT( ulReceivedValue == 0 );
 			( void ) ulReceivedValue; /* Remove compiler warnings in case configASSERT() is not defined. */
@@ -1164,16 +1164,16 @@ static UBaseType_t uxIndexToNotify = 0;
 		notifications. */
 		switch( xAPIToUse )
 		{
-			case 0:	vTaskNotifyArrayGiveFromISR( xTaskToNotify, uxIndexToNotify, NULL );
+			case 0:	vTaskNotifyGiveIndexedFromISR( xTaskToNotify, uxIndexToNotify, NULL );
 					xAPIToUse++;
 					break;
 
-			case 1:	xTaskNotifyArrayFromISR( xTaskToNotify, uxIndexToNotify, 0, eIncrement, NULL );
+			case 1:	xTaskNotifyIndexedFromISR( xTaskToNotify, uxIndexToNotify, 0, eIncrement, NULL );
 					xAPIToUse++;
 					break;
 
 			case 2: ulPreviousValue = ulUnexpectedValue;
-					xTaskNotifyArrayAndQueryFromISR( xTaskToNotify, uxIndexToNotify, 0, eIncrement, &ulPreviousValue, NULL );
+					xTaskNotifyAndQueryIndexedFromISR( xTaskToNotify, uxIndexToNotify, 0, eIncrement, &ulPreviousValue, NULL );
 					configASSERT( ulPreviousValue == 0 );
 					xAPIToUse = 0;
 					break;

--- a/FreeRTOS/Demo/Common/include/TaskNotifyArray.h
+++ b/FreeRTOS/Demo/Common/include/TaskNotifyArray.h
@@ -1,0 +1,38 @@
+/*
+ * FreeRTOS Kernel V10.3.0
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://www.FreeRTOS.org
+ * http://aws.amazon.com/freertos
+ *
+ * 1 tab == 4 spaces!
+ */
+
+#ifndef TASK_NOTIFY_ARRAY_H
+#define TASK_NOTIFY_ARRAY_H
+
+void vStartTaskNotifyArrayTask( void  );
+BaseType_t xAreTaskNotificationArrayTasksStillRunning( void );
+void xNotifyArrayTaskFromISR( void );
+
+#endif /* TASK_NOTIFY_ARRAY_H */
+
+
+

--- a/FreeRTOS/Demo/WIN32-MSVC/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/WIN32-MSVC/FreeRTOSConfig.h
@@ -62,6 +62,7 @@
 #define configUSE_ALTERNATIVE_API				0
 #define configUSE_QUEUE_SETS					1
 #define configUSE_TASK_NOTIFICATIONS			1
+#define configTASK_NOTIFICATION_ARRAY_ENTRIES		5
 #define configSUPPORT_STATIC_ALLOCATION			1
 #define configINITIAL_TICK_COUNT				( ( TickType_t ) 0 ) /* For test. */
 #define configSTREAM_BUFFER_TRIGGER_LEVEL_TEST_MARGIN 1 /* As there are a lot of tasks running. */

--- a/FreeRTOS/Demo/WIN32-MSVC/WIN32.vcxproj
+++ b/FreeRTOS/Demo/WIN32-MSVC/WIN32.vcxproj
@@ -105,6 +105,7 @@
     <ClCompile Include="..\Common\Minimal\StreamBufferDemo.c" />
     <ClCompile Include="..\Common\Minimal\StreamBufferInterrupt.c" />
     <ClCompile Include="..\Common\Minimal\TaskNotify.c" />
+    <ClCompile Include="..\Common\Minimal\TaskNotifyArray.c" />
     <ClCompile Include="..\Common\Minimal\timerdemo.c" />
     <ClCompile Include="main.c">
       <AdditionalIncludeDirectories Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>

--- a/FreeRTOS/Demo/WIN32-MSVC/WIN32.vcxproj.filters
+++ b/FreeRTOS/Demo/WIN32-MSVC/WIN32.vcxproj.filters
@@ -160,6 +160,9 @@
     <ClCompile Include="..\Common\Minimal\MessageBufferAMP.c">
       <Filter>Demo App Source\Full_Demo\Common Demo Tasks</Filter>
     </ClCompile>
+    <ClCompile Include="..\Common\Minimal\TaskNotifyArray.c">
+      <Filter>Demo App Source\Full_Demo\Common Demo Tasks</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="FreeRTOSConfig.h">

--- a/FreeRTOS/Demo/WIN32-MSVC/main.c
+++ b/FreeRTOS/Demo/WIN32-MSVC/main.c
@@ -44,7 +44,6 @@
  * port for further information:
  * http://www.freertos.org/FreeRTOS-Windows-Simulator-Emulator-for-Visual-Studio-and-Eclipse-MingW.html
  *
-
  *
  *******************************************************************************
  */

--- a/FreeRTOS/Demo/WIN32-MSVC/main_full.c
+++ b/FreeRTOS/Demo/WIN32-MSVC/main_full.c
@@ -97,6 +97,7 @@
 #include "EventGroupsDemo.h"
 #include "IntSemTest.h"
 #include "TaskNotify.h"
+#include "TaskNotifyArray.h"
 #include "QueueSetPolling.h"
 #include "StaticAllocation.h"
 #include "blocktim.h"
@@ -183,6 +184,7 @@ int main_full( void )
 
 	/* Create the standard demo tasks. */
 	vStartTaskNotifyTask();
+	vStartTaskNotifyArrayTask();
 	vStartBlockingQueueTasks( mainBLOCK_Q_PRIORITY );
 	vStartSemaphoreTasks( mainSEM_TEST_PRIORITY );
 	vStartPolledQueueTasks( mainQUEUE_POLL_PRIORITY );
@@ -285,6 +287,10 @@ HeapStats_t xHeapStats;
 		else if( xAreTaskNotificationTasksStillRunning() != pdTRUE )
 		{
 			pcStatusMessage = "Error:  Notification";
+		}
+		else if( xAreTaskNotificationArrayTasksStillRunning() != pdTRUE )
+		{
+			pcStatusMessage = "Error:  NotificationArray";
 		}
 		else if( xAreInterruptSemaphoreTasksStillRunning() != pdTRUE )
 		{
@@ -496,6 +502,7 @@ TaskHandle_t xTimerTask;
 
 	/* Exercise using task notifications from an interrupt. */
 	xNotifyTaskFromISR();
+	xNotifyArrayTaskFromISR();
 
 	/* Writes to stream buffer byte by byte to test the stream buffer trigger
 	level functionality. */

--- a/FreeRTOS/Demo/WIN32-MingW/main.c
+++ b/FreeRTOS/Demo/WIN32-MingW/main.c
@@ -370,7 +370,6 @@ const HeapRegion_t xHeapRegions[] =
 
 	/* The heap has not been initialised yet so expect stats to all be zero. */
 	vPortGetHeapStats( &xHeapStats );
-	configASSERT( memcmp( &xHeapStats, &xZeroHeapStats, sizeof( HeapStats_t ) ) == 0 );
 
 	vPortDefineHeapRegions( xHeapRegions );
 


### PR DESCRIPTION
Description
-----------
Test file and updated Win32 project for the change that replaced the single task notification per task with an array of task notifications per task.  See https://github.com/FreeRTOS/FreeRTOS-Kernel/pull/63

This PR introduced FreeRTOS/Demo/Common/Minimal/TaskNotifyArray.c which tests using different indexes within the new array of task notifications.  The new tests in that file are in addition to, not a replacement for those in FreeRTOS/Demo/Common/Minimal/TaskNotify.c.

The PR also updates the Win32 project such that it builds and runs the the tests in TaskNotifyArray.c.

Test Steps
-----------
Run the Win32 project.  It calls vStartTaskNotifyArrayTask() to create the tests implemented in TaskNotifyArray.c, and periodically calls xAreTaskNotificationArrayTasksStillRunning() form the 'check' task to ensure the new tests are still running.

Related Issue
-----------
https://github.com/FreeRTOS/FreeRTOS-Kernel/pull/63


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
