### PR TITLE
Maintenance: version bump

### DIFF
--- a/FreeRTOS-Plus/Demo/Common/FreeRTOS_Plus_CLI_Demos/File-Related-CLI-commands.c
+++ b/FreeRTOS-Plus/Demo/Common/FreeRTOS_Plus_CLI_Demos/File-Related-CLI-commands.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS-Plus/Demo/Common/FreeRTOS_Plus_CLI_Demos/Sample-CLI-commands.c
+++ b/FreeRTOS-Plus/Demo/Common/FreeRTOS_Plus_CLI_Demos/Sample-CLI-commands.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS-Plus/Demo/Common/FreeRTOS_Plus_CLI_Demos/UARTCommandConsole.c
+++ b/FreeRTOS-Plus/Demo/Common/FreeRTOS_Plus_CLI_Demos/UARTCommandConsole.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS-Plus/Demo/Common/FreeRTOS_Plus_CLI_Demos/UDP-Related-CLI-commands.c
+++ b/FreeRTOS-Plus/Demo/Common/FreeRTOS_Plus_CLI_Demos/UDP-Related-CLI-commands.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS-Plus/Demo/Common/FreeRTOS_Plus_FAT_SL_Demos/CreateExampleFiles/File-system-demo.c
+++ b/FreeRTOS-Plus/Demo/Common/FreeRTOS_Plus_FAT_SL_Demos/CreateExampleFiles/File-system-demo.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS-Plus/Demo/Common/FreeRTOS_Plus_UDP_Demos/CLICommands/CLI-commands.c
+++ b/FreeRTOS-Plus/Demo/Common/FreeRTOS_Plus_UDP_Demos/CLICommands/CLI-commands.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS-Plus/Demo/Common/FreeRTOS_Plus_UDP_Demos/CLICommands/UDPCommandInterpreter.h
+++ b/FreeRTOS-Plus/Demo/Common/FreeRTOS_Plus_UDP_Demos/CLICommands/UDPCommandInterpreter.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS-Plus/Demo/Common/FreeRTOS_Plus_UDP_Demos/CLICommands/UDPCommandServer.c
+++ b/FreeRTOS-Plus/Demo/Common/FreeRTOS_Plus_UDP_Demos/CLICommands/UDPCommandServer.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS-Plus/Demo/Common/FreeRTOS_Plus_UDP_Demos/EchoClients/TwoEchoClients.c
+++ b/FreeRTOS-Plus/Demo/Common/FreeRTOS_Plus_UDP_Demos/EchoClients/TwoEchoClients.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS-Plus/Demo/Common/FreeRTOS_Plus_UDP_Demos/EchoClients/TwoEchoClients.h
+++ b/FreeRTOS-Plus/Demo/Common/FreeRTOS_Plus_UDP_Demos/EchoClients/TwoEchoClients.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS-Plus/Demo/Common/FreeRTOS_Plus_UDP_Demos/TraceMacros/Example1/DemoIPTrace.c
+++ b/FreeRTOS-Plus/Demo/Common/FreeRTOS_Plus_UDP_Demos/TraceMacros/Example1/DemoIPTrace.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS-Plus/Demo/Common/FreeRTOS_Plus_UDP_Demos/TraceMacros/Example1/DemoIPTrace.h
+++ b/FreeRTOS-Plus/Demo/Common/FreeRTOS_Plus_UDP_Demos/TraceMacros/Example1/DemoIPTrace.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_CLI_with_Trace_Windows_Simulator/CLI-commands.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_CLI_with_Trace_Windows_Simulator/CLI-commands.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_CLI_with_Trace_Windows_Simulator/FreeRTOSConfig.h
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_CLI_with_Trace_Windows_Simulator/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_CLI_with_Trace_Windows_Simulator/Run-time-stats-utils.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_CLI_with_Trace_Windows_Simulator/Run-time-stats-utils.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_CLI_with_Trace_Windows_Simulator/UDPCommandServer.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_CLI_with_Trace_Windows_Simulator/UDPCommandServer.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_CLI_with_Trace_Windows_Simulator/main.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_CLI_with_Trace_Windows_Simulator/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_Reliance_Edge_and_CLI_Windows_Simulator/ConfigurationFiles/FreeRTOSConfig.h
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_Reliance_Edge_and_CLI_Windows_Simulator/ConfigurationFiles/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_Reliance_Edge_and_CLI_Windows_Simulator/File-Related-CLI-commands.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_Reliance_Edge_and_CLI_Windows_Simulator/File-Related-CLI-commands.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_Reliance_Edge_and_CLI_Windows_Simulator/File-system-demo.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_Reliance_Edge_and_CLI_Windows_Simulator/File-system-demo.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_Reliance_Edge_and_CLI_Windows_Simulator/Run-time-stats-utils.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_Reliance_Edge_and_CLI_Windows_Simulator/Run-time-stats-utils.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_Reliance_Edge_and_CLI_Windows_Simulator/Sample-CLI-commands.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_Reliance_Edge_and_CLI_Windows_Simulator/Sample-CLI-commands.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_Reliance_Edge_and_CLI_Windows_Simulator/UDPCommandServer.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_Reliance_Edge_and_CLI_Windows_Simulator/UDPCommandServer.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_Reliance_Edge_and_CLI_Windows_Simulator/main.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_Reliance_Edge_and_CLI_Windows_Simulator/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Minimal_Windows_Simulator/DemoTasks/SimpleUDPClientAndServer.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Minimal_Windows_Simulator/DemoTasks/SimpleUDPClientAndServer.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Minimal_Windows_Simulator/DemoTasks/TCPEchoClient_SingleTasks.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Minimal_Windows_Simulator/DemoTasks/TCPEchoClient_SingleTasks.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Minimal_Windows_Simulator/DemoTasks/include/SimpleUDPClientAndServer.h
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Minimal_Windows_Simulator/DemoTasks/include/SimpleUDPClientAndServer.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Minimal_Windows_Simulator/DemoTasks/include/TCPEchoClient_SingleTasks.h
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Minimal_Windows_Simulator/DemoTasks/include/TCPEchoClient_SingleTasks.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Minimal_Windows_Simulator/FreeRTOSConfig.h
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Minimal_Windows_Simulator/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Minimal_Windows_Simulator/FreeRTOSIPConfig.h
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Minimal_Windows_Simulator/FreeRTOSIPConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Minimal_Windows_Simulator/WinPCap/arch.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Minimal_Windows_Simulator/WinPCap/arch.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Minimal_Windows_Simulator/WinPCap/netif.h
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Minimal_Windows_Simulator/WinPCap/netif.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Minimal_Windows_Simulator/demo_logging.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Minimal_Windows_Simulator/demo_logging.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Minimal_Windows_Simulator/demo_logging.h
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Minimal_Windows_Simulator/demo_logging.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Minimal_Windows_Simulator/main.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Minimal_Windows_Simulator/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_WolfSSL_Windows_Simulator/FreeRTOSConfig.h
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_WolfSSL_Windows_Simulator/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_WolfSSL_Windows_Simulator/SecureTCPClientTask.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_WolfSSL_Windows_Simulator/SecureTCPClientTask.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_WolfSSL_Windows_Simulator/SecureTCPServerTask.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_WolfSSL_Windows_Simulator/SecureTCPServerTask.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_WolfSSL_Windows_Simulator/main.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_WolfSSL_Windows_Simulator/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM7_AT91FR40008_GCC/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/ARM7_AT91FR40008_GCC/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM7_AT91FR40008_GCC/Makefile
+++ b/FreeRTOS/Demo/ARM7_AT91FR40008_GCC/Makefile
@@ -1,5 +1,5 @@
 #/*
-# * FreeRTOS Kernel V10.3.0
+# * FreeRTOS Kernel V10.3.1
 # * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 # *
 # * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM7_AT91FR40008_GCC/ParTest/ParTest.c
+++ b/FreeRTOS/Demo/ARM7_AT91FR40008_GCC/ParTest/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM7_AT91FR40008_GCC/main.c
+++ b/FreeRTOS/Demo/ARM7_AT91FR40008_GCC/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM7_AT91FR40008_GCC/serial/serial.c
+++ b/FreeRTOS/Demo/ARM7_AT91FR40008_GCC/serial/serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM7_AT91FR40008_GCC/serial/serialISR.c
+++ b/FreeRTOS/Demo/ARM7_AT91FR40008_GCC/serial/serialISR.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM7_AT91SAM7S64_IAR/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/ARM7_AT91SAM7S64_IAR/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM7_AT91SAM7S64_IAR/ParTest/ParTest.c
+++ b/FreeRTOS/Demo/ARM7_AT91SAM7S64_IAR/ParTest/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM7_AT91SAM7S64_IAR/USB/USBSample.c
+++ b/FreeRTOS/Demo/ARM7_AT91SAM7S64_IAR/USB/USBSample.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM7_AT91SAM7S64_IAR/main.c
+++ b/FreeRTOS/Demo/ARM7_AT91SAM7S64_IAR/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM7_AT91SAM7S64_IAR/serial/serial.c
+++ b/FreeRTOS/Demo/ARM7_AT91SAM7S64_IAR/serial/serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM7_LPC2106_GCC/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/ARM7_LPC2106_GCC/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM7_LPC2106_GCC/Makefile
+++ b/FreeRTOS/Demo/ARM7_LPC2106_GCC/Makefile
@@ -1,5 +1,5 @@
 #/*
-# * FreeRTOS Kernel V10.3.0
+# * FreeRTOS Kernel V10.3.1
 # * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 # *
 # * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM7_LPC2106_GCC/ParTest/ParTest.c
