### PR TITLE
Remove Empty and Un-referenced folder from FreeRTOS-Plus/Demo

### DIFF
--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_UDP_CLI_FAT_SL_SAM4E_Atmel_Studio/ReadMe.txt
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_UDP_CLI_FAT_SL_SAM4E_Atmel_Studio/ReadMe.txt
@@ -1,4 +1,0 @@
-FreeRTOS+UDP was removed in FreeRTOS V10.1.0 as it was replaced by FreeRTOS+TCP,
-which was brought into the main download in FreeRTOS V10.0.0.  FreeRTOS+TCP can
-be configured as a UDP only stack, and FreeRTOS+UDP does not contain the patches
-applied to FreeRTOS+TCP.

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_UDP_CLI_FAT_SL_SAM4E_Atmel_Studio/See also FreeRTOS+TCP.url
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_UDP_CLI_FAT_SL_SAM4E_Atmel_Studio/See also FreeRTOS+TCP.url
@@ -1,5 +1,0 @@
-[{000214A0-0000-0000-C000-000000000046}]
-Prop3=19,2
-[InternetShortcut]
-URL=http://www.freertos.org/FreeRTOS-Plus/FreeRTOS_Plus_TCP/index.html
-IDList=


### PR DESCRIPTION
Description
-----------
This is a part of ongoing effort to cleanup the +TCP library and related segments of it. 
In the [FreeRTOS+/Demo folder](https://github.com/FreeRTOS/FreeRTOS/tree/master/FreeRTOS-Plus/Demo), there are 4 directories which are empty with a README saying that this demo has been removed. Out of these 4 Demo directories, 3 are referenced on FreeRTOS.org and cannot be directly removed. See details below.
- [FreeRTOS_Plus_UDP_CLI_FAT_SL_SAM4E_Atmel_Studio](https://github.com/FreeRTOS/FreeRTOS/tree/master/FreeRTOS-Plus/Demo/FreeRTOS_Plus_UDP_CLI_FAT_SL_SAM4E_Atmel_Studio).....: [This page](https://freertos.org/Atmel_SAM4E_RTOS_Demo.html#DemoApp) talks about but never references the Demo.
- [FreeRTOS_Plus_UDP_and_CLI_LPC1830_GCC](https://github.com/FreeRTOS/FreeRTOS/tree/master/FreeRTOS-Plus/Demo/FreeRTOS_Plus_UDP_and_CLI_LPC1830_GCC)..........................: Referenced [here](https://freertos.org/FreeRTOS-Plus/FreeRTOS_Plus_UDP/Embedded_Ethernet_Examples/RTOS_UDP_and_CLI_LPC1830_NGX.html).
- [FreeRTOS_Plus_UDP_and_CLI_Windows_Simulator](https://github.com/FreeRTOS/FreeRTOS/tree/master/FreeRTOS-Plus/Demo/FreeRTOS_Plus_UDP_and_CLI_Windows_Simulator)..............: Referenced [here](https://freertos.org/FreeRTOS-Plus/FreeRTOS_Plus_UDP/Embedded_Ethernet_Examples/RTOS_UDP_CLI_Windows_Simulator.html).
- [FreeRTOS_Plus_FAT_SL_and_CLI_Windows_Simulator](https://github.com/FreeRTOS/FreeRTOS/tree/master/FreeRTOS-Plus/Demo/FreeRTOS_Plus_FAT_SL_and_CLI_Windows_Simulator)..........: Referenced [here](https://freertos.org/FreeRTOS-Plus/FreeRTOS_Plus_FAT_SL/Demos/File_System_Win32_Simulator_demo.html).

The first Demo however is not referenced anywhere. It is therefore being removed. The other Demos will be either removed or replaced later in subsequent PRs.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
