### PR TITLE
Fixed Imports for Infineon XMC1100 Board

### DIFF
--- a/FreeRTOS/Demo/CORTEX_M0_Infineon_XMC1000_IAR_Keil_GCC/main-blinky.c
+++ b/FreeRTOS/Demo/CORTEX_M0_Infineon_XMC1000_IAR_Keil_GCC/main-blinky.c
@@ -68,7 +68,7 @@
 #include "queue.h"
 
 /* Demo includes. */
-#include "ParTest.h"
+#include "partest.h"
 
 /* Priorities at which the tasks are created. */
 #define mainQUEUE_RECEIVE_TASK_PRIORITY		( tskIDLE_PRIORITY + 2 )

--- a/FreeRTOS/Demo/CORTEX_M0_Infineon_XMC1000_IAR_Keil_GCC/main-full.c
+++ b/FreeRTOS/Demo/CORTEX_M0_Infineon_XMC1000_IAR_Keil_GCC/main-full.c
@@ -86,7 +86,7 @@
 #include "blocktim.h"
 #include "countsem.h"
 #include "recmutex.h"
-#include "ParTest.h"
+#include "partest.h"
 #include "dynamic.h"
 #include "QueueOverwrite.h"
 #include "QueueSet.h"

--- a/FreeRTOS/Demo/CORTEX_M0_Infineon_XMC1000_IAR_Keil_GCC/main.c
+++ b/FreeRTOS/Demo/CORTEX_M0_Infineon_XMC1000_IAR_Keil_GCC/main.c
@@ -51,7 +51,7 @@
 #include "semphr.h"
 
 /* Demo application include. */
-#include "ParTest.h"
+#include "partest.h"
 #include "QueueSet.h"
 
 /* Set mainCREATE_SIMPLE_BLINKY_DEMO_ONLY to one to run the simple blinky demo,


### PR DESCRIPTION
Fixed Imports for Infineon XMC1100 Board

Description
-----------
Changed the imports from "ParTest.h" to "partest.h" in order to be getting found.

Test Steps
-----------
Run the build process.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