+++ b/FreeRTOS/Demo/ARM7_LPC2106_GCC/ParTest/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM7_LPC2106_GCC/main.c
+++ b/FreeRTOS/Demo/ARM7_LPC2106_GCC/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM7_LPC2106_GCC/serial/serial.c
+++ b/FreeRTOS/Demo/ARM7_LPC2106_GCC/serial/serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM7_LPC2106_GCC/serial/serialISR.c
+++ b/FreeRTOS/Demo/ARM7_LPC2106_GCC/serial/serialISR.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM7_LPC2129_IAR/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/ARM7_LPC2129_IAR/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM7_LPC2129_IAR/ParTest/ParTest.c
+++ b/FreeRTOS/Demo/ARM7_LPC2129_IAR/ParTest/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM7_LPC2129_IAR/main.c
+++ b/FreeRTOS/Demo/ARM7_LPC2129_IAR/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM7_LPC2129_IAR/serial/serial.c
+++ b/FreeRTOS/Demo/ARM7_LPC2129_IAR/serial/serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM7_LPC2129_Keil_RVDS/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/ARM7_LPC2129_Keil_RVDS/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM7_LPC2129_Keil_RVDS/ParTest/ParTest.c
+++ b/FreeRTOS/Demo/ARM7_LPC2129_Keil_RVDS/ParTest/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM7_LPC2129_Keil_RVDS/main.c
+++ b/FreeRTOS/Demo/ARM7_LPC2129_Keil_RVDS/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM7_LPC2129_Keil_RVDS/serial/serial.c
+++ b/FreeRTOS/Demo/ARM7_LPC2129_Keil_RVDS/serial/serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM7_LPC2129_Keil_RVDS/serial/serialISR.s
+++ b/FreeRTOS/Demo/ARM7_LPC2129_Keil_RVDS/serial/serialISR.s
@@ -1,5 +1,5 @@
 ;/*
-; * FreeRTOS Kernel V10.3.0
+; * FreeRTOS Kernel V10.3.1
 ; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 ; *
 ; * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM7_LPC2138_Rowley/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/ARM7_LPC2138_Rowley/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM7_LPC2138_Rowley/main.c
+++ b/FreeRTOS/Demo/ARM7_LPC2138_Rowley/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM7_LPC2138_Rowley/mainISR.c
+++ b/FreeRTOS/Demo/ARM7_LPC2138_Rowley/mainISR.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM7_LPC2368_Eclipse/RTOSDemo/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/ARM7_LPC2368_Eclipse/RTOSDemo/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM7_LPC2368_Eclipse/RTOSDemo/Makefile
+++ b/FreeRTOS/Demo/ARM7_LPC2368_Eclipse/RTOSDemo/Makefile
@@ -1,5 +1,5 @@
 #/*
-# * FreeRTOS Kernel V10.3.0
+# * FreeRTOS Kernel V10.3.1
 # * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 # *
 # * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM7_LPC2368_Eclipse/RTOSDemo/ParTest/ParTest.c
+++ b/FreeRTOS/Demo/ARM7_LPC2368_Eclipse/RTOSDemo/ParTest/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM7_LPC2368_Eclipse/RTOSDemo/main.c
+++ b/FreeRTOS/Demo/ARM7_LPC2368_Eclipse/RTOSDemo/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM7_LPC2368_Eclipse/RTOSDemo/webserver/uIP_Task.c
+++ b/FreeRTOS/Demo/ARM7_LPC2368_Eclipse/RTOSDemo/webserver/uIP_Task.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM7_LPC2368_Rowley/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/ARM7_LPC2368_Rowley/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM7_LPC2368_Rowley/ParTest/ParTest.c
+++ b/FreeRTOS/Demo/ARM7_LPC2368_Rowley/ParTest/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM7_LPC2368_Rowley/main.c
+++ b/FreeRTOS/Demo/ARM7_LPC2368_Rowley/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM7_LPC2368_Rowley/webserver/uIP_Task.c
+++ b/FreeRTOS/Demo/ARM7_LPC2368_Rowley/webserver/uIP_Task.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM7_STR71x_IAR/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/ARM7_STR71x_IAR/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM7_STR71x_IAR/ParTest/ParTest.c
+++ b/FreeRTOS/Demo/ARM7_STR71x_IAR/ParTest/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM7_STR71x_IAR/main.c
+++ b/FreeRTOS/Demo/ARM7_STR71x_IAR/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM7_STR71x_IAR/serial/serial.c
+++ b/FreeRTOS/Demo/ARM7_STR71x_IAR/serial/serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM7_STR75x_GCC/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/ARM7_STR75x_GCC/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM7_STR75x_GCC/ParTest/ParTest.c
+++ b/FreeRTOS/Demo/ARM7_STR75x_GCC/ParTest/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM7_STR75x_GCC/main.c
+++ b/FreeRTOS/Demo/ARM7_STR75x_GCC/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM7_STR75x_GCC/serial/serial.c
+++ b/FreeRTOS/Demo/ARM7_STR75x_GCC/serial/serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM7_STR75x_GCC/serial/serialISR.c
+++ b/FreeRTOS/Demo/ARM7_STR75x_GCC/serial/serialISR.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM7_STR75x_IAR/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/ARM7_STR75x_IAR/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM7_STR75x_IAR/ParTest/ParTest.c
+++ b/FreeRTOS/Demo/ARM7_STR75x_IAR/ParTest/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM7_STR75x_IAR/main.c
+++ b/FreeRTOS/Demo/ARM7_STR75x_IAR/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM7_STR75x_IAR/serial/serial.c
+++ b/FreeRTOS/Demo/ARM7_STR75x_IAR/serial/serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM9_AT91SAM9XE_IAR/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/ARM9_AT91SAM9XE_IAR/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM9_AT91SAM9XE_IAR/ParTest/ParTest.c
+++ b/FreeRTOS/Demo/ARM9_AT91SAM9XE_IAR/ParTest/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM9_AT91SAM9XE_IAR/main.c
+++ b/FreeRTOS/Demo/ARM9_AT91SAM9XE_IAR/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM9_AT91SAM9XE_IAR/serial/serial.c
+++ b/FreeRTOS/Demo/ARM9_AT91SAM9XE_IAR/serial/serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM9_STR91X_IAR/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/ARM9_STR91X_IAR/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM9_STR91X_IAR/ParTest/ParTest.c
+++ b/FreeRTOS/Demo/ARM9_STR91X_IAR/ParTest/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM9_STR91X_IAR/lwip/include/lwIPWebServer/BasicWEB.h
+++ b/FreeRTOS/Demo/ARM9_STR91X_IAR/lwip/include/lwIPWebServer/BasicWEB.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM9_STR91X_IAR/lwip/lwipWebServer/BasicWEB.c
+++ b/FreeRTOS/Demo/ARM9_STR91X_IAR/lwip/lwipWebServer/BasicWEB.c
@@ -1,6 +1,6 @@
 
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM9_STR91X_IAR/main.c
+++ b/FreeRTOS/Demo/ARM9_STR91X_IAR/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM9_STR91X_IAR/serial/serial.c
+++ b/FreeRTOS/Demo/ARM9_STR91X_IAR/serial/serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ARM9_STR91X_IAR/webserver/uIP_Task.c
+++ b/FreeRTOS/Demo/ARM9_STR91X_IAR/webserver/uIP_Task.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/AVR32_UC3/main.c
+++ b/FreeRTOS/Demo/AVR32_UC3/main.c
@@ -30,7 +30,7 @@
  *****************************************************************************/
 
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/AVR_ATMega323_IAR/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/AVR_ATMega323_IAR/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/AVR_ATMega323_IAR/ParTest/ParTest.c
+++ b/FreeRTOS/Demo/AVR_ATMega323_IAR/ParTest/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/AVR_ATMega323_IAR/main.c
+++ b/FreeRTOS/Demo/AVR_ATMega323_IAR/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/AVR_ATMega323_IAR/regtest.c
+++ b/FreeRTOS/Demo/AVR_ATMega323_IAR/regtest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/AVR_ATMega323_IAR/regtest.h
+++ b/FreeRTOS/Demo/AVR_ATMega323_IAR/regtest.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/AVR_ATMega323_IAR/serial/serial.c
+++ b/FreeRTOS/Demo/AVR_ATMega323_IAR/serial/serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/AVR_ATMega323_WinAVR/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/AVR_ATMega323_WinAVR/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/AVR_ATMega323_WinAVR/ParTest/ParTest.c
+++ b/FreeRTOS/Demo/AVR_ATMega323_WinAVR/ParTest/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/AVR_ATMega323_WinAVR/main.c
+++ b/FreeRTOS/Demo/AVR_ATMega323_WinAVR/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/AVR_ATMega323_WinAVR/regtest.c
+++ b/FreeRTOS/Demo/AVR_ATMega323_WinAVR/regtest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/AVR_ATMega323_WinAVR/regtest.h
+++ b/FreeRTOS/Demo/AVR_ATMega323_WinAVR/regtest.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/AVR_ATMega323_WinAVR/serial/serial.c
+++ b/FreeRTOS/Demo/AVR_ATMega323_WinAVR/serial/serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/AVR_ATmega328PB_Xplained_mini_GCC/RTOSDemo/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/AVR_ATmega328PB_Xplained_mini_GCC/RTOSDemo/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/AVR_ATmega328PB_Xplained_mini_GCC/RTOSDemo/ParTest.c
+++ b/FreeRTOS/Demo/AVR_ATmega328PB_Xplained_mini_GCC/RTOSDemo/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/AVR_ATmega328PB_Xplained_mini_GCC/RTOSDemo/main.c
+++ b/FreeRTOS/Demo/AVR_ATmega328PB_Xplained_mini_GCC/RTOSDemo/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/AVR_ATmega328PB_Xplained_mini_GCC/RTOSDemo/regtest.c
+++ b/FreeRTOS/Demo/AVR_ATmega328PB_Xplained_mini_GCC/RTOSDemo/regtest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/AVR_ATmega328PB_Xplained_mini_GCC/RTOSDemo/regtest.h
+++ b/FreeRTOS/Demo/AVR_ATmega328PB_Xplained_mini_GCC/RTOSDemo/regtest.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A2F200_IAR_and_Keil/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_A2F200_IAR_and_Keil/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A2F200_IAR_and_Keil/ParTest.c
+++ b/FreeRTOS/Demo/CORTEX_A2F200_IAR_and_Keil/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A2F200_IAR_and_Keil/main-blinky.c
+++ b/FreeRTOS/Demo/CORTEX_A2F200_IAR_and_Keil/main-blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A2F200_IAR_and_Keil/main-full.c
+++ b/FreeRTOS/Demo/CORTEX_A2F200_IAR_and_Keil/main-full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A2F200_IAR_and_Keil/uIP_Task.c
+++ b/FreeRTOS/Demo/CORTEX_A2F200_IAR_and_Keil/uIP_Task.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A2F200_SoftConsole/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_A2F200_SoftConsole/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A2F200_SoftConsole/ParTest.c
+++ b/FreeRTOS/Demo/CORTEX_A2F200_SoftConsole/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A2F200_SoftConsole/main-blinky.c
+++ b/FreeRTOS/Demo/CORTEX_A2F200_SoftConsole/main-blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A2F200_SoftConsole/main-full.c
+++ b/FreeRTOS/Demo/CORTEX_A2F200_SoftConsole/main-full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A2F200_SoftConsole/uIP_Task.c
+++ b/FreeRTOS/Demo/CORTEX_A2F200_SoftConsole/uIP_Task.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A53_64-bit_UltraScale_MPSoC/RTOSDemo_A53/src/Blinky_Demo/main_blinky.c
+++ b/FreeRTOS/Demo/CORTEX_A53_64-bit_UltraScale_MPSoC/RTOSDemo_A53/src/Blinky_Demo/main_blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A53_64-bit_UltraScale_MPSoC/RTOSDemo_A53/src/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_A53_64-bit_UltraScale_MPSoC/RTOSDemo_A53/src/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A53_64-bit_UltraScale_MPSoC/RTOSDemo_A53/src/FreeRTOS_tick_config.c
+++ b/FreeRTOS/Demo/CORTEX_A53_64-bit_UltraScale_MPSoC/RTOSDemo_A53/src/FreeRTOS_tick_config.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A53_64-bit_UltraScale_MPSoC/RTOSDemo_A53/src/Full_Demo/IntQueueTimer.c
+++ b/FreeRTOS/Demo/CORTEX_A53_64-bit_UltraScale_MPSoC/RTOSDemo_A53/src/Full_Demo/IntQueueTimer.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A53_64-bit_UltraScale_MPSoC/RTOSDemo_A53/src/Full_Demo/IntQueueTimer.h
+++ b/FreeRTOS/Demo/CORTEX_A53_64-bit_UltraScale_MPSoC/RTOSDemo_A53/src/Full_Demo/IntQueueTimer.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A53_64-bit_UltraScale_MPSoC/RTOSDemo_A53/src/Full_Demo/main_full.c
+++ b/FreeRTOS/Demo/CORTEX_A53_64-bit_UltraScale_MPSoC/RTOSDemo_A53/src/Full_Demo/main_full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A53_64-bit_UltraScale_MPSoC/RTOSDemo_A53/src/Full_Demo/reg_test.S
+++ b/FreeRTOS/Demo/CORTEX_A53_64-bit_UltraScale_MPSoC/RTOSDemo_A53/src/Full_Demo/reg_test.S
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A53_64-bit_UltraScale_MPSoC/RTOSDemo_A53/src/main.c
+++ b/FreeRTOS/Demo/CORTEX_A53_64-bit_UltraScale_MPSoC/RTOSDemo_A53/src/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A5_SAMA5D2x_Xplained_IAR/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_A5_SAMA5D2x_Xplained_IAR/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A5_SAMA5D2x_Xplained_IAR/FreeRTOS_tick_config.c
+++ b/FreeRTOS/Demo/CORTEX_A5_SAMA5D2x_Xplained_IAR/FreeRTOS_tick_config.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A5_SAMA5D2x_Xplained_IAR/Full_Demo/IntQueueTimer.c
+++ b/FreeRTOS/Demo/CORTEX_A5_SAMA5D2x_Xplained_IAR/Full_Demo/IntQueueTimer.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A5_SAMA5D2x_Xplained_IAR/Full_Demo/IntQueueTimer.h
+++ b/FreeRTOS/Demo/CORTEX_A5_SAMA5D2x_Xplained_IAR/Full_Demo/IntQueueTimer.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A5_SAMA5D2x_Xplained_IAR/Full_Demo/main_full.c
+++ b/FreeRTOS/Demo/CORTEX_A5_SAMA5D2x_Xplained_IAR/Full_Demo/main_full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A5_SAMA5D2x_Xplained_IAR/Full_Demo/reg_test.S
+++ b/FreeRTOS/Demo/CORTEX_A5_SAMA5D2x_Xplained_IAR/Full_Demo/reg_test.S
@@ -1,5 +1,5 @@
 ;/*
-; * FreeRTOS Kernel V10.3.0
+; * FreeRTOS Kernel V10.3.1
 ; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 ; *
 ; * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A5_SAMA5D2x_Xplained_IAR/LEDs.c
+++ b/FreeRTOS/Demo/CORTEX_A5_SAMA5D2x_Xplained_IAR/LEDs.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A5_SAMA5D2x_Xplained_IAR/blinky_demo/main_blinky.c
+++ b/FreeRTOS/Demo/CORTEX_A5_SAMA5D2x_Xplained_IAR/blinky_demo/main_blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A5_SAMA5D2x_Xplained_IAR/main.c
+++ b/FreeRTOS/Demo/CORTEX_A5_SAMA5D2x_Xplained_IAR/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A5_SAMA5D3x_Xplained_IAR/CDCCommandConsole.c
+++ b/FreeRTOS/Demo/CORTEX_A5_SAMA5D3x_Xplained_IAR/CDCCommandConsole.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A5_SAMA5D3x_Xplained_IAR/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_A5_SAMA5D3x_Xplained_IAR/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A5_SAMA5D3x_Xplained_IAR/FreeRTOS_tick_config.c
+++ b/FreeRTOS/Demo/CORTEX_A5_SAMA5D3x_Xplained_IAR/FreeRTOS_tick_config.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A5_SAMA5D3x_Xplained_IAR/Full_Demo/IntQueueTimer.c
+++ b/FreeRTOS/Demo/CORTEX_A5_SAMA5D3x_Xplained_IAR/Full_Demo/IntQueueTimer.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A5_SAMA5D3x_Xplained_IAR/Full_Demo/IntQueueTimer.h
+++ b/FreeRTOS/Demo/CORTEX_A5_SAMA5D3x_Xplained_IAR/Full_Demo/IntQueueTimer.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A5_SAMA5D3x_Xplained_IAR/Full_Demo/main_full.c
+++ b/FreeRTOS/Demo/CORTEX_A5_SAMA5D3x_Xplained_IAR/Full_Demo/main_full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A5_SAMA5D3x_Xplained_IAR/Full_Demo/reg_test.S
+++ b/FreeRTOS/Demo/CORTEX_A5_SAMA5D3x_Xplained_IAR/Full_Demo/reg_test.S
@@ -1,5 +1,5 @@
 ;/*
-; * FreeRTOS Kernel V10.3.0
+; * FreeRTOS Kernel V10.3.1
 ; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 ; *
 ; * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A5_SAMA5D3x_Xplained_IAR/LEDs.c
+++ b/FreeRTOS/Demo/CORTEX_A5_SAMA5D3x_Xplained_IAR/LEDs.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A5_SAMA5D3x_Xplained_IAR/blinky_demo/main_blinky.c
+++ b/FreeRTOS/Demo/CORTEX_A5_SAMA5D3x_Xplained_IAR/blinky_demo/main_blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A5_SAMA5D3x_Xplained_IAR/main.c
+++ b/FreeRTOS/Demo/CORTEX_A5_SAMA5D3x_Xplained_IAR/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A5_SAMA5D4x_EK_IAR/Blinky_Demo/main_blinky.c
+++ b/FreeRTOS/Demo/CORTEX_A5_SAMA5D4x_EK_IAR/Blinky_Demo/main_blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A5_SAMA5D4x_EK_IAR/CDCCommandConsole.c
+++ b/FreeRTOS/Demo/CORTEX_A5_SAMA5D4x_EK_IAR/CDCCommandConsole.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A5_SAMA5D4x_EK_IAR/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_A5_SAMA5D4x_EK_IAR/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A5_SAMA5D4x_EK_IAR/FreeRTOS_tick_config.c
+++ b/FreeRTOS/Demo/CORTEX_A5_SAMA5D4x_EK_IAR/FreeRTOS_tick_config.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A5_SAMA5D4x_EK_IAR/Full_Demo/IntQueueTimer.c
+++ b/FreeRTOS/Demo/CORTEX_A5_SAMA5D4x_EK_IAR/Full_Demo/IntQueueTimer.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A5_SAMA5D4x_EK_IAR/Full_Demo/IntQueueTimer.h
+++ b/FreeRTOS/Demo/CORTEX_A5_SAMA5D4x_EK_IAR/Full_Demo/IntQueueTimer.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A5_SAMA5D4x_EK_IAR/Full_Demo/main_full.c
+++ b/FreeRTOS/Demo/CORTEX_A5_SAMA5D4x_EK_IAR/Full_Demo/main_full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A5_SAMA5D4x_EK_IAR/Full_Demo/reg_test.S
+++ b/FreeRTOS/Demo/CORTEX_A5_SAMA5D4x_EK_IAR/Full_Demo/reg_test.S
@@ -1,5 +1,5 @@
 ;/*
-; * FreeRTOS Kernel V10.3.0
+; * FreeRTOS Kernel V10.3.1
 ; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 ; *
 ; * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A5_SAMA5D4x_EK_IAR/LEDs.c
+++ b/FreeRTOS/Demo/CORTEX_A5_SAMA5D4x_EK_IAR/LEDs.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A5_SAMA5D4x_EK_IAR/main.c
+++ b/FreeRTOS/Demo/CORTEX_A5_SAMA5D4x_EK_IAR/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A9_Cyclone_V_SoC_DK/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_A9_Cyclone_V_SoC_DK/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A9_Cyclone_V_SoC_DK/LEDs.c
+++ b/FreeRTOS/Demo/CORTEX_A9_Cyclone_V_SoC_DK/LEDs.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A9_Cyclone_V_SoC_DK/main.c
+++ b/FreeRTOS/Demo/CORTEX_A9_Cyclone_V_SoC_DK/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A9_Cyclone_V_SoC_DK/main_blinky.c
+++ b/FreeRTOS/Demo/CORTEX_A9_Cyclone_V_SoC_DK/main_blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A9_Cyclone_V_SoC_DK/main_full.c
+++ b/FreeRTOS/Demo/CORTEX_A9_Cyclone_V_SoC_DK/main_full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A9_Cyclone_V_SoC_DK/reg_test.S
+++ b/FreeRTOS/Demo/CORTEX_A9_Cyclone_V_SoC_DK/reg_test.S
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A9_Cyclone_V_SoC_DK/serial.c
+++ b/FreeRTOS/Demo/CORTEX_A9_Cyclone_V_SoC_DK/serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A9_Zynq_ZC702/RTOSDemo/src/Blinky_Demo/main_blinky.c
+++ b/FreeRTOS/Demo/CORTEX_A9_Zynq_ZC702/RTOSDemo/src/Blinky_Demo/main_blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A9_Zynq_ZC702/RTOSDemo/src/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_A9_Zynq_ZC702/RTOSDemo/src/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A9_Zynq_ZC702/RTOSDemo/src/FreeRTOS_tick_config.c
+++ b/FreeRTOS/Demo/CORTEX_A9_Zynq_ZC702/RTOSDemo/src/FreeRTOS_tick_config.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A9_Zynq_ZC702/RTOSDemo/src/Full_Demo/IntQueueTimer.c
+++ b/FreeRTOS/Demo/CORTEX_A9_Zynq_ZC702/RTOSDemo/src/Full_Demo/IntQueueTimer.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A9_Zynq_ZC702/RTOSDemo/src/Full_Demo/IntQueueTimer.h
+++ b/FreeRTOS/Demo/CORTEX_A9_Zynq_ZC702/RTOSDemo/src/Full_Demo/IntQueueTimer.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A9_Zynq_ZC702/RTOSDemo/src/Full_Demo/main_full.c
+++ b/FreeRTOS/Demo/CORTEX_A9_Zynq_ZC702/RTOSDemo/src/Full_Demo/main_full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A9_Zynq_ZC702/RTOSDemo/src/Full_Demo/reg_test.S
+++ b/FreeRTOS/Demo/CORTEX_A9_Zynq_ZC702/RTOSDemo/src/Full_Demo/reg_test.S
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A9_Zynq_ZC702/RTOSDemo/src/Full_Demo/serial.c
+++ b/FreeRTOS/Demo/CORTEX_A9_Zynq_ZC702/RTOSDemo/src/Full_Demo/serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A9_Zynq_ZC702/RTOSDemo/src/ParTest.c
+++ b/FreeRTOS/Demo/CORTEX_A9_Zynq_ZC702/RTOSDemo/src/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A9_Zynq_ZC702/RTOSDemo/src/lwIP_Demo/lwIP_Apps/apps/BasicSocketCommandServer/BasicSocketCommandServer.c
+++ b/FreeRTOS/Demo/CORTEX_A9_Zynq_ZC702/RTOSDemo/src/lwIP_Demo/lwIP_Apps/apps/BasicSocketCommandServer/BasicSocketCommandServer.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A9_Zynq_ZC702/RTOSDemo/src/lwIP_Demo/lwIP_Apps/lwIP_Apps.c
+++ b/FreeRTOS/Demo/CORTEX_A9_Zynq_ZC702/RTOSDemo/src/lwIP_Demo/lwIP_Apps/lwIP_Apps.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A9_Zynq_ZC702/RTOSDemo/src/lwIP_Demo/lwIP_Apps/lwIP_Apps.h
+++ b/FreeRTOS/Demo/CORTEX_A9_Zynq_ZC702/RTOSDemo/src/lwIP_Demo/lwIP_Apps/lwIP_Apps.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A9_Zynq_ZC702/RTOSDemo/src/lwIP_Demo/main_lwIP.c
+++ b/FreeRTOS/Demo/CORTEX_A9_Zynq_ZC702/RTOSDemo/src/lwIP_Demo/main_lwIP.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_A9_Zynq_ZC702/RTOSDemo/src/main.c
+++ b/FreeRTOS/Demo/CORTEX_A9_Zynq_ZC702/RTOSDemo/src/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_AT91SAM3U256_IAR/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_AT91SAM3U256_IAR/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_AT91SAM3U256_IAR/ParTest/ParTest.c
+++ b/FreeRTOS/Demo/CORTEX_AT91SAM3U256_IAR/ParTest/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_AT91SAM3U256_IAR/lcd_message.h
+++ b/FreeRTOS/Demo/CORTEX_AT91SAM3U256_IAR/lcd_message.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_AT91SAM3U256_IAR/main.c
+++ b/FreeRTOS/Demo/CORTEX_AT91SAM3U256_IAR/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_AT91SAM3U256_IAR/serial/serial.c
+++ b/FreeRTOS/Demo/CORTEX_AT91SAM3U256_IAR/serial/serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_ATSAM3S-EK2_Atmel_Studio/src/Common-Demo-Source/comtest.c
+++ b/FreeRTOS/Demo/CORTEX_ATSAM3S-EK2_Atmel_Studio/src/Common-Demo-Source/comtest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_ATSAM3S-EK2_Atmel_Studio/src/Common-Demo-Source/include/demo_serial.h
+++ b/FreeRTOS/Demo/CORTEX_ATSAM3S-EK2_Atmel_Studio/src/Common-Demo-Source/include/demo_serial.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_ATSAM3S-EK2_Atmel_Studio/src/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_ATSAM3S-EK2_Atmel_Studio/src/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_ATSAM3S-EK2_Atmel_Studio/src/ParTest.c
+++ b/FreeRTOS/Demo/CORTEX_ATSAM3S-EK2_Atmel_Studio/src/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_ATSAM3S-EK2_Atmel_Studio/src/main.c
+++ b/FreeRTOS/Demo/CORTEX_ATSAM3S-EK2_Atmel_Studio/src/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_ATSAM3S-EK2_Atmel_Studio/src/main_blinky.c
+++ b/FreeRTOS/Demo/CORTEX_ATSAM3S-EK2_Atmel_Studio/src/main_blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_ATSAM3S-EK2_Atmel_Studio/src/main_full.c
+++ b/FreeRTOS/Demo/CORTEX_ATSAM3S-EK2_Atmel_Studio/src/main_full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_ATSAM3S-EK2_Atmel_Studio/src/serial.c
+++ b/FreeRTOS/Demo/CORTEX_ATSAM3S-EK2_Atmel_Studio/src/serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_ATSAM3X_Atmel_Studio/src/Common-Demo-Source/comtest.c
+++ b/FreeRTOS/Demo/CORTEX_ATSAM3X_Atmel_Studio/src/Common-Demo-Source/comtest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_ATSAM3X_Atmel_Studio/src/Common-Demo-Source/include/demo_serial.h
+++ b/FreeRTOS/Demo/CORTEX_ATSAM3X_Atmel_Studio/src/Common-Demo-Source/include/demo_serial.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_ATSAM3X_Atmel_Studio/src/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_ATSAM3X_Atmel_Studio/src/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_ATSAM3X_Atmel_Studio/src/ParTest.c
+++ b/FreeRTOS/Demo/CORTEX_ATSAM3X_Atmel_Studio/src/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_ATSAM3X_Atmel_Studio/src/main.c
+++ b/FreeRTOS/Demo/CORTEX_ATSAM3X_Atmel_Studio/src/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_ATSAM3X_Atmel_Studio/src/main_blinky.c
+++ b/FreeRTOS/Demo/CORTEX_ATSAM3X_Atmel_Studio/src/main_blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_ATSAM3X_Atmel_Studio/src/main_full.c
+++ b/FreeRTOS/Demo/CORTEX_ATSAM3X_Atmel_Studio/src/main_full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_ATSAM3X_Atmel_Studio/src/serial.c
+++ b/FreeRTOS/Demo/CORTEX_ATSAM3X_Atmel_Studio/src/serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_CY8C5588_PSoC_Creator_GCC/FreeRTOS_Demo.cydsn/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_CY8C5588_PSoC_Creator_GCC/FreeRTOS_Demo.cydsn/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_CY8C5588_PSoC_Creator_GCC/FreeRTOS_Demo.cydsn/IntQueueTimer.c
+++ b/FreeRTOS/Demo/CORTEX_CY8C5588_PSoC_Creator_GCC/FreeRTOS_Demo.cydsn/IntQueueTimer.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_CY8C5588_PSoC_Creator_GCC/FreeRTOS_Demo.cydsn/IntQueueTimer.h
+++ b/FreeRTOS/Demo/CORTEX_CY8C5588_PSoC_Creator_GCC/FreeRTOS_Demo.cydsn/IntQueueTimer.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_CY8C5588_PSoC_Creator_GCC/FreeRTOS_Demo.cydsn/ParTest.c
+++ b/FreeRTOS/Demo/CORTEX_CY8C5588_PSoC_Creator_GCC/FreeRTOS_Demo.cydsn/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_CY8C5588_PSoC_Creator_GCC/FreeRTOS_Demo.cydsn/Serial.c
+++ b/FreeRTOS/Demo/CORTEX_CY8C5588_PSoC_Creator_GCC/FreeRTOS_Demo.cydsn/Serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_CY8C5588_PSoC_Creator_GCC/FreeRTOS_Demo.cydsn/TimerTest.c
+++ b/FreeRTOS/Demo/CORTEX_CY8C5588_PSoC_Creator_GCC/FreeRTOS_Demo.cydsn/TimerTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_CY8C5588_PSoC_Creator_GCC/FreeRTOS_Demo.cydsn/main.c
+++ b/FreeRTOS/Demo/CORTEX_CY8C5588_PSoC_Creator_GCC/FreeRTOS_Demo.cydsn/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_CY8C5588_PSoC_Creator_Keil/FreeRTOS_Demo.cydsn/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_CY8C5588_PSoC_Creator_Keil/FreeRTOS_Demo.cydsn/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_CY8C5588_PSoC_Creator_Keil/FreeRTOS_Demo.cydsn/IntQueueTimer.c
+++ b/FreeRTOS/Demo/CORTEX_CY8C5588_PSoC_Creator_Keil/FreeRTOS_Demo.cydsn/IntQueueTimer.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_CY8C5588_PSoC_Creator_Keil/FreeRTOS_Demo.cydsn/IntQueueTimer.h
+++ b/FreeRTOS/Demo/CORTEX_CY8C5588_PSoC_Creator_Keil/FreeRTOS_Demo.cydsn/IntQueueTimer.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_CY8C5588_PSoC_Creator_Keil/FreeRTOS_Demo.cydsn/ParTest.c
+++ b/FreeRTOS/Demo/CORTEX_CY8C5588_PSoC_Creator_Keil/FreeRTOS_Demo.cydsn/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_CY8C5588_PSoC_Creator_Keil/FreeRTOS_Demo.cydsn/Serial.c
+++ b/FreeRTOS/Demo/CORTEX_CY8C5588_PSoC_Creator_Keil/FreeRTOS_Demo.cydsn/Serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_CY8C5588_PSoC_Creator_Keil/FreeRTOS_Demo.cydsn/TimerTest.c
+++ b/FreeRTOS/Demo/CORTEX_CY8C5588_PSoC_Creator_Keil/FreeRTOS_Demo.cydsn/TimerTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_CY8C5588_PSoC_Creator_Keil/FreeRTOS_Demo.cydsn/main.c
+++ b/FreeRTOS/Demo/CORTEX_CY8C5588_PSoC_Creator_Keil/FreeRTOS_Demo.cydsn/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_CY8C5588_PSoC_Creator_RVDS/FreeRTOS_Demo.cydsn/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_CY8C5588_PSoC_Creator_RVDS/FreeRTOS_Demo.cydsn/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_CY8C5588_PSoC_Creator_RVDS/FreeRTOS_Demo.cydsn/IntQueueTimer.c
+++ b/FreeRTOS/Demo/CORTEX_CY8C5588_PSoC_Creator_RVDS/FreeRTOS_Demo.cydsn/IntQueueTimer.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_CY8C5588_PSoC_Creator_RVDS/FreeRTOS_Demo.cydsn/IntQueueTimer.h
+++ b/FreeRTOS/Demo/CORTEX_CY8C5588_PSoC_Creator_RVDS/FreeRTOS_Demo.cydsn/IntQueueTimer.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_CY8C5588_PSoC_Creator_RVDS/FreeRTOS_Demo.cydsn/ParTest.c
+++ b/FreeRTOS/Demo/CORTEX_CY8C5588_PSoC_Creator_RVDS/FreeRTOS_Demo.cydsn/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_CY8C5588_PSoC_Creator_RVDS/FreeRTOS_Demo.cydsn/Serial.c
+++ b/FreeRTOS/Demo/CORTEX_CY8C5588_PSoC_Creator_RVDS/FreeRTOS_Demo.cydsn/Serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_CY8C5588_PSoC_Creator_RVDS/FreeRTOS_Demo.cydsn/TimerTest.c
+++ b/FreeRTOS/Demo/CORTEX_CY8C5588_PSoC_Creator_RVDS/FreeRTOS_Demo.cydsn/TimerTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_CY8C5588_PSoC_Creator_RVDS/FreeRTOS_Demo.cydsn/main.c
+++ b/FreeRTOS/Demo/CORTEX_CY8C5588_PSoC_Creator_RVDS/FreeRTOS_Demo.cydsn/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_EFM32_Giant_Gecko_Simplicity_Studio/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_EFM32_Giant_Gecko_Simplicity_Studio/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_EFM32_Giant_Gecko_Simplicity_Studio/Full_Demo/RegTest.c
+++ b/FreeRTOS/Demo/CORTEX_EFM32_Giant_Gecko_Simplicity_Studio/Full_Demo/RegTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_EFM32_Giant_Gecko_Simplicity_Studio/Full_Demo/main_full.c
+++ b/FreeRTOS/Demo/CORTEX_EFM32_Giant_Gecko_Simplicity_Studio/Full_Demo/main_full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_EFM32_Giant_Gecko_Simplicity_Studio/Low_Power_Demo/low_power_tick_management_BURTC.c
+++ b/FreeRTOS/Demo/CORTEX_EFM32_Giant_Gecko_Simplicity_Studio/Low_Power_Demo/low_power_tick_management_BURTC.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_EFM32_Giant_Gecko_Simplicity_Studio/Low_Power_Demo/low_power_tick_management_RTC.c
+++ b/FreeRTOS/Demo/CORTEX_EFM32_Giant_Gecko_Simplicity_Studio/Low_Power_Demo/low_power_tick_management_RTC.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_EFM32_Giant_Gecko_Simplicity_Studio/Low_Power_Demo/main_low_power.c
+++ b/FreeRTOS/Demo/CORTEX_EFM32_Giant_Gecko_Simplicity_Studio/Low_Power_Demo/main_low_power.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_EFM32_Giant_Gecko_Simplicity_Studio/main.c
+++ b/FreeRTOS/Demo/CORTEX_EFM32_Giant_Gecko_Simplicity_Studio/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_EFM32_Pearl_Gecko_Simplicity_Studio/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_EFM32_Pearl_Gecko_Simplicity_Studio/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_EFM32_Pearl_Gecko_Simplicity_Studio/Full_Demo/RegTest.c
+++ b/FreeRTOS/Demo/CORTEX_EFM32_Pearl_Gecko_Simplicity_Studio/Full_Demo/RegTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_EFM32_Pearl_Gecko_Simplicity_Studio/Full_Demo/main_full.c
+++ b/FreeRTOS/Demo/CORTEX_EFM32_Pearl_Gecko_Simplicity_Studio/Full_Demo/main_full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_EFM32_Pearl_Gecko_Simplicity_Studio/Low_Power_Demo/low_power_tick_management_RTCC.c
+++ b/FreeRTOS/Demo/CORTEX_EFM32_Pearl_Gecko_Simplicity_Studio/Low_Power_Demo/low_power_tick_management_RTCC.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_EFM32_Pearl_Gecko_Simplicity_Studio/Low_Power_Demo/main_low_power.c
+++ b/FreeRTOS/Demo/CORTEX_EFM32_Pearl_Gecko_Simplicity_Studio/Low_Power_Demo/main_low_power.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_EFM32_Pearl_Gecko_Simplicity_Studio/main.c
+++ b/FreeRTOS/Demo/CORTEX_EFM32_Pearl_Gecko_Simplicity_Studio/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_Kinetis_K60_Tower_IAR/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_Kinetis_K60_Tower_IAR/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_Kinetis_K60_Tower_IAR/ParTest.c
+++ b/FreeRTOS/Demo/CORTEX_Kinetis_K60_Tower_IAR/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_Kinetis_K60_Tower_IAR/main-full.c
+++ b/FreeRTOS/Demo/CORTEX_Kinetis_K60_Tower_IAR/main-full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_Kinetis_K60_Tower_IAR/main_blinky.c
+++ b/FreeRTOS/Demo/CORTEX_Kinetis_K60_Tower_IAR/main_blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_Kinetis_K60_Tower_IAR/uIP_Task.c
+++ b/FreeRTOS/Demo/CORTEX_Kinetis_K60_Tower_IAR/uIP_Task.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_Kinetis_K60_Tower_IAR/webserver/EMAC.c
+++ b/FreeRTOS/Demo/CORTEX_Kinetis_K60_Tower_IAR/webserver/EMAC.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_Kinetis_K60_Tower_IAR/webserver/EMAC.h
+++ b/FreeRTOS/Demo/CORTEX_Kinetis_K60_Tower_IAR/webserver/EMAC.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LM3S102_GCC/Demo1/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_LM3S102_GCC/Demo1/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LM3S102_GCC/Demo1/main.c
+++ b/FreeRTOS/Demo/CORTEX_LM3S102_GCC/Demo1/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LM3S102_GCC/Demo2/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_LM3S102_GCC/Demo2/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LM3S102_GCC/Demo2/main.c
+++ b/FreeRTOS/Demo/CORTEX_LM3S102_GCC/Demo2/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LM3S102_GCC/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_LM3S102_GCC/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LM3S102_GCC/ParTest/ParTest.c
+++ b/FreeRTOS/Demo/CORTEX_LM3S102_GCC/ParTest/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LM3S102_GCC/main.c
+++ b/FreeRTOS/Demo/CORTEX_LM3S102_GCC/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LM3S102_Rowley/Demo1/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_LM3S102_Rowley/Demo1/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LM3S102_Rowley/Demo1/ParTest.c
+++ b/FreeRTOS/Demo/CORTEX_LM3S102_Rowley/Demo1/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LM3S102_Rowley/Demo1/main.c
+++ b/FreeRTOS/Demo/CORTEX_LM3S102_Rowley/Demo1/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LM3S102_Rowley/Demo2/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_LM3S102_Rowley/Demo2/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LM3S102_Rowley/Demo2/ParTest.c
+++ b/FreeRTOS/Demo/CORTEX_LM3S102_Rowley/Demo2/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LM3S102_Rowley/Demo2/main.c
+++ b/FreeRTOS/Demo/CORTEX_LM3S102_Rowley/Demo2/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LM3S102_Rowley/Demo3/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_LM3S102_Rowley/Demo3/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LM3S102_Rowley/Demo3/ParTest.c
+++ b/FreeRTOS/Demo/CORTEX_LM3S102_Rowley/Demo3/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LM3S102_Rowley/Demo3/main.c
+++ b/FreeRTOS/Demo/CORTEX_LM3S102_Rowley/Demo3/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LM3S316_IAR/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_LM3S316_IAR/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LM3S316_IAR/ParTest/ParTest.c
+++ b/FreeRTOS/Demo/CORTEX_LM3S316_IAR/ParTest/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LM3S316_IAR/commstest.c
+++ b/FreeRTOS/Demo/CORTEX_LM3S316_IAR/commstest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LM3S316_IAR/commstest.h
+++ b/FreeRTOS/Demo/CORTEX_LM3S316_IAR/commstest.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LM3S316_IAR/main.c
+++ b/FreeRTOS/Demo/CORTEX_LM3S316_IAR/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LM3S811_GCC/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_LM3S811_GCC/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LM3S811_GCC/main.c
+++ b/FreeRTOS/Demo/CORTEX_LM3S811_GCC/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LM3S811_IAR/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_LM3S811_IAR/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LM3S811_IAR/main.c
+++ b/FreeRTOS/Demo/CORTEX_LM3S811_IAR/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LM3S811_KEIL/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_LM3S811_KEIL/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LM3S811_KEIL/heap/heap_1.c
+++ b/FreeRTOS/Demo/CORTEX_LM3S811_KEIL/heap/heap_1.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LM3S811_KEIL/main.c
+++ b/FreeRTOS/Demo/CORTEX_LM3S811_KEIL/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LM3Sxxxx_IAR_Keil/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_LM3Sxxxx_IAR_Keil/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LM3Sxxxx_IAR_Keil/IntQueueTimer.c
+++ b/FreeRTOS/Demo/CORTEX_LM3Sxxxx_IAR_Keil/IntQueueTimer.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LM3Sxxxx_IAR_Keil/IntQueueTimer.h
+++ b/FreeRTOS/Demo/CORTEX_LM3Sxxxx_IAR_Keil/IntQueueTimer.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LM3Sxxxx_IAR_Keil/ParTest/ParTest.c
+++ b/FreeRTOS/Demo/CORTEX_LM3Sxxxx_IAR_Keil/ParTest/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LM3Sxxxx_IAR_Keil/main.c
+++ b/FreeRTOS/Demo/CORTEX_LM3Sxxxx_IAR_Keil/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LM3Sxxxx_IAR_Keil/timertest.c
+++ b/FreeRTOS/Demo/CORTEX_LM3Sxxxx_IAR_Keil/timertest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LM3Sxxxx_IAR_Keil/webserver/emac.c
+++ b/FreeRTOS/Demo/CORTEX_LM3Sxxxx_IAR_Keil/webserver/emac.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LM3Sxxxx_IAR_Keil/webserver/uIP_Task.c
+++ b/FreeRTOS/Demo/CORTEX_LM3Sxxxx_IAR_Keil/webserver/uIP_Task.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LM3Sxxxx_Rowley/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_LM3Sxxxx_Rowley/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LM3Sxxxx_Rowley/IntQueueTimer.c
+++ b/FreeRTOS/Demo/CORTEX_LM3Sxxxx_Rowley/IntQueueTimer.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LM3Sxxxx_Rowley/IntQueueTimer.h
+++ b/FreeRTOS/Demo/CORTEX_LM3Sxxxx_Rowley/IntQueueTimer.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LM3Sxxxx_Rowley/ParTest/ParTest.c
+++ b/FreeRTOS/Demo/CORTEX_LM3Sxxxx_Rowley/ParTest/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LM3Sxxxx_Rowley/main.c
+++ b/FreeRTOS/Demo/CORTEX_LM3Sxxxx_Rowley/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LM3Sxxxx_Rowley/timertest.c
+++ b/FreeRTOS/Demo/CORTEX_LM3Sxxxx_Rowley/timertest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LM3Sxxxx_Rowley/webserver/emac.c
+++ b/FreeRTOS/Demo/CORTEX_LM3Sxxxx_Rowley/webserver/emac.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LM3Sxxxx_Rowley/webserver/uIP_Task.c
+++ b/FreeRTOS/Demo/CORTEX_LM3Sxxxx_Rowley/webserver/uIP_Task.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LPC1768_GCC_RedSuite/src/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_LPC1768_GCC_RedSuite/src/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LPC1768_GCC_RedSuite/src/ParTest.c
+++ b/FreeRTOS/Demo/CORTEX_LPC1768_GCC_RedSuite/src/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LPC1768_GCC_RedSuite/src/main.c
+++ b/FreeRTOS/Demo/CORTEX_LPC1768_GCC_RedSuite/src/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LPC1768_GCC_RedSuite/src/webserver/emac.c
+++ b/FreeRTOS/Demo/CORTEX_LPC1768_GCC_RedSuite/src/webserver/emac.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LPC1768_GCC_RedSuite/src/webserver/uIP_Task.c
+++ b/FreeRTOS/Demo/CORTEX_LPC1768_GCC_RedSuite/src/webserver/uIP_Task.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LPC1768_GCC_Rowley/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_LPC1768_GCC_Rowley/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LPC1768_GCC_Rowley/LED.h
+++ b/FreeRTOS/Demo/CORTEX_LPC1768_GCC_Rowley/LED.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LPC1768_GCC_Rowley/ParTest.c
+++ b/FreeRTOS/Demo/CORTEX_LPC1768_GCC_Rowley/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LPC1768_GCC_Rowley/main.c
+++ b/FreeRTOS/Demo/CORTEX_LPC1768_GCC_Rowley/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LPC1768_GCC_Rowley/webserver/emac.c
+++ b/FreeRTOS/Demo/CORTEX_LPC1768_GCC_Rowley/webserver/emac.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LPC1768_GCC_Rowley/webserver/uIP_Task.c
+++ b/FreeRTOS/Demo/CORTEX_LPC1768_GCC_Rowley/webserver/uIP_Task.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LPC1768_IAR/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_LPC1768_IAR/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LPC1768_IAR/LED.h
+++ b/FreeRTOS/Demo/CORTEX_LPC1768_IAR/LED.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LPC1768_IAR/ParTest.c
+++ b/FreeRTOS/Demo/CORTEX_LPC1768_IAR/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LPC1768_IAR/main.c
+++ b/FreeRTOS/Demo/CORTEX_LPC1768_IAR/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LPC1768_IAR/webserver/emac.c
+++ b/FreeRTOS/Demo/CORTEX_LPC1768_IAR/webserver/emac.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_LPC1768_IAR/webserver/uIP_Task.c
+++ b/FreeRTOS/Demo/CORTEX_LPC1768_IAR/webserver/uIP_Task.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M0+_Atmel_SAMD20_XPlained/RTOSDemo/src/RegTest.c
+++ b/FreeRTOS/Demo/CORTEX_M0+_Atmel_SAMD20_XPlained/RTOSDemo/src/RegTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M0+_Atmel_SAMD20_XPlained/RTOSDemo/src/Sample-CLI-commands.c
+++ b/FreeRTOS/Demo/CORTEX_M0+_Atmel_SAMD20_XPlained/RTOSDemo/src/Sample-CLI-commands.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M0+_Atmel_SAMD20_XPlained/RTOSDemo/src/UARTCommandConsole.c
+++ b/FreeRTOS/Demo/CORTEX_M0+_Atmel_SAMD20_XPlained/RTOSDemo/src/UARTCommandConsole.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M0+_Atmel_SAMD20_XPlained/RTOSDemo/src/UARTCommandConsole.h
+++ b/FreeRTOS/Demo/CORTEX_M0+_Atmel_SAMD20_XPlained/RTOSDemo/src/UARTCommandConsole.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M0+_Atmel_SAMD20_XPlained/RTOSDemo/src/config/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_M0+_Atmel_SAMD20_XPlained/RTOSDemo/src/config/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M0+_Atmel_SAMD20_XPlained/RTOSDemo/src/main-blinky.c
+++ b/FreeRTOS/Demo/CORTEX_M0+_Atmel_SAMD20_XPlained/RTOSDemo/src/main-blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M0+_Atmel_SAMD20_XPlained/RTOSDemo/src/main-full.c
+++ b/FreeRTOS/Demo/CORTEX_M0+_Atmel_SAMD20_XPlained/RTOSDemo/src/main-full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M0+_Atmel_SAMD20_XPlained/RTOSDemo/src/main.c
+++ b/FreeRTOS/Demo/CORTEX_M0+_Atmel_SAMD20_XPlained/RTOSDemo/src/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M0+_LPC51U68_GCC_IAR_KEIL/GCC_specific/RegTest.c
+++ b/FreeRTOS/Demo/CORTEX_M0+_LPC51U68_GCC_IAR_KEIL/GCC_specific/RegTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M0+_LPC51U68_GCC_IAR_KEIL/GCC_specific/compiler_attributes.h
+++ b/FreeRTOS/Demo/CORTEX_M0+_LPC51U68_GCC_IAR_KEIL/GCC_specific/compiler_attributes.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M0+_LPC51U68_GCC_IAR_KEIL/IAR_specific/RegTest_IAR.s
+++ b/FreeRTOS/Demo/CORTEX_M0+_LPC51U68_GCC_IAR_KEIL/IAR_specific/RegTest_IAR.s
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M0+_LPC51U68_GCC_IAR_KEIL/IAR_specific/compiler_attributes.h
+++ b/FreeRTOS/Demo/CORTEX_M0+_LPC51U68_GCC_IAR_KEIL/IAR_specific/compiler_attributes.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M0+_LPC51U68_GCC_IAR_KEIL/Keil_specific/RegTest_Keil.s
+++ b/FreeRTOS/Demo/CORTEX_M0+_LPC51U68_GCC_IAR_KEIL/Keil_specific/RegTest_Keil.s
@@ -1,5 +1,5 @@
 ;/*
-; * FreeRTOS Kernel V10.3.0
+; * FreeRTOS Kernel V10.3.1
 ; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 ; *
 ; * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M0+_LPC51U68_GCC_IAR_KEIL/Keil_specific/compiler_attributes.h
+++ b/FreeRTOS/Demo/CORTEX_M0+_LPC51U68_GCC_IAR_KEIL/Keil_specific/compiler_attributes.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M0+_LPC51U68_GCC_IAR_KEIL/app/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_M0+_LPC51U68_GCC_IAR_KEIL/app/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M0+_LPC51U68_GCC_IAR_KEIL/app/IntQueueTimer.c
+++ b/FreeRTOS/Demo/CORTEX_M0+_LPC51U68_GCC_IAR_KEIL/app/IntQueueTimer.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M0+_LPC51U68_GCC_IAR_KEIL/app/IntQueueTimer.h
+++ b/FreeRTOS/Demo/CORTEX_M0+_LPC51U68_GCC_IAR_KEIL/app/IntQueueTimer.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M0+_LPC51U68_GCC_IAR_KEIL/app/main_blinky.c
+++ b/FreeRTOS/Demo/CORTEX_M0+_LPC51U68_GCC_IAR_KEIL/app/main_blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M0+_LPC51U68_GCC_IAR_KEIL/app/main_full.c
+++ b/FreeRTOS/Demo/CORTEX_M0+_LPC51U68_GCC_IAR_KEIL/app/main_full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M0_Infineon_XMC1000_IAR_Keil_GCC/Atollic_Specific/RegTest.c
+++ b/FreeRTOS/Demo/CORTEX_M0_Infineon_XMC1000_IAR_Keil_GCC/Atollic_Specific/RegTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M0_Infineon_XMC1000_IAR_Keil_GCC/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_M0_Infineon_XMC1000_IAR_Keil_GCC/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M0_Infineon_XMC1000_IAR_Keil_GCC/IAR_Specific/RegTest_IAR.s
+++ b/FreeRTOS/Demo/CORTEX_M0_Infineon_XMC1000_IAR_Keil_GCC/IAR_Specific/RegTest_IAR.s
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M0_Infineon_XMC1000_IAR_Keil_GCC/Keil_Specific/RegTest_Keil.s
+++ b/FreeRTOS/Demo/CORTEX_M0_Infineon_XMC1000_IAR_Keil_GCC/Keil_Specific/RegTest_Keil.s
@@ -1,5 +1,5 @@
 ;/*
-; * FreeRTOS Kernel V10.3.0
+; * FreeRTOS Kernel V10.3.1
 ; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 ; *
 ; * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M0_Infineon_XMC1000_IAR_Keil_GCC/ParTest_XMC1100.c
+++ b/FreeRTOS/Demo/CORTEX_M0_Infineon_XMC1000_IAR_Keil_GCC/ParTest_XMC1100.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M0_Infineon_XMC1000_IAR_Keil_GCC/ParTest_XMC1200.c
+++ b/FreeRTOS/Demo/CORTEX_M0_Infineon_XMC1000_IAR_Keil_GCC/ParTest_XMC1200.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M0_Infineon_XMC1000_IAR_Keil_GCC/ParTest_XMC1300.c
+++ b/FreeRTOS/Demo/CORTEX_M0_Infineon_XMC1000_IAR_Keil_GCC/ParTest_XMC1300.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M0_Infineon_XMC1000_IAR_Keil_GCC/main-blinky.c
+++ b/FreeRTOS/Demo/CORTEX_M0_Infineon_XMC1000_IAR_Keil_GCC/main-blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M0_Infineon_XMC1000_IAR_Keil_GCC/main-full.c
+++ b/FreeRTOS/Demo/CORTEX_M0_Infineon_XMC1000_IAR_Keil_GCC/main-full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M0_Infineon_XMC1000_IAR_Keil_GCC/main.c
+++ b/FreeRTOS/Demo/CORTEX_M0_Infineon_XMC1000_IAR_Keil_GCC/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M0_LPC1114_LPCXpresso/RTOSDemo/Source/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_M0_LPC1114_LPCXpresso/RTOSDemo/Source/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M0_LPC1114_LPCXpresso/RTOSDemo/Source/IntQueueTimer.c
+++ b/FreeRTOS/Demo/CORTEX_M0_LPC1114_LPCXpresso/RTOSDemo/Source/IntQueueTimer.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M0_LPC1114_LPCXpresso/RTOSDemo/Source/IntQueueTimer.h
+++ b/FreeRTOS/Demo/CORTEX_M0_LPC1114_LPCXpresso/RTOSDemo/Source/IntQueueTimer.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M0_LPC1114_LPCXpresso/RTOSDemo/Source/RegTest.c
+++ b/FreeRTOS/Demo/CORTEX_M0_LPC1114_LPCXpresso/RTOSDemo/Source/RegTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M0_LPC1114_LPCXpresso/RTOSDemo/Source/main-blinky.c
+++ b/FreeRTOS/Demo/CORTEX_M0_LPC1114_LPCXpresso/RTOSDemo/Source/main-blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M0_LPC1114_LPCXpresso/RTOSDemo/Source/main-full.c
+++ b/FreeRTOS/Demo/CORTEX_M0_LPC1114_LPCXpresso/RTOSDemo/Source/main-full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M0_LPC1114_LPCXpresso/RTOSDemo/Source/main.c
+++ b/FreeRTOS/Demo/CORTEX_M0_LPC1114_LPCXpresso/RTOSDemo/Source/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M0_STM32F0518_IAR/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_M0_STM32F0518_IAR/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M0_STM32F0518_IAR/ParTest.c
+++ b/FreeRTOS/Demo/CORTEX_M0_STM32F0518_IAR/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M0_STM32F0518_IAR/RegTest.s
+++ b/FreeRTOS/Demo/CORTEX_M0_STM32F0518_IAR/RegTest.s
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M0_STM32F0518_IAR/main-blinky.c
+++ b/FreeRTOS/Demo/CORTEX_M0_STM32F0518_IAR/main-blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M0_STM32F0518_IAR/main-full.c
+++ b/FreeRTOS/Demo/CORTEX_M0_STM32F0518_IAR/main-full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M0_STM32F0518_IAR/main.c
+++ b/FreeRTOS/Demo/CORTEX_M0_STM32F0518_IAR/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_CEC1302_Keil_GCC/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_M4F_CEC1302_Keil_GCC/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_CEC1302_Keil_GCC/GCC_Specific/RegTest.c
+++ b/FreeRTOS/Demo/CORTEX_M4F_CEC1302_Keil_GCC/GCC_Specific/RegTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_CEC1302_Keil_GCC/Keil_Specific/RegTest.c
+++ b/FreeRTOS/Demo/CORTEX_M4F_CEC1302_Keil_GCC/Keil_Specific/RegTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_CEC1302_Keil_GCC/main.c
+++ b/FreeRTOS/Demo/CORTEX_M4F_CEC1302_Keil_GCC/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_CEC1302_Keil_GCC/main_full/IntQueueTimer.c
+++ b/FreeRTOS/Demo/CORTEX_M4F_CEC1302_Keil_GCC/main_full/IntQueueTimer.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_CEC1302_Keil_GCC/main_full/IntQueueTimer.h
+++ b/FreeRTOS/Demo/CORTEX_M4F_CEC1302_Keil_GCC/main_full/IntQueueTimer.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_CEC1302_Keil_GCC/main_full/main_full.c
+++ b/FreeRTOS/Demo/CORTEX_M4F_CEC1302_Keil_GCC/main_full/main_full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_CEC1302_Keil_GCC/main_low_power/low_power_tick_config.c
+++ b/FreeRTOS/Demo/CORTEX_M4F_CEC1302_Keil_GCC/main_low_power/low_power_tick_config.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_CEC1302_Keil_GCC/main_low_power/main_low_power.c
+++ b/FreeRTOS/Demo/CORTEX_M4F_CEC1302_Keil_GCC/main_low_power/main_low_power.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_CEC1302_MikroC/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_M4F_CEC1302_MikroC/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_CEC1302_MikroC/MikroC_Specific/RegTest.c
+++ b/FreeRTOS/Demo/CORTEX_M4F_CEC1302_MikroC/MikroC_Specific/RegTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_CEC1302_MikroC/main.c
+++ b/FreeRTOS/Demo/CORTEX_M4F_CEC1302_MikroC/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_CEC1302_MikroC/main_full/IntQueueTimer.c
+++ b/FreeRTOS/Demo/CORTEX_M4F_CEC1302_MikroC/main_full/IntQueueTimer.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_CEC1302_MikroC/main_full/IntQueueTimer.h
+++ b/FreeRTOS/Demo/CORTEX_M4F_CEC1302_MikroC/main_full/IntQueueTimer.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_CEC1302_MikroC/main_full/main_full.c
+++ b/FreeRTOS/Demo/CORTEX_M4F_CEC1302_MikroC/main_full/main_full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_CEC1302_MikroC/main_low_power/low_power_tick_config.c
+++ b/FreeRTOS/Demo/CORTEX_M4F_CEC1302_MikroC/main_low_power/low_power_tick_config.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_CEC1302_MikroC/main_low_power/main_low_power.c
+++ b/FreeRTOS/Demo/CORTEX_M4F_CEC1302_MikroC/main_low_power/main_low_power.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_CEC_MEC_17xx_51xx_Keil_GCC/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_M4F_CEC_MEC_17xx_51xx_Keil_GCC/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_CEC_MEC_17xx_51xx_Keil_GCC/main.c
+++ b/FreeRTOS/Demo/CORTEX_M4F_CEC_MEC_17xx_51xx_Keil_GCC/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_Infineon_XMC4000_GCC_Dave/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_M4F_Infineon_XMC4000_GCC_Dave/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_Infineon_XMC4000_GCC_Dave/main.c
+++ b/FreeRTOS/Demo/CORTEX_M4F_Infineon_XMC4000_GCC_Dave/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_Infineon_XMC4000_GCC_Dave/main_blinky.c
+++ b/FreeRTOS/Demo/CORTEX_M4F_Infineon_XMC4000_GCC_Dave/main_blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_Infineon_XMC4000_GCC_Dave/main_full.c
+++ b/FreeRTOS/Demo/CORTEX_M4F_Infineon_XMC4000_GCC_Dave/main_full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_Infineon_XMC4000_IAR/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_M4F_Infineon_XMC4000_IAR/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_Infineon_XMC4000_IAR/RegTest.s
+++ b/FreeRTOS/Demo/CORTEX_M4F_Infineon_XMC4000_IAR/RegTest.s
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_Infineon_XMC4000_IAR/main.c
+++ b/FreeRTOS/Demo/CORTEX_M4F_Infineon_XMC4000_IAR/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_Infineon_XMC4000_IAR/main_blinky.c
+++ b/FreeRTOS/Demo/CORTEX_M4F_Infineon_XMC4000_IAR/main_blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_Infineon_XMC4000_IAR/main_full.c
+++ b/FreeRTOS/Demo/CORTEX_M4F_Infineon_XMC4000_IAR/main_full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_Infineon_XMC4000_Keil/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_M4F_Infineon_XMC4000_Keil/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_Infineon_XMC4000_Keil/RegTest.c
+++ b/FreeRTOS/Demo/CORTEX_M4F_Infineon_XMC4000_Keil/RegTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_Infineon_XMC4000_Keil/main.c
+++ b/FreeRTOS/Demo/CORTEX_M4F_Infineon_XMC4000_Keil/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_Infineon_XMC4000_Keil/main_blinky.c
+++ b/FreeRTOS/Demo/CORTEX_M4F_Infineon_XMC4000_Keil/main_blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_Infineon_XMC4000_Keil/main_full.c
+++ b/FreeRTOS/Demo/CORTEX_M4F_Infineon_XMC4000_Keil/main_full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_Infineon_XMC4000_Tasking/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_M4F_Infineon_XMC4000_Tasking/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_Infineon_XMC4000_Tasking/main.c
+++ b/FreeRTOS/Demo/CORTEX_M4F_Infineon_XMC4000_Tasking/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_Infineon_XMC4000_Tasking/main_blinky.c
+++ b/FreeRTOS/Demo/CORTEX_M4F_Infineon_XMC4000_Tasking/main_blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_Infineon_XMC4000_Tasking/main_full.c
+++ b/FreeRTOS/Demo/CORTEX_M4F_Infineon_XMC4000_Tasking/main_full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_Infineon_XMC4500_GCC_Atollic/src/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_M4F_Infineon_XMC4500_GCC_Atollic/src/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_Infineon_XMC4500_GCC_Atollic/src/main.c
+++ b/FreeRTOS/Demo/CORTEX_M4F_Infineon_XMC4500_GCC_Atollic/src/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_Infineon_XMC4500_GCC_Atollic/src/main_blinky.c
+++ b/FreeRTOS/Demo/CORTEX_M4F_Infineon_XMC4500_GCC_Atollic/src/main_blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_Infineon_XMC4500_GCC_Atollic/src/main_full.c
+++ b/FreeRTOS/Demo/CORTEX_M4F_Infineon_XMC4500_GCC_Atollic/src/main_full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_M0_LPC43xx_Keil/M4/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_M4F_M0_LPC43xx_Keil/M4/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_M0_LPC43xx_Keil/M4/ParTest.c
+++ b/FreeRTOS/Demo/CORTEX_M4F_M0_LPC43xx_Keil/M4/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_M0_LPC43xx_Keil/M4/RegTest.c
+++ b/FreeRTOS/Demo/CORTEX_M4F_M0_LPC43xx_Keil/M4/RegTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_M0_LPC43xx_Keil/M4/main.c
+++ b/FreeRTOS/Demo/CORTEX_M4F_M0_LPC43xx_Keil/M4/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_MSP432_LaunchPad_IAR_CCS_Keil/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_M4F_MSP432_LaunchPad_IAR_CCS_Keil/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_MSP432_LaunchPad_IAR_CCS_Keil/Full_Demo/IntQueueTimer.c
+++ b/FreeRTOS/Demo/CORTEX_M4F_MSP432_LaunchPad_IAR_CCS_Keil/Full_Demo/IntQueueTimer.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_MSP432_LaunchPad_IAR_CCS_Keil/Full_Demo/IntQueueTimer.h
+++ b/FreeRTOS/Demo/CORTEX_M4F_MSP432_LaunchPad_IAR_CCS_Keil/Full_Demo/IntQueueTimer.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_MSP432_LaunchPad_IAR_CCS_Keil/Full_Demo/RegTest.asm
+++ b/FreeRTOS/Demo/CORTEX_M4F_MSP432_LaunchPad_IAR_CCS_Keil/Full_Demo/RegTest.asm
@@ -1,5 +1,5 @@
 ;/*
-; * FreeRTOS Kernel V10.3.0
+; * FreeRTOS Kernel V10.3.1
 ; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 ; *
 ; * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_MSP432_LaunchPad_IAR_CCS_Keil/Full_Demo/RegTest.c
+++ b/FreeRTOS/Demo/CORTEX_M4F_MSP432_LaunchPad_IAR_CCS_Keil/Full_Demo/RegTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_MSP432_LaunchPad_IAR_CCS_Keil/Full_Demo/RegTest.s
+++ b/FreeRTOS/Demo/CORTEX_M4F_MSP432_LaunchPad_IAR_CCS_Keil/Full_Demo/RegTest.s
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_MSP432_LaunchPad_IAR_CCS_Keil/Full_Demo/RunTimeStatsTimer.c
+++ b/FreeRTOS/Demo/CORTEX_M4F_MSP432_LaunchPad_IAR_CCS_Keil/Full_Demo/RunTimeStatsTimer.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_MSP432_LaunchPad_IAR_CCS_Keil/Full_Demo/main_full.c
+++ b/FreeRTOS/Demo/CORTEX_M4F_MSP432_LaunchPad_IAR_CCS_Keil/Full_Demo/main_full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_MSP432_LaunchPad_IAR_CCS_Keil/Full_Demo/serial.c
+++ b/FreeRTOS/Demo/CORTEX_M4F_MSP432_LaunchPad_IAR_CCS_Keil/Full_Demo/serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_MSP432_LaunchPad_IAR_CCS_Keil/SimplyBlinkyDemo/main_blinky.c
+++ b/FreeRTOS/Demo/CORTEX_M4F_MSP432_LaunchPad_IAR_CCS_Keil/SimplyBlinkyDemo/main_blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_MSP432_LaunchPad_IAR_CCS_Keil/main.c
+++ b/FreeRTOS/Demo/CORTEX_M4F_MSP432_LaunchPad_IAR_CCS_Keil/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_STM32F407ZG-SK/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_M4F_STM32F407ZG-SK/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_STM32F407ZG-SK/ParTest.c
+++ b/FreeRTOS/Demo/CORTEX_M4F_STM32F407ZG-SK/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_STM32F407ZG-SK/RegTest.s
+++ b/FreeRTOS/Demo/CORTEX_M4F_STM32F407ZG-SK/RegTest.s
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4F_STM32F407ZG-SK/main.c
+++ b/FreeRTOS/Demo/CORTEX_M4F_STM32F407ZG-SK/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4_ATSAM4L_Atmel_Studio/src/ParTest.c
+++ b/FreeRTOS/Demo/CORTEX_M4_ATSAM4L_Atmel_Studio/src/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4_ATSAM4L_Atmel_Studio/src/SAM4L_low_power_tick_management.c
+++ b/FreeRTOS/Demo/CORTEX_M4_ATSAM4L_Atmel_Studio/src/SAM4L_low_power_tick_management.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4_ATSAM4L_Atmel_Studio/src/config/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_M4_ATSAM4L_Atmel_Studio/src/config/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4_ATSAM4L_Atmel_Studio/src/main.c
+++ b/FreeRTOS/Demo/CORTEX_M4_ATSAM4L_Atmel_Studio/src/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4_ATSAM4L_Atmel_Studio/src/main_full.c
+++ b/FreeRTOS/Demo/CORTEX_M4_ATSAM4L_Atmel_Studio/src/main_full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4_ATSAM4L_Atmel_Studio/src/main_low_power.c
+++ b/FreeRTOS/Demo/CORTEX_M4_ATSAM4L_Atmel_Studio/src/main_low_power.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4_ATSAM4S_Atmel_Studio/src/Common-Demo-Source/comtest.c
+++ b/FreeRTOS/Demo/CORTEX_M4_ATSAM4S_Atmel_Studio/src/Common-Demo-Source/comtest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4_ATSAM4S_Atmel_Studio/src/Common-Demo-Source/include/demo_serial.h
+++ b/FreeRTOS/Demo/CORTEX_M4_ATSAM4S_Atmel_Studio/src/Common-Demo-Source/include/demo_serial.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4_ATSAM4S_Atmel_Studio/src/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_M4_ATSAM4S_Atmel_Studio/src/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4_ATSAM4S_Atmel_Studio/src/IntQueueTimer.c
+++ b/FreeRTOS/Demo/CORTEX_M4_ATSAM4S_Atmel_Studio/src/IntQueueTimer.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4_ATSAM4S_Atmel_Studio/src/IntQueueTimer.h
+++ b/FreeRTOS/Demo/CORTEX_M4_ATSAM4S_Atmel_Studio/src/IntQueueTimer.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4_ATSAM4S_Atmel_Studio/src/ParTest.c
+++ b/FreeRTOS/Demo/CORTEX_M4_ATSAM4S_Atmel_Studio/src/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4_ATSAM4S_Atmel_Studio/src/main.c
+++ b/FreeRTOS/Demo/CORTEX_M4_ATSAM4S_Atmel_Studio/src/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4_ATSAM4S_Atmel_Studio/src/main_blinky.c
+++ b/FreeRTOS/Demo/CORTEX_M4_ATSAM4S_Atmel_Studio/src/main_blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4_ATSAM4S_Atmel_Studio/src/main_full.c
+++ b/FreeRTOS/Demo/CORTEX_M4_ATSAM4S_Atmel_Studio/src/main_full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4_ATSAM4S_Atmel_Studio/src/serial.c
+++ b/FreeRTOS/Demo/CORTEX_M4_ATSAM4S_Atmel_Studio/src/serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4_SimpleLink_CC3220SF_CCS/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_M4_SimpleLink_CC3220SF_CCS/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4_SimpleLink_CC3220SF_CCS/Full_Demo/RegTest.asm
+++ b/FreeRTOS/Demo/CORTEX_M4_SimpleLink_CC3220SF_CCS/Full_Demo/RegTest.asm
@@ -1,5 +1,5 @@
 ;/*
-; * FreeRTOS Kernel V10.3.0
+; * FreeRTOS Kernel V10.3.1
 ; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 ; *
 ; * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4_SimpleLink_CC3220SF_CCS/Full_Demo/main_full.c
+++ b/FreeRTOS/Demo/CORTEX_M4_SimpleLink_CC3220SF_CCS/Full_Demo/main_full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4_SimpleLink_CC3220SF_CCS/Simply_Blinky_Demo/main_blinky.c
+++ b/FreeRTOS/Demo/CORTEX_M4_SimpleLink_CC3220SF_CCS/Simply_Blinky_Demo/main_blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M4_SimpleLink_CC3220SF_CCS/main.c
+++ b/FreeRTOS/Demo/CORTEX_M4_SimpleLink_CC3220SF_CCS/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M7_M4_AMP_STM32H745I_Discovery_IAR/CM4/main.c
+++ b/FreeRTOS/Demo/CORTEX_M7_M4_AMP_STM32H745I_Discovery_IAR/CM4/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M7_M4_AMP_STM32H745I_Discovery_IAR/CM7/main.c
+++ b/FreeRTOS/Demo/CORTEX_M7_M4_AMP_STM32H745I_Discovery_IAR/CM7/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M7_SAME70_Xplained_AtmelStudio/src/Blinky_Demo/main_blinky.c
+++ b/FreeRTOS/Demo/CORTEX_M7_SAME70_Xplained_AtmelStudio/src/Blinky_Demo/main_blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M7_SAME70_Xplained_AtmelStudio/src/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_M7_SAME70_Xplained_AtmelStudio/src/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M7_SAME70_Xplained_AtmelStudio/src/Full_Demo/IntQueueTimer.c
+++ b/FreeRTOS/Demo/CORTEX_M7_SAME70_Xplained_AtmelStudio/src/Full_Demo/IntQueueTimer.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M7_SAME70_Xplained_AtmelStudio/src/Full_Demo/IntQueueTimer.h
+++ b/FreeRTOS/Demo/CORTEX_M7_SAME70_Xplained_AtmelStudio/src/Full_Demo/IntQueueTimer.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M7_SAME70_Xplained_AtmelStudio/src/Full_Demo/RegTest_GCC.c
+++ b/FreeRTOS/Demo/CORTEX_M7_SAME70_Xplained_AtmelStudio/src/Full_Demo/RegTest_GCC.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M7_SAME70_Xplained_AtmelStudio/src/Full_Demo/main_full.c
+++ b/FreeRTOS/Demo/CORTEX_M7_SAME70_Xplained_AtmelStudio/src/Full_Demo/main_full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M7_SAME70_Xplained_AtmelStudio/src/main.c
+++ b/FreeRTOS/Demo/CORTEX_M7_SAME70_Xplained_AtmelStudio/src/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M7_SAMV71_Xplained_AtmelStudio/Blinky_Demo/main_blinky.c
+++ b/FreeRTOS/Demo/CORTEX_M7_SAMV71_Xplained_AtmelStudio/Blinky_Demo/main_blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M7_SAMV71_Xplained_AtmelStudio/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_M7_SAMV71_Xplained_AtmelStudio/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M7_SAMV71_Xplained_AtmelStudio/Full_Demo/IntQueueTimer.c
+++ b/FreeRTOS/Demo/CORTEX_M7_SAMV71_Xplained_AtmelStudio/Full_Demo/IntQueueTimer.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M7_SAMV71_Xplained_AtmelStudio/Full_Demo/IntQueueTimer.h
+++ b/FreeRTOS/Demo/CORTEX_M7_SAMV71_Xplained_AtmelStudio/Full_Demo/IntQueueTimer.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M7_SAMV71_Xplained_AtmelStudio/Full_Demo/RegTest_GCC.c
+++ b/FreeRTOS/Demo/CORTEX_M7_SAMV71_Xplained_AtmelStudio/Full_Demo/RegTest_GCC.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M7_SAMV71_Xplained_AtmelStudio/Full_Demo/main_full.c
+++ b/FreeRTOS/Demo/CORTEX_M7_SAMV71_Xplained_AtmelStudio/Full_Demo/main_full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M7_SAMV71_Xplained_AtmelStudio/main.c
+++ b/FreeRTOS/Demo/CORTEX_M7_SAMV71_Xplained_AtmelStudio/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M7_SAMV71_Xplained_IAR_Keil/Blinky_Demo/main_blinky.c
+++ b/FreeRTOS/Demo/CORTEX_M7_SAMV71_Xplained_IAR_Keil/Blinky_Demo/main_blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M7_SAMV71_Xplained_IAR_Keil/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_M7_SAMV71_Xplained_IAR_Keil/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M7_SAMV71_Xplained_IAR_Keil/Full_Demo/IntQueueTimer.c
+++ b/FreeRTOS/Demo/CORTEX_M7_SAMV71_Xplained_IAR_Keil/Full_Demo/IntQueueTimer.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M7_SAMV71_Xplained_IAR_Keil/Full_Demo/IntQueueTimer.h
+++ b/FreeRTOS/Demo/CORTEX_M7_SAMV71_Xplained_IAR_Keil/Full_Demo/IntQueueTimer.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M7_SAMV71_Xplained_IAR_Keil/Full_Demo/RegTest.c
+++ b/FreeRTOS/Demo/CORTEX_M7_SAMV71_Xplained_IAR_Keil/Full_Demo/RegTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M7_SAMV71_Xplained_IAR_Keil/Full_Demo/RegTest.s
+++ b/FreeRTOS/Demo/CORTEX_M7_SAMV71_Xplained_IAR_Keil/Full_Demo/RegTest.s
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M7_SAMV71_Xplained_IAR_Keil/Full_Demo/main_full.c
+++ b/FreeRTOS/Demo/CORTEX_M7_SAMV71_Xplained_IAR_Keil/Full_Demo/main_full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M7_SAMV71_Xplained_IAR_Keil/main.c
+++ b/FreeRTOS/Demo/CORTEX_M7_SAMV71_Xplained_IAR_Keil/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M7_STM32F7_STM32756G-EVAL_IAR_Keil/Blinky_Demo/main_blinky.c
+++ b/FreeRTOS/Demo/CORTEX_M7_STM32F7_STM32756G-EVAL_IAR_Keil/Blinky_Demo/main_blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M7_STM32F7_STM32756G-EVAL_IAR_Keil/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_M7_STM32F7_STM32756G-EVAL_IAR_Keil/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M7_STM32F7_STM32756G-EVAL_IAR_Keil/Full_Demo/IntQueueTimer.c
+++ b/FreeRTOS/Demo/CORTEX_M7_STM32F7_STM32756G-EVAL_IAR_Keil/Full_Demo/IntQueueTimer.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M7_STM32F7_STM32756G-EVAL_IAR_Keil/Full_Demo/IntQueueTimer.h
+++ b/FreeRTOS/Demo/CORTEX_M7_STM32F7_STM32756G-EVAL_IAR_Keil/Full_Demo/IntQueueTimer.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M7_STM32F7_STM32756G-EVAL_IAR_Keil/Full_Demo/RegTest_IAR.s
+++ b/FreeRTOS/Demo/CORTEX_M7_STM32F7_STM32756G-EVAL_IAR_Keil/Full_Demo/RegTest_IAR.s
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M7_STM32F7_STM32756G-EVAL_IAR_Keil/Full_Demo/RegTest_Keil.c
+++ b/FreeRTOS/Demo/CORTEX_M7_STM32F7_STM32756G-EVAL_IAR_Keil/Full_Demo/RegTest_Keil.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M7_STM32F7_STM32756G-EVAL_IAR_Keil/Full_Demo/main_full.c
+++ b/FreeRTOS/Demo/CORTEX_M7_STM32F7_STM32756G-EVAL_IAR_Keil/Full_Demo/main_full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_M7_STM32F7_STM32756G-EVAL_IAR_Keil/main.c
+++ b/FreeRTOS/Demo/CORTEX_M7_STM32F7_STM32756G-EVAL_IAR_Keil/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_MB9A310_IAR_Keil/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_MB9A310_IAR_Keil/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_MB9A310_IAR_Keil/ParTest.c
+++ b/FreeRTOS/Demo/CORTEX_MB9A310_IAR_Keil/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_MB9A310_IAR_Keil/main-full.c
+++ b/FreeRTOS/Demo/CORTEX_MB9A310_IAR_Keil/main-full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_MB9A310_IAR_Keil/main_blinky.c
+++ b/FreeRTOS/Demo/CORTEX_MB9A310_IAR_Keil/main_blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_MB9A310_IAR_Keil/serial.c
+++ b/FreeRTOS/Demo/CORTEX_MB9A310_IAR_Keil/serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_MB9B500_IAR_Keil/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_MB9B500_IAR_Keil/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_MB9B500_IAR_Keil/ParTest.c
+++ b/FreeRTOS/Demo/CORTEX_MB9B500_IAR_Keil/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_MB9B500_IAR_Keil/main-full.c
+++ b/FreeRTOS/Demo/CORTEX_MB9B500_IAR_Keil/main-full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_MB9B500_IAR_Keil/main_blinky.c
+++ b/FreeRTOS/Demo/CORTEX_MB9B500_IAR_Keil/main_blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_MB9B500_IAR_Keil/serial.c
+++ b/FreeRTOS/Demo/CORTEX_MB9B500_IAR_Keil/serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_MPU_CEC_MEC_17xx_51xx_Keil_GCC/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_MPU_CEC_MEC_17xx_51xx_Keil_GCC/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_MPU_CEC_MEC_17xx_51xx_Keil_GCC/GCC_Specific/RegTest.c
+++ b/FreeRTOS/Demo/CORTEX_MPU_CEC_MEC_17xx_51xx_Keil_GCC/GCC_Specific/RegTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_MPU_CEC_MEC_17xx_51xx_Keil_GCC/Keil_Specific/RegTest.c
+++ b/FreeRTOS/Demo/CORTEX_MPU_CEC_MEC_17xx_51xx_Keil_GCC/Keil_Specific/RegTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_MPU_CEC_MEC_17xx_51xx_Keil_GCC/main.c
+++ b/FreeRTOS/Demo/CORTEX_MPU_CEC_MEC_17xx_51xx_Keil_GCC/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_MPU_LPC54018_MCUXpresso/Config/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_MPU_LPC54018_MCUXpresso/Config/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_MPU_LPC54018_MCUXpresso/Demo/main.c
+++ b/FreeRTOS/Demo/CORTEX_MPU_LPC54018_MCUXpresso/Demo/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_MPU_LPC54018_MCUXpresso/Demo/mpu_demo.c
+++ b/FreeRTOS/Demo/CORTEX_MPU_LPC54018_MCUXpresso/Demo/mpu_demo.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_MPU_LPC54018_MCUXpresso/Demo/mpu_demo.h
+++ b/FreeRTOS/Demo/CORTEX_MPU_LPC54018_MCUXpresso/Demo/mpu_demo.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_MPU_LPC54018_MCUXpresso/Projects/MCUXpresso/Startup/memfault_handler.c
+++ b/FreeRTOS/Demo/CORTEX_MPU_LPC54018_MCUXpresso/Projects/MCUXpresso/Startup/memfault_handler.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_MPU_M23_Nuvoton_NuMaker_PFM_M2351_IAR_GCC/Projects/IAR/Config/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_MPU_M23_Nuvoton_NuMaker_PFM_M2351_IAR_GCC/Projects/IAR/Config/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_MPU_M23_Nuvoton_NuMaker_PFM_M2351_IAR_GCC/Projects/IAR/NonSecure/fault_handler.s
+++ b/FreeRTOS/Demo/CORTEX_MPU_M23_Nuvoton_NuMaker_PFM_M2351_IAR_GCC/Projects/IAR/NonSecure/fault_handler.s
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_MPU_M23_Nuvoton_NuMaker_PFM_M2351_IAR_GCC/Projects/IAR/NonSecure/main_ns.c
+++ b/FreeRTOS/Demo/CORTEX_MPU_M23_Nuvoton_NuMaker_PFM_M2351_IAR_GCC/Projects/IAR/NonSecure/main_ns.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_MPU_M23_Nuvoton_NuMaker_PFM_M2351_IAR_GCC/Projects/IAR/Secure/main_s.c
+++ b/FreeRTOS/Demo/CORTEX_MPU_M23_Nuvoton_NuMaker_PFM_M2351_IAR_GCC/Projects/IAR/Secure/main_s.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_MPU_M23_Nuvoton_NuMaker_PFM_M2351_IAR_GCC/Projects/Keil/Config/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_MPU_M23_Nuvoton_NuMaker_PFM_M2351_IAR_GCC/Projects/Keil/Config/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_MPU_M23_Nuvoton_NuMaker_PFM_M2351_IAR_GCC/Projects/Keil/NonSecure/main_ns.c
+++ b/FreeRTOS/Demo/CORTEX_MPU_M23_Nuvoton_NuMaker_PFM_M2351_IAR_GCC/Projects/Keil/NonSecure/main_ns.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_MPU_M23_Nuvoton_NuMaker_PFM_M2351_IAR_GCC/Projects/Keil/Secure/main_s.c
+++ b/FreeRTOS/Demo/CORTEX_MPU_M23_Nuvoton_NuMaker_PFM_M2351_IAR_GCC/Projects/Keil/Secure/main_s.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_MPU_M33F_NXP_LPC55S69_MCUXpresso/Projects/MCUXpresso/Config/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_MPU_M33F_NXP_LPC55S69_MCUXpresso/Projects/MCUXpresso/Config/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_MPU_M33F_NXP_LPC55S69_MCUXpresso/Projects/MCUXpresso/NonSecure/main_ns.c
+++ b/FreeRTOS/Demo/CORTEX_MPU_M33F_NXP_LPC55S69_MCUXpresso/Projects/MCUXpresso/NonSecure/main_ns.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_MPU_M33F_NXP_LPC55S69_MCUXpresso/Projects/MCUXpresso/Secure/main_s.c
+++ b/FreeRTOS/Demo/CORTEX_MPU_M33F_NXP_LPC55S69_MCUXpresso/Projects/MCUXpresso/Secure/main_s.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_MPU_M33F_Simulator_Keil_GCC/Config/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_MPU_M33F_Simulator_Keil_GCC/Config/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_MPU_M33F_Simulator_Keil_GCC/NonSecure/main_ns.c
+++ b/FreeRTOS/Demo/CORTEX_MPU_M33F_Simulator_Keil_GCC/NonSecure/main_ns.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_MPU_M33F_Simulator_Keil_GCC/Secure/main_s.c
+++ b/FreeRTOS/Demo/CORTEX_MPU_M33F_Simulator_Keil_GCC/Secure/main_s.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_MPU_M3_NUCLEO_L152RE_GCC/Config/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_MPU_M3_NUCLEO_L152RE_GCC/Config/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_MPU_M3_NUCLEO_L152RE_GCC/Demo/app_main.c
+++ b/FreeRTOS/Demo/CORTEX_MPU_M3_NUCLEO_L152RE_GCC/Demo/app_main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_MPU_M3_NUCLEO_L152RE_GCC/Demo/app_main.h
+++ b/FreeRTOS/Demo/CORTEX_MPU_M3_NUCLEO_L152RE_GCC/Demo/app_main.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_MPU_M3_NUCLEO_L152RE_GCC/Demo/mpu_demo.c
+++ b/FreeRTOS/Demo/CORTEX_MPU_M3_NUCLEO_L152RE_GCC/Demo/mpu_demo.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_MPU_M3_NUCLEO_L152RE_GCC/Demo/mpu_demo.h
+++ b/FreeRTOS/Demo/CORTEX_MPU_M3_NUCLEO_L152RE_GCC/Demo/mpu_demo.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_MPU_M3_NUCLEO_L152RE_GCC/Projects/GCC/Startup/memfault_handler.c
+++ b/FreeRTOS/Demo/CORTEX_MPU_M3_NUCLEO_L152RE_GCC/Projects/GCC/Startup/memfault_handler.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_MPU_STM32L4_Discovery_GCC_IAR_Keil/Config/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_MPU_STM32L4_Discovery_GCC_IAR_Keil/Config/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_MPU_STM32L4_Discovery_GCC_IAR_Keil/Demo/app_main.c
+++ b/FreeRTOS/Demo/CORTEX_MPU_STM32L4_Discovery_GCC_IAR_Keil/Demo/app_main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_MPU_STM32L4_Discovery_GCC_IAR_Keil/Demo/app_main.h
+++ b/FreeRTOS/Demo/CORTEX_MPU_STM32L4_Discovery_GCC_IAR_Keil/Demo/app_main.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_MPU_STM32L4_Discovery_GCC_IAR_Keil/Demo/mpu_demo.c
+++ b/FreeRTOS/Demo/CORTEX_MPU_STM32L4_Discovery_GCC_IAR_Keil/Demo/mpu_demo.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_MPU_STM32L4_Discovery_GCC_IAR_Keil/Demo/mpu_demo.h
+++ b/FreeRTOS/Demo/CORTEX_MPU_STM32L4_Discovery_GCC_IAR_Keil/Demo/mpu_demo.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_MPU_STM32L4_Discovery_GCC_IAR_Keil/Projects/GCC/Startup/memfault_handler.c
+++ b/FreeRTOS/Demo/CORTEX_MPU_STM32L4_Discovery_GCC_IAR_Keil/Projects/GCC/Startup/memfault_handler.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_MPU_STM32L4_Discovery_GCC_IAR_Keil/Projects/IAR/memfault_handler.s
+++ b/FreeRTOS/Demo/CORTEX_MPU_STM32L4_Discovery_GCC_IAR_Keil/Projects/IAR/memfault_handler.s
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_MPU_STM32L4_Discovery_GCC_IAR_Keil/Projects/Keil/memfault_handler.c
+++ b/FreeRTOS/Demo/CORTEX_MPU_STM32L4_Discovery_GCC_IAR_Keil/Projects/Keil/memfault_handler.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_MPU_Simulator_Keil_GCC/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_MPU_Simulator_Keil_GCC/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_MPU_Simulator_Keil_GCC/GCC_Specific/RegTest.c
+++ b/FreeRTOS/Demo/CORTEX_MPU_Simulator_Keil_GCC/GCC_Specific/RegTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_MPU_Simulator_Keil_GCC/Keil_Specific/RegTest.c
+++ b/FreeRTOS/Demo/CORTEX_MPU_Simulator_Keil_GCC/Keil_Specific/RegTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_MPU_Simulator_Keil_GCC/main.c
+++ b/FreeRTOS/Demo/CORTEX_MPU_Simulator_Keil_GCC/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_MPU_Static_Simulator_Keil_GCC/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_MPU_Static_Simulator_Keil_GCC/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_MPU_Static_Simulator_Keil_GCC/GCC_Specific/RegTest.c
+++ b/FreeRTOS/Demo/CORTEX_MPU_Static_Simulator_Keil_GCC/GCC_Specific/RegTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_MPU_Static_Simulator_Keil_GCC/Keil_Specific/RegTest.c
+++ b/FreeRTOS/Demo/CORTEX_MPU_Static_Simulator_Keil_GCC/Keil_Specific/RegTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_MPU_Static_Simulator_Keil_GCC/main.c
+++ b/FreeRTOS/Demo/CORTEX_MPU_Static_Simulator_Keil_GCC/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_R4F_RZ_T_GCC_IAR/System/IAR/Interrupt_Entry_Stubs.asm
+++ b/FreeRTOS/Demo/CORTEX_R4F_RZ_T_GCC_IAR/System/IAR/Interrupt_Entry_Stubs.asm
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_R4F_RZ_T_GCC_IAR/src/Blinky_Demo/main_blinky.c
+++ b/FreeRTOS/Demo/CORTEX_R4F_RZ_T_GCC_IAR/src/Blinky_Demo/main_blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_R4F_RZ_T_GCC_IAR/src/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_R4F_RZ_T_GCC_IAR/src/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_R4F_RZ_T_GCC_IAR/src/FreeRTOS_tick_config.c
+++ b/FreeRTOS/Demo/CORTEX_R4F_RZ_T_GCC_IAR/src/FreeRTOS_tick_config.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_R4F_RZ_T_GCC_IAR/src/Full_Demo/IntQueueTimer.c
+++ b/FreeRTOS/Demo/CORTEX_R4F_RZ_T_GCC_IAR/src/Full_Demo/IntQueueTimer.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_R4F_RZ_T_GCC_IAR/src/Full_Demo/IntQueueTimer.h
+++ b/FreeRTOS/Demo/CORTEX_R4F_RZ_T_GCC_IAR/src/Full_Demo/IntQueueTimer.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_R4F_RZ_T_GCC_IAR/src/Full_Demo/main_full.c
+++ b/FreeRTOS/Demo/CORTEX_R4F_RZ_T_GCC_IAR/src/Full_Demo/main_full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_R4F_RZ_T_GCC_IAR/src/Full_Demo/reg_test_GCC.S
+++ b/FreeRTOS/Demo/CORTEX_R4F_RZ_T_GCC_IAR/src/Full_Demo/reg_test_GCC.S
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_R4F_RZ_T_GCC_IAR/src/Full_Demo/reg_test_IAR.asm
+++ b/FreeRTOS/Demo/CORTEX_R4F_RZ_T_GCC_IAR/src/Full_Demo/reg_test_IAR.asm
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_R4F_RZ_T_GCC_IAR/src/main.c
+++ b/FreeRTOS/Demo/CORTEX_R4F_RZ_T_GCC_IAR/src/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_R4_RM48_TMS570_CCS5/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_R4_RM48_TMS570_CCS5/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_R4_RM48_TMS570_CCS5/Library/het.c
+++ b/FreeRTOS/Demo/CORTEX_R4_RM48_TMS570_CCS5/Library/het.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_R4_RM48_TMS570_CCS5/Library/het.h
+++ b/FreeRTOS/Demo/CORTEX_R4_RM48_TMS570_CCS5/Library/het.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_R4_RM48_TMS570_CCS5/ParTest.c
+++ b/FreeRTOS/Demo/CORTEX_R4_RM48_TMS570_CCS5/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_R4_RM48_TMS570_CCS5/flop_hercules.c
+++ b/FreeRTOS/Demo/CORTEX_R4_RM48_TMS570_CCS5/flop_hercules.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_R4_RM48_TMS570_CCS5/flop_hercules.h
+++ b/FreeRTOS/Demo/CORTEX_R4_RM48_TMS570_CCS5/flop_hercules.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_R4_RM48_TMS570_CCS5/main.c
+++ b/FreeRTOS/Demo/CORTEX_R4_RM48_TMS570_CCS5/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_R4_RM48_TMS570_CCS5/main_blinky.c
+++ b/FreeRTOS/Demo/CORTEX_R4_RM48_TMS570_CCS5/main_blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_R4_RM48_TMS570_CCS5/main_full.c
+++ b/FreeRTOS/Demo/CORTEX_R4_RM48_TMS570_CCS5/main_full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_R4_RM48_TMS570_CCS5/reg_test.asm
+++ b/FreeRTOS/Demo/CORTEX_R4_RM48_TMS570_CCS5/reg_test.asm
@@ -1,5 +1,5 @@
 ;/*
-; * FreeRTOS Kernel V10.3.0
+; * FreeRTOS Kernel V10.3.1
 ; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 ; *
 ; * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_R4_RM48_TMS570_CCS5/serial.c
+++ b/FreeRTOS/Demo/CORTEX_R4_RM48_TMS570_CCS5/serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_R5_UltraScale_MPSoC/RTOSDemo_R5/src/Blinky_Demo/main_blinky.c
+++ b/FreeRTOS/Demo/CORTEX_R5_UltraScale_MPSoC/RTOSDemo_R5/src/Blinky_Demo/main_blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_R5_UltraScale_MPSoC/RTOSDemo_R5/src/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_R5_UltraScale_MPSoC/RTOSDemo_R5/src/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_R5_UltraScale_MPSoC/RTOSDemo_R5/src/FreeRTOS_tick_config.c
+++ b/FreeRTOS/Demo/CORTEX_R5_UltraScale_MPSoC/RTOSDemo_R5/src/FreeRTOS_tick_config.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_R5_UltraScale_MPSoC/RTOSDemo_R5/src/Full_Demo/IntQueueTimer.c
+++ b/FreeRTOS/Demo/CORTEX_R5_UltraScale_MPSoC/RTOSDemo_R5/src/Full_Demo/IntQueueTimer.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_R5_UltraScale_MPSoC/RTOSDemo_R5/src/Full_Demo/IntQueueTimer.h
+++ b/FreeRTOS/Demo/CORTEX_R5_UltraScale_MPSoC/RTOSDemo_R5/src/Full_Demo/IntQueueTimer.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_R5_UltraScale_MPSoC/RTOSDemo_R5/src/Full_Demo/main_full.c
+++ b/FreeRTOS/Demo/CORTEX_R5_UltraScale_MPSoC/RTOSDemo_R5/src/Full_Demo/main_full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_R5_UltraScale_MPSoC/RTOSDemo_R5/src/Full_Demo/reg_test.S
+++ b/FreeRTOS/Demo/CORTEX_R5_UltraScale_MPSoC/RTOSDemo_R5/src/Full_Demo/reg_test.S
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_R5_UltraScale_MPSoC/RTOSDemo_R5/src/main.c
+++ b/FreeRTOS/Demo/CORTEX_R5_UltraScale_MPSoC/RTOSDemo_R5/src/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_STM32F100_Atollic/Simple_Demo_Source/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_STM32F100_Atollic/Simple_Demo_Source/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_STM32F100_Atollic/Simple_Demo_Source/main.c
+++ b/FreeRTOS/Demo/CORTEX_STM32F100_Atollic/Simple_Demo_Source/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_STM32F103_GCC_Rowley/Drivers/STM32_USART.c
+++ b/FreeRTOS/Demo/CORTEX_STM32F103_GCC_Rowley/Drivers/STM32_USART.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_STM32F103_GCC_Rowley/Drivers/STM32_USART.h
+++ b/FreeRTOS/Demo/CORTEX_STM32F103_GCC_Rowley/Drivers/STM32_USART.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_STM32F103_GCC_Rowley/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_STM32F103_GCC_Rowley/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_STM32F103_GCC_Rowley/ParTest/ParTest_MCBSTM32.c
+++ b/FreeRTOS/Demo/CORTEX_STM32F103_GCC_Rowley/ParTest/ParTest_MCBSTM32.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_STM32F103_GCC_Rowley/ParTest/ParTest_ST_Eval.c
+++ b/FreeRTOS/Demo/CORTEX_STM32F103_GCC_Rowley/ParTest/ParTest_ST_Eval.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_STM32F103_GCC_Rowley/main.c
+++ b/FreeRTOS/Demo/CORTEX_STM32F103_GCC_Rowley/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_STM32F103_IAR/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_STM32F103_IAR/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_STM32F103_IAR/ParTest/ParTest.c
+++ b/FreeRTOS/Demo/CORTEX_STM32F103_IAR/ParTest/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_STM32F103_IAR/main.c
+++ b/FreeRTOS/Demo/CORTEX_STM32F103_IAR/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_STM32F103_IAR/serial/serial.c
+++ b/FreeRTOS/Demo/CORTEX_STM32F103_IAR/serial/serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_STM32F103_IAR/timertest.c
+++ b/FreeRTOS/Demo/CORTEX_STM32F103_IAR/timertest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_STM32F103_Keil/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_STM32F103_Keil/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_STM32F103_Keil/ParTest/ParTest.c
+++ b/FreeRTOS/Demo/CORTEX_STM32F103_Keil/ParTest/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_STM32F103_Keil/main.c
+++ b/FreeRTOS/Demo/CORTEX_STM32F103_Keil/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_STM32F103_Keil/serial/serial.c
+++ b/FreeRTOS/Demo/CORTEX_STM32F103_Keil/serial/serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_STM32F103_Keil/timertest.c
+++ b/FreeRTOS/Demo/CORTEX_STM32F103_Keil/timertest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_STM32F103_Primer_GCC/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_STM32F103_Primer_GCC/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_STM32F103_Primer_GCC/ParTest/ParTest.c
+++ b/FreeRTOS/Demo/CORTEX_STM32F103_Primer_GCC/ParTest/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_STM32F103_Primer_GCC/bitmap.h
+++ b/FreeRTOS/Demo/CORTEX_STM32F103_Primer_GCC/bitmap.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_STM32F103_Primer_GCC/main.c
+++ b/FreeRTOS/Demo/CORTEX_STM32F103_Primer_GCC/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_STM32F103_Primer_GCC/timertest.c
+++ b/FreeRTOS/Demo/CORTEX_STM32F103_Primer_GCC/timertest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_STM32F107_GCC_Rowley/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_STM32F107_GCC_Rowley/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_STM32F107_GCC_Rowley/ParTest/ParTest.c
+++ b/FreeRTOS/Demo/CORTEX_STM32F107_GCC_Rowley/ParTest/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_STM32F107_GCC_Rowley/main.c
+++ b/FreeRTOS/Demo/CORTEX_STM32F107_GCC_Rowley/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_STM32F107_GCC_Rowley/scsc.tmp
+++ b/FreeRTOS/Demo/CORTEX_STM32F107_GCC_Rowley/scsc.tmp
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_STM32F107_GCC_Rowley/timertest.c
+++ b/FreeRTOS/Demo/CORTEX_STM32F107_GCC_Rowley/timertest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_STM32F107_GCC_Rowley/webserver/emac.c
+++ b/FreeRTOS/Demo/CORTEX_STM32F107_GCC_Rowley/webserver/emac.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_STM32F107_GCC_Rowley/webserver/emac.c.scsc
+++ b/FreeRTOS/Demo/CORTEX_STM32F107_GCC_Rowley/webserver/emac.c.scsc
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_STM32F107_GCC_Rowley/webserver/emac.h
+++ b/FreeRTOS/Demo/CORTEX_STM32F107_GCC_Rowley/webserver/emac.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_STM32F107_GCC_Rowley/webserver/emac.h.scsc
+++ b/FreeRTOS/Demo/CORTEX_STM32F107_GCC_Rowley/webserver/emac.h.scsc
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_STM32F107_GCC_Rowley/webserver/uIP_Task.c
+++ b/FreeRTOS/Demo/CORTEX_STM32F107_GCC_Rowley/webserver/uIP_Task.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_STM32L152_Discovery_IAR/STM32L_low_power_tick_management.c
+++ b/FreeRTOS/Demo/CORTEX_STM32L152_Discovery_IAR/STM32L_low_power_tick_management.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_STM32L152_Discovery_IAR/include/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_STM32L152_Discovery_IAR/include/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_STM32L152_Discovery_IAR/main.c
+++ b/FreeRTOS/Demo/CORTEX_STM32L152_Discovery_IAR/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_STM32L152_Discovery_IAR/main_full.c
+++ b/FreeRTOS/Demo/CORTEX_STM32L152_Discovery_IAR/main_full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_STM32L152_Discovery_IAR/main_low_power.c
+++ b/FreeRTOS/Demo/CORTEX_STM32L152_Discovery_IAR/main_low_power.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_STM32L152_IAR/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_STM32L152_IAR/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_STM32L152_IAR/ParTest.c
+++ b/FreeRTOS/Demo/CORTEX_STM32L152_IAR/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_STM32L152_IAR/main.c
+++ b/FreeRTOS/Demo/CORTEX_STM32L152_IAR/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTEX_STM32L152_IAR/serial.c
+++ b/FreeRTOS/Demo/CORTEX_STM32L152_IAR/serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTUS_APS3_GCC/Demo/7seg.c
+++ b/FreeRTOS/Demo/CORTUS_APS3_GCC/Demo/7seg.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTUS_APS3_GCC/Demo/7seg.h
+++ b/FreeRTOS/Demo/CORTUS_APS3_GCC/Demo/7seg.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTUS_APS3_GCC/Demo/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTUS_APS3_GCC/Demo/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTUS_APS3_GCC/Demo/ParTest.c
+++ b/FreeRTOS/Demo/CORTUS_APS3_GCC/Demo/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTUS_APS3_GCC/Demo/RegTest.c
+++ b/FreeRTOS/Demo/CORTUS_APS3_GCC/Demo/RegTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTUS_APS3_GCC/Demo/RegTest.h
+++ b/FreeRTOS/Demo/CORTUS_APS3_GCC/Demo/RegTest.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTUS_APS3_GCC/Demo/demoGpio.h
+++ b/FreeRTOS/Demo/CORTUS_APS3_GCC/Demo/demoGpio.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTUS_APS3_GCC/Demo/main.c
+++ b/FreeRTOS/Demo/CORTUS_APS3_GCC/Demo/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/CORTUS_APS3_GCC/Demo/serial.c
+++ b/FreeRTOS/Demo/CORTUS_APS3_GCC/Demo/serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ColdFire_MCF51CN128_CodeWarrior/Sources/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/ColdFire_MCF51CN128_CodeWarrior/Sources/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ColdFire_MCF51CN128_CodeWarrior/Sources/ParTest/ParTest.c
+++ b/FreeRTOS/Demo/ColdFire_MCF51CN128_CodeWarrior/Sources/ParTest/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ColdFire_MCF51CN128_CodeWarrior/Sources/httpd/uIP_Task.c
+++ b/FreeRTOS/Demo/ColdFire_MCF51CN128_CodeWarrior/Sources/httpd/uIP_Task.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ColdFire_MCF51CN128_CodeWarrior/Sources/main.c
+++ b/FreeRTOS/Demo/ColdFire_MCF51CN128_CodeWarrior/Sources/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ColdFire_MCF52221_CodeWarrior/sources/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/ColdFire_MCF52221_CodeWarrior/sources/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ColdFire_MCF52221_CodeWarrior/sources/FreeRTOS_Tick_Setup.c
+++ b/FreeRTOS/Demo/ColdFire_MCF52221_CodeWarrior/sources/FreeRTOS_Tick_Setup.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ColdFire_MCF52221_CodeWarrior/sources/ParTest/ParTest.c
+++ b/FreeRTOS/Demo/ColdFire_MCF52221_CodeWarrior/sources/ParTest/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ColdFire_MCF52221_CodeWarrior/sources/main.c
+++ b/FreeRTOS/Demo/ColdFire_MCF52221_CodeWarrior/sources/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ColdFire_MCF52221_CodeWarrior/sources/serial/serial.c
+++ b/FreeRTOS/Demo/ColdFire_MCF52221_CodeWarrior/sources/serial/serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ColdFire_MCF52259_CodeWarrior/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/ColdFire_MCF52259_CodeWarrior/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ColdFire_MCF52259_CodeWarrior/FreeRTOS_Tick_Setup.c
+++ b/FreeRTOS/Demo/ColdFire_MCF52259_CodeWarrior/FreeRTOS_Tick_Setup.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ColdFire_MCF52259_CodeWarrior/HTTPDemo.c
+++ b/FreeRTOS/Demo/ColdFire_MCF52259_CodeWarrior/HTTPDemo.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ColdFire_MCF52259_CodeWarrior/HTTPDemo.h
+++ b/FreeRTOS/Demo/ColdFire_MCF52259_CodeWarrior/HTTPDemo.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ColdFire_MCF52259_CodeWarrior/ParTest/ParTest.c
+++ b/FreeRTOS/Demo/ColdFire_MCF52259_CodeWarrior/ParTest/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/ColdFire_MCF52259_CodeWarrior/main.c
+++ b/FreeRTOS/Demo/ColdFire_MCF52259_CodeWarrior/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/ARMv8M/mpu_demo/mpu_demo.c
+++ b/FreeRTOS/Demo/Common/ARMv8M/mpu_demo/mpu_demo.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/ARMv8M/mpu_demo/mpu_demo.h
+++ b/FreeRTOS/Demo/Common/ARMv8M/mpu_demo/mpu_demo.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/ARMv8M/tz_demo/nsc_functions.c
+++ b/FreeRTOS/Demo/Common/ARMv8M/tz_demo/nsc_functions.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/ARMv8M/tz_demo/nsc_functions.h
+++ b/FreeRTOS/Demo/Common/ARMv8M/tz_demo/nsc_functions.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/ARMv8M/tz_demo/tz_demo.c
+++ b/FreeRTOS/Demo/Common/ARMv8M/tz_demo/tz_demo.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/ARMv8M/tz_demo/tz_demo.h
+++ b/FreeRTOS/Demo/Common/ARMv8M/tz_demo/tz_demo.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/Full/BlockQ.c
+++ b/FreeRTOS/Demo/Common/Full/BlockQ.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/Full/PollQ.c
+++ b/FreeRTOS/Demo/Common/Full/PollQ.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/Full/comtest.c
+++ b/FreeRTOS/Demo/Common/Full/comtest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/Full/death.c
+++ b/FreeRTOS/Demo/Common/Full/death.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/Full/dynamic.c
+++ b/FreeRTOS/Demo/Common/Full/dynamic.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/Full/events.c
+++ b/FreeRTOS/Demo/Common/Full/events.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/Full/flash.c
+++ b/FreeRTOS/Demo/Common/Full/flash.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/Full/flop.c
+++ b/FreeRTOS/Demo/Common/Full/flop.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/Full/integer.c
+++ b/FreeRTOS/Demo/Common/Full/integer.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/Full/print.c
+++ b/FreeRTOS/Demo/Common/Full/print.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/Full/semtest.c
+++ b/FreeRTOS/Demo/Common/Full/semtest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/Minimal/AbortDelay.c
+++ b/FreeRTOS/Demo/Common/Minimal/AbortDelay.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/Minimal/BlockQ.c
+++ b/FreeRTOS/Demo/Common/Minimal/BlockQ.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/Minimal/EventGroupsDemo.c
+++ b/FreeRTOS/Demo/Common/Minimal/EventGroupsDemo.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/Minimal/GenQTest.c
+++ b/FreeRTOS/Demo/Common/Minimal/GenQTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/Minimal/IntQueue.c
+++ b/FreeRTOS/Demo/Common/Minimal/IntQueue.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/Minimal/IntSemTest.c
+++ b/FreeRTOS/Demo/Common/Minimal/IntSemTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/Minimal/MessageBufferAMP.c
+++ b/FreeRTOS/Demo/Common/Minimal/MessageBufferAMP.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/Minimal/MessageBufferDemo.c
+++ b/FreeRTOS/Demo/Common/Minimal/MessageBufferDemo.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/Minimal/PollQ.c
+++ b/FreeRTOS/Demo/Common/Minimal/PollQ.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/Minimal/QPeek.c
+++ b/FreeRTOS/Demo/Common/Minimal/QPeek.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/Minimal/QueueOverwrite.c
+++ b/FreeRTOS/Demo/Common/Minimal/QueueOverwrite.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/Minimal/QueueSet.c
+++ b/FreeRTOS/Demo/Common/Minimal/QueueSet.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/Minimal/QueueSetPolling.c
+++ b/FreeRTOS/Demo/Common/Minimal/QueueSetPolling.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/Minimal/StaticAllocation.c
+++ b/FreeRTOS/Demo/Common/Minimal/StaticAllocation.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/Minimal/StreamBufferDemo.c
+++ b/FreeRTOS/Demo/Common/Minimal/StreamBufferDemo.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/Minimal/StreamBufferInterrupt.c
+++ b/FreeRTOS/Demo/Common/Minimal/StreamBufferInterrupt.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/Minimal/TaskNotify.c
+++ b/FreeRTOS/Demo/Common/Minimal/TaskNotify.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/Minimal/TimerDemo.c
+++ b/FreeRTOS/Demo/Common/Minimal/TimerDemo.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/Minimal/blocktim.c
+++ b/FreeRTOS/Demo/Common/Minimal/blocktim.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/Minimal/comtest.c
+++ b/FreeRTOS/Demo/Common/Minimal/comtest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/Minimal/comtest_strings.c
+++ b/FreeRTOS/Demo/Common/Minimal/comtest_strings.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/Minimal/countsem.c
+++ b/FreeRTOS/Demo/Common/Minimal/countsem.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/Minimal/crflash.c
+++ b/FreeRTOS/Demo/Common/Minimal/crflash.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/Minimal/crhook.c
+++ b/FreeRTOS/Demo/Common/Minimal/crhook.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/Minimal/death.c
+++ b/FreeRTOS/Demo/Common/Minimal/death.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/Minimal/dynamic.c
+++ b/FreeRTOS/Demo/Common/Minimal/dynamic.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/Minimal/flash.c
+++ b/FreeRTOS/Demo/Common/Minimal/flash.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/Minimal/flash_timer.c
+++ b/FreeRTOS/Demo/Common/Minimal/flash_timer.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/Minimal/flop.c
+++ b/FreeRTOS/Demo/Common/Minimal/flop.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/Minimal/integer.c
+++ b/FreeRTOS/Demo/Common/Minimal/integer.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/Minimal/recmutex.c
+++ b/FreeRTOS/Demo/Common/Minimal/recmutex.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/Minimal/semtest.c
+++ b/FreeRTOS/Demo/Common/Minimal/semtest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/Minimal/sp_flop.c
+++ b/FreeRTOS/Demo/Common/Minimal/sp_flop.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/ethernet/lwip-1.4.0/ports/MicroBlaze-Ethernet-Lite/ethernetif.c
+++ b/FreeRTOS/Demo/Common/ethernet/lwip-1.4.0/ports/MicroBlaze-Ethernet-Lite/ethernetif.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/ethernet/lwip-1.4.0/ports/win32/WinPCap/arch.c
+++ b/FreeRTOS/Demo/Common/ethernet/lwip-1.4.0/ports/win32/WinPCap/arch.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/ethernet/lwip-1.4.0/ports/win32/WinPCap/netif.h
+++ b/FreeRTOS/Demo/Common/ethernet/lwip-1.4.0/ports/win32/WinPCap/netif.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/ethernet/lwip-1.4.0/ports/win32/ethernetif.c
+++ b/FreeRTOS/Demo/Common/ethernet/lwip-1.4.0/ports/win32/ethernetif.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/include/AbortDelay.h
+++ b/FreeRTOS/Demo/Common/include/AbortDelay.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/include/BlockQ.h
+++ b/FreeRTOS/Demo/Common/include/BlockQ.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/include/EventGroupsDemo.h
+++ b/FreeRTOS/Demo/Common/include/EventGroupsDemo.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/include/GenQTest.h
+++ b/FreeRTOS/Demo/Common/include/GenQTest.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/include/IntQueue.h
+++ b/FreeRTOS/Demo/Common/include/IntQueue.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/include/IntSemTest.h
+++ b/FreeRTOS/Demo/Common/include/IntSemTest.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/include/MessageBufferAMP.h
+++ b/FreeRTOS/Demo/Common/include/MessageBufferAMP.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/include/MessageBufferDemo.h
+++ b/FreeRTOS/Demo/Common/include/MessageBufferDemo.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/include/PollQ.h
+++ b/FreeRTOS/Demo/Common/include/PollQ.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/include/QPeek.h
+++ b/FreeRTOS/Demo/Common/include/QPeek.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/include/QueueOverwrite.h
+++ b/FreeRTOS/Demo/Common/include/QueueOverwrite.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/include/QueueSet.h
+++ b/FreeRTOS/Demo/Common/include/QueueSet.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/include/QueueSetPolling.h
+++ b/FreeRTOS/Demo/Common/include/QueueSetPolling.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/include/StaticAllocation.h
+++ b/FreeRTOS/Demo/Common/include/StaticAllocation.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/include/StreamBufferDemo.h
+++ b/FreeRTOS/Demo/Common/include/StreamBufferDemo.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/include/StreamBufferInterrupt.h
+++ b/FreeRTOS/Demo/Common/include/StreamBufferInterrupt.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/include/TaskNotify.h
+++ b/FreeRTOS/Demo/Common/include/TaskNotify.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/include/TaskNotifyArray.h
+++ b/FreeRTOS/Demo/Common/include/TaskNotifyArray.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/include/TimerDemo.h
+++ b/FreeRTOS/Demo/Common/include/TimerDemo.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/include/blocktim.h
+++ b/FreeRTOS/Demo/Common/include/blocktim.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/include/comtest.h
+++ b/FreeRTOS/Demo/Common/include/comtest.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/include/comtest2.h
+++ b/FreeRTOS/Demo/Common/include/comtest2.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/include/comtest_strings.h
+++ b/FreeRTOS/Demo/Common/include/comtest_strings.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/include/countsem.h
+++ b/FreeRTOS/Demo/Common/include/countsem.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/include/crflash.h
+++ b/FreeRTOS/Demo/Common/include/crflash.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/include/crhook.h
+++ b/FreeRTOS/Demo/Common/include/crhook.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/include/death.h
+++ b/FreeRTOS/Demo/Common/include/death.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/include/dynamic.h
+++ b/FreeRTOS/Demo/Common/include/dynamic.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/include/fileIO.h
+++ b/FreeRTOS/Demo/Common/include/fileIO.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/include/flash.h
+++ b/FreeRTOS/Demo/Common/include/flash.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/include/flash_timer.h
+++ b/FreeRTOS/Demo/Common/include/flash_timer.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/include/flop.h
+++ b/FreeRTOS/Demo/Common/include/flop.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/include/integer.h
+++ b/FreeRTOS/Demo/Common/include/integer.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/include/mevents.h
+++ b/FreeRTOS/Demo/Common/include/mevents.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/include/partest.h
+++ b/FreeRTOS/Demo/Common/include/partest.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/include/print.h
+++ b/FreeRTOS/Demo/Common/include/print.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/include/recmutex.h
+++ b/FreeRTOS/Demo/Common/include/recmutex.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/include/semtest.h
+++ b/FreeRTOS/Demo/Common/include/semtest.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Common/include/serial.h
+++ b/FreeRTOS/Demo/Common/include/serial.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Cygnal/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/Cygnal/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Cygnal/Makefile
+++ b/FreeRTOS/Demo/Cygnal/Makefile
@@ -1,5 +1,5 @@
 #/*
-# * FreeRTOS Kernel V10.3.0
+# * FreeRTOS Kernel V10.3.1
 # * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 # *
 # * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Cygnal/ParTest/ParTest.c
+++ b/FreeRTOS/Demo/Cygnal/ParTest/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Cygnal/main.c
+++ b/FreeRTOS/Demo/Cygnal/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Cygnal/serial/serial.c
+++ b/FreeRTOS/Demo/Cygnal/serial/serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Flshlite/FRConfig.h
+++ b/FreeRTOS/Demo/Flshlite/FRConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Flshlite/FileIO/fileIO.c
+++ b/FreeRTOS/Demo/Flshlite/FileIO/fileIO.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Flshlite/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/Flshlite/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Flshlite/ParTest/ParTest.c
+++ b/FreeRTOS/Demo/Flshlite/ParTest/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Flshlite/main.c
+++ b/FreeRTOS/Demo/Flshlite/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Flshlite/serial/serial.c
+++ b/FreeRTOS/Demo/Flshlite/serial/serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/H8S/RTOSDemo/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/H8S/RTOSDemo/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/H8S/RTOSDemo/ParTest/ParTest.c
+++ b/FreeRTOS/Demo/H8S/RTOSDemo/ParTest/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/H8S/RTOSDemo/main.c
+++ b/FreeRTOS/Demo/H8S/RTOSDemo/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/H8S/RTOSDemo/serial/serial.c
+++ b/FreeRTOS/Demo/H8S/RTOSDemo/serial/serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/HCS12_CodeWarrior_banked/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/HCS12_CodeWarrior_banked/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/HCS12_CodeWarrior_banked/ParTest/ParTest.c
+++ b/FreeRTOS/Demo/HCS12_CodeWarrior_banked/ParTest/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/HCS12_CodeWarrior_banked/main.c
+++ b/FreeRTOS/Demo/HCS12_CodeWarrior_banked/main.c
@@ -1,6 +1,6 @@
 
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/HCS12_CodeWarrior_banked/serial/serial.c
+++ b/FreeRTOS/Demo/HCS12_CodeWarrior_banked/serial/serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/HCS12_CodeWarrior_small/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/HCS12_CodeWarrior_small/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/HCS12_CodeWarrior_small/ParTest/ParTest.c
+++ b/FreeRTOS/Demo/HCS12_CodeWarrior_small/ParTest/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/HCS12_CodeWarrior_small/main.c
+++ b/FreeRTOS/Demo/HCS12_CodeWarrior_small/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/HCS12_CodeWarrior_small/serial/serial.c
+++ b/FreeRTOS/Demo/HCS12_CodeWarrior_small/serial/serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/HCS12_GCC_banked/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/HCS12_GCC_banked/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/HCS12_GCC_banked/ParTest.c
+++ b/FreeRTOS/Demo/HCS12_GCC_banked/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/HCS12_GCC_banked/main.c
+++ b/FreeRTOS/Demo/HCS12_GCC_banked/main.c
@@ -1,6 +1,6 @@
 
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/HCS12_GCC_banked/startup.c
+++ b/FreeRTOS/Demo/HCS12_GCC_banked/startup.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/IA32_flat_GCC_Galileo_Gen_2/Blinky_Demo/main_blinky.c
+++ b/FreeRTOS/Demo/IA32_flat_GCC_Galileo_Gen_2/Blinky_Demo/main_blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/IA32_flat_GCC_Galileo_Gen_2/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/IA32_flat_GCC_Galileo_Gen_2/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/IA32_flat_GCC_Galileo_Gen_2/Full_Demo/IntQueueTimer.c
+++ b/FreeRTOS/Demo/IA32_flat_GCC_Galileo_Gen_2/Full_Demo/IntQueueTimer.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/IA32_flat_GCC_Galileo_Gen_2/Full_Demo/IntQueueTimer.h
+++ b/FreeRTOS/Demo/IA32_flat_GCC_Galileo_Gen_2/Full_Demo/IntQueueTimer.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/IA32_flat_GCC_Galileo_Gen_2/Full_Demo/RegTest.S
+++ b/FreeRTOS/Demo/IA32_flat_GCC_Galileo_Gen_2/Full_Demo/RegTest.S
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/IA32_flat_GCC_Galileo_Gen_2/Full_Demo/main_full.c
+++ b/FreeRTOS/Demo/IA32_flat_GCC_Galileo_Gen_2/Full_Demo/main_full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/IA32_flat_GCC_Galileo_Gen_2/Support_Files/freestanding_functions.c
+++ b/FreeRTOS/Demo/IA32_flat_GCC_Galileo_Gen_2/Support_Files/freestanding_functions.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/IA32_flat_GCC_Galileo_Gen_2/Support_Files/math.h
+++ b/FreeRTOS/Demo/IA32_flat_GCC_Galileo_Gen_2/Support_Files/math.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/IA32_flat_GCC_Galileo_Gen_2/Support_Files/startup.S
+++ b/FreeRTOS/Demo/IA32_flat_GCC_Galileo_Gen_2/Support_Files/startup.S
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/IA32_flat_GCC_Galileo_Gen_2/Support_Files/stdint.h
+++ b/FreeRTOS/Demo/IA32_flat_GCC_Galileo_Gen_2/Support_Files/stdint.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/IA32_flat_GCC_Galileo_Gen_2/main.c
+++ b/FreeRTOS/Demo/IA32_flat_GCC_Galileo_Gen_2/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/MB91460_Softune/SRC/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/MB91460_Softune/SRC/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/MB91460_Softune/SRC/crflash_modified.c
+++ b/FreeRTOS/Demo/MB91460_Softune/SRC/crflash_modified.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/MB91460_Softune/SRC/main.c
+++ b/FreeRTOS/Demo/MB91460_Softune/SRC/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/MB91460_Softune/SRC/partest/partest.c
+++ b/FreeRTOS/Demo/MB91460_Softune/SRC/partest/partest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/MB91460_Softune/SRC/serial/serial.c
+++ b/FreeRTOS/Demo/MB91460_Softune/SRC/serial/serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/MB96340_Softune/FreeRTOS_96348hs_SK16FX100PMC/Src/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/MB96340_Softune/FreeRTOS_96348hs_SK16FX100PMC/Src/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/MB96340_Softune/FreeRTOS_96348hs_SK16FX100PMC/Src/crflash_sk16fx100mpc.c
+++ b/FreeRTOS/Demo/MB96340_Softune/FreeRTOS_96348hs_SK16FX100PMC/Src/crflash_sk16fx100mpc.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/MB96340_Softune/FreeRTOS_96348hs_SK16FX100PMC/Src/main.c
+++ b/FreeRTOS/Demo/MB96340_Softune/FreeRTOS_96348hs_SK16FX100PMC/Src/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/MB96340_Softune/FreeRTOS_96348hs_SK16FX100PMC/Src/partest/partest.c
+++ b/FreeRTOS/Demo/MB96340_Softune/FreeRTOS_96348hs_SK16FX100PMC/Src/partest/partest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/MB96340_Softune/FreeRTOS_96348hs_SK16FX100PMC/Src/serial/serial.c
+++ b/FreeRTOS/Demo/MB96340_Softune/FreeRTOS_96348hs_SK16FX100PMC/Src/serial/serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/MB96350_Softune_Dice_Kit/DiceTask.c
+++ b/FreeRTOS/Demo/MB96350_Softune_Dice_Kit/DiceTask.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/MB96350_Softune_Dice_Kit/DiceTask.h
+++ b/FreeRTOS/Demo/MB96350_Softune_Dice_Kit/DiceTask.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/MB96350_Softune_Dice_Kit/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/MB96350_Softune_Dice_Kit/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/MB96350_Softune_Dice_Kit/ParTest/ParTest.c
+++ b/FreeRTOS/Demo/MB96350_Softune_Dice_Kit/ParTest/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/MB96350_Softune_Dice_Kit/SegmentToggleTasks.c
+++ b/FreeRTOS/Demo/MB96350_Softune_Dice_Kit/SegmentToggleTasks.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/MB96350_Softune_Dice_Kit/main.c
+++ b/FreeRTOS/Demo/MB96350_Softune_Dice_Kit/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/MSP430X_MSP430F5438_CCS/Demo_Source/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/MSP430X_MSP430F5438_CCS/Demo_Source/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/MSP430X_MSP430F5438_CCS/Demo_Source/ParTest.c
+++ b/FreeRTOS/Demo/MSP430X_MSP430F5438_CCS/Demo_Source/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/MSP430X_MSP430F5438_CCS/Demo_Source/RegTest.asm
+++ b/FreeRTOS/Demo/MSP430X_MSP430F5438_CCS/Demo_Source/RegTest.asm
@@ -1,6 +1,6 @@
 ;
 ;/*
-; * FreeRTOS Kernel V10.3.0
+; * FreeRTOS Kernel V10.3.1
 ; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 ; *
 ; * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/MSP430X_MSP430F5438_CCS/Demo_Source/RunTimeStatsConfig.c
+++ b/FreeRTOS/Demo/MSP430X_MSP430F5438_CCS/Demo_Source/RunTimeStatsConfig.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/MSP430X_MSP430F5438_CCS/Demo_Source/main.c
+++ b/FreeRTOS/Demo/MSP430X_MSP430F5438_CCS/Demo_Source/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/MSP430X_MSP430F5438_CCS/Demo_Source/serial.c
+++ b/FreeRTOS/Demo/MSP430X_MSP430F5438_CCS/Demo_Source/serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/MSP430X_MSP430F5438_IAR/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/MSP430X_MSP430F5438_IAR/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/MSP430X_MSP430F5438_IAR/ParTest.c
+++ b/FreeRTOS/Demo/MSP430X_MSP430F5438_IAR/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/MSP430X_MSP430F5438_IAR/RegTest.s43
+++ b/FreeRTOS/Demo/MSP430X_MSP430F5438_IAR/RegTest.s43
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/MSP430X_MSP430F5438_IAR/RunTimeStatsConfig.c
+++ b/FreeRTOS/Demo/MSP430X_MSP430F5438_IAR/RunTimeStatsConfig.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/MSP430X_MSP430F5438_IAR/main.c
+++ b/FreeRTOS/Demo/MSP430X_MSP430F5438_IAR/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/MSP430X_MSP430F5438_IAR/serial.c
+++ b/FreeRTOS/Demo/MSP430X_MSP430F5438_IAR/serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/MSP430X_MSP430FR5969_LaunchPad_IAR_CCS/Blinky_Demo/main_blinky.c
+++ b/FreeRTOS/Demo/MSP430X_MSP430FR5969_LaunchPad_IAR_CCS/Blinky_Demo/main_blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/MSP430X_MSP430FR5969_LaunchPad_IAR_CCS/CCS_Only/RegTest.asm
+++ b/FreeRTOS/Demo/MSP430X_MSP430FR5969_LaunchPad_IAR_CCS/CCS_Only/RegTest.asm
@@ -1,6 +1,6 @@
 ;
 ;/*
-; * FreeRTOS Kernel V10.3.0
+; * FreeRTOS Kernel V10.3.1
 ; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 ; *
 ; * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/MSP430X_MSP430FR5969_LaunchPad_IAR_CCS/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/MSP430X_MSP430FR5969_LaunchPad_IAR_CCS/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/MSP430X_MSP430FR5969_LaunchPad_IAR_CCS/Full_Demo/main_full.c
+++ b/FreeRTOS/Demo/MSP430X_MSP430FR5969_LaunchPad_IAR_CCS/Full_Demo/main_full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/MSP430X_MSP430FR5969_LaunchPad_IAR_CCS/Full_Demo/serial.c
+++ b/FreeRTOS/Demo/MSP430X_MSP430FR5969_LaunchPad_IAR_CCS/Full_Demo/serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/MSP430X_MSP430FR5969_LaunchPad_IAR_CCS/IAR_Only/RegTest.s43
+++ b/FreeRTOS/Demo/MSP430X_MSP430FR5969_LaunchPad_IAR_CCS/IAR_Only/RegTest.s43
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/MSP430X_MSP430FR5969_LaunchPad_IAR_CCS/LEDs.c
+++ b/FreeRTOS/Demo/MSP430X_MSP430FR5969_LaunchPad_IAR_CCS/LEDs.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/MSP430X_MSP430FR5969_LaunchPad_IAR_CCS/main.c
+++ b/FreeRTOS/Demo/MSP430X_MSP430FR5969_LaunchPad_IAR_CCS/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/MicroBlaze_Kintex7_EthernetLite/RTOSDemo/src/Blinky_Demo/main_blinky.c
+++ b/FreeRTOS/Demo/MicroBlaze_Kintex7_EthernetLite/RTOSDemo/src/Blinky_Demo/main_blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/MicroBlaze_Kintex7_EthernetLite/RTOSDemo/src/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/MicroBlaze_Kintex7_EthernetLite/RTOSDemo/src/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/MicroBlaze_Kintex7_EthernetLite/RTOSDemo/src/Full_Demo/RegisterTests.S
+++ b/FreeRTOS/Demo/MicroBlaze_Kintex7_EthernetLite/RTOSDemo/src/Full_Demo/RegisterTests.S
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/MicroBlaze_Kintex7_EthernetLite/RTOSDemo/src/Full_Demo/main_full.c
+++ b/FreeRTOS/Demo/MicroBlaze_Kintex7_EthernetLite/RTOSDemo/src/Full_Demo/main_full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/MicroBlaze_Kintex7_EthernetLite/RTOSDemo/src/LEDs.c
+++ b/FreeRTOS/Demo/MicroBlaze_Kintex7_EthernetLite/RTOSDemo/src/LEDs.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/MicroBlaze_Kintex7_EthernetLite/RTOSDemo/src/lwIP_Demo/lwIP_Apps/apps/BasicSocketCommandServer/BasicSocketCommandServer.c
+++ b/FreeRTOS/Demo/MicroBlaze_Kintex7_EthernetLite/RTOSDemo/src/lwIP_Demo/lwIP_Apps/apps/BasicSocketCommandServer/BasicSocketCommandServer.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/MicroBlaze_Kintex7_EthernetLite/RTOSDemo/src/lwIP_Demo/lwIP_Apps/lwIP_Apps.c
+++ b/FreeRTOS/Demo/MicroBlaze_Kintex7_EthernetLite/RTOSDemo/src/lwIP_Demo/lwIP_Apps/lwIP_Apps.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/MicroBlaze_Kintex7_EthernetLite/RTOSDemo/src/lwIP_Demo/lwIP_Apps/lwIP_Apps.h
+++ b/FreeRTOS/Demo/MicroBlaze_Kintex7_EthernetLite/RTOSDemo/src/lwIP_Demo/lwIP_Apps/lwIP_Apps.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/MicroBlaze_Kintex7_EthernetLite/RTOSDemo/src/lwIP_Demo/main_lwIP.c
+++ b/FreeRTOS/Demo/MicroBlaze_Kintex7_EthernetLite/RTOSDemo/src/lwIP_Demo/main_lwIP.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/MicroBlaze_Kintex7_EthernetLite/RTOSDemo/src/main.c
+++ b/FreeRTOS/Demo/MicroBlaze_Kintex7_EthernetLite/RTOSDemo/src/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/MicroBlaze_Kintex7_EthernetLite/RTOSDemo/src/serial.c
+++ b/FreeRTOS/Demo/MicroBlaze_Kintex7_EthernetLite/RTOSDemo/src/serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/NEC_78K0R_IAR/ButtonISR.s26
+++ b/FreeRTOS/Demo/NEC_78K0R_IAR/ButtonISR.s26
@@ -1,5 +1,5 @@
 ;/*
-; * FreeRTOS Kernel V10.3.0
+; * FreeRTOS Kernel V10.3.1
 ; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 ; *
 ; * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/NEC_78K0R_IAR/ButtonTask.c
+++ b/FreeRTOS/Demo/NEC_78K0R_IAR/ButtonTask.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/NEC_78K0R_IAR/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/NEC_78K0R_IAR/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/NEC_78K0R_IAR/RegTest.s26
+++ b/FreeRTOS/Demo/NEC_78K0R_IAR/RegTest.s26
@@ -1,5 +1,5 @@
 ;/*
-; * FreeRTOS Kernel V10.3.0
+; * FreeRTOS Kernel V10.3.1
 ; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 ; *
 ; * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/NEC_78K0R_IAR/main.c
+++ b/FreeRTOS/Demo/NEC_78K0R_IAR/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/NEC_V850ES_IAR/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/NEC_V850ES_IAR/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/NEC_V850ES_IAR/LowLevelInit/LowLevelInit.c
+++ b/FreeRTOS/Demo/NEC_V850ES_IAR/LowLevelInit/LowLevelInit.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/NEC_V850ES_IAR/LowLevelInit/LowLevelInit_Fx3.c
+++ b/FreeRTOS/Demo/NEC_V850ES_IAR/LowLevelInit/LowLevelInit_Fx3.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/NEC_V850ES_IAR/LowLevelInit/LowLevelInit_Hx2.c
+++ b/FreeRTOS/Demo/NEC_V850ES_IAR/LowLevelInit/LowLevelInit_Hx2.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/NEC_V850ES_IAR/ParTest/ParTest_Fx3_App_Board.c
+++ b/FreeRTOS/Demo/NEC_V850ES_IAR/ParTest/ParTest_Fx3_App_Board.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/NEC_V850ES_IAR/ParTest/ParTest_Generic_Target_Board.c
+++ b/FreeRTOS/Demo/NEC_V850ES_IAR/ParTest/ParTest_Generic_Target_Board.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/NEC_V850ES_IAR/RegTest.s85
+++ b/FreeRTOS/Demo/NEC_V850ES_IAR/RegTest.s85
@@ -1,5 +1,5 @@
 ;/*
-; * FreeRTOS Kernel V10.3.0
+; * FreeRTOS Kernel V10.3.1
 ; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 ; *
 ; * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/NEC_V850ES_IAR/main.c
+++ b/FreeRTOS/Demo/NEC_V850ES_IAR/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/NEC_V850ES_IAR/serial/serial.c
+++ b/FreeRTOS/Demo/NEC_V850ES_IAR/serial/serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/NiosII_CycloneIII_DBC3C40_GCC/RTOSDemo/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/NiosII_CycloneIII_DBC3C40_GCC/RTOSDemo/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/NiosII_CycloneIII_DBC3C40_GCC/RTOSDemo/ParTest/ParTest.c
+++ b/FreeRTOS/Demo/NiosII_CycloneIII_DBC3C40_GCC/RTOSDemo/ParTest/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/NiosII_CycloneIII_DBC3C40_GCC/RTOSDemo/main.c
+++ b/FreeRTOS/Demo/NiosII_CycloneIII_DBC3C40_GCC/RTOSDemo/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/NiosII_CycloneIII_DBC3C40_GCC/RTOSDemo/serial.c
+++ b/FreeRTOS/Demo/NiosII_CycloneIII_DBC3C40_GCC/RTOSDemo/serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC18_MPLAB/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/PIC18_MPLAB/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC18_MPLAB/ParTest/ParTest.c
+++ b/FreeRTOS/Demo/PIC18_MPLAB/ParTest/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC18_MPLAB/main1.c
+++ b/FreeRTOS/Demo/PIC18_MPLAB/main1.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC18_MPLAB/main2.c
+++ b/FreeRTOS/Demo/PIC18_MPLAB/main2.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC18_MPLAB/main3.c
+++ b/FreeRTOS/Demo/PIC18_MPLAB/main3.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC18_MPLAB/serial/serial.c
+++ b/FreeRTOS/Demo/PIC18_MPLAB/serial/serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC18_WizC/Demo1/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/PIC18_WizC/Demo1/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC18_WizC/Demo1/WIZCmake.h
+++ b/FreeRTOS/Demo/PIC18_WizC/Demo1/WIZCmake.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC18_WizC/Demo1/fuses.c
+++ b/FreeRTOS/Demo/PIC18_WizC/Demo1/fuses.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC18_WizC/Demo1/interrupt.c
+++ b/FreeRTOS/Demo/PIC18_WizC/Demo1/interrupt.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC18_WizC/Demo1/main.c
+++ b/FreeRTOS/Demo/PIC18_WizC/Demo1/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC18_WizC/Demo2/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/PIC18_WizC/Demo2/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC18_WizC/Demo2/WIZCmake.h
+++ b/FreeRTOS/Demo/PIC18_WizC/Demo2/WIZCmake.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC18_WizC/Demo2/fuses.c
+++ b/FreeRTOS/Demo/PIC18_WizC/Demo2/fuses.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC18_WizC/Demo2/interrupt.c
+++ b/FreeRTOS/Demo/PIC18_WizC/Demo2/interrupt.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC18_WizC/Demo2/main.c
+++ b/FreeRTOS/Demo/PIC18_WizC/Demo2/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC18_WizC/Demo3/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/PIC18_WizC/Demo3/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC18_WizC/Demo3/WIZCmake.h
+++ b/FreeRTOS/Demo/PIC18_WizC/Demo3/WIZCmake.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC18_WizC/Demo3/fuses.c
+++ b/FreeRTOS/Demo/PIC18_WizC/Demo3/fuses.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC18_WizC/Demo3/interrupt.c
+++ b/FreeRTOS/Demo/PIC18_WizC/Demo3/interrupt.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC18_WizC/Demo3/main.c
+++ b/FreeRTOS/Demo/PIC18_WizC/Demo3/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC18_WizC/Demo4/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/PIC18_WizC/Demo4/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC18_WizC/Demo4/WIZCmake.h
+++ b/FreeRTOS/Demo/PIC18_WizC/Demo4/WIZCmake.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC18_WizC/Demo4/fuses.c
+++ b/FreeRTOS/Demo/PIC18_WizC/Demo4/fuses.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC18_WizC/Demo4/interrupt.c
+++ b/FreeRTOS/Demo/PIC18_WizC/Demo4/interrupt.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC18_WizC/Demo4/main.c
+++ b/FreeRTOS/Demo/PIC18_WizC/Demo4/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC18_WizC/Demo5/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/PIC18_WizC/Demo5/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC18_WizC/Demo5/WIZCmake.h
+++ b/FreeRTOS/Demo/PIC18_WizC/Demo5/WIZCmake.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC18_WizC/Demo5/fuses.c
+++ b/FreeRTOS/Demo/PIC18_WizC/Demo5/fuses.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC18_WizC/Demo5/interrupt.c
+++ b/FreeRTOS/Demo/PIC18_WizC/Demo5/interrupt.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC18_WizC/Demo5/main.c
+++ b/FreeRTOS/Demo/PIC18_WizC/Demo5/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC18_WizC/Demo6/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/PIC18_WizC/Demo6/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC18_WizC/Demo6/WIZCmake.h
+++ b/FreeRTOS/Demo/PIC18_WizC/Demo6/WIZCmake.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC18_WizC/Demo6/fuses.c
+++ b/FreeRTOS/Demo/PIC18_WizC/Demo6/fuses.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC18_WizC/Demo6/interrupt.c
+++ b/FreeRTOS/Demo/PIC18_WizC/Demo6/interrupt.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC18_WizC/Demo6/main.c
+++ b/FreeRTOS/Demo/PIC18_WizC/Demo6/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC18_WizC/Demo7/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/PIC18_WizC/Demo7/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC18_WizC/Demo7/WIZCmake.h
+++ b/FreeRTOS/Demo/PIC18_WizC/Demo7/WIZCmake.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC18_WizC/Demo7/fuses.c
+++ b/FreeRTOS/Demo/PIC18_WizC/Demo7/fuses.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC18_WizC/Demo7/interrupt.c
+++ b/FreeRTOS/Demo/PIC18_WizC/Demo7/interrupt.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC18_WizC/Demo7/main.c
+++ b/FreeRTOS/Demo/PIC18_WizC/Demo7/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC18_WizC/ParTest/ParTest.c
+++ b/FreeRTOS/Demo/PIC18_WizC/ParTest/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC18_WizC/serial/isrSerialRx.c
+++ b/FreeRTOS/Demo/PIC18_WizC/serial/isrSerialRx.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC18_WizC/serial/isrSerialTx.c
+++ b/FreeRTOS/Demo/PIC18_WizC/serial/isrSerialTx.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC18_WizC/serial/serial.c
+++ b/FreeRTOS/Demo/PIC18_WizC/serial/serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC24_MPLAB/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/PIC24_MPLAB/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC24_MPLAB/ParTest/ParTest.c
+++ b/FreeRTOS/Demo/PIC24_MPLAB/ParTest/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC24_MPLAB/lcd.c
+++ b/FreeRTOS/Demo/PIC24_MPLAB/lcd.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC24_MPLAB/lcd.h
+++ b/FreeRTOS/Demo/PIC24_MPLAB/lcd.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC24_MPLAB/main.c
+++ b/FreeRTOS/Demo/PIC24_MPLAB/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC24_MPLAB/serial/serial.c
+++ b/FreeRTOS/Demo/PIC24_MPLAB/serial/serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC24_MPLAB/timertest.c
+++ b/FreeRTOS/Demo/PIC24_MPLAB/timertest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC24_MPLAB/timertest.h
+++ b/FreeRTOS/Demo/PIC24_MPLAB/timertest.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC32MEC14xx_MPLAB/src/Blinky_Demo/main_blinky.c
+++ b/FreeRTOS/Demo/PIC32MEC14xx_MPLAB/src/Blinky_Demo/main_blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC32MEC14xx_MPLAB/src/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/PIC32MEC14xx_MPLAB/src/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC32MEC14xx_MPLAB/src/Full_Demo/IntQueueTimer.c
+++ b/FreeRTOS/Demo/PIC32MEC14xx_MPLAB/src/Full_Demo/IntQueueTimer.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC32MEC14xx_MPLAB/src/Full_Demo/IntQueueTimer.h
+++ b/FreeRTOS/Demo/PIC32MEC14xx_MPLAB/src/Full_Demo/IntQueueTimer.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC32MEC14xx_MPLAB/src/Full_Demo/IntQueueTimer_isr.S
+++ b/FreeRTOS/Demo/PIC32MEC14xx_MPLAB/src/Full_Demo/IntQueueTimer_isr.S
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC32MEC14xx_MPLAB/src/Full_Demo/RegisterTestTasks.S
+++ b/FreeRTOS/Demo/PIC32MEC14xx_MPLAB/src/Full_Demo/RegisterTestTasks.S
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC32MEC14xx_MPLAB/src/Full_Demo/main_full.c
+++ b/FreeRTOS/Demo/PIC32MEC14xx_MPLAB/src/Full_Demo/main_full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC32MEC14xx_MPLAB/src/Full_Demo/timertest.c
+++ b/FreeRTOS/Demo/PIC32MEC14xx_MPLAB/src/Full_Demo/timertest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC32MEC14xx_MPLAB/src/Full_Demo/timertest.h
+++ b/FreeRTOS/Demo/PIC32MEC14xx_MPLAB/src/Full_Demo/timertest.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC32MEC14xx_MPLAB/src/main.c
+++ b/FreeRTOS/Demo/PIC32MEC14xx_MPLAB/src/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC32MX_MPLAB/ConfigPerformance.c
+++ b/FreeRTOS/Demo/PIC32MX_MPLAB/ConfigPerformance.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC32MX_MPLAB/ConfigPerformance.h
+++ b/FreeRTOS/Demo/PIC32MX_MPLAB/ConfigPerformance.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC32MX_MPLAB/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/PIC32MX_MPLAB/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC32MX_MPLAB/IntQueueTimer.c
+++ b/FreeRTOS/Demo/PIC32MX_MPLAB/IntQueueTimer.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC32MX_MPLAB/IntQueueTimer.h
+++ b/FreeRTOS/Demo/PIC32MX_MPLAB/IntQueueTimer.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC32MX_MPLAB/IntQueueTimer_isr.S
+++ b/FreeRTOS/Demo/PIC32MX_MPLAB/IntQueueTimer_isr.S
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC32MX_MPLAB/ParTest/ParTest_Explorer16.c
+++ b/FreeRTOS/Demo/PIC32MX_MPLAB/ParTest/ParTest_Explorer16.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC32MX_MPLAB/ParTest/ParTest_USBII_Starter_Kit.c
+++ b/FreeRTOS/Demo/PIC32MX_MPLAB/ParTest/ParTest_USBII_Starter_Kit.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC32MX_MPLAB/RegisterTestTasks.S
+++ b/FreeRTOS/Demo/PIC32MX_MPLAB/RegisterTestTasks.S
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC32MX_MPLAB/lcd.c
+++ b/FreeRTOS/Demo/PIC32MX_MPLAB/lcd.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC32MX_MPLAB/lcd.h
+++ b/FreeRTOS/Demo/PIC32MX_MPLAB/lcd.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC32MX_MPLAB/main.c
+++ b/FreeRTOS/Demo/PIC32MX_MPLAB/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC32MX_MPLAB/main_blinky.c
+++ b/FreeRTOS/Demo/PIC32MX_MPLAB/main_blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC32MX_MPLAB/main_full.c
+++ b/FreeRTOS/Demo/PIC32MX_MPLAB/main_full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC32MX_MPLAB/serial/serial.c
+++ b/FreeRTOS/Demo/PIC32MX_MPLAB/serial/serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC32MX_MPLAB/timertest.c
+++ b/FreeRTOS/Demo/PIC32MX_MPLAB/timertest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC32MX_MPLAB/timertest.h
+++ b/FreeRTOS/Demo/PIC32MX_MPLAB/timertest.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC32MX_MPLAB/timertest_isr.S
+++ b/FreeRTOS/Demo/PIC32MX_MPLAB/timertest_isr.S
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC32MZ_MPLAB/ConfigPerformance.c
+++ b/FreeRTOS/Demo/PIC32MZ_MPLAB/ConfigPerformance.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC32MZ_MPLAB/ConfigPerformance.h
+++ b/FreeRTOS/Demo/PIC32MZ_MPLAB/ConfigPerformance.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC32MZ_MPLAB/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/PIC32MZ_MPLAB/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC32MZ_MPLAB/ISRTriggeredTask.c
+++ b/FreeRTOS/Demo/PIC32MZ_MPLAB/ISRTriggeredTask.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC32MZ_MPLAB/ISRTriggeredTask_isr.S
+++ b/FreeRTOS/Demo/PIC32MZ_MPLAB/ISRTriggeredTask_isr.S
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC32MZ_MPLAB/IntQueueTimer.c
+++ b/FreeRTOS/Demo/PIC32MZ_MPLAB/IntQueueTimer.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC32MZ_MPLAB/IntQueueTimer.h
+++ b/FreeRTOS/Demo/PIC32MZ_MPLAB/IntQueueTimer.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC32MZ_MPLAB/IntQueueTimer_isr.S
+++ b/FreeRTOS/Demo/PIC32MZ_MPLAB/IntQueueTimer_isr.S
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC32MZ_MPLAB/ParTest/ParTest.c
+++ b/FreeRTOS/Demo/PIC32MZ_MPLAB/ParTest/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC32MZ_MPLAB/RegisterTestTasks.S
+++ b/FreeRTOS/Demo/PIC32MZ_MPLAB/RegisterTestTasks.S
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC32MZ_MPLAB/flop_mz.c
+++ b/FreeRTOS/Demo/PIC32MZ_MPLAB/flop_mz.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC32MZ_MPLAB/flop_mz.h
+++ b/FreeRTOS/Demo/PIC32MZ_MPLAB/flop_mz.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC32MZ_MPLAB/main.c
+++ b/FreeRTOS/Demo/PIC32MZ_MPLAB/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC32MZ_MPLAB/main_blinky.c
+++ b/FreeRTOS/Demo/PIC32MZ_MPLAB/main_blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC32MZ_MPLAB/main_full.c
+++ b/FreeRTOS/Demo/PIC32MZ_MPLAB/main_full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC32MZ_MPLAB/timertest.c
+++ b/FreeRTOS/Demo/PIC32MZ_MPLAB/timertest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC32MZ_MPLAB/timertest.h
+++ b/FreeRTOS/Demo/PIC32MZ_MPLAB/timertest.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PIC32MZ_MPLAB/timertest_isr.S
+++ b/FreeRTOS/Demo/PIC32MZ_MPLAB/timertest_isr.S
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PPC440_DP_FPU_Xilinx_Virtex5_GCC/RTOSDemo/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/PPC440_DP_FPU_Xilinx_Virtex5_GCC/RTOSDemo/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PPC440_DP_FPU_Xilinx_Virtex5_GCC/RTOSDemo/flop/flop-reg-test.c
+++ b/FreeRTOS/Demo/PPC440_DP_FPU_Xilinx_Virtex5_GCC/RTOSDemo/flop/flop-reg-test.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PPC440_DP_FPU_Xilinx_Virtex5_GCC/RTOSDemo/flop/flop-reg-test.h
+++ b/FreeRTOS/Demo/PPC440_DP_FPU_Xilinx_Virtex5_GCC/RTOSDemo/flop/flop-reg-test.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PPC440_DP_FPU_Xilinx_Virtex5_GCC/RTOSDemo/flop/flop.c
+++ b/FreeRTOS/Demo/PPC440_DP_FPU_Xilinx_Virtex5_GCC/RTOSDemo/flop/flop.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PPC440_DP_FPU_Xilinx_Virtex5_GCC/RTOSDemo/main.c
+++ b/FreeRTOS/Demo/PPC440_DP_FPU_Xilinx_Virtex5_GCC/RTOSDemo/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PPC440_DP_FPU_Xilinx_Virtex5_GCC/RTOSDemo/partest/partest.c
+++ b/FreeRTOS/Demo/PPC440_DP_FPU_Xilinx_Virtex5_GCC/RTOSDemo/partest/partest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PPC440_DP_FPU_Xilinx_Virtex5_GCC/RTOSDemo/serial/serial.c
+++ b/FreeRTOS/Demo/PPC440_DP_FPU_Xilinx_Virtex5_GCC/RTOSDemo/serial/serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PPC440_SP_FPU_Xilinx_Virtex5_GCC/RTOSDemo/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/PPC440_SP_FPU_Xilinx_Virtex5_GCC/RTOSDemo/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PPC440_SP_FPU_Xilinx_Virtex5_GCC/RTOSDemo/flop/flop-reg-test.c
+++ b/FreeRTOS/Demo/PPC440_SP_FPU_Xilinx_Virtex5_GCC/RTOSDemo/flop/flop-reg-test.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PPC440_SP_FPU_Xilinx_Virtex5_GCC/RTOSDemo/flop/flop-reg-test.h
+++ b/FreeRTOS/Demo/PPC440_SP_FPU_Xilinx_Virtex5_GCC/RTOSDemo/flop/flop-reg-test.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PPC440_SP_FPU_Xilinx_Virtex5_GCC/RTOSDemo/flop/flop.c
+++ b/FreeRTOS/Demo/PPC440_SP_FPU_Xilinx_Virtex5_GCC/RTOSDemo/flop/flop.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PPC440_SP_FPU_Xilinx_Virtex5_GCC/RTOSDemo/main.c
+++ b/FreeRTOS/Demo/PPC440_SP_FPU_Xilinx_Virtex5_GCC/RTOSDemo/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PPC440_SP_FPU_Xilinx_Virtex5_GCC/RTOSDemo/partest/partest.c
+++ b/FreeRTOS/Demo/PPC440_SP_FPU_Xilinx_Virtex5_GCC/RTOSDemo/partest/partest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PPC440_SP_FPU_Xilinx_Virtex5_GCC/RTOSDemo/serial/serial.c
+++ b/FreeRTOS/Demo/PPC440_SP_FPU_Xilinx_Virtex5_GCC/RTOSDemo/serial/serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PPC440_Xilinx_Virtex5_GCC/RTOSDemo/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/PPC440_Xilinx_Virtex5_GCC/RTOSDemo/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PPC440_Xilinx_Virtex5_GCC/RTOSDemo/flop/flop-reg-test.c
+++ b/FreeRTOS/Demo/PPC440_Xilinx_Virtex5_GCC/RTOSDemo/flop/flop-reg-test.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PPC440_Xilinx_Virtex5_GCC/RTOSDemo/flop/flop-reg-test.h
+++ b/FreeRTOS/Demo/PPC440_Xilinx_Virtex5_GCC/RTOSDemo/flop/flop-reg-test.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PPC440_Xilinx_Virtex5_GCC/RTOSDemo/flop/flop.c
+++ b/FreeRTOS/Demo/PPC440_Xilinx_Virtex5_GCC/RTOSDemo/flop/flop.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PPC440_Xilinx_Virtex5_GCC/RTOSDemo/main.c
+++ b/FreeRTOS/Demo/PPC440_Xilinx_Virtex5_GCC/RTOSDemo/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PPC440_Xilinx_Virtex5_GCC/RTOSDemo/partest/partest.c
+++ b/FreeRTOS/Demo/PPC440_Xilinx_Virtex5_GCC/RTOSDemo/partest/partest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/PPC440_Xilinx_Virtex5_GCC/RTOSDemo/serial/serial.c
+++ b/FreeRTOS/Demo/PPC440_Xilinx_Virtex5_GCC/RTOSDemo/serial/serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Posix_GCC/SConstruct
+++ b/FreeRTOS/Demo/Posix_GCC/SConstruct
@@ -1,4 +1,4 @@
-# FreeRTOS Kernel V10.3.0
+# FreeRTOS Kernel V10.3.1
 # Copyright (C) 2020 Cambridge Consultants Ltd.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Posix_GCC/src/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/Posix_GCC/src/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Posix_GCC/src/FreeRTOSIPConfig.h
+++ b/FreeRTOS/Demo/Posix_GCC/src/FreeRTOSIPConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Posix_GCC/src/SConscript
+++ b/FreeRTOS/Demo/Posix_GCC/src/SConscript
@@ -1,4 +1,4 @@
-# FreeRTOS Kernel V10.3.0
+# FreeRTOS Kernel V10.3.1
 # Copyright (C) 2020 Cambridge Consultants Ltd.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Posix_GCC/src/TCPEchoClient_SingleTasks.c
+++ b/FreeRTOS/Demo/Posix_GCC/src/TCPEchoClient_SingleTasks.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Posix_GCC/src/TCPEchoClient_SingleTasks.h
+++ b/FreeRTOS/Demo/Posix_GCC/src/TCPEchoClient_SingleTasks.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Posix_GCC/src/code_coverage_additions.c
+++ b/FreeRTOS/Demo/Posix_GCC/src/code_coverage_additions.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Posix_GCC/src/console.c
+++ b/FreeRTOS/Demo/Posix_GCC/src/console.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Cambridge Consultants Ltd.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Posix_GCC/src/console.h
+++ b/FreeRTOS/Demo/Posix_GCC/src/console.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Cambridge Consultants Ltd.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Posix_GCC/src/main.c
+++ b/FreeRTOS/Demo/Posix_GCC/src/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Posix_GCC/src/main_blinky.c
+++ b/FreeRTOS/Demo/Posix_GCC/src/main_blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Posix_GCC/src/main_full.c
+++ b/FreeRTOS/Demo/Posix_GCC/src/main_full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Posix_GCC/src/main_networking.c
+++ b/FreeRTOS/Demo/Posix_GCC/src/main_networking.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Posix_GCC/src/run-time-stats-utils.c
+++ b/FreeRTOS/Demo/Posix_GCC/src/run-time-stats-utils.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RISC-V-Qemu-sifive_e-Eclipse-GCC/blinky_demo/main_blinky.c
+++ b/FreeRTOS/Demo/RISC-V-Qemu-sifive_e-Eclipse-GCC/blinky_demo/main_blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RISC-V-Qemu-sifive_e-Eclipse-GCC/full_demo/RegTest.S
+++ b/FreeRTOS/Demo/RISC-V-Qemu-sifive_e-Eclipse-GCC/full_demo/RegTest.S
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RISC-V-Qemu-sifive_e-Eclipse-GCC/full_demo/main_full.c
+++ b/FreeRTOS/Demo/RISC-V-Qemu-sifive_e-Eclipse-GCC/full_demo/main_full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RISC-V-Qemu-sifive_e-Eclipse-GCC/main.c
+++ b/FreeRTOS/Demo/RISC-V-Qemu-sifive_e-Eclipse-GCC/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RISC-V_RV32M1_Vega_GCC_Eclipse/projects/RTOSDemo_ri5cy/blinky_demo/main_blinky.c
+++ b/FreeRTOS/Demo/RISC-V_RV32M1_Vega_GCC_Eclipse/projects/RTOSDemo_ri5cy/blinky_demo/main_blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RISC-V_RV32M1_Vega_GCC_Eclipse/projects/RTOSDemo_ri5cy/full_demo/RegTest.S
+++ b/FreeRTOS/Demo/RISC-V_RV32M1_Vega_GCC_Eclipse/projects/RTOSDemo_ri5cy/full_demo/RegTest.S
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RISC-V_RV32M1_Vega_GCC_Eclipse/projects/RTOSDemo_ri5cy/full_demo/main_full.c
+++ b/FreeRTOS/Demo/RISC-V_RV32M1_Vega_GCC_Eclipse/projects/RTOSDemo_ri5cy/full_demo/main_full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RISC-V_RV32M1_Vega_GCC_Eclipse/projects/RTOSDemo_ri5cy/main.c
+++ b/FreeRTOS/Demo/RISC-V_RV32M1_Vega_GCC_Eclipse/projects/RTOSDemo_ri5cy/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RISC-V_RV32_SiFive_HiFive1-RevB_FreedomStudio/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/RISC-V_RV32_SiFive_HiFive1-RevB_FreedomStudio/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RISC-V_RV32_SiFive_HiFive1-RevB_FreedomStudio/blinky_demo/main_blinky.c
+++ b/FreeRTOS/Demo/RISC-V_RV32_SiFive_HiFive1-RevB_FreedomStudio/blinky_demo/main_blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RISC-V_RV32_SiFive_HiFive1-RevB_FreedomStudio/full_demo/RegTest.S
+++ b/FreeRTOS/Demo/RISC-V_RV32_SiFive_HiFive1-RevB_FreedomStudio/full_demo/RegTest.S
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RISC-V_RV32_SiFive_HiFive1-RevB_FreedomStudio/full_demo/main_full.c
+++ b/FreeRTOS/Demo/RISC-V_RV32_SiFive_HiFive1-RevB_FreedomStudio/full_demo/main_full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RISC-V_RV32_SiFive_HiFive1-RevB_FreedomStudio/main.c
+++ b/FreeRTOS/Demo/RISC-V_RV32_SiFive_HiFive1-RevB_FreedomStudio/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RISC-V_RV32_SiFive_HiFive1-RevB_IAR/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/RISC-V_RV32_SiFive_HiFive1-RevB_IAR/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RISC-V_RV32_SiFive_HiFive1-RevB_IAR/blinky_demo/main_blinky.c
+++ b/FreeRTOS/Demo/RISC-V_RV32_SiFive_HiFive1-RevB_IAR/blinky_demo/main_blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RISC-V_RV32_SiFive_HiFive1-RevB_IAR/full_demo/RegTest.s
+++ b/FreeRTOS/Demo/RISC-V_RV32_SiFive_HiFive1-RevB_IAR/full_demo/RegTest.s
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RISC-V_RV32_SiFive_HiFive1-RevB_IAR/full_demo/main_full.c
+++ b/FreeRTOS/Demo/RISC-V_RV32_SiFive_HiFive1-RevB_IAR/full_demo/main_full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RISC-V_RV32_SiFive_HiFive1-RevB_IAR/main.c
+++ b/FreeRTOS/Demo/RISC-V_RV32_SiFive_HiFive1-RevB_IAR/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RISC-V_Renode_Emulator_SoftConsole/blinky_demo/main_blinky.c
+++ b/FreeRTOS/Demo/RISC-V_Renode_Emulator_SoftConsole/blinky_demo/main_blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RISC-V_Renode_Emulator_SoftConsole/full_demo/RegTest.S
+++ b/FreeRTOS/Demo/RISC-V_Renode_Emulator_SoftConsole/full_demo/RegTest.S
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RISC-V_Renode_Emulator_SoftConsole/full_demo/main_full.c
+++ b/FreeRTOS/Demo/RISC-V_Renode_Emulator_SoftConsole/full_demo/main_full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RISC-V_Renode_Emulator_SoftConsole/main.c
+++ b/FreeRTOS/Demo/RISC-V_Renode_Emulator_SoftConsole/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RL78_RL78G13_Promo_Board_IAR/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/RL78_RL78G13_Promo_Board_IAR/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RL78_RL78G13_Promo_Board_IAR/RegTest.s87
+++ b/FreeRTOS/Demo/RL78_RL78G13_Promo_Board_IAR/RegTest.s87
@@ -1,5 +1,5 @@
 ;/*
-; * FreeRTOS Kernel V10.3.0
+; * FreeRTOS Kernel V10.3.1
 ; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 ; *
 ; * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RL78_RL78G13_Promo_Board_IAR/main.c
+++ b/FreeRTOS/Demo/RL78_RL78G13_Promo_Board_IAR/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RL78_multiple_IAR/ExampleISR.s87
+++ b/FreeRTOS/Demo/RL78_multiple_IAR/ExampleISR.s87
@@ -1,5 +1,5 @@
 ;/*
-; * FreeRTOS Kernel V10.3.0
+; * FreeRTOS Kernel V10.3.1
 ; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 ; *
 ; * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RL78_multiple_IAR/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/RL78_multiple_IAR/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RL78_multiple_IAR/RegTest.s87
+++ b/FreeRTOS/Demo/RL78_multiple_IAR/RegTest.s87
@@ -1,5 +1,5 @@
 ;/*
-; * FreeRTOS Kernel V10.3.0
+; * FreeRTOS Kernel V10.3.1
 ; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 ; *
 ; * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RL78_multiple_IAR/demo_specific_io.h
+++ b/FreeRTOS/Demo/RL78_multiple_IAR/demo_specific_io.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RL78_multiple_IAR/main.c
+++ b/FreeRTOS/Demo/RL78_multiple_IAR/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RL78_multiple_IAR/main_blinky.c
+++ b/FreeRTOS/Demo/RL78_multiple_IAR/main_blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RL78_multiple_IAR/main_full.c
+++ b/FreeRTOS/Demo/RL78_multiple_IAR/main_full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX100-RSK_GCC_e2studio/RTOSDemo/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/RX100-RSK_GCC_e2studio/RTOSDemo/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX100-RSK_GCC_e2studio/RTOSDemo/ParTest.c
+++ b/FreeRTOS/Demo/RX100-RSK_GCC_e2studio/RTOSDemo/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX100-RSK_GCC_e2studio/RTOSDemo/main.c
+++ b/FreeRTOS/Demo/RX100-RSK_GCC_e2studio/RTOSDemo/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX100-RSK_GCC_e2studio/RTOSDemo/main_full.c
+++ b/FreeRTOS/Demo/RX100-RSK_GCC_e2studio/RTOSDemo/main_full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX100-RSK_GCC_e2studio/RTOSDemo/main_low_power.c
+++ b/FreeRTOS/Demo/RX100-RSK_GCC_e2studio/RTOSDemo/main_low_power.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX100-RSK_IAR/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/RX100-RSK_IAR/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX100-RSK_IAR/ParTest.c
+++ b/FreeRTOS/Demo/RX100-RSK_IAR/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX100-RSK_IAR/PriorityDefinitions.h
+++ b/FreeRTOS/Demo/RX100-RSK_IAR/PriorityDefinitions.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX100-RSK_IAR/main.c
+++ b/FreeRTOS/Demo/RX100-RSK_IAR/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX100-RSK_IAR/main_full.c
+++ b/FreeRTOS/Demo/RX100-RSK_IAR/main_full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX100-RSK_IAR/main_low_power.c
+++ b/FreeRTOS/Demo/RX100-RSK_IAR/main_low_power.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX100-RSK_IAR/reg_test.s
+++ b/FreeRTOS/Demo/RX100-RSK_IAR/reg_test.s
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX100-RSK_Renesas_e2studio/RTOSDemo/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/RX100-RSK_Renesas_e2studio/RTOSDemo/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX100-RSK_Renesas_e2studio/RTOSDemo/ParTest.c
+++ b/FreeRTOS/Demo/RX100-RSK_Renesas_e2studio/RTOSDemo/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX100-RSK_Renesas_e2studio/RTOSDemo/main.c
+++ b/FreeRTOS/Demo/RX100-RSK_Renesas_e2studio/RTOSDemo/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX100-RSK_Renesas_e2studio/RTOSDemo/main_full.c
+++ b/FreeRTOS/Demo/RX100-RSK_Renesas_e2studio/RTOSDemo/main_full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX100-RSK_Renesas_e2studio/RTOSDemo/main_low_power.c
+++ b/FreeRTOS/Demo/RX100-RSK_Renesas_e2studio/RTOSDemo/main_low_power.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX100_RX113-RSK_GCC_e2studio_IAR/src/Blinky_Demo/main_blinky.c
+++ b/FreeRTOS/Demo/RX100_RX113-RSK_GCC_e2studio_IAR/src/Blinky_Demo/main_blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX100_RX113-RSK_GCC_e2studio_IAR/src/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/RX100_RX113-RSK_GCC_e2studio_IAR/src/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX100_RX113-RSK_GCC_e2studio_IAR/src/Full_Demo/IntQueueTimer.c
+++ b/FreeRTOS/Demo/RX100_RX113-RSK_GCC_e2studio_IAR/src/Full_Demo/IntQueueTimer.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX100_RX113-RSK_GCC_e2studio_IAR/src/Full_Demo/IntQueueTimer.h
+++ b/FreeRTOS/Demo/RX100_RX113-RSK_GCC_e2studio_IAR/src/Full_Demo/IntQueueTimer.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX100_RX113-RSK_GCC_e2studio_IAR/src/Full_Demo/RegTest_GCC.S
+++ b/FreeRTOS/Demo/RX100_RX113-RSK_GCC_e2studio_IAR/src/Full_Demo/RegTest_GCC.S
@@ -1,5 +1,5 @@
 ;/*
-; * FreeRTOS Kernel V10.3.0
+; * FreeRTOS Kernel V10.3.1
 ; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 ; *
 ; * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX100_RX113-RSK_GCC_e2studio_IAR/src/Full_Demo/RegTest_IAR.s
+++ b/FreeRTOS/Demo/RX100_RX113-RSK_GCC_e2studio_IAR/src/Full_Demo/RegTest_IAR.s
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX100_RX113-RSK_GCC_e2studio_IAR/src/Full_Demo/main_full.c
+++ b/FreeRTOS/Demo/RX100_RX113-RSK_GCC_e2studio_IAR/src/Full_Demo/main_full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX100_RX113-RSK_GCC_e2studio_IAR/src/PriorityDefinitions.h
+++ b/FreeRTOS/Demo/RX100_RX113-RSK_GCC_e2studio_IAR/src/PriorityDefinitions.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX100_RX113-RSK_GCC_e2studio_IAR/src/main.c
+++ b/FreeRTOS/Demo/RX100_RX113-RSK_GCC_e2studio_IAR/src/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX100_RX113-RSK_Renesas_e2studio/src/Blinky_Demo/main_blinky.c
+++ b/FreeRTOS/Demo/RX100_RX113-RSK_Renesas_e2studio/src/Blinky_Demo/main_blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX100_RX113-RSK_Renesas_e2studio/src/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/RX100_RX113-RSK_Renesas_e2studio/src/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX100_RX113-RSK_Renesas_e2studio/src/Full_Demo/IntQueueTimer.c
+++ b/FreeRTOS/Demo/RX100_RX113-RSK_Renesas_e2studio/src/Full_Demo/IntQueueTimer.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX100_RX113-RSK_Renesas_e2studio/src/Full_Demo/IntQueueTimer.h
+++ b/FreeRTOS/Demo/RX100_RX113-RSK_Renesas_e2studio/src/Full_Demo/IntQueueTimer.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX100_RX113-RSK_Renesas_e2studio/src/Full_Demo/main_full.c
+++ b/FreeRTOS/Demo/RX100_RX113-RSK_Renesas_e2studio/src/Full_Demo/main_full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX100_RX113-RSK_Renesas_e2studio/src/main.c
+++ b/FreeRTOS/Demo/RX100_RX113-RSK_Renesas_e2studio/src/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX200_RX210-RSK_Renesas/RTOSDemo/ButtonAndLCD.c
+++ b/FreeRTOS/Demo/RX200_RX210-RSK_Renesas/RTOSDemo/ButtonAndLCD.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX200_RX210-RSK_Renesas/RTOSDemo/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/RX200_RX210-RSK_Renesas/RTOSDemo/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX200_RX210-RSK_Renesas/RTOSDemo/HighFrequencyTimerTest.c
+++ b/FreeRTOS/Demo/RX200_RX210-RSK_Renesas/RTOSDemo/HighFrequencyTimerTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX200_RX210-RSK_Renesas/RTOSDemo/IntQueueTimer.c
+++ b/FreeRTOS/Demo/RX200_RX210-RSK_Renesas/RTOSDemo/IntQueueTimer.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX200_RX210-RSK_Renesas/RTOSDemo/ParTest.c
+++ b/FreeRTOS/Demo/RX200_RX210-RSK_Renesas/RTOSDemo/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX200_RX210-RSK_Renesas/RTOSDemo/include/ButtonAndLCD.h
+++ b/FreeRTOS/Demo/RX200_RX210-RSK_Renesas/RTOSDemo/include/ButtonAndLCD.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX200_RX210-RSK_Renesas/RTOSDemo/include/IntQueueTimer.h
+++ b/FreeRTOS/Demo/RX200_RX210-RSK_Renesas/RTOSDemo/include/IntQueueTimer.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX200_RX210-RSK_Renesas/RTOSDemo/main-blinky.c
+++ b/FreeRTOS/Demo/RX200_RX210-RSK_Renesas/RTOSDemo/main-blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX200_RX210-RSK_Renesas/RTOSDemo/main-full.c
+++ b/FreeRTOS/Demo/RX200_RX210-RSK_Renesas/RTOSDemo/main-full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX200_RX231-RSK_GCC_e2studio_IAR/src/Blinky_Demo/main_blinky.c
+++ b/FreeRTOS/Demo/RX200_RX231-RSK_GCC_e2studio_IAR/src/Blinky_Demo/main_blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX200_RX231-RSK_GCC_e2studio_IAR/src/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/RX200_RX231-RSK_GCC_e2studio_IAR/src/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX200_RX231-RSK_GCC_e2studio_IAR/src/Full_Demo/IntQueueTimer.c
+++ b/FreeRTOS/Demo/RX200_RX231-RSK_GCC_e2studio_IAR/src/Full_Demo/IntQueueTimer.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX200_RX231-RSK_GCC_e2studio_IAR/src/Full_Demo/IntQueueTimer.h
+++ b/FreeRTOS/Demo/RX200_RX231-RSK_GCC_e2studio_IAR/src/Full_Demo/IntQueueTimer.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX200_RX231-RSK_GCC_e2studio_IAR/src/Full_Demo/RegTest_GCC.S
+++ b/FreeRTOS/Demo/RX200_RX231-RSK_GCC_e2studio_IAR/src/Full_Demo/RegTest_GCC.S
@@ -1,5 +1,5 @@
 ;/*
-; * FreeRTOS Kernel V10.3.0
+; * FreeRTOS Kernel V10.3.1
 ; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 ; *
 ; * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX200_RX231-RSK_GCC_e2studio_IAR/src/Full_Demo/RegTest_IAR.s
+++ b/FreeRTOS/Demo/RX200_RX231-RSK_GCC_e2studio_IAR/src/Full_Demo/RegTest_IAR.s
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX200_RX231-RSK_GCC_e2studio_IAR/src/Full_Demo/main_full.c
+++ b/FreeRTOS/Demo/RX200_RX231-RSK_GCC_e2studio_IAR/src/Full_Demo/main_full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX200_RX231-RSK_GCC_e2studio_IAR/src/PriorityDefinitions.h
+++ b/FreeRTOS/Demo/RX200_RX231-RSK_GCC_e2studio_IAR/src/PriorityDefinitions.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX200_RX231-RSK_GCC_e2studio_IAR/src/main.c
+++ b/FreeRTOS/Demo/RX200_RX231-RSK_GCC_e2studio_IAR/src/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX200_RX231-RSK_Renesas_e2studio/src/Blinky_Demo/main_blinky.c
+++ b/FreeRTOS/Demo/RX200_RX231-RSK_Renesas_e2studio/src/Blinky_Demo/main_blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX200_RX231-RSK_Renesas_e2studio/src/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/RX200_RX231-RSK_Renesas_e2studio/src/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX200_RX231-RSK_Renesas_e2studio/src/Full_Demo/IntQueueTimer.c
+++ b/FreeRTOS/Demo/RX200_RX231-RSK_Renesas_e2studio/src/Full_Demo/IntQueueTimer.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX200_RX231-RSK_Renesas_e2studio/src/Full_Demo/IntQueueTimer.h
+++ b/FreeRTOS/Demo/RX200_RX231-RSK_Renesas_e2studio/src/Full_Demo/IntQueueTimer.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX200_RX231-RSK_Renesas_e2studio/src/Full_Demo/main_full.c
+++ b/FreeRTOS/Demo/RX200_RX231-RSK_Renesas_e2studio/src/Full_Demo/main_full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX200_RX231-RSK_Renesas_e2studio/src/main.c
+++ b/FreeRTOS/Demo/RX200_RX231-RSK_Renesas_e2studio/src/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX62N-RDK_GNURX/RTOSDemo/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/RX600_RX62N-RDK_GNURX/RTOSDemo/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX62N-RDK_GNURX/RTOSDemo/HighFrequencyTimerTest.c
+++ b/FreeRTOS/Demo/RX600_RX62N-RDK_GNURX/RTOSDemo/HighFrequencyTimerTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX62N-RDK_GNURX/RTOSDemo/IntQueueTimer.c
+++ b/FreeRTOS/Demo/RX600_RX62N-RDK_GNURX/RTOSDemo/IntQueueTimer.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX62N-RDK_GNURX/RTOSDemo/ParTest.c
+++ b/FreeRTOS/Demo/RX600_RX62N-RDK_GNURX/RTOSDemo/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX62N-RDK_GNURX/RTOSDemo/include/IntQueueTimer.h
+++ b/FreeRTOS/Demo/RX600_RX62N-RDK_GNURX/RTOSDemo/include/IntQueueTimer.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX62N-RDK_GNURX/RTOSDemo/main-blinky.c
+++ b/FreeRTOS/Demo/RX600_RX62N-RDK_GNURX/RTOSDemo/main-blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX62N-RDK_GNURX/RTOSDemo/main-full.c
+++ b/FreeRTOS/Demo/RX600_RX62N-RDK_GNURX/RTOSDemo/main-full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX62N-RDK_GNURX/RTOSDemo/uIP_Task.c
+++ b/FreeRTOS/Demo/RX600_RX62N-RDK_GNURX/RTOSDemo/uIP_Task.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX62N-RDK_GNURX/RTOSDemo/webserver/EMAC.c
+++ b/FreeRTOS/Demo/RX600_RX62N-RDK_GNURX/RTOSDemo/webserver/EMAC.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX62N-RDK_IAR/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/RX600_RX62N-RDK_IAR/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX62N-RDK_IAR/HighFrequencyTimerTest.c
+++ b/FreeRTOS/Demo/RX600_RX62N-RDK_IAR/HighFrequencyTimerTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX62N-RDK_IAR/IntQueueTimer.c
+++ b/FreeRTOS/Demo/RX600_RX62N-RDK_IAR/IntQueueTimer.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX62N-RDK_IAR/ParTest.c
+++ b/FreeRTOS/Demo/RX600_RX62N-RDK_IAR/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX62N-RDK_IAR/PriorityDefinitions.h
+++ b/FreeRTOS/Demo/RX600_RX62N-RDK_IAR/PriorityDefinitions.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX62N-RDK_IAR/RegTest.s
+++ b/FreeRTOS/Demo/RX600_RX62N-RDK_IAR/RegTest.s
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX62N-RDK_IAR/include/IntQueueTimer.h
+++ b/FreeRTOS/Demo/RX600_RX62N-RDK_IAR/include/IntQueueTimer.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX62N-RDK_IAR/main-blinky.c
+++ b/FreeRTOS/Demo/RX600_RX62N-RDK_IAR/main-blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX62N-RDK_IAR/main-full.c
+++ b/FreeRTOS/Demo/RX600_RX62N-RDK_IAR/main-full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX62N-RDK_IAR/uIP_Task.c
+++ b/FreeRTOS/Demo/RX600_RX62N-RDK_IAR/uIP_Task.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX62N-RDK_IAR/webserver/EMAC.c
+++ b/FreeRTOS/Demo/RX600_RX62N-RDK_IAR/webserver/EMAC.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX62N-RDK_Renesas/RTOSDemo/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/RX600_RX62N-RDK_Renesas/RTOSDemo/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX62N-RDK_Renesas/RTOSDemo/HighFrequencyTimerTest.c
+++ b/FreeRTOS/Demo/RX600_RX62N-RDK_Renesas/RTOSDemo/HighFrequencyTimerTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX62N-RDK_Renesas/RTOSDemo/IntQueueTimer.c
+++ b/FreeRTOS/Demo/RX600_RX62N-RDK_Renesas/RTOSDemo/IntQueueTimer.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX62N-RDK_Renesas/RTOSDemo/ParTest.c
+++ b/FreeRTOS/Demo/RX600_RX62N-RDK_Renesas/RTOSDemo/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX62N-RDK_Renesas/RTOSDemo/include/IntQueueTimer.h
+++ b/FreeRTOS/Demo/RX600_RX62N-RDK_Renesas/RTOSDemo/include/IntQueueTimer.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX62N-RDK_Renesas/RTOSDemo/main-blinky.c
+++ b/FreeRTOS/Demo/RX600_RX62N-RDK_Renesas/RTOSDemo/main-blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX62N-RDK_Renesas/RTOSDemo/main-full.c
+++ b/FreeRTOS/Demo/RX600_RX62N-RDK_Renesas/RTOSDemo/main-full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX62N-RDK_Renesas/RTOSDemo/uIP_Task.c
+++ b/FreeRTOS/Demo/RX600_RX62N-RDK_Renesas/RTOSDemo/uIP_Task.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX62N-RDK_Renesas/RTOSDemo/webserver/EMAC.c
+++ b/FreeRTOS/Demo/RX600_RX62N-RDK_Renesas/RTOSDemo/webserver/EMAC.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX62N-RSK_GNURX/RTOSDemo/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/RX600_RX62N-RSK_GNURX/RTOSDemo/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX62N-RSK_GNURX/RTOSDemo/HighFrequencyTimerTest.c
+++ b/FreeRTOS/Demo/RX600_RX62N-RSK_GNURX/RTOSDemo/HighFrequencyTimerTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX62N-RSK_GNURX/RTOSDemo/IntQueueTimer.c
+++ b/FreeRTOS/Demo/RX600_RX62N-RSK_GNURX/RTOSDemo/IntQueueTimer.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX62N-RSK_GNURX/RTOSDemo/ParTest.c
+++ b/FreeRTOS/Demo/RX600_RX62N-RSK_GNURX/RTOSDemo/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX62N-RSK_GNURX/RTOSDemo/include/IntQueueTimer.h
+++ b/FreeRTOS/Demo/RX600_RX62N-RSK_GNURX/RTOSDemo/include/IntQueueTimer.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX62N-RSK_GNURX/RTOSDemo/main-blinky.c
+++ b/FreeRTOS/Demo/RX600_RX62N-RSK_GNURX/RTOSDemo/main-blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX62N-RSK_GNURX/RTOSDemo/main-full.c
+++ b/FreeRTOS/Demo/RX600_RX62N-RSK_GNURX/RTOSDemo/main-full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX62N-RSK_GNURX/RTOSDemo/uIP_Task.c
+++ b/FreeRTOS/Demo/RX600_RX62N-RSK_GNURX/RTOSDemo/uIP_Task.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX62N-RSK_GNURX/RTOSDemo/webserver/EMAC.c
+++ b/FreeRTOS/Demo/RX600_RX62N-RSK_GNURX/RTOSDemo/webserver/EMAC.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX62N-RSK_IAR/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/RX600_RX62N-RSK_IAR/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX62N-RSK_IAR/HighFrequencyTimerTest.c
+++ b/FreeRTOS/Demo/RX600_RX62N-RSK_IAR/HighFrequencyTimerTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX62N-RSK_IAR/IntQueueTimer.c
+++ b/FreeRTOS/Demo/RX600_RX62N-RSK_IAR/IntQueueTimer.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX62N-RSK_IAR/ParTest.c
+++ b/FreeRTOS/Demo/RX600_RX62N-RSK_IAR/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX62N-RSK_IAR/PriorityDefinitions.h
+++ b/FreeRTOS/Demo/RX600_RX62N-RSK_IAR/PriorityDefinitions.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX62N-RSK_IAR/RegTest.s
+++ b/FreeRTOS/Demo/RX600_RX62N-RSK_IAR/RegTest.s
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX62N-RSK_IAR/include/IntQueueTimer.h
+++ b/FreeRTOS/Demo/RX600_RX62N-RSK_IAR/include/IntQueueTimer.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX62N-RSK_IAR/main-blinky.c
+++ b/FreeRTOS/Demo/RX600_RX62N-RSK_IAR/main-blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX62N-RSK_IAR/main-full.c
+++ b/FreeRTOS/Demo/RX600_RX62N-RSK_IAR/main-full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX62N-RSK_IAR/uIP_Task.c
+++ b/FreeRTOS/Demo/RX600_RX62N-RSK_IAR/uIP_Task.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX62N-RSK_IAR/webserver/EMAC.c
+++ b/FreeRTOS/Demo/RX600_RX62N-RSK_IAR/webserver/EMAC.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX62N-RSK_Renesas/RTOSDemo/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/RX600_RX62N-RSK_Renesas/RTOSDemo/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX62N-RSK_Renesas/RTOSDemo/HighFrequencyTimerTest.c
+++ b/FreeRTOS/Demo/RX600_RX62N-RSK_Renesas/RTOSDemo/HighFrequencyTimerTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX62N-RSK_Renesas/RTOSDemo/IntQueueTimer.c
+++ b/FreeRTOS/Demo/RX600_RX62N-RSK_Renesas/RTOSDemo/IntQueueTimer.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX62N-RSK_Renesas/RTOSDemo/ParTest.c
+++ b/FreeRTOS/Demo/RX600_RX62N-RSK_Renesas/RTOSDemo/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX62N-RSK_Renesas/RTOSDemo/include/IntQueueTimer.h
+++ b/FreeRTOS/Demo/RX600_RX62N-RSK_Renesas/RTOSDemo/include/IntQueueTimer.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX62N-RSK_Renesas/RTOSDemo/main-blinky.c
+++ b/FreeRTOS/Demo/RX600_RX62N-RSK_Renesas/RTOSDemo/main-blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX62N-RSK_Renesas/RTOSDemo/main-full.c
+++ b/FreeRTOS/Demo/RX600_RX62N-RSK_Renesas/RTOSDemo/main-full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX62N-RSK_Renesas/RTOSDemo/uIP_Task.c
+++ b/FreeRTOS/Demo/RX600_RX62N-RSK_Renesas/RTOSDemo/uIP_Task.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX62N-RSK_Renesas/RTOSDemo/webserver/EMAC.c
+++ b/FreeRTOS/Demo/RX600_RX62N-RSK_Renesas/RTOSDemo/webserver/EMAC.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX630-RSK_Renesas/RTOSDemo/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/RX600_RX630-RSK_Renesas/RTOSDemo/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX630-RSK_Renesas/RTOSDemo/HighFrequencyTimerTest.c
+++ b/FreeRTOS/Demo/RX600_RX630-RSK_Renesas/RTOSDemo/HighFrequencyTimerTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX630-RSK_Renesas/RTOSDemo/IntQueueTimer.c
+++ b/FreeRTOS/Demo/RX600_RX630-RSK_Renesas/RTOSDemo/IntQueueTimer.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX630-RSK_Renesas/RTOSDemo/ParTest.c
+++ b/FreeRTOS/Demo/RX600_RX630-RSK_Renesas/RTOSDemo/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX630-RSK_Renesas/RTOSDemo/include/IntQueueTimer.h
+++ b/FreeRTOS/Demo/RX600_RX630-RSK_Renesas/RTOSDemo/include/IntQueueTimer.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX630-RSK_Renesas/RTOSDemo/main-blinky.c
+++ b/FreeRTOS/Demo/RX600_RX630-RSK_Renesas/RTOSDemo/main-blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX630-RSK_Renesas/RTOSDemo/main-full.c
+++ b/FreeRTOS/Demo/RX600_RX630-RSK_Renesas/RTOSDemo/main-full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX63N-RDK_Renesas/RTOSDemo/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/RX600_RX63N-RDK_Renesas/RTOSDemo/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX63N-RDK_Renesas/RTOSDemo/HighFrequencyTimerTest.c
+++ b/FreeRTOS/Demo/RX600_RX63N-RDK_Renesas/RTOSDemo/HighFrequencyTimerTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX63N-RDK_Renesas/RTOSDemo/IntQueueTimer.c
+++ b/FreeRTOS/Demo/RX600_RX63N-RDK_Renesas/RTOSDemo/IntQueueTimer.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX63N-RDK_Renesas/RTOSDemo/IntQueueTimer.h
+++ b/FreeRTOS/Demo/RX600_RX63N-RDK_Renesas/RTOSDemo/IntQueueTimer.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX63N-RDK_Renesas/RTOSDemo/ParTest.c
+++ b/FreeRTOS/Demo/RX600_RX63N-RDK_Renesas/RTOSDemo/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX63N-RDK_Renesas/RTOSDemo/main-blinky.c
+++ b/FreeRTOS/Demo/RX600_RX63N-RDK_Renesas/RTOSDemo/main-blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX63N-RDK_Renesas/RTOSDemo/main-full.c
+++ b/FreeRTOS/Demo/RX600_RX63N-RDK_Renesas/RTOSDemo/main-full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX63N-RDK_Renesas/RTOSDemo/uIP_Task.c
+++ b/FreeRTOS/Demo/RX600_RX63N-RDK_Renesas/RTOSDemo/uIP_Task.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX63N-RDK_Renesas/RTOSDemo/webserver/EMAC.c
+++ b/FreeRTOS/Demo/RX600_RX63N-RDK_Renesas/RTOSDemo/webserver/EMAC.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX64M_RSK_GCC_e2studio/src/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/RX600_RX64M_RSK_GCC_e2studio/src/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX64M_RSK_GCC_e2studio/src/IntQueueTimer.c
+++ b/FreeRTOS/Demo/RX600_RX64M_RSK_GCC_e2studio/src/IntQueueTimer.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX64M_RSK_GCC_e2studio/src/IntQueueTimer.h
+++ b/FreeRTOS/Demo/RX600_RX64M_RSK_GCC_e2studio/src/IntQueueTimer.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX64M_RSK_GCC_e2studio/src/ParTest.c
+++ b/FreeRTOS/Demo/RX600_RX64M_RSK_GCC_e2studio/src/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX64M_RSK_GCC_e2studio/src/RegTest.S
+++ b/FreeRTOS/Demo/RX600_RX64M_RSK_GCC_e2studio/src/RegTest.S
@@ -1,5 +1,5 @@
 ;/*
-; * FreeRTOS Kernel V10.3.0
+; * FreeRTOS Kernel V10.3.1
 ; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 ; *
 ; * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX64M_RSK_GCC_e2studio/src/main.c
+++ b/FreeRTOS/Demo/RX600_RX64M_RSK_GCC_e2studio/src/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX64M_RSK_GCC_e2studio/src/main_blinky.c
+++ b/FreeRTOS/Demo/RX600_RX64M_RSK_GCC_e2studio/src/main_blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX64M_RSK_GCC_e2studio/src/main_full.c
+++ b/FreeRTOS/Demo/RX600_RX64M_RSK_GCC_e2studio/src/main_full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX64M_RSK_Renesas_e2studio/Source/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/RX600_RX64M_RSK_Renesas_e2studio/Source/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX64M_RSK_Renesas_e2studio/Source/IntQueueTimer.c
+++ b/FreeRTOS/Demo/RX600_RX64M_RSK_Renesas_e2studio/Source/IntQueueTimer.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX64M_RSK_Renesas_e2studio/Source/IntQueueTimer.h
+++ b/FreeRTOS/Demo/RX600_RX64M_RSK_Renesas_e2studio/Source/IntQueueTimer.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX64M_RSK_Renesas_e2studio/Source/ParTest.c
+++ b/FreeRTOS/Demo/RX600_RX64M_RSK_Renesas_e2studio/Source/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX64M_RSK_Renesas_e2studio/Source/RegTest.src
+++ b/FreeRTOS/Demo/RX600_RX64M_RSK_Renesas_e2studio/Source/RegTest.src
@@ -1,5 +1,5 @@
 ;/*
-; * FreeRTOS Kernel V10.3.0
+; * FreeRTOS Kernel V10.3.1
 ; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 ; *
 ; * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX64M_RSK_Renesas_e2studio/Source/main.c
+++ b/FreeRTOS/Demo/RX600_RX64M_RSK_Renesas_e2studio/Source/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX64M_RSK_Renesas_e2studio/Source/main_blinky.c
+++ b/FreeRTOS/Demo/RX600_RX64M_RSK_Renesas_e2studio/Source/main_blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX600_RX64M_RSK_Renesas_e2studio/Source/main_full.c
+++ b/FreeRTOS/Demo/RX600_RX64M_RSK_Renesas_e2studio/Source/main_full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX700_RX71M_RSK_GCC_e2studio_IAR/src/Blinky_Demo/main_blinky.c
+++ b/FreeRTOS/Demo/RX700_RX71M_RSK_GCC_e2studio_IAR/src/Blinky_Demo/main_blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX700_RX71M_RSK_GCC_e2studio_IAR/src/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/RX700_RX71M_RSK_GCC_e2studio_IAR/src/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX700_RX71M_RSK_GCC_e2studio_IAR/src/Full_Demo/IntQueueTimer.c
+++ b/FreeRTOS/Demo/RX700_RX71M_RSK_GCC_e2studio_IAR/src/Full_Demo/IntQueueTimer.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX700_RX71M_RSK_GCC_e2studio_IAR/src/Full_Demo/IntQueueTimer.h
+++ b/FreeRTOS/Demo/RX700_RX71M_RSK_GCC_e2studio_IAR/src/Full_Demo/IntQueueTimer.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX700_RX71M_RSK_GCC_e2studio_IAR/src/Full_Demo/RegTest_GCC.S
+++ b/FreeRTOS/Demo/RX700_RX71M_RSK_GCC_e2studio_IAR/src/Full_Demo/RegTest_GCC.S
@@ -1,5 +1,5 @@
 ;/*
-; * FreeRTOS Kernel V10.3.0
+; * FreeRTOS Kernel V10.3.1
 ; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 ; *
 ; * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX700_RX71M_RSK_GCC_e2studio_IAR/src/Full_Demo/RegTest_IAR.s
+++ b/FreeRTOS/Demo/RX700_RX71M_RSK_GCC_e2studio_IAR/src/Full_Demo/RegTest_IAR.s
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX700_RX71M_RSK_GCC_e2studio_IAR/src/Full_Demo/main_full.c
+++ b/FreeRTOS/Demo/RX700_RX71M_RSK_GCC_e2studio_IAR/src/Full_Demo/main_full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX700_RX71M_RSK_GCC_e2studio_IAR/src/PriorityDefinitions.h
+++ b/FreeRTOS/Demo/RX700_RX71M_RSK_GCC_e2studio_IAR/src/PriorityDefinitions.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX700_RX71M_RSK_GCC_e2studio_IAR/src/main.c
+++ b/FreeRTOS/Demo/RX700_RX71M_RSK_GCC_e2studio_IAR/src/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX700_RX71M_RSK_Renesas_e2studio/src/Blinky_Demo/main_blinky.c
+++ b/FreeRTOS/Demo/RX700_RX71M_RSK_Renesas_e2studio/src/Blinky_Demo/main_blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX700_RX71M_RSK_Renesas_e2studio/src/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/RX700_RX71M_RSK_Renesas_e2studio/src/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX700_RX71M_RSK_Renesas_e2studio/src/Full_Demo/IntQueueTimer.c
+++ b/FreeRTOS/Demo/RX700_RX71M_RSK_Renesas_e2studio/src/Full_Demo/IntQueueTimer.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX700_RX71M_RSK_Renesas_e2studio/src/Full_Demo/IntQueueTimer.h
+++ b/FreeRTOS/Demo/RX700_RX71M_RSK_Renesas_e2studio/src/Full_Demo/IntQueueTimer.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX700_RX71M_RSK_Renesas_e2studio/src/Full_Demo/main_full.c
+++ b/FreeRTOS/Demo/RX700_RX71M_RSK_Renesas_e2studio/src/Full_Demo/main_full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/RX700_RX71M_RSK_Renesas_e2studio/src/main.c
+++ b/FreeRTOS/Demo/RX700_RX71M_RSK_Renesas_e2studio/src/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/SuperH_SH7216_Renesas/RTOSDemo/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/SuperH_SH7216_Renesas/RTOSDemo/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/SuperH_SH7216_Renesas/RTOSDemo/ParTest/ParTest.c
+++ b/FreeRTOS/Demo/SuperH_SH7216_Renesas/RTOSDemo/ParTest/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/SuperH_SH7216_Renesas/RTOSDemo/flop.c
+++ b/FreeRTOS/Demo/SuperH_SH7216_Renesas/RTOSDemo/flop.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/SuperH_SH7216_Renesas/RTOSDemo/main.c
+++ b/FreeRTOS/Demo/SuperH_SH7216_Renesas/RTOSDemo/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/SuperH_SH7216_Renesas/RTOSDemo/regtest.src
+++ b/FreeRTOS/Demo/SuperH_SH7216_Renesas/RTOSDemo/regtest.src
@@ -1,5 +1,5 @@
 ;/*
-; * FreeRTOS Kernel V10.3.0
+; * FreeRTOS Kernel V10.3.1
 ; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 ; *
 ; * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/SuperH_SH7216_Renesas/RTOSDemo/uIP_Task.c
+++ b/FreeRTOS/Demo/SuperH_SH7216_Renesas/RTOSDemo/uIP_Task.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/SuperH_SH7216_Renesas/RTOSDemo/webserver/EMAC.c
+++ b/FreeRTOS/Demo/SuperH_SH7216_Renesas/RTOSDemo/webserver/EMAC.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/SuperH_SH7216_Renesas/RTOSDemo/webserver/EMAC_ISR.src
+++ b/FreeRTOS/Demo/SuperH_SH7216_Renesas/RTOSDemo/webserver/EMAC_ISR.src
@@ -1,5 +1,5 @@
 ;/*
-; * FreeRTOS Kernel V10.3.0
+; * FreeRTOS Kernel V10.3.1
 ; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 ; *
 ; * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/T-HEAD_CB2201_CDK/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/T-HEAD_CB2201_CDK/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Tensilica_Simulator_Xplorer_XCC/main.c
+++ b/FreeRTOS/Demo/Tensilica_Simulator_Xplorer_XCC/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Tensilica_Simulator_Xplorer_XCC/main_blinky.c
+++ b/FreeRTOS/Demo/Tensilica_Simulator_Xplorer_XCC/main_blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/Tensilica_Simulator_Xplorer_XCC/regtest_xtensa.S
+++ b/FreeRTOS/Demo/Tensilica_Simulator_Xplorer_XCC/regtest_xtensa.S
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/TriCore_TC1782_TriBoard_GCC/RTOSDemo/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/TriCore_TC1782_TriBoard_GCC/RTOSDemo/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/TriCore_TC1782_TriBoard_GCC/RTOSDemo/InterruptNestTest.c
+++ b/FreeRTOS/Demo/TriCore_TC1782_TriBoard_GCC/RTOSDemo/InterruptNestTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/TriCore_TC1782_TriBoard_GCC/RTOSDemo/InterruptNestTest.h
+++ b/FreeRTOS/Demo/TriCore_TC1782_TriBoard_GCC/RTOSDemo/InterruptNestTest.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/TriCore_TC1782_TriBoard_GCC/RTOSDemo/ParTest.c
+++ b/FreeRTOS/Demo/TriCore_TC1782_TriBoard_GCC/RTOSDemo/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/TriCore_TC1782_TriBoard_GCC/RTOSDemo/main.c
+++ b/FreeRTOS/Demo/TriCore_TC1782_TriBoard_GCC/RTOSDemo/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/TriCore_TC1782_TriBoard_GCC/RTOSDemo/serial.c
+++ b/FreeRTOS/Demo/TriCore_TC1782_TriBoard_GCC/RTOSDemo/serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/WIN32-MSVC-Static-Allocation-Only/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/WIN32-MSVC-Static-Allocation-Only/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/WIN32-MSVC-Static-Allocation-Only/main.c
+++ b/FreeRTOS/Demo/WIN32-MSVC-Static-Allocation-Only/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/WIN32-MSVC/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/WIN32-MSVC/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/WIN32-MSVC/Run-time-stats-utils.c
+++ b/FreeRTOS/Demo/WIN32-MSVC/Run-time-stats-utils.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/WIN32-MSVC/main.c
+++ b/FreeRTOS/Demo/WIN32-MSVC/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/WIN32-MSVC/main_blinky.c
+++ b/FreeRTOS/Demo/WIN32-MSVC/main_blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/WIN32-MSVC/main_full.c
+++ b/FreeRTOS/Demo/WIN32-MSVC/main_full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/WIN32-MingW/DemosModifiedForLowTickRate/recmutex.c
+++ b/FreeRTOS/Demo/WIN32-MingW/DemosModifiedForLowTickRate/recmutex.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/WIN32-MingW/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/WIN32-MingW/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/WIN32-MingW/Run-time-stats-utils.c
+++ b/FreeRTOS/Demo/WIN32-MingW/Run-time-stats-utils.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/WIN32-MingW/code_coverage_additions.c
+++ b/FreeRTOS/Demo/WIN32-MingW/code_coverage_additions.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/WIN32-MingW/main.c
+++ b/FreeRTOS/Demo/WIN32-MingW/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/WIN32-MingW/main_blinky.c
+++ b/FreeRTOS/Demo/WIN32-MingW/main_blinky.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/WIN32-MingW/main_full.c
+++ b/FreeRTOS/Demo/WIN32-MingW/main_full.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/WizNET_DEMO_GCC_ARM7/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/WizNET_DEMO_GCC_ARM7/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/WizNET_DEMO_GCC_ARM7/HTTP_Serv.c
+++ b/FreeRTOS/Demo/WizNET_DEMO_GCC_ARM7/HTTP_Serv.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/WizNET_DEMO_GCC_ARM7/HTTP_Serv.h
+++ b/FreeRTOS/Demo/WizNET_DEMO_GCC_ARM7/HTTP_Serv.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/WizNET_DEMO_GCC_ARM7/Makefile
+++ b/FreeRTOS/Demo/WizNET_DEMO_GCC_ARM7/Makefile
@@ -1,5 +1,5 @@
 #/*
-# * FreeRTOS Kernel V10.3.0
+# * FreeRTOS Kernel V10.3.1
 # * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 # *
 # * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/WizNET_DEMO_GCC_ARM7/TCP.c
+++ b/FreeRTOS/Demo/WizNET_DEMO_GCC_ARM7/TCP.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/WizNET_DEMO_GCC_ARM7/TCP.h
+++ b/FreeRTOS/Demo/WizNET_DEMO_GCC_ARM7/TCP.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/WizNET_DEMO_GCC_ARM7/TCPISR.c
+++ b/FreeRTOS/Demo/WizNET_DEMO_GCC_ARM7/TCPISR.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/WizNET_DEMO_GCC_ARM7/html_pages.h
+++ b/FreeRTOS/Demo/WizNET_DEMO_GCC_ARM7/html_pages.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/WizNET_DEMO_GCC_ARM7/i2c.c
+++ b/FreeRTOS/Demo/WizNET_DEMO_GCC_ARM7/i2c.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/WizNET_DEMO_GCC_ARM7/i2c.h
+++ b/FreeRTOS/Demo/WizNET_DEMO_GCC_ARM7/i2c.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/WizNET_DEMO_GCC_ARM7/i2cISR.c
+++ b/FreeRTOS/Demo/WizNET_DEMO_GCC_ARM7/i2cISR.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/WizNET_DEMO_GCC_ARM7/main.c
+++ b/FreeRTOS/Demo/WizNET_DEMO_GCC_ARM7/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/WizNET_DEMO_TERN_186/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/WizNET_DEMO_TERN_186/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/WizNET_DEMO_TERN_186/HTTPTask.c
+++ b/FreeRTOS/Demo/WizNET_DEMO_TERN_186/HTTPTask.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/WizNET_DEMO_TERN_186/HTTPTask.h
+++ b/FreeRTOS/Demo/WizNET_DEMO_TERN_186/HTTPTask.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/WizNET_DEMO_TERN_186/main.c
+++ b/FreeRTOS/Demo/WizNET_DEMO_TERN_186/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/WizNET_DEMO_TERN_186/serial/serial.c
+++ b/FreeRTOS/Demo/WizNET_DEMO_TERN_186/serial/serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/dsPIC_MPLAB/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/dsPIC_MPLAB/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/dsPIC_MPLAB/ParTest/ParTest.c
+++ b/FreeRTOS/Demo/dsPIC_MPLAB/ParTest/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/dsPIC_MPLAB/lcd.c
+++ b/FreeRTOS/Demo/dsPIC_MPLAB/lcd.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/dsPIC_MPLAB/lcd.h
+++ b/FreeRTOS/Demo/dsPIC_MPLAB/lcd.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/dsPIC_MPLAB/main.c
+++ b/FreeRTOS/Demo/dsPIC_MPLAB/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/dsPIC_MPLAB/serial/serial.c
+++ b/FreeRTOS/Demo/dsPIC_MPLAB/serial/serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/dsPIC_MPLAB/timertest.c
+++ b/FreeRTOS/Demo/dsPIC_MPLAB/timertest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/dsPIC_MPLAB/timertest.h
+++ b/FreeRTOS/Demo/dsPIC_MPLAB/timertest.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/lwIP_Demo_Rowley_ARM7/BasicWEB.c
+++ b/FreeRTOS/Demo/lwIP_Demo_Rowley_ARM7/BasicWEB.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/lwIP_Demo_Rowley_ARM7/BasicWEB.h
+++ b/FreeRTOS/Demo/lwIP_Demo_Rowley_ARM7/BasicWEB.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/lwIP_Demo_Rowley_ARM7/EMAC/SAM7_EMAC.c
+++ b/FreeRTOS/Demo/lwIP_Demo_Rowley_ARM7/EMAC/SAM7_EMAC.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/lwIP_Demo_Rowley_ARM7/EMAC/SAM7_EMAC.h
+++ b/FreeRTOS/Demo/lwIP_Demo_Rowley_ARM7/EMAC/SAM7_EMAC.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/lwIP_Demo_Rowley_ARM7/EMAC/SAM7_EMAC_ISR.c
+++ b/FreeRTOS/Demo/lwIP_Demo_Rowley_ARM7/EMAC/SAM7_EMAC_ISR.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/lwIP_Demo_Rowley_ARM7/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/lwIP_Demo_Rowley_ARM7/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/lwIP_Demo_Rowley_ARM7/ParTest/ParTest.c
+++ b/FreeRTOS/Demo/lwIP_Demo_Rowley_ARM7/ParTest/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/lwIP_Demo_Rowley_ARM7/USB/USB-CDC.c
+++ b/FreeRTOS/Demo/lwIP_Demo_Rowley_ARM7/USB/USB-CDC.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/lwIP_Demo_Rowley_ARM7/USB/USB-CDC.h
+++ b/FreeRTOS/Demo/lwIP_Demo_Rowley_ARM7/USB/USB-CDC.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/lwIP_Demo_Rowley_ARM7/USB/USBIsr.c
+++ b/FreeRTOS/Demo/lwIP_Demo_Rowley_ARM7/USB/USBIsr.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/lwIP_Demo_Rowley_ARM7/USB/descriptors.h
+++ b/FreeRTOS/Demo/lwIP_Demo_Rowley_ARM7/USB/descriptors.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/lwIP_Demo_Rowley_ARM7/USB/usb.h
+++ b/FreeRTOS/Demo/lwIP_Demo_Rowley_ARM7/USB/usb.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/lwIP_Demo_Rowley_ARM7/main.c
+++ b/FreeRTOS/Demo/lwIP_Demo_Rowley_ARM7/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/lwIP_Demo_Rowley_ARM7/makefile
+++ b/FreeRTOS/Demo/lwIP_Demo_Rowley_ARM7/makefile
@@ -1,5 +1,5 @@
 #/*
-# * FreeRTOS Kernel V10.3.0
+# * FreeRTOS Kernel V10.3.1
 # * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 # *
 # * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/msp430_CrossWorks/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/msp430_CrossWorks/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/msp430_CrossWorks/ParTest/ParTest.c
+++ b/FreeRTOS/Demo/msp430_CrossWorks/ParTest/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/msp430_CrossWorks/main.c
+++ b/FreeRTOS/Demo/msp430_CrossWorks/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/msp430_CrossWorks/serial/serial.c
+++ b/FreeRTOS/Demo/msp430_CrossWorks/serial/serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/msp430_CrossWorks/serial/serialASM.asm
+++ b/FreeRTOS/Demo/msp430_CrossWorks/serial/serialASM.asm
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/msp430_GCC/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/msp430_GCC/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/msp430_GCC/ParTest/ParTest.c
+++ b/FreeRTOS/Demo/msp430_GCC/ParTest/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/msp430_GCC/main.c
+++ b/FreeRTOS/Demo/msp430_GCC/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/msp430_GCC/makefile
+++ b/FreeRTOS/Demo/msp430_GCC/makefile
@@ -1,5 +1,5 @@
 #/*
-# * FreeRTOS Kernel V10.3.0
+# * FreeRTOS Kernel V10.3.1
 # * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 # *
 # * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/msp430_GCC/serial/serial.c
+++ b/FreeRTOS/Demo/msp430_GCC/serial/serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/msp430_IAR/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/msp430_IAR/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/msp430_IAR/ParTest/ParTest.c
+++ b/FreeRTOS/Demo/msp430_IAR/ParTest/ParTest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/msp430_IAR/main.c
+++ b/FreeRTOS/Demo/msp430_IAR/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/msp430_IAR/serial/serial.c
+++ b/FreeRTOS/Demo/msp430_IAR/serial/serial.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS/Demo/msp430_IAR/serial/serialASM.s43
+++ b/FreeRTOS/Demo/msp430_IAR/serial/serialASM.s43
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS Kernel V10.3.1
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of


### PR DESCRIPTION
Description
-----------
We messed up versioning during V10.3.1 launch. Fixing in this PR. 

Test Steps
-----------
Fetch this PR, and grep "V10.3.0". Should not see V10.3.0 in any file header comment. Except:

1. These directories are "don't-care" for the scope of this PR: ```FreeRTOS/Test/*``` and ```FreeRTOS-Plus/Test/*```. Since they are added post V10.3.1 release. We'll need to address versioning issue later.
2. ```FreeRTOS/Source/portable/ThirdParty/GCC/Posix/port.c``` and ```FreeRTOS/Source/portable/ThirdParty/GCC/Posix/portmacro.h``` do have V10.3.0 as version number in header file. But note that 1/ it needs to be addressed in FreeRTOS-Kernel repo instead of here; 2/ these two were brought in after V10.3.1. )

Related Issue
-----------
N/A


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
