### PR TITLE
BlockQ.c: Swap two tasks to conform the task priority

### DIFF
--- a/FreeRTOS/Demo/Common/Full/BlockQ.c
+++ b/FreeRTOS/Demo/Common/Full/BlockQ.c
@@ -170,8 +170,8 @@ const TickType_t xDontBlock = ( TickType_t ) 0;
 	pxQueueParameters4->xBlockTime = xBlockTime;
 	pxQueueParameters4->psCheckVariable = &( sBlockingConsumerCount[ 1 ] );
 
-	xTaskCreate( vBlockingQueueProducer, "QProdB3", blckqSTACK_SIZE, ( void * ) pxQueueParameters3, tskIDLE_PRIORITY, NULL );
-	xTaskCreate( vBlockingQueueConsumer, "QConsB4", blckqSTACK_SIZE, ( void * ) pxQueueParameters4, uxPriority, NULL );
+	xTaskCreate( vBlockingQueueConsumer, "QConsB3", blckqSTACK_SIZE, ( void * ) pxQueueParameters3, tskIDLE_PRIORITY, NULL );
+	xTaskCreate( vBlockingQueueProducer, "QProdB4", blckqSTACK_SIZE, ( void * ) pxQueueParameters4, uxPriority, NULL );
 
 
 


### PR DESCRIPTION
<!--- Title -->

Description
-----------
According to the comment just above the change, "QConsB" should have the idle priority since "QConsB1" has a custom priority, `uxPriority`. Moreover, [the same code section](https://github.com/FreeRTOS/FreeRTOS/blob/master/FreeRTOS/Demo/Common/Minimal/BlockQ.c#L155) in another folder shows this application intends to test the consumer/producer at different priority setting.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
