### PR TITLE
Try harder to avoid DHCP race condition and potential live-lock

### DIFF
--- a/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/FreeRTOS_DHCP.c
+++ b/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/FreeRTOS_DHCP.c
@@ -58,7 +58,7 @@
 
 /* Timer parameters */
 #ifndef dhcpINITIAL_DHCP_TX_PERIOD
-	#define dhcpINITIAL_TIMER_PERIOD			( pdMS_TO_TICKS( 250U ) )
+	#define dhcpINITIAL_TIMER_PERIOD			( pdMS_TO_TICKS( 2500U ) )
 	#define dhcpINITIAL_DHCP_TX_PERIOD			( pdMS_TO_TICKS( 5000U ) )
 #endif
 


### PR DESCRIPTION
There is a race condition in the stack between the IPTask and the Ethernet Driver Task.

Description
-----------
I'm not sure that this is the best way to "fix" the race. Technically the race still exists and if the IPTask doesn't get scheduled for
more than 2,500ms then the condition will reappear.

Perhaps it's better to rewrite vDHCPProcess()'s eLeasedAddress state to check whether the DHCP lease really is up for renewal?

Anyway, this is a patch for discussion and makes the issue go away for me for now.

Test Steps
-----------
This is a race condition so is inherently difficult to reproduce.
I discovered it because I had some FreeRTOS_debug_printfs()'s scattered around and was running packet captures on my development machine.

Sometimes when requesting a DHCP lease the stack will get stuck in a loop of requesting acknowledging and re-requesting. If this happens you will see a lot of network traffic from the target and repeated Network Up notifications.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
