### PR TITLE
Add demo completion string for CI checks to pass

### DIFF
--- a/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_light_weight/DemoTasks/LightWeightMQTTExample.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_light_weight/DemoTasks/LightWeightMQTTExample.c
@@ -76,6 +76,8 @@ static void prvMQTTDemoTask( void * pvParameters )
     vTaskDelay( pdMS_TO_TICKS( 1000 ) );
     LogInfo( ( "In the light weight MQTT demo." ) );
     vTaskDelay( pdMS_TO_TICKS( 1000 ) );
+
+    LogInfo( ( "Demo completed successfully.\r\n" ) );
 }
 
 /*-----------------------------------------------------------*/


### PR DESCRIPTION
Add success string in stubbed Lightweight MQTT demo to support CI nightly checks 

**Note**: The complete implementation for the Beta2 light-weight MQTT demo is being added in #119 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
