### PR TITLE
Remove unnecessary semicolon from the linker file

### DIFF
--- a/FreeRTOS/Demo/CORTEX_MPU_M33F_NXP_LPC55S69_MCUXpresso/Projects/MCUXpresso/NonSecure/FreeRTOSDemo_ns.ld
+++ b/FreeRTOS/Demo/CORTEX_MPU_M33F_NXP_LPC55S69_MCUXpresso/Projects/MCUXpresso/NonSecure/FreeRTOSDemo_ns.ld
@@ -126,7 +126,7 @@ SECTIONS
         /* Privileged data - It needs to be 32 byte aligned to satisfy MPU requirements. */
         . = ALIGN(32);
         __privileged_sram_start__ = .;
-        *(privileged_data);
+        *(privileged_data)
         . = ALIGN(32);
         /* End address must be the last address in the region, therefore, -1. */
         __privileged_sram_end__ = . - 1;


### PR DESCRIPTION
This was creating problem with the onboard LPCLink debug probe.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
