### PR TITLE
FreeRTOS+TCP using same uncrustify rules as AWS and FreeRTOS kernel

### DIFF
--- a/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/FreeRTOS_ARP.c
+++ b/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/FreeRTOS_ARP.c
@@ -40,21 +40,21 @@
 #include "FreeRTOS_ARP.h"
 #include "FreeRTOS_UDP_IP.h"
 #include "FreeRTOS_DHCP.h"
-#if( ipconfigUSE_LLMNR == 1 )
-	#include "FreeRTOS_DNS.h"
+#if ( ipconfigUSE_LLMNR == 1 )
+    #include "FreeRTOS_DNS.h"
 #endif /* ipconfigUSE_LLMNR */
 #include "NetworkBufferManagement.h"
 #include "NetworkInterface.h"
 
 
 /* When the age of an entry in the ARP table reaches this value (it counts down
-to zero, so this is an old entry) an ARP request will be sent to see if the
-entry is still valid and can therefore be refreshed. */
-#define arpMAX_ARP_AGE_BEFORE_NEW_ARP_REQUEST		( 3 )
+ * to zero, so this is an old entry) an ARP request will be sent to see if the
+ * entry is still valid and can therefore be refreshed. */
+#define arpMAX_ARP_AGE_BEFORE_NEW_ARP_REQUEST    ( 3 )
 
 /* The time between gratuitous ARPs. */
 #ifndef arpGRATUITOUS_ARP_PERIOD
-	#define arpGRATUITOUS_ARP_PERIOD					( pdMS_TO_TICKS( 20000U ) )
+    #define arpGRATUITOUS_ARP_PERIOD    ( pdMS_TO_TICKS( 20000U ) )
 #endif
 
 /*-----------------------------------------------------------*/
@@ -62,7 +62,8 @@ entry is still valid and can therefore be refreshed. */
 /*
  * Lookup an MAC address in the ARP cache from the IP address.
  */
-static eARPLookupResult_t prvCacheLookup( uint32_t ulAddressToLookup, MACAddress_t * const pxMACAddress );
+static eARPLookupResult_t prvCacheLookup( uint32_t ulAddressToLookup,
+                                          MACAddress_t * const pxMACAddress );
 
 /*-----------------------------------------------------------*/
 
@@ -70,7 +71,7 @@ static eARPLookupResult_t prvCacheLookup( uint32_t ulAddressToLookup, MACAddress
 static ARPCacheRow_t xARPCache[ ipconfigARP_CACHE_ENTRIES ];
 
 /* The time at which the last gratuitous ARP was sent.  Gratuitous ARPs are used
-to ensure ARP tables are up to date and to detect IP address conflicts. */
+ * to ensure ARP tables are up to date and to detect IP address conflicts. */
 static TickType_t xLastGratuitousARPTime = ( TickType_t ) 0;
 
 /*
@@ -78,688 +79,708 @@ static TickType_t xLastGratuitousARPTime = ( TickType_t ) 0;
  * driver can try out a random LinkLayer IP address (169.254.x.x).  It will send out a
  * gratuitos ARP message and, after a period of time, check the variables here below:
  */
-#if( ipconfigARP_USE_CLASH_DETECTION != 0 )
-	/* Becomes non-zero if another device responded to a gratuitos ARP message. */
-	BaseType_t xARPHadIPClash;
-	/* MAC-address of the other device containing the same IP-address. */
-	MACAddress_t xARPClashMacAddress;
+#if ( ipconfigARP_USE_CLASH_DETECTION != 0 )
+    /* Becomes non-zero if another device responded to a gratuitos ARP message. */
+    BaseType_t xARPHadIPClash;
+    /* MAC-address of the other device containing the same IP-address. */
+    MACAddress_t xARPClashMacAddress;
 #endif /* ipconfigARP_USE_CLASH_DETECTION */
 
 /*-----------------------------------------------------------*/
 
 eFrameProcessingResult_t eARPProcessPacket( ARPPacket_t * const pxARPFrame )
 {
-eFrameProcessingResult_t eReturn = eReleaseBuffer;
-ARPHeader_t *pxARPHeader;
-uint32_t ulTargetProtocolAddress, ulSenderProtocolAddress;
+    eFrameProcessingResult_t eReturn = eReleaseBuffer;
+    ARPHeader_t * pxARPHeader;
+    uint32_t ulTargetProtocolAddress, ulSenderProtocolAddress;
 
-	pxARPHeader = &( pxARPFrame->xARPHeader );
+    pxARPHeader = &( pxARPFrame->xARPHeader );
 
-	/* The field ulSenderProtocolAddress is badly aligned, copy byte-by-byte. */
-	( void ) memcpy( &( ulSenderProtocolAddress ), pxARPHeader->ucSenderProtocolAddress, sizeof( ulSenderProtocolAddress ) );
-	/* The field ulTargetProtocolAddress is well-aligned, a 32-bits copy. */
-	ulTargetProtocolAddress = pxARPHeader->ulTargetProtocolAddress;
+    /* The field ulSenderProtocolAddress is badly aligned, copy byte-by-byte. */
+    ( void ) memcpy( &( ulSenderProtocolAddress ), pxARPHeader->ucSenderProtocolAddress, sizeof( ulSenderProtocolAddress ) );
+    /* The field ulTargetProtocolAddress is well-aligned, a 32-bits copy. */
+    ulTargetProtocolAddress = pxARPHeader->ulTargetProtocolAddress;
 
-	traceARP_PACKET_RECEIVED();
+    traceARP_PACKET_RECEIVED();
 
-	/* Don't do anything if the local IP address is zero because
-	that means a DHCP request has not completed. */
-	if( *ipLOCAL_IP_ADDRESS_POINTER != 0UL )
-	{
-		switch( pxARPHeader->usOperation )
-		{
-			case ipARP_REQUEST	:
-				/* The packet contained an ARP request.  Was it for the IP
-				address of the node running this code? */
-				if( ulTargetProtocolAddress == *ipLOCAL_IP_ADDRESS_POINTER )
-				{
-					iptraceSENDING_ARP_REPLY( ulSenderProtocolAddress );
+    /* Don't do anything if the local IP address is zero because
+     * that means a DHCP request has not completed. */
+    if( *ipLOCAL_IP_ADDRESS_POINTER != 0UL )
+    {
+        switch( pxARPHeader->usOperation )
+        {
+            case ipARP_REQUEST:
 
-					/* The request is for the address of this node.  Add the
-					entry into the ARP cache, or refresh the entry if it
-					already exists. */
-					vARPRefreshCacheEntry( &( pxARPHeader->xSenderHardwareAddress ), ulSenderProtocolAddress );
+                /* The packet contained an ARP request.  Was it for the IP
+                 * address of the node running this code? */
+                if( ulTargetProtocolAddress == *ipLOCAL_IP_ADDRESS_POINTER )
+                {
+                    iptraceSENDING_ARP_REPLY( ulSenderProtocolAddress );
 
-					/* Generate a reply payload in the same buffer. */
-					pxARPHeader->usOperation = ( uint16_t ) ipARP_REPLY;
-					if( ulTargetProtocolAddress == ulSenderProtocolAddress )
-					{
-						/* A double IP address is detected! */
-						/* Give the sources MAC address the value of the broadcast address, will be swapped later */
-						( void ) memcpy( pxARPFrame->xEthernetHeader.xSourceAddress.ucBytes, xBroadcastMACAddress.ucBytes, sizeof( xBroadcastMACAddress ) );
-						( void ) memset( pxARPHeader->xTargetHardwareAddress.ucBytes, 0, sizeof( MACAddress_t ) );
-						pxARPHeader->ulTargetProtocolAddress = 0UL;
-					}
-					else
-					{
-						( void ) memcpy( pxARPHeader->xTargetHardwareAddress.ucBytes, pxARPHeader->xSenderHardwareAddress.ucBytes, sizeof( MACAddress_t ) );
-						pxARPHeader->ulTargetProtocolAddress = ulSenderProtocolAddress;
-					}
-					( void ) memcpy( pxARPHeader->xSenderHardwareAddress.ucBytes, ipLOCAL_MAC_ADDRESS, sizeof( MACAddress_t ) );
-					( void ) memcpy( pxARPHeader->ucSenderProtocolAddress, ipLOCAL_IP_ADDRESS_POINTER, sizeof( pxARPHeader->ucSenderProtocolAddress ) );
+                    /* The request is for the address of this node.  Add the
+                     * entry into the ARP cache, or refresh the entry if it
+                     * already exists. */
+                    vARPRefreshCacheEntry( &( pxARPHeader->xSenderHardwareAddress ), ulSenderProtocolAddress );
 
-					eReturn = eReturnEthernetFrame;
-				}
-				break;
+                    /* Generate a reply payload in the same buffer. */
+                    pxARPHeader->usOperation = ( uint16_t ) ipARP_REPLY;
 
-			case ipARP_REPLY :
-				iptracePROCESSING_RECEIVED_ARP_REPLY( ulTargetProtocolAddress );
-				vARPRefreshCacheEntry( &( pxARPHeader->xSenderHardwareAddress ), ulSenderProtocolAddress );
-				/* Process received ARP frame to see if there is a clash. */
-				#if( ipconfigARP_USE_CLASH_DETECTION != 0 )
-				{
-					if( ulSenderProtocolAddress == *ipLOCAL_IP_ADDRESS_POINTER )
-					{
-						xARPHadIPClash = pdTRUE;
-						/* Remember the MAC-address of the other device which has the same IP-address. */
-						( void ) memcpy( xARPClashMacAddress.ucBytes, pxARPHeader->xSenderHardwareAddress.ucBytes, sizeof( xARPClashMacAddress.ucBytes ) );
-					}
-				}
-				#endif /* ipconfigARP_USE_CLASH_DETECTION */
-				break;
+                    if( ulTargetProtocolAddress == ulSenderProtocolAddress )
+                    {
+                        /* A double IP address is detected! */
+                        /* Give the sources MAC address the value of the broadcast address, will be swapped later */
+                        ( void ) memcpy( pxARPFrame->xEthernetHeader.xSourceAddress.ucBytes, xBroadcastMACAddress.ucBytes, sizeof( xBroadcastMACAddress ) );
+                        ( void ) memset( pxARPHeader->xTargetHardwareAddress.ucBytes, 0, sizeof( MACAddress_t ) );
+                        pxARPHeader->ulTargetProtocolAddress = 0UL;
+                    }
+                    else
+                    {
+                        ( void ) memcpy( pxARPHeader->xTargetHardwareAddress.ucBytes, pxARPHeader->xSenderHardwareAddress.ucBytes, sizeof( MACAddress_t ) );
+                        pxARPHeader->ulTargetProtocolAddress = ulSenderProtocolAddress;
+                    }
 
-			default :
-				/* Invalid. */
-				break;
-		}
-	}
+                    ( void ) memcpy( pxARPHeader->xSenderHardwareAddress.ucBytes, ipLOCAL_MAC_ADDRESS, sizeof( MACAddress_t ) );
+                    ( void ) memcpy( pxARPHeader->ucSenderProtocolAddress, ipLOCAL_IP_ADDRESS_POINTER, sizeof( pxARPHeader->ucSenderProtocolAddress ) );
 
-	return eReturn;
+                    eReturn = eReturnEthernetFrame;
+                }
+
+                break;
+
+            case ipARP_REPLY:
+                iptracePROCESSING_RECEIVED_ARP_REPLY( ulTargetProtocolAddress );
+                vARPRefreshCacheEntry( &( pxARPHeader->xSenderHardwareAddress ), ulSenderProtocolAddress );
+                /* Process received ARP frame to see if there is a clash. */
+                #if ( ipconfigARP_USE_CLASH_DETECTION != 0 )
+                    {
+                        if( ulSenderProtocolAddress == *ipLOCAL_IP_ADDRESS_POINTER )
+                        {
+                            xARPHadIPClash = pdTRUE;
+                            /* Remember the MAC-address of the other device which has the same IP-address. */
+                            ( void ) memcpy( xARPClashMacAddress.ucBytes, pxARPHeader->xSenderHardwareAddress.ucBytes, sizeof( xARPClashMacAddress.ucBytes ) );
+                        }
+                    }
+                #endif /* ipconfigARP_USE_CLASH_DETECTION */
+                break;
+
+            default:
+                /* Invalid. */
+                break;
+        }
+    }
+
+    return eReturn;
 }
 /*-----------------------------------------------------------*/
 
-#if( ipconfigUSE_ARP_REMOVE_ENTRY != 0 )
+#if ( ipconfigUSE_ARP_REMOVE_ENTRY != 0 )
 
-	uint32_t ulARPRemoveCacheEntryByMac( const MACAddress_t * pxMACAddress )
-	{
-	BaseType_t x;
-	uint32_t lResult = 0;
+    uint32_t ulARPRemoveCacheEntryByMac( const MACAddress_t * pxMACAddress )
+    {
+        BaseType_t x;
+        uint32_t lResult = 0;
 
-		/* For each entry in the ARP cache table. */
-		for( x = 0; x < ipconfigARP_CACHE_ENTRIES; x++ )
-		{
-			if( ( memcmp( xARPCache[ x ].xMACAddress.ucBytes, pxMACAddress->ucBytes, sizeof( pxMACAddress->ucBytes ) ) == 0 ) )
-			{
-				lResult = xARPCache[ x ].ulIPAddress;
-				( void ) memset( &xARPCache[ x ], 0, sizeof( xARPCache[ x ] ) );
-				break;
-			}
-		}
+        /* For each entry in the ARP cache table. */
+        for( x = 0; x < ipconfigARP_CACHE_ENTRIES; x++ )
+        {
+            if( ( memcmp( xARPCache[ x ].xMACAddress.ucBytes, pxMACAddress->ucBytes, sizeof( pxMACAddress->ucBytes ) ) == 0 ) )
+            {
+                lResult = xARPCache[ x ].ulIPAddress;
+                ( void ) memset( &xARPCache[ x ], 0, sizeof( xARPCache[ x ] ) );
+                break;
+            }
+        }
 
-		return lResult;
-	}
+        return lResult;
+    }
 
-#endif	/* ipconfigUSE_ARP_REMOVE_ENTRY != 0 */
+#endif /* ipconfigUSE_ARP_REMOVE_ENTRY != 0 */
 /*-----------------------------------------------------------*/
 
-void vARPRefreshCacheEntry( const MACAddress_t * pxMACAddress, const uint32_t ulIPAddress )
+void vARPRefreshCacheEntry( const MACAddress_t * pxMACAddress,
+                            const uint32_t ulIPAddress )
 {
-BaseType_t x = 0;
-BaseType_t xIpEntry = -1;
-BaseType_t xMacEntry = -1;
-BaseType_t xUseEntry = 0;
-uint8_t ucMinAgeFound = 0U;
+    BaseType_t x = 0;
+    BaseType_t xIpEntry = -1;
+    BaseType_t xMacEntry = -1;
+    BaseType_t xUseEntry = 0;
+    uint8_t ucMinAgeFound = 0U;
 
-#if( ipconfigARP_STORES_REMOTE_ADDRESSES == 0 )
-	/* Only process the IP address if it is on the local network.
-	Unless: when '*ipLOCAL_IP_ADDRESS_POINTER' equals zero, the IP-address
-	and netmask are still unknown. */
-	if( ( ( ulIPAddress & xNetworkAddressing.ulNetMask ) == ( ( *ipLOCAL_IP_ADDRESS_POINTER ) & xNetworkAddressing.ulNetMask ) ) ||
-		( *ipLOCAL_IP_ADDRESS_POINTER == 0UL ) )
-#else
-		/* If ipconfigARP_STORES_REMOTE_ADDRESSES is non-zero, IP addresses with
-		a different netmask will also be stored.  After when replying to a UDP
-		message from a different netmask, the IP address can be looped up and a
-		reply sent.  This option is useful for systems with multiple gateways,
-		the reply will surely arrive.  If ipconfigARP_STORES_REMOTE_ADDRESSES is
-		zero the the gateway address is the only option. */
+    #if ( ipconfigARP_STORES_REMOTE_ADDRESSES == 0 )
+        /* Only process the IP address if it is on the local network.
+         * Unless: when '*ipLOCAL_IP_ADDRESS_POINTER' equals zero, the IP-address
+         * and netmask are still unknown. */
+        if( ( ( ulIPAddress & xNetworkAddressing.ulNetMask ) == ( ( *ipLOCAL_IP_ADDRESS_POINTER ) & xNetworkAddressing.ulNetMask ) ) ||
+            ( *ipLOCAL_IP_ADDRESS_POINTER == 0UL ) )
+    #else
+        /* If ipconfigARP_STORES_REMOTE_ADDRESSES is non-zero, IP addresses with
+         * a different netmask will also be stored.  After when replying to a UDP
+         * message from a different netmask, the IP address can be looped up and a
+         * reply sent.  This option is useful for systems with multiple gateways,
+         * the reply will surely arrive.  If ipconfigARP_STORES_REMOTE_ADDRESSES is
+         * zero the the gateway address is the only option. */
 
-	if( pdTRUE )
-#endif
-	{
-		/* Start with the maximum possible number. */
-		ucMinAgeFound--;
+        if( pdTRUE )
+    #endif
+    {
+        /* Start with the maximum possible number. */
+        ucMinAgeFound--;
 
-		/* For each entry in the ARP cache table. */
-		for( x = 0; x < ipconfigARP_CACHE_ENTRIES; x++ )
-		{
-		BaseType_t xMatchingMAC;
+        /* For each entry in the ARP cache table. */
+        for( x = 0; x < ipconfigARP_CACHE_ENTRIES; x++ )
+        {
+            BaseType_t xMatchingMAC;
 
-			if( pxMACAddress != NULL )
-			{
-				if( memcmp( xARPCache[ x ].xMACAddress.ucBytes, pxMACAddress->ucBytes, sizeof( pxMACAddress->ucBytes ) ) == 0 )
-				{
-					xMatchingMAC = pdTRUE;
-				}
-				else
-				{
-					xMatchingMAC = pdFALSE;
-				}
-			}
-			else
-			{
-				xMatchingMAC = pdFALSE;
-			}
-			/* Does this line in the cache table hold an entry for the IP
-			address	being queried? */
-			if( xARPCache[ x ].ulIPAddress == ulIPAddress )
-			{
-				if( pxMACAddress == NULL )
-				{
-					/* In case the parameter pxMACAddress is NULL, an entry will be reserved to
-					indicate that there is an outstanding ARP request, This entry will have
-					"ucValid == pdFALSE". */
-					xIpEntry = x;
-					break;
-				}
+            if( pxMACAddress != NULL )
+            {
+                if( memcmp( xARPCache[ x ].xMACAddress.ucBytes, pxMACAddress->ucBytes, sizeof( pxMACAddress->ucBytes ) ) == 0 )
+                {
+                    xMatchingMAC = pdTRUE;
+                }
+                else
+                {
+                    xMatchingMAC = pdFALSE;
+                }
+            }
+            else
+            {
+                xMatchingMAC = pdFALSE;
+            }
 
-				/* See if the MAC-address also matches. */
-				if( xMatchingMAC != pdFALSE )
-				{
-					/* This function will be called for each received packet
-					As this is by far the most common path the coding standard
-					is relaxed in this case and a return is permitted as an
-					optimisation. */
-					xARPCache[ x ].ucAge = ( uint8_t ) ipconfigMAX_ARP_AGE;
-					xARPCache[ x ].ucValid = ( uint8_t ) pdTRUE;
-					return;
-				}
+            /* Does this line in the cache table hold an entry for the IP
+             * address	being queried? */
+            if( xARPCache[ x ].ulIPAddress == ulIPAddress )
+            {
+                if( pxMACAddress == NULL )
+                {
+                    /* In case the parameter pxMACAddress is NULL, an entry will be reserved to
+                     * indicate that there is an outstanding ARP request, This entry will have
+                     * "ucValid == pdFALSE". */
+                    xIpEntry = x;
+                    break;
+                }
 
-				/* Found an entry containing ulIPAddress, but the MAC address
-				doesn't match.  Might be an entry with ucValid=pdFALSE, waiting
-				for an ARP reply.  Still want to see if there is match with the
-				given MAC address.ucBytes.  If found, either of the two entries
-				must be cleared. */
-				xIpEntry = x;
-			}
-			else if( xMatchingMAC != pdFALSE )
-			{
-				/* Found an entry with the given MAC-address, but the IP-address
-				is different.  Continue looping to find a possible match with
-				ulIPAddress. */
-	#if( ipconfigARP_STORES_REMOTE_ADDRESSES != 0 )
-				/* If ARP stores the MAC address of IP addresses outside the
-				network, than the MAC address of the gateway should not be
-				overwritten. */
-				BaseType_t bIsLocal[ 2 ];
-				bIsLocal[ 0 ] = ( ( xARPCache[ x ].ulIPAddress & xNetworkAddressing.ulNetMask ) == ( ( *ipLOCAL_IP_ADDRESS_POINTER ) & xNetworkAddressing.ulNetMask ) );
-				bIsLocal[ 1 ] = ( ( ulIPAddress & xNetworkAddressing.ulNetMask ) == ( ( *ipLOCAL_IP_ADDRESS_POINTER ) & xNetworkAddressing.ulNetMask ) );
-				if( bIsLocal[ 0 ] == bIsLocal[ 1 ] )
-				{
-					xMacEntry = x;
-				}
-	#else
-				xMacEntry = x;
-	#endif
-			}
-			/* _HT_
-			Shouldn't we test for xARPCache[ x ].ucValid == pdFALSE here ? */
-			else if( xARPCache[ x ].ucAge < ucMinAgeFound )
-			{
-				/* As the table is traversed, remember the table row that
-				contains the oldest entry (the lowest age count, as ages are
-				decremented to zero) so the row can be re-used if this function
-				needs to add an entry that does not already exist. */
-				ucMinAgeFound = xARPCache[ x ].ucAge;
-				xUseEntry = x;
-			}
-			else
-			{
-				/* Nothing happes to this cache entry for now. */
-			}
-		}
+                /* See if the MAC-address also matches. */
+                if( xMatchingMAC != pdFALSE )
+                {
+                    /* This function will be called for each received packet
+                     * As this is by far the most common path the coding standard
+                     * is relaxed in this case and a return is permitted as an
+                     * optimisation. */
+                    xARPCache[ x ].ucAge = ( uint8_t ) ipconfigMAX_ARP_AGE;
+                    xARPCache[ x ].ucValid = ( uint8_t ) pdTRUE;
+                    return;
+                }
 
-		if( xMacEntry >= 0 )
-		{
-			xUseEntry = xMacEntry;
+                /* Found an entry containing ulIPAddress, but the MAC address
+                 * doesn't match.  Might be an entry with ucValid=pdFALSE, waiting
+                 * for an ARP reply.  Still want to see if there is match with the
+                 * given MAC address.ucBytes.  If found, either of the two entries
+                 * must be cleared. */
+                xIpEntry = x;
+            }
+            else if( xMatchingMAC != pdFALSE )
+            {
+                /* Found an entry with the given MAC-address, but the IP-address
+                 * is different.  Continue looping to find a possible match with
+                 * ulIPAddress. */
+                #if ( ipconfigARP_STORES_REMOTE_ADDRESSES != 0 )
+                    /* If ARP stores the MAC address of IP addresses outside the
+                     * network, than the MAC address of the gateway should not be
+                     * overwritten. */
+                    BaseType_t bIsLocal[ 2 ];
+                    bIsLocal[ 0 ] = ( ( xARPCache[ x ].ulIPAddress & xNetworkAddressing.ulNetMask ) == ( ( *ipLOCAL_IP_ADDRESS_POINTER ) & xNetworkAddressing.ulNetMask ) );
+                    bIsLocal[ 1 ] = ( ( ulIPAddress & xNetworkAddressing.ulNetMask ) == ( ( *ipLOCAL_IP_ADDRESS_POINTER ) & xNetworkAddressing.ulNetMask ) );
 
-			if( xIpEntry >= 0 )
-			{
-				/* Both the MAC address as well as the IP address were found in
-				different locations: clear the entry which matches the
-				IP-address */
-				( void ) memset( &( xARPCache[ xIpEntry ] ), 0, sizeof( ARPCacheRow_t ) );
-			}
-		}
-		else if( xIpEntry >= 0 )
-		{
-			/* An entry containing the IP-address was found, but it had a different MAC address */
-			xUseEntry = xIpEntry;
-		}
-		else
-		{
-			/* No matching entry found. */
-		}
+                    if( bIsLocal[ 0 ] == bIsLocal[ 1 ] )
+                    {
+                        xMacEntry = x;
+                    }
+                #else
+                    xMacEntry = x;
+                #endif /* if ( ipconfigARP_STORES_REMOTE_ADDRESSES != 0 ) */
+            }
 
-		/* If the entry was not found, we use the oldest entry and set the IPaddress */
-		xARPCache[ xUseEntry ].ulIPAddress = ulIPAddress;
+            /* _HT_
+             * Shouldn't we test for xARPCache[ x ].ucValid == pdFALSE here ? */
+            else if( xARPCache[ x ].ucAge < ucMinAgeFound )
+            {
+                /* As the table is traversed, remember the table row that
+                 * contains the oldest entry (the lowest age count, as ages are
+                 * decremented to zero) so the row can be re-used if this function
+                 * needs to add an entry that does not already exist. */
+                ucMinAgeFound = xARPCache[ x ].ucAge;
+                xUseEntry = x;
+            }
+            else
+            {
+                /* Nothing happes to this cache entry for now. */
+            }
+        }
 
-		if( pxMACAddress != NULL )
-		{
-			( void ) memcpy( xARPCache[ xUseEntry ].xMACAddress.ucBytes, pxMACAddress->ucBytes, sizeof( pxMACAddress->ucBytes ) );
+        if( xMacEntry >= 0 )
+        {
+            xUseEntry = xMacEntry;
 
-			iptraceARP_TABLE_ENTRY_CREATED( ulIPAddress, (*pxMACAddress) );
-			/* And this entry does not need immediate attention */
-			xARPCache[ xUseEntry ].ucAge = ( uint8_t ) ipconfigMAX_ARP_AGE;
-			xARPCache[ xUseEntry ].ucValid = ( uint8_t ) pdTRUE;
-		}
-		else if( xIpEntry < 0 )
-		{
-			xARPCache[ xUseEntry ].ucAge = ( uint8_t ) ipconfigMAX_ARP_RETRANSMISSIONS;
-			xARPCache[ xUseEntry ].ucValid = ( uint8_t ) pdFALSE;
-		}
-		else
-		{
-			/* Nothing will be stored. */
-		}
-	}
+            if( xIpEntry >= 0 )
+            {
+                /* Both the MAC address as well as the IP address were found in
+                 * different locations: clear the entry which matches the
+                 * IP-address */
+                ( void ) memset( &( xARPCache[ xIpEntry ] ), 0, sizeof( ARPCacheRow_t ) );
+            }
+        }
+        else if( xIpEntry >= 0 )
+        {
+            /* An entry containing the IP-address was found, but it had a different MAC address */
+            xUseEntry = xIpEntry;
+        }
+        else
+        {
+            /* No matching entry found. */
+        }
+
+        /* If the entry was not found, we use the oldest entry and set the IPaddress */
+        xARPCache[ xUseEntry ].ulIPAddress = ulIPAddress;
+
+        if( pxMACAddress != NULL )
+        {
+            ( void ) memcpy( xARPCache[ xUseEntry ].xMACAddress.ucBytes, pxMACAddress->ucBytes, sizeof( pxMACAddress->ucBytes ) );
+
+            iptraceARP_TABLE_ENTRY_CREATED( ulIPAddress, ( *pxMACAddress ) );
+            /* And this entry does not need immediate attention */
+            xARPCache[ xUseEntry ].ucAge = ( uint8_t ) ipconfigMAX_ARP_AGE;
+            xARPCache[ xUseEntry ].ucValid = ( uint8_t ) pdTRUE;
+        }
+        else if( xIpEntry < 0 )
+        {
+            xARPCache[ xUseEntry ].ucAge = ( uint8_t ) ipconfigMAX_ARP_RETRANSMISSIONS;
+            xARPCache[ xUseEntry ].ucValid = ( uint8_t ) pdFALSE;
+        }
+        else
+        {
+            /* Nothing will be stored. */
+        }
+    }
 }
 /*-----------------------------------------------------------*/
 
-#if( ipconfigUSE_ARP_REVERSED_LOOKUP == 1 )
-	eARPLookupResult_t eARPGetCacheEntryByMac( MACAddress_t * const pxMACAddress, uint32_t *pulIPAddress )
-	{
-	BaseType_t x;
-	eARPLookupResult_t eReturn = eARPCacheMiss;
+#if ( ipconfigUSE_ARP_REVERSED_LOOKUP == 1 )
+    eARPLookupResult_t eARPGetCacheEntryByMac( MACAddress_t * const pxMACAddress,
+                                               uint32_t * pulIPAddress )
+    {
+        BaseType_t x;
+        eARPLookupResult_t eReturn = eARPCacheMiss;
 
-		/* Loop through each entry in the ARP cache. */
-		for( x = 0; x < ipconfigARP_CACHE_ENTRIES; x++ )
-		{
-			/* Does this row in the ARP cache table hold an entry for the MAC
-			address being searched? */
-			if( memcmp( pxMACAddress->ucBytes, xARPCache[ x ].xMACAddress.ucBytes, sizeof( MACAddress_t ) ) == 0 )
-			{
-				*pulIPAddress = xARPCache[ x ].ulIPAddress;
-				eReturn = eARPCacheHit;
-				break;
-			}
-		}
+        /* Loop through each entry in the ARP cache. */
+        for( x = 0; x < ipconfigARP_CACHE_ENTRIES; x++ )
+        {
+            /* Does this row in the ARP cache table hold an entry for the MAC
+             * address being searched? */
+            if( memcmp( pxMACAddress->ucBytes, xARPCache[ x ].xMACAddress.ucBytes, sizeof( MACAddress_t ) ) == 0 )
+            {
+                *pulIPAddress = xARPCache[ x ].ulIPAddress;
+                eReturn = eARPCacheHit;
+                break;
+            }
+        }
 
-		return eReturn;
-	}
+        return eReturn;
+    }
 #endif /* ipconfigUSE_ARP_REVERSED_LOOKUP */
 
 /*-----------------------------------------------------------*/
 
-eARPLookupResult_t eARPGetCacheEntry( uint32_t *pulIPAddress, MACAddress_t * const pxMACAddress )
+eARPLookupResult_t eARPGetCacheEntry( uint32_t * pulIPAddress,
+                                      MACAddress_t * const pxMACAddress )
 {
-eARPLookupResult_t eReturn;
-uint32_t ulAddressToLookup;
-ulAddressToLookup = *pulIPAddress;
+    eARPLookupResult_t eReturn;
+    uint32_t ulAddressToLookup;
 
-#if( ipconfigUSE_LLMNR == 1 )
-	if( ulAddressToLookup == ipLLMNR_IP_ADDR )	/* Is in network byte order. */
-	{
-		/* The LLMNR IP-address has a fixed virtual MAC address. */
-		( void ) memcpy( pxMACAddress->ucBytes, xLLMNR_MacAdress.ucBytes, sizeof( MACAddress_t ) );
-		eReturn = eARPCacheHit;
-	}
-	else
-#endif
-	if( xIsIPv4Multicast( ulAddressToLookup ) != 0 )
-	{
-		/* Get the lowest 23 bits of the IP-address. */
-		vSetMultiCastIPv4MacAddress( ulAddressToLookup, pxMACAddress );
+    ulAddressToLookup = *pulIPAddress;
 
-		eReturn = eARPCacheHit;
-	}
-	else if( ( *pulIPAddress == ipBROADCAST_IP_ADDRESS ) ||	/* Is it the general broadcast address 255.255.255.255? */
-		( *pulIPAddress == xNetworkAddressing.ulBroadcastAddress ) )/* Or a local broadcast address, eg 192.168.1.255? */
-	{
-		/* This is a broadcast so it uses the broadcast MAC address. */
-		( void ) memcpy( pxMACAddress->ucBytes, xBroadcastMACAddress.ucBytes, sizeof( MACAddress_t ) );
-		eReturn = eARPCacheHit;
-	}
-	else if( *ipLOCAL_IP_ADDRESS_POINTER == 0UL )
-	{
-		/* The IP address has not yet been assigned, so there is nothing that
-		can be done. */
-		eReturn = eCantSendPacket;
-	}
-	else
-	{
-		eReturn = eARPCacheMiss;
+    #if ( ipconfigUSE_LLMNR == 1 )
+        if( ulAddressToLookup == ipLLMNR_IP_ADDR ) /* Is in network byte order. */
+        {
+            /* The LLMNR IP-address has a fixed virtual MAC address. */
+            ( void ) memcpy( pxMACAddress->ucBytes, xLLMNR_MacAdress.ucBytes, sizeof( MACAddress_t ) );
+            eReturn = eARPCacheHit;
+        }
+        else
+    #endif
 
-		if( ( *pulIPAddress & xNetworkAddressing.ulNetMask ) != ( ( *ipLOCAL_IP_ADDRESS_POINTER ) & xNetworkAddressing.ulNetMask ) )
-		{
-			/* No matching end-point is found, look for a gateway. */
-#if( ipconfigARP_STORES_REMOTE_ADDRESSES == 1 )
-			eReturn = prvCacheLookup( *pulIPAddress, pxMACAddress );
+    if( xIsIPv4Multicast( ulAddressToLookup ) != 0 )
+    {
+        /* Get the lowest 23 bits of the IP-address. */
+        vSetMultiCastIPv4MacAddress( ulAddressToLookup, pxMACAddress );
 
-			if( eReturn == eARPCacheHit )
-			{
-				/* The stack is configured to store 'remote IP addresses', i.e. addresses
-				belonging to a different the netmask.  prvCacheLookup() returned a hit, so
-				the MAC address is known. */
-			}
-			else
-#endif
-			{
-				/* The IP address is off the local network, so look up the
-				hardware address of the router, if any. */
-				if( xNetworkAddressing.ulGatewayAddress != ( uint32_t ) 0U )
-				{
-					ulAddressToLookup = xNetworkAddressing.ulGatewayAddress;
-				}
-				else
-				{
-					ulAddressToLookup = *pulIPAddress;
-				}
-			}
-		}
-		else
-		{
-			/* The IP address is on the local network, so lookup the requested
-			IP address directly. */
-			ulAddressToLookup = *pulIPAddress;
-		}
+        eReturn = eARPCacheHit;
+    }
+    else if( ( *pulIPAddress == ipBROADCAST_IP_ADDRESS ) ||               /* Is it the general broadcast address 255.255.255.255? */
+             ( *pulIPAddress == xNetworkAddressing.ulBroadcastAddress ) ) /* Or a local broadcast address, eg 192.168.1.255? */
+    {
+        /* This is a broadcast so it uses the broadcast MAC address. */
+        ( void ) memcpy( pxMACAddress->ucBytes, xBroadcastMACAddress.ucBytes, sizeof( MACAddress_t ) );
+        eReturn = eARPCacheHit;
+    }
+    else if( *ipLOCAL_IP_ADDRESS_POINTER == 0UL )
+    {
+        /* The IP address has not yet been assigned, so there is nothing that
+         * can be done. */
+        eReturn = eCantSendPacket;
+    }
+    else
+    {
+        eReturn = eARPCacheMiss;
 
-		#if( ipconfigARP_STORES_REMOTE_ADDRESSES == 1 )
-		if( eReturn == eARPCacheMiss )	/*lint !e774: (Info -- Boolean within 'if' always evaluates to True, depending on configuration. */
-		#else
-		/* No cache look-up was done, so the result is still 'eARPCacheMiss'. */
-		#endif
-		{
-			if( ulAddressToLookup == 0UL )
-			{
-				/* The address is not on the local network, and there is not a
-				router. */
-				eReturn = eCantSendPacket;
-			}
-			else
-			{
-				eReturn = prvCacheLookup( ulAddressToLookup, pxMACAddress );
+        if( ( *pulIPAddress & xNetworkAddressing.ulNetMask ) != ( ( *ipLOCAL_IP_ADDRESS_POINTER ) & xNetworkAddressing.ulNetMask ) )
+        {
+            /* No matching end-point is found, look for a gateway. */
+            #if ( ipconfigARP_STORES_REMOTE_ADDRESSES == 1 )
+                eReturn = prvCacheLookup( *pulIPAddress, pxMACAddress );
 
-				if( eReturn == eARPCacheMiss )
-				{
-					/* It might be that the ARP has to go to the gateway. */
-					*pulIPAddress = ulAddressToLookup;
-				}
-			}
-		}
-	}
+                if( eReturn == eARPCacheHit )
+                {
+                    /* The stack is configured to store 'remote IP addresses', i.e. addresses
+                     * belonging to a different the netmask.  prvCacheLookup() returned a hit, so
+                     * the MAC address is known. */
+                }
+                else
+            #endif
+            {
+                /* The IP address is off the local network, so look up the
+                 * hardware address of the router, if any. */
+                if( xNetworkAddressing.ulGatewayAddress != ( uint32_t ) 0U )
+                {
+                    ulAddressToLookup = xNetworkAddressing.ulGatewayAddress;
+                }
+                else
+                {
+                    ulAddressToLookup = *pulIPAddress;
+                }
+            }
+        }
+        else
+        {
+            /* The IP address is on the local network, so lookup the requested
+             * IP address directly. */
+            ulAddressToLookup = *pulIPAddress;
+        }
 
-	return eReturn;
+        #if ( ipconfigARP_STORES_REMOTE_ADDRESSES == 1 )
+            if( eReturn == eARPCacheMiss ) /*lint !e774: (Info -- Boolean within 'if' always evaluates to True, depending on configuration. */
+        #else
+            /* No cache look-up was done, so the result is still 'eARPCacheMiss'. */
+        #endif
+        {
+            if( ulAddressToLookup == 0UL )
+            {
+                /* The address is not on the local network, and there is not a
+                 * router. */
+                eReturn = eCantSendPacket;
+            }
+            else
+            {
+                eReturn = prvCacheLookup( ulAddressToLookup, pxMACAddress );
+
+                if( eReturn == eARPCacheMiss )
+                {
+                    /* It might be that the ARP has to go to the gateway. */
+                    *pulIPAddress = ulAddressToLookup;
+                }
+            }
+        }
+    }
+
+    return eReturn;
 }
 
 /*-----------------------------------------------------------*/
 
-static eARPLookupResult_t prvCacheLookup( uint32_t ulAddressToLookup, MACAddress_t * const pxMACAddress )
+static eARPLookupResult_t prvCacheLookup( uint32_t ulAddressToLookup,
+                                          MACAddress_t * const pxMACAddress )
 {
-BaseType_t x;
-eARPLookupResult_t eReturn = eARPCacheMiss;
+    BaseType_t x;
+    eARPLookupResult_t eReturn = eARPCacheMiss;
 
-	/* Loop through each entry in the ARP cache. */
-	for( x = 0; x < ipconfigARP_CACHE_ENTRIES; x++ )
-	{
-		/* Does this row in the ARP cache table hold an entry for the IP address
-		being queried? */
-		if( xARPCache[ x ].ulIPAddress == ulAddressToLookup )
-		{
-			/* A matching valid entry was found. */
-			if( xARPCache[ x ].ucValid == ( uint8_t ) pdFALSE )
-			{
-				/* This entry is waiting an ARP reply, so is not valid. */
-				eReturn = eCantSendPacket;
-			}
-			else
-			{
-				/* A valid entry was found. */
-				( void ) memcpy( pxMACAddress->ucBytes, xARPCache[ x ].xMACAddress.ucBytes, sizeof( MACAddress_t ) );
-				eReturn = eARPCacheHit;
-			}
-			break;
-		}
-	}
+    /* Loop through each entry in the ARP cache. */
+    for( x = 0; x < ipconfigARP_CACHE_ENTRIES; x++ )
+    {
+        /* Does this row in the ARP cache table hold an entry for the IP address
+         * being queried? */
+        if( xARPCache[ x ].ulIPAddress == ulAddressToLookup )
+        {
+            /* A matching valid entry was found. */
+            if( xARPCache[ x ].ucValid == ( uint8_t ) pdFALSE )
+            {
+                /* This entry is waiting an ARP reply, so is not valid. */
+                eReturn = eCantSendPacket;
+            }
+            else
+            {
+                /* A valid entry was found. */
+                ( void ) memcpy( pxMACAddress->ucBytes, xARPCache[ x ].xMACAddress.ucBytes, sizeof( MACAddress_t ) );
+                eReturn = eARPCacheHit;
+            }
 
-	return eReturn;
+            break;
+        }
+    }
+
+    return eReturn;
 }
 /*-----------------------------------------------------------*/
 
 void vARPAgeCache( void )
 {
-BaseType_t x;
-TickType_t xTimeNow;
+    BaseType_t x;
+    TickType_t xTimeNow;
 
-	/* Loop through each entry in the ARP cache. */
-	for( x = 0; x < ipconfigARP_CACHE_ENTRIES; x++ )
-	{
-		/* If the entry is valid (its age is greater than zero). */
-		if( xARPCache[ x ].ucAge > 0U )
-		{
-			/* Decrement the age value of the entry in this ARP cache table row.
-			When the age reaches zero it is no longer considered valid. */
-			( xARPCache[ x ].ucAge )--;
+    /* Loop through each entry in the ARP cache. */
+    for( x = 0; x < ipconfigARP_CACHE_ENTRIES; x++ )
+    {
+        /* If the entry is valid (its age is greater than zero). */
+        if( xARPCache[ x ].ucAge > 0U )
+        {
+            /* Decrement the age value of the entry in this ARP cache table row.
+             * When the age reaches zero it is no longer considered valid. */
+            ( xARPCache[ x ].ucAge )--;
 
-			/* If the entry is not yet valid, then it is waiting an ARP
-			reply, and the ARP request should be retransmitted. */
-			if( xARPCache[ x ].ucValid == ( uint8_t ) pdFALSE )
-			{
-				FreeRTOS_OutputARPRequest( xARPCache[ x ].ulIPAddress );
-			}
-			else if( xARPCache[ x ].ucAge <= ( uint8_t ) arpMAX_ARP_AGE_BEFORE_NEW_ARP_REQUEST )
-			{
-				/* This entry will get removed soon.  See if the MAC address is
-				still valid to prevent this happening. */
-				iptraceARP_TABLE_ENTRY_WILL_EXPIRE( xARPCache[ x ].ulIPAddress );
-				FreeRTOS_OutputARPRequest( xARPCache[ x ].ulIPAddress );
-			}
-			else
-			{
-				/* The age has just ticked down, with nothing to do. */
-			}
+            /* If the entry is not yet valid, then it is waiting an ARP
+             * reply, and the ARP request should be retransmitted. */
+            if( xARPCache[ x ].ucValid == ( uint8_t ) pdFALSE )
+            {
+                FreeRTOS_OutputARPRequest( xARPCache[ x ].ulIPAddress );
+            }
+            else if( xARPCache[ x ].ucAge <= ( uint8_t ) arpMAX_ARP_AGE_BEFORE_NEW_ARP_REQUEST )
+            {
+                /* This entry will get removed soon.  See if the MAC address is
+                 * still valid to prevent this happening. */
+                iptraceARP_TABLE_ENTRY_WILL_EXPIRE( xARPCache[ x ].ulIPAddress );
+                FreeRTOS_OutputARPRequest( xARPCache[ x ].ulIPAddress );
+            }
+            else
+            {
+                /* The age has just ticked down, with nothing to do. */
+            }
 
-			if( xARPCache[ x ].ucAge == 0U )
-			{
-				/* The entry is no longer valid.  Wipe it out. */
-				iptraceARP_TABLE_ENTRY_EXPIRED( xARPCache[ x ].ulIPAddress );
-				xARPCache[ x ].ulIPAddress = 0UL;
-			}
-		}
-	}
+            if( xARPCache[ x ].ucAge == 0U )
+            {
+                /* The entry is no longer valid.  Wipe it out. */
+                iptraceARP_TABLE_ENTRY_EXPIRED( xARPCache[ x ].ulIPAddress );
+                xARPCache[ x ].ulIPAddress = 0UL;
+            }
+        }
+    }
 
-	xTimeNow = xTaskGetTickCount ();
+    xTimeNow = xTaskGetTickCount();
 
-	if( ( xLastGratuitousARPTime == ( TickType_t ) 0 ) || ( ( xTimeNow - xLastGratuitousARPTime ) > ( TickType_t ) arpGRATUITOUS_ARP_PERIOD ) )
-	{
-		FreeRTOS_OutputARPRequest( *ipLOCAL_IP_ADDRESS_POINTER );
-		xLastGratuitousARPTime = xTimeNow;
-	}
+    if( ( xLastGratuitousARPTime == ( TickType_t ) 0 ) || ( ( xTimeNow - xLastGratuitousARPTime ) > ( TickType_t ) arpGRATUITOUS_ARP_PERIOD ) )
+    {
+        FreeRTOS_OutputARPRequest( *ipLOCAL_IP_ADDRESS_POINTER );
+        xLastGratuitousARPTime = xTimeNow;
+    }
 }
 /*-----------------------------------------------------------*/
 
 void vARPSendGratuitous( void )
 {
-	/* Setting xLastGratuitousARPTime to 0 will force a gratuitous ARP the next
-	time vARPAgeCache() is called. */
-	xLastGratuitousARPTime = ( TickType_t ) 0;
+    /* Setting xLastGratuitousARPTime to 0 will force a gratuitous ARP the next
+     * time vARPAgeCache() is called. */
+    xLastGratuitousARPTime = ( TickType_t ) 0;
 
-	/* Let the IP-task call vARPAgeCache(). */
-	( void ) xSendEventToIPTask( eARPTimerEvent );
+    /* Let the IP-task call vARPAgeCache(). */
+    ( void ) xSendEventToIPTask( eARPTimerEvent );
 }
 
 /*-----------------------------------------------------------*/
 void FreeRTOS_OutputARPRequest( uint32_t ulIPAddress )
 {
-NetworkBufferDescriptor_t *pxNetworkBuffer;
+    NetworkBufferDescriptor_t * pxNetworkBuffer;
 
-	/* This is called from the context of the IP event task, so a block time
-	must not be used. */
-	pxNetworkBuffer = pxGetNetworkBufferWithDescriptor( sizeof( ARPPacket_t ), ( TickType_t ) 0U );
+    /* This is called from the context of the IP event task, so a block time
+     * must not be used. */
+    pxNetworkBuffer = pxGetNetworkBufferWithDescriptor( sizeof( ARPPacket_t ), ( TickType_t ) 0U );
 
-	if( pxNetworkBuffer != NULL )
-	{
-		pxNetworkBuffer->ulIPAddress = ulIPAddress;
-		vARPGenerateRequestPacket( pxNetworkBuffer );
+    if( pxNetworkBuffer != NULL )
+    {
+        pxNetworkBuffer->ulIPAddress = ulIPAddress;
+        vARPGenerateRequestPacket( pxNetworkBuffer );
 
-		#if defined( ipconfigETHERNET_MINIMUM_PACKET_BYTES )
-		{
-			if( pxNetworkBuffer->xDataLength < ( size_t ) ipconfigETHERNET_MINIMUM_PACKET_BYTES )
-			{
-			BaseType_t xIndex;
+        #if defined( ipconfigETHERNET_MINIMUM_PACKET_BYTES )
+            {
+                if( pxNetworkBuffer->xDataLength < ( size_t ) ipconfigETHERNET_MINIMUM_PACKET_BYTES )
+                {
+                    BaseType_t xIndex;
 
-				for( xIndex = ( BaseType_t ) pxNetworkBuffer->xDataLength; xIndex < ( BaseType_t ) ipconfigETHERNET_MINIMUM_PACKET_BYTES; xIndex++ )
-				{
-					pxNetworkBuffer->pucEthernetBuffer[ xIndex ] = 0U;
-				}
-				pxNetworkBuffer->xDataLength = ( size_t ) ipconfigETHERNET_MINIMUM_PACKET_BYTES;
-			}
-		}
-		#endif
+                    for( xIndex = ( BaseType_t ) pxNetworkBuffer->xDataLength; xIndex < ( BaseType_t ) ipconfigETHERNET_MINIMUM_PACKET_BYTES; xIndex++ )
+                    {
+                        pxNetworkBuffer->pucEthernetBuffer[ xIndex ] = 0U;
+                    }
 
-		if( xIsCallingFromIPTask() != 0 )
-		{
-			/* Only the IP-task is allowed to call this function directly. */
-			( void ) xNetworkInterfaceOutput( pxNetworkBuffer, pdTRUE );
-		}
-		else
-		{
-		IPStackEvent_t xSendEvent;
+                    pxNetworkBuffer->xDataLength = ( size_t ) ipconfigETHERNET_MINIMUM_PACKET_BYTES;
+                }
+            }
+        #endif /* if defined( ipconfigETHERNET_MINIMUM_PACKET_BYTES ) */
 
-			/* Send a message to the IP-task to send this ARP packet. */
-			xSendEvent.eEventType = eNetworkTxEvent;
-			xSendEvent.pvData = pxNetworkBuffer;
-			if( xSendEventStructToIPTask( &xSendEvent, ( TickType_t ) portMAX_DELAY ) == pdFAIL )
-			{
-				/* Failed to send the message, so release the network buffer. */
-				vReleaseNetworkBufferAndDescriptor( pxNetworkBuffer );
-			}
-		}
-	}
+        if( xIsCallingFromIPTask() != 0 )
+        {
+            /* Only the IP-task is allowed to call this function directly. */
+            ( void ) xNetworkInterfaceOutput( pxNetworkBuffer, pdTRUE );
+        }
+        else
+        {
+            IPStackEvent_t xSendEvent;
+
+            /* Send a message to the IP-task to send this ARP packet. */
+            xSendEvent.eEventType = eNetworkTxEvent;
+            xSendEvent.pvData = pxNetworkBuffer;
+
+            if( xSendEventStructToIPTask( &xSendEvent, ( TickType_t ) portMAX_DELAY ) == pdFAIL )
+            {
+                /* Failed to send the message, so release the network buffer. */
+                vReleaseNetworkBufferAndDescriptor( pxNetworkBuffer );
+            }
+        }
+    }
 }
 
 void vARPGenerateRequestPacket( NetworkBufferDescriptor_t * const pxNetworkBuffer )
 {
 /* Part of the Ethernet and ARP headers are always constant when sending an IPv4
-ARP packet.  This array defines the constant parts, allowing this part of the
-packet to be filled in using a simple memcpy() instead of individual writes. */
-static const uint8_t xDefaultPartARPPacketHeader[] =
-{
-	0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 	/* Ethernet destination address. */
-	0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 	/* Ethernet source address. */
-	0x08, 0x06, 							/* Ethernet frame type (ipARP_FRAME_TYPE). */
-	0x00, 0x01, 							/* usHardwareType (ipARP_HARDWARE_TYPE_ETHERNET). */
-	0x08, 0x00,								/* usProtocolType. */
-	ipMAC_ADDRESS_LENGTH_BYTES, 			/* ucHardwareAddressLength. */
-	ipIP_ADDRESS_LENGTH_BYTES, 				/* ucProtocolAddressLength. */
-	0x00, 0x01, 							/* usOperation (ipARP_REQUEST). */
-	0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 	/* xSenderHardwareAddress. */
-	0x00, 0x00, 0x00, 0x00, 				/* ulSenderProtocolAddress. */
-	0x00, 0x00, 0x00, 0x00, 0x00, 0x00 		/* xTargetHardwareAddress. */
-};
+ * ARP packet.  This array defines the constant parts, allowing this part of the
+ * packet to be filled in using a simple memcpy() instead of individual writes. */
+    static const uint8_t xDefaultPartARPPacketHeader[] =
+    {
+        0xff, 0xff, 0xff, 0xff, 0xff, 0xff, /* Ethernet destination address. */
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, /* Ethernet source address. */
+        0x08, 0x06,                         /* Ethernet frame type (ipARP_FRAME_TYPE). */
+        0x00, 0x01,                         /* usHardwareType (ipARP_HARDWARE_TYPE_ETHERNET). */
+        0x08, 0x00,                         /* usProtocolType. */
+        ipMAC_ADDRESS_LENGTH_BYTES,         /* ucHardwareAddressLength. */
+        ipIP_ADDRESS_LENGTH_BYTES,          /* ucProtocolAddressLength. */
+        0x00, 0x01,                         /* usOperation (ipARP_REQUEST). */
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, /* xSenderHardwareAddress. */
+        0x00, 0x00, 0x00, 0x00,             /* ulSenderProtocolAddress. */
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00  /* xTargetHardwareAddress. */
+    };
 
-ARPPacket_t *pxARPPacket;
+    ARPPacket_t * pxARPPacket;
 
-	/* Buffer allocation ensures that buffers always have space
-	for an ARP packet. See buffer allocation implementations 1
-	and 2 under portable/BufferManagement. */
-	configASSERT( pxNetworkBuffer != NULL );
-	configASSERT( pxNetworkBuffer->xDataLength >= sizeof(ARPPacket_t) );
+    /* Buffer allocation ensures that buffers always have space
+     * for an ARP packet. See buffer allocation implementations 1
+     * and 2 under portable/BufferManagement. */
+    configASSERT( pxNetworkBuffer != NULL );
+    configASSERT( pxNetworkBuffer->xDataLength >= sizeof( ARPPacket_t ) );
 
-	pxARPPacket = ipPOINTER_CAST( ARPPacket_t *, pxNetworkBuffer->pucEthernetBuffer );
+    pxARPPacket = ipPOINTER_CAST( ARPPacket_t *, pxNetworkBuffer->pucEthernetBuffer );
 
-	/* memcpy the const part of the header information into the correct
-	location in the packet.  This copies:
-		xEthernetHeader.ulDestinationAddress
-		xEthernetHeader.usFrameType;
-		xARPHeader.usHardwareType;
-		xARPHeader.usProtocolType;
-		xARPHeader.ucHardwareAddressLength;
-		xARPHeader.ucProtocolAddressLength;
-		xARPHeader.usOperation;
-		xARPHeader.xTargetHardwareAddress;
-	*/
-	( void ) memcpy( pxARPPacket, xDefaultPartARPPacketHeader, sizeof( xDefaultPartARPPacketHeader ) );
-	( void ) memcpy( pxARPPacket->xEthernetHeader.xSourceAddress.ucBytes , ipLOCAL_MAC_ADDRESS, ( size_t ) ipMAC_ADDRESS_LENGTH_BYTES );
-	( void ) memcpy( pxARPPacket->xARPHeader.xSenderHardwareAddress.ucBytes, ipLOCAL_MAC_ADDRESS, ( size_t ) ipMAC_ADDRESS_LENGTH_BYTES );
+    /* memcpy the const part of the header information into the correct
+     * location in the packet.  This copies:
+     *  xEthernetHeader.ulDestinationAddress
+     *  xEthernetHeader.usFrameType;
+     *  xARPHeader.usHardwareType;
+     *  xARPHeader.usProtocolType;
+     *  xARPHeader.ucHardwareAddressLength;
+     *  xARPHeader.ucProtocolAddressLength;
+     *  xARPHeader.usOperation;
+     *  xARPHeader.xTargetHardwareAddress;
+     */
+    ( void ) memcpy( pxARPPacket, xDefaultPartARPPacketHeader, sizeof( xDefaultPartARPPacketHeader ) );
+    ( void ) memcpy( pxARPPacket->xEthernetHeader.xSourceAddress.ucBytes, ipLOCAL_MAC_ADDRESS, ( size_t ) ipMAC_ADDRESS_LENGTH_BYTES );
+    ( void ) memcpy( pxARPPacket->xARPHeader.xSenderHardwareAddress.ucBytes, ipLOCAL_MAC_ADDRESS, ( size_t ) ipMAC_ADDRESS_LENGTH_BYTES );
 
-	( void ) memcpy( pxARPPacket->xARPHeader.ucSenderProtocolAddress, ipLOCAL_IP_ADDRESS_POINTER, sizeof( pxARPPacket->xARPHeader.ucSenderProtocolAddress ) );
-	pxARPPacket->xARPHeader.ulTargetProtocolAddress = pxNetworkBuffer->ulIPAddress;
+    ( void ) memcpy( pxARPPacket->xARPHeader.ucSenderProtocolAddress, ipLOCAL_IP_ADDRESS_POINTER, sizeof( pxARPPacket->xARPHeader.ucSenderProtocolAddress ) );
+    pxARPPacket->xARPHeader.ulTargetProtocolAddress = pxNetworkBuffer->ulIPAddress;
 
-	pxNetworkBuffer->xDataLength = sizeof( ARPPacket_t );
+    pxNetworkBuffer->xDataLength = sizeof( ARPPacket_t );
 
-	iptraceCREATING_ARP_REQUEST( pxNetworkBuffer->ulIPAddress );
+    iptraceCREATING_ARP_REQUEST( pxNetworkBuffer->ulIPAddress );
 }
 /*-----------------------------------------------------------*/
 
 void FreeRTOS_ClearARP( void )
 {
-	( void ) memset( xARPCache, 0, sizeof( xARPCache ) );
+    ( void ) memset( xARPCache, 0, sizeof( xARPCache ) );
 }
 /*-----------------------------------------------------------*/
 
 #if 1
-BaseType_t xCheckLoopback( NetworkBufferDescriptor_t * const pxDescriptor, BaseType_t bReleaseAfterSend )
-{
-BaseType_t xResult = pdFALSE;
-NetworkBufferDescriptor_t * pxUseDescriptor = pxDescriptor;
-const IPPacket_t *pxIPPacket = ipPOINTER_CAST( IPPacket_t *, pxUseDescriptor->pucEthernetBuffer );
+    BaseType_t xCheckLoopback( NetworkBufferDescriptor_t * const pxDescriptor,
+                               BaseType_t bReleaseAfterSend )
+    {
+        BaseType_t xResult = pdFALSE;
+        NetworkBufferDescriptor_t * pxUseDescriptor = pxDescriptor;
+        const IPPacket_t * pxIPPacket = ipPOINTER_CAST( IPPacket_t *, pxUseDescriptor->pucEthernetBuffer );
 
-	/* This function will check if the target IP-address belongs to this device.
-	 * If so, the packet will be passed to the IP-stack, who will answer it.
-	 * The function is to be called within the function xNetworkInterfaceOutput().
-	 */
+        /* This function will check if the target IP-address belongs to this device.
+         * If so, the packet will be passed to the IP-stack, who will answer it.
+         * The function is to be called within the function xNetworkInterfaceOutput().
+         */
 
-	if( pxIPPacket->xEthernetHeader.usFrameType == ipIPv4_FRAME_TYPE )
-	{
-		if( memcmp( pxIPPacket->xEthernetHeader.xDestinationAddress.ucBytes, ipLOCAL_MAC_ADDRESS, ipMAC_ADDRESS_LENGTH_BYTES ) == 0 )
-		{
-			xResult = pdTRUE;
-			if( bReleaseAfterSend == pdFALSE )
-			{
-				/* Driver is not allowed to transfer the ownership
-				of descriptor,  so make a copy of it */
-				pxUseDescriptor =
-					pxDuplicateNetworkBufferWithDescriptor( pxDescriptor, pxDescriptor->xDataLength );
-			}
-			if( pxUseDescriptor != NULL )
-			{
-			IPStackEvent_t xRxEvent;
+        if( pxIPPacket->xEthernetHeader.usFrameType == ipIPv4_FRAME_TYPE )
+        {
+            if( memcmp( pxIPPacket->xEthernetHeader.xDestinationAddress.ucBytes, ipLOCAL_MAC_ADDRESS, ipMAC_ADDRESS_LENGTH_BYTES ) == 0 )
+            {
+                xResult = pdTRUE;
 
-				xRxEvent.eEventType = eNetworkRxEvent;
-				xRxEvent.pvData = pxUseDescriptor;
-				if( xSendEventStructToIPTask( &xRxEvent, 0U ) != pdTRUE )
-				{
-					vReleaseNetworkBufferAndDescriptor( pxUseDescriptor );
-					iptraceETHERNET_RX_EVENT_LOST();
-					FreeRTOS_printf( ( "prvEMACRxPoll: Can not queue return packet!\n" ) );
-				}
-				
-			}
-		}
-	}
-	return xResult;
-}
+                if( bReleaseAfterSend == pdFALSE )
+                {
+                    /* Driver is not allowed to transfer the ownership
+                     * of descriptor,  so make a copy of it */
+                    pxUseDescriptor =
+                        pxDuplicateNetworkBufferWithDescriptor( pxDescriptor, pxDescriptor->xDataLength );
+                }
+
+                if( pxUseDescriptor != NULL )
+                {
+                    IPStackEvent_t xRxEvent;
+
+                    xRxEvent.eEventType = eNetworkRxEvent;
+                    xRxEvent.pvData = pxUseDescriptor;
+
+                    if( xSendEventStructToIPTask( &xRxEvent, 0U ) != pdTRUE )
+                    {
+                        vReleaseNetworkBufferAndDescriptor( pxUseDescriptor );
+                        iptraceETHERNET_RX_EVENT_LOST();
+                        FreeRTOS_printf( ( "prvEMACRxPoll: Can not queue return packet!\n" ) );
+                    }
+                }
+            }
+        }
+
+        return xResult;
+    }
 #endif /* 0 */
 /*-----------------------------------------------------------*/
 
-#if( ipconfigHAS_PRINTF != 0 ) || ( ipconfigHAS_DEBUG_PRINTF != 0 )
+#if ( ipconfigHAS_PRINTF != 0 ) || ( ipconfigHAS_DEBUG_PRINTF != 0 )
 
-	void FreeRTOS_PrintARPCache( void )
-	{
-	BaseType_t x, xCount = 0;
+    void FreeRTOS_PrintARPCache( void )
+    {
+        BaseType_t x, xCount = 0;
 
-		/* Loop through each entry in the ARP cache. */
-		for( x = 0; x < ipconfigARP_CACHE_ENTRIES; x++ )
-		{
-			if( ( xARPCache[ x ].ulIPAddress != 0UL ) && ( xARPCache[ x ].ucAge > ( uint8_t ) 0U ) )
-			{
-				/* See if the MAC-address also matches, and we're all happy */
-				FreeRTOS_printf( ( "Arp %2ld: %3u - %16lxip : %02x:%02x:%02x : %02x:%02x:%02x\n",
-					x,
-					xARPCache[ x ].ucAge,
-					xARPCache[ x ].ulIPAddress,
-					xARPCache[ x ].xMACAddress.ucBytes[0],
-					xARPCache[ x ].xMACAddress.ucBytes[1],
-					xARPCache[ x ].xMACAddress.ucBytes[2],
-					xARPCache[ x ].xMACAddress.ucBytes[3],
-					xARPCache[ x ].xMACAddress.ucBytes[4],
-					xARPCache[ x ].xMACAddress.ucBytes[5] ) );
-				xCount++;
-			}
-		}
+        /* Loop through each entry in the ARP cache. */
+        for( x = 0; x < ipconfigARP_CACHE_ENTRIES; x++ )
+        {
+            if( ( xARPCache[ x ].ulIPAddress != 0UL ) && ( xARPCache[ x ].ucAge > ( uint8_t ) 0U ) )
+            {
+                /* See if the MAC-address also matches, and we're all happy */
+                FreeRTOS_printf( ( "Arp %2ld: %3u - %16lxip : %02x:%02x:%02x : %02x:%02x:%02x\n",
+                                   x,
+                                   xARPCache[ x ].ucAge,
+                                   xARPCache[ x ].ulIPAddress,
+                                   xARPCache[ x ].xMACAddress.ucBytes[ 0 ],
+                                   xARPCache[ x ].xMACAddress.ucBytes[ 1 ],
+                                   xARPCache[ x ].xMACAddress.ucBytes[ 2 ],
+                                   xARPCache[ x ].xMACAddress.ucBytes[ 3 ],
+                                   xARPCache[ x ].xMACAddress.ucBytes[ 4 ],
+                                   xARPCache[ x ].xMACAddress.ucBytes[ 5 ] ) );
+                xCount++;
+            }
+        }
 
-		FreeRTOS_printf( ( "Arp has %ld entries\n", xCount ) );
-	}
+        FreeRTOS_printf( ( "Arp has %ld entries\n", xCount ) );
+    }
 
 #endif /* ( ipconfigHAS_PRINTF != 0 ) || ( ipconfigHAS_DEBUG_PRINTF != 0 ) */

--- a/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/FreeRTOS_DHCP.c
+++ b/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/FreeRTOS_DHCP.c
@@ -40,1028 +40,1049 @@
 #include "FreeRTOS_ARP.h"
 
 /* Exclude the entire file if DHCP is not enabled. */
-#if( ipconfigUSE_DHCP != 0 )
+#if ( ipconfigUSE_DHCP != 0 )
 
-#include "NetworkInterface.h"
-#include "NetworkBufferManagement.h"
+    #include "NetworkInterface.h"
+    #include "NetworkBufferManagement.h"
 
-#if ( ipconfigUSE_DHCP != 0 ) && ( ipconfigNETWORK_MTU < 586U )
-	/* DHCP must be able to receive an options field of 312 bytes, the fixed
-	part of the DHCP packet is 240 bytes, and the IP/UDP headers take 28 bytes. */
-	#error ipconfigNETWORK_MTU needs to be at least 586 to use DHCP
-#endif
+    #if ( ipconfigUSE_DHCP != 0 ) && ( ipconfigNETWORK_MTU < 586U )
+
+        /* DHCP must be able to receive an options field of 312 bytes, the fixed
+         * part of the DHCP packet is 240 bytes, and the IP/UDP headers take 28 bytes. */
+        #error ipconfigNETWORK_MTU needs to be at least 586 to use DHCP
+    #endif
 
 /* Parameter widths in the DHCP packet. */
-#define dhcpCLIENT_HARDWARE_ADDRESS_LENGTH		16
-#define dhcpSERVER_HOST_NAME_LENGTH				64
-#define dhcpBOOT_FILE_NAME_LENGTH 				128
+    #define dhcpCLIENT_HARDWARE_ADDRESS_LENGTH    16
+    #define dhcpSERVER_HOST_NAME_LENGTH           64
+    #define dhcpBOOT_FILE_NAME_LENGTH             128
 
 /* Timer parameters */
-#ifndef dhcpINITIAL_DHCP_TX_PERIOD
-	#define dhcpINITIAL_TIMER_PERIOD			( pdMS_TO_TICKS( 250U ) )
-	#define dhcpINITIAL_DHCP_TX_PERIOD			( pdMS_TO_TICKS( 5000U ) )
-#endif
+    #ifndef dhcpINITIAL_DHCP_TX_PERIOD
+        #define dhcpINITIAL_TIMER_PERIOD      ( pdMS_TO_TICKS( 250U ) )
+        #define dhcpINITIAL_DHCP_TX_PERIOD    ( pdMS_TO_TICKS( 5000U ) )
+    #endif
 
 /* Codes of interest found in the DHCP options field. */
-#define dhcpIPv4_ZERO_PAD_OPTION_CODE			( 0U )
-#define dhcpIPv4_SUBNET_MASK_OPTION_CODE		( 1U )
-#define dhcpIPv4_GATEWAY_OPTION_CODE			( 3U )
-#define dhcpIPv4_DNS_SERVER_OPTIONS_CODE		( 6U )
-#define dhcpIPv4_DNS_HOSTNAME_OPTIONS_CODE		( 12U )
-#define dhcpIPv4_REQUEST_IP_ADDRESS_OPTION_CODE	( 50U )
-#define dhcpIPv4_LEASE_TIME_OPTION_CODE			( 51U )
-#define dhcpIPv4_MESSAGE_TYPE_OPTION_CODE		( 53U )
-#define dhcpIPv4_SERVER_IP_ADDRESS_OPTION_CODE	( 54U )
-#define dhcpIPv4_PARAMETER_REQUEST_OPTION_CODE	( 55U )
-#define dhcpIPv4_CLIENT_IDENTIFIER_OPTION_CODE	( 61U )
+    #define dhcpIPv4_ZERO_PAD_OPTION_CODE              ( 0U )
+    #define dhcpIPv4_SUBNET_MASK_OPTION_CODE           ( 1U )
+    #define dhcpIPv4_GATEWAY_OPTION_CODE               ( 3U )
+    #define dhcpIPv4_DNS_SERVER_OPTIONS_CODE           ( 6U )
+    #define dhcpIPv4_DNS_HOSTNAME_OPTIONS_CODE         ( 12U )
+    #define dhcpIPv4_REQUEST_IP_ADDRESS_OPTION_CODE    ( 50U )
+    #define dhcpIPv4_LEASE_TIME_OPTION_CODE            ( 51U )
+    #define dhcpIPv4_MESSAGE_TYPE_OPTION_CODE          ( 53U )
+    #define dhcpIPv4_SERVER_IP_ADDRESS_OPTION_CODE     ( 54U )
+    #define dhcpIPv4_PARAMETER_REQUEST_OPTION_CODE     ( 55U )
+    #define dhcpIPv4_CLIENT_IDENTIFIER_OPTION_CODE     ( 61U )
 
 /* The four DHCP message types of interest. */
-#define dhcpMESSAGE_TYPE_DISCOVER				( 1 )
-#define dhcpMESSAGE_TYPE_OFFER					( 2 )
-#define dhcpMESSAGE_TYPE_REQUEST				( 3 )
-#define dhcpMESSAGE_TYPE_ACK					( 5 )
-#define dhcpMESSAGE_TYPE_NACK					( 6 )
+    #define dhcpMESSAGE_TYPE_DISCOVER                  ( 1 )
+    #define dhcpMESSAGE_TYPE_OFFER                     ( 2 )
+    #define dhcpMESSAGE_TYPE_REQUEST                   ( 3 )
+    #define dhcpMESSAGE_TYPE_ACK                       ( 5 )
+    #define dhcpMESSAGE_TYPE_NACK                      ( 6 )
 
 /* Offsets into the transmitted DHCP options fields at which various parameters
-are located. */
-#define dhcpCLIENT_IDENTIFIER_OFFSET			( 6U )
-#define dhcpREQUESTED_IP_ADDRESS_OFFSET			( 14U )
-#define dhcpDHCP_SERVER_IP_ADDRESS_OFFSET		( 20U )
+ * are located. */
+    #define dhcpCLIENT_IDENTIFIER_OFFSET               ( 6U )
+    #define dhcpREQUESTED_IP_ADDRESS_OFFSET            ( 14U )
+    #define dhcpDHCP_SERVER_IP_ADDRESS_OFFSET          ( 20U )
 
 /* Values used in the DHCP packets. */
-#define dhcpREQUEST_OPCODE						( 1U )
-#define dhcpREPLY_OPCODE						( 2U )
-#define dhcpADDRESS_TYPE_ETHERNET				( 1U )
-#define dhcpETHERNET_ADDRESS_LENGTH				( 6U )
+    #define dhcpREQUEST_OPCODE                         ( 1U )
+    #define dhcpREPLY_OPCODE                           ( 2U )
+    #define dhcpADDRESS_TYPE_ETHERNET                  ( 1U )
+    #define dhcpETHERNET_ADDRESS_LENGTH                ( 6U )
 
 /* The following define is temporary and serves to make the /single source
-code more similar to the /multi version. */
+ * code more similar to the /multi version. */
 
-#define	EP_DHCPData			xDHCPData
-#define	EP_IPv4_SETTINGS	xNetworkAddressing
+    #define EP_DHCPData         xDHCPData
+    #define EP_IPv4_SETTINGS    xNetworkAddressing
 
 /* If a lease time is not received, use the default of two days. */
 /* 48 hours in ticks.  Can not use pdMS_TO_TICKS() as integer overflow can occur. */
-#define dhcpDEFAULT_LEASE_TIME					( ( 48UL * 60UL * 60UL ) * configTICK_RATE_HZ )
+    #define dhcpDEFAULT_LEASE_TIME          ( ( 48UL * 60UL * 60UL ) * configTICK_RATE_HZ )
 
 /* Don't allow the lease time to be too short. */
-#define dhcpMINIMUM_LEASE_TIME					( pdMS_TO_TICKS( 60000UL ) )	/* 60 seconds in ticks. */
+    #define dhcpMINIMUM_LEASE_TIME          ( pdMS_TO_TICKS( 60000UL ) )        /* 60 seconds in ticks. */
 
 /* Marks the end of the variable length options field in the DHCP packet. */
-#define dhcpOPTION_END_BYTE 0xffu
+    #define dhcpOPTION_END_BYTE             0xffu
 
 /* Offset into a DHCP message at which the first byte of the options is
-located. */
-#define dhcpFIRST_OPTION_BYTE_OFFSET			( 0xf0U )
+ * located. */
+    #define dhcpFIRST_OPTION_BYTE_OFFSET    ( 0xf0U )
 
 /* Standard DHCP port numbers and magic cookie value.
-DHCPv4 uses UDP port number  68 for clients and port number  67 for servers.
-*/
-#if( ipconfigBYTE_ORDER == pdFREERTOS_LITTLE_ENDIAN )
-	#define dhcpCLIENT_PORT_IPv4	0x4400U
-	#define dhcpSERVER_PORT_IPv4	0x4300U
-	#define dhcpCOOKIE				0x63538263UL
-	#define dhcpBROADCAST			0x0080U
-#else
-	#define dhcpCLIENT_PORT_IPv4	0x0044U
-	#define dhcpSERVER_PORT_IPv4	0x0043U
-	#define dhcpCOOKIE				0x63825363UL
-	#define dhcpBROADCAST			0x8000U
-#endif /* ( ipconfigBYTE_ORDER == pdFREERTOS_LITTLE_ENDIAN ) */
+ * DHCPv4 uses UDP port number  68 for clients and port number  67 for servers.
+ */
+    #if ( ipconfigBYTE_ORDER == pdFREERTOS_LITTLE_ENDIAN )
+        #define dhcpCLIENT_PORT_IPv4    0x4400U
+        #define dhcpSERVER_PORT_IPv4    0x4300U
+        #define dhcpCOOKIE              0x63538263UL
+        #define dhcpBROADCAST           0x0080U
+    #else
+        #define dhcpCLIENT_PORT_IPv4    0x0044U
+        #define dhcpSERVER_PORT_IPv4    0x0043U
+        #define dhcpCOOKIE              0x63825363UL
+        #define dhcpBROADCAST           0x8000U
+    #endif /* ( ipconfigBYTE_ORDER == pdFREERTOS_LITTLE_ENDIAN ) */
 
-#include "pack_struct_start.h"
-struct xDHCPMessage_IPv4
-{
-	uint8_t ucOpcode;
-	uint8_t ucAddressType;
-	uint8_t ucAddressLength;
-	uint8_t ucHops;
-	uint32_t ulTransactionID;
-	uint16_t usElapsedTime;
-	uint16_t usFlags;
-	uint32_t ulClientIPAddress_ciaddr;
-	uint32_t ulYourIPAddress_yiaddr;
-	uint32_t ulServerIPAddress_siaddr;
-	uint32_t ulRelayAgentIPAddress_giaddr;
-	uint8_t ucClientHardwareAddress[ dhcpCLIENT_HARDWARE_ADDRESS_LENGTH ];
-	uint8_t ucServerHostName[ dhcpSERVER_HOST_NAME_LENGTH ];
-	uint8_t ucBootFileName[ dhcpBOOT_FILE_NAME_LENGTH ];
-	uint32_t ulDHCPCookie;
-	/* Option bytes from here on. */
-}
-#include "pack_struct_end.h"
-typedef struct xDHCPMessage_IPv4 DHCPMessage_IPv4_t;
+    #include "pack_struct_start.h"
+    struct xDHCPMessage_IPv4
+    {
+        uint8_t ucOpcode;
+        uint8_t ucAddressType;
+        uint8_t ucAddressLength;
+        uint8_t ucHops;
+        uint32_t ulTransactionID;
+        uint16_t usElapsedTime;
+        uint16_t usFlags;
+        uint32_t ulClientIPAddress_ciaddr;
+        uint32_t ulYourIPAddress_yiaddr;
+        uint32_t ulServerIPAddress_siaddr;
+        uint32_t ulRelayAgentIPAddress_giaddr;
+        uint8_t ucClientHardwareAddress[ dhcpCLIENT_HARDWARE_ADDRESS_LENGTH ];
+        uint8_t ucServerHostName[ dhcpSERVER_HOST_NAME_LENGTH ];
+        uint8_t ucBootFileName[ dhcpBOOT_FILE_NAME_LENGTH ];
+        uint32_t ulDHCPCookie;
+        /* Option bytes from here on. */
+    }
+    #include "pack_struct_end.h"
+    typedef struct xDHCPMessage_IPv4 DHCPMessage_IPv4_t;
 
 /* The UDP socket used for all incoming and outgoing DHCP traffic. */
-static Socket_t xDHCPSocket;
+    static Socket_t xDHCPSocket;
 
-#if( ipconfigDHCP_FALL_BACK_AUTO_IP != 0 )
-	/* Define the Link Layer IP address: 169.254.x.x */
-	#define LINK_LAYER_ADDRESS_0	169
-	#define LINK_LAYER_ADDRESS_1	254
+    #if ( ipconfigDHCP_FALL_BACK_AUTO_IP != 0 )
+        /* Define the Link Layer IP address: 169.254.x.x */
+        #define LINK_LAYER_ADDRESS_0    169
+        #define LINK_LAYER_ADDRESS_1    254
 
-	/* Define the netmask used: 255.255.0.0 */
-	#define LINK_LAYER_NETMASK_0	255
-	#define LINK_LAYER_NETMASK_1	255
-	#define LINK_LAYER_NETMASK_2	0
-	#define LINK_LAYER_NETMASK_3	0
-#endif
+        /* Define the netmask used: 255.255.0.0 */
+        #define LINK_LAYER_NETMASK_0    255
+        #define LINK_LAYER_NETMASK_1    255
+        #define LINK_LAYER_NETMASK_2    0
+        #define LINK_LAYER_NETMASK_3    0
+    #endif
 
 
 /*
  * Generate a DHCP discover message and send it on the DHCP socket.
  */
-static void prvSendDHCPDiscover( void );
+    static void prvSendDHCPDiscover( void );
 
 /*
  * Interpret message received on the DHCP socket.
  */
-static BaseType_t prvProcessDHCPReplies( BaseType_t xExpectedMessageType );
+    static BaseType_t prvProcessDHCPReplies( BaseType_t xExpectedMessageType );
 
 /*
  * Generate a DHCP request packet, and send it on the DHCP socket.
  */
-static void prvSendDHCPRequest( void );
+    static void prvSendDHCPRequest( void );
 
 /*
  * Prepare to start a DHCP transaction.  This initialises some state variables
  * and creates the DHCP socket if necessary.
  */
-static void prvInitialiseDHCP( void );
+    static void prvInitialiseDHCP( void );
 
 /*
  * Creates the part of outgoing DHCP messages that are common to all outgoing
  * DHCP messages.
  */
-static uint8_t *prvCreatePartDHCPMessage( struct freertos_sockaddr *pxAddress,
-										  BaseType_t xOpcode,
-										  const uint8_t * const pucOptionsArray,
-										  size_t *pxOptionsArraySize );
+    static uint8_t * prvCreatePartDHCPMessage( struct freertos_sockaddr * pxAddress,
+                                               BaseType_t xOpcode,
+                                               const uint8_t * const pucOptionsArray,
+                                               size_t * pxOptionsArraySize );
 
 /*
  * Create the DHCP socket, if it has not been created already.
  */
-static void prvCreateDHCPSocket( void );
+    static void prvCreateDHCPSocket( void );
 
 /*
  * Close the DHCP socket.
  */
-static void prvCloseDHCPSocket( void );
+    static void prvCloseDHCPSocket( void );
 
 /*
  * After DHCP has failed to answer, prepare everything to start searching
  * for (trying-out) LinkLayer IP-addresses, using the random method: Send
  * a gratuitous ARP request and wait if another device responds to it.
  */
-#if( ipconfigDHCP_FALL_BACK_AUTO_IP != 0 )
-	static void prvPrepareLinkLayerIPLookUp( void );
-#endif
+    #if ( ipconfigDHCP_FALL_BACK_AUTO_IP != 0 )
+        static void prvPrepareLinkLayerIPLookUp( void );
+    #endif
 
 /*-----------------------------------------------------------*/
 
 /* Hold information in between steps in the DHCP state machine. */
-static DHCPData_t xDHCPData;
+    static DHCPData_t xDHCPData;
 
 /*-----------------------------------------------------------*/
 
-BaseType_t xIsDHCPSocket( Socket_t xSocket )
-{
-BaseType_t xReturn;
+    BaseType_t xIsDHCPSocket( Socket_t xSocket )
+    {
+        BaseType_t xReturn;
 
-	if( xDHCPSocket == xSocket )
-	{
-		xReturn = pdTRUE;
-	}
-	else
-	{
-		xReturn = pdFALSE;
-	}
+        if( xDHCPSocket == xSocket )
+        {
+            xReturn = pdTRUE;
+        }
+        else
+        {
+            xReturn = pdFALSE;
+        }
 
-	return xReturn;
-}
+        return xReturn;
+    }
 /*-----------------------------------------------------------*/
 
-void vDHCPProcess( BaseType_t xReset )
-{
-BaseType_t xGivingUp = pdFALSE;
-#if( ipconfigUSE_DHCP_HOOK != 0 )
-	eDHCPCallbackAnswer_t eAnswer;
-#endif	/* ipconfigUSE_DHCP_HOOK */
+    void vDHCPProcess( BaseType_t xReset )
+    {
+        BaseType_t xGivingUp = pdFALSE;
 
-	/* Is DHCP starting over? */
-	if( xReset != pdFALSE )
-	{
-		EP_DHCPData.eDHCPState = eWaitingSendFirstDiscover;
-	}
+        #if ( ipconfigUSE_DHCP_HOOK != 0 )
+            eDHCPCallbackAnswer_t eAnswer;
+        #endif /* ipconfigUSE_DHCP_HOOK */
 
-	switch( EP_DHCPData.eDHCPState )
-	{
-		case eWaitingSendFirstDiscover :
-			/* Ask the user if a DHCP discovery is required. */
-		#if( ipconfigUSE_DHCP_HOOK != 0 )
-			eAnswer = xApplicationDHCPHook( eDHCPPhasePreDiscover, xNetworkAddressing.ulDefaultIPAddress );
-			if( eAnswer == eDHCPContinue )
-		#endif	/* ipconfigUSE_DHCP_HOOK */
-			{
-				/* Initial state.  Create the DHCP socket, timer, etc. if they
-				have not already been created. */
-				prvInitialiseDHCP();
+        /* Is DHCP starting over? */
+        if( xReset != pdFALSE )
+        {
+            EP_DHCPData.eDHCPState = eWaitingSendFirstDiscover;
+        }
 
-				/* See if prvInitialiseDHCP() has creates a socket. */
-				if( xDHCPSocket == NULL )
-				{
-					xGivingUp = pdTRUE;
-				}
-				else
-				{
+        switch( EP_DHCPData.eDHCPState )
+        {
+            case eWaitingSendFirstDiscover:
+                /* Ask the user if a DHCP discovery is required. */
+                #if ( ipconfigUSE_DHCP_HOOK != 0 )
+                    eAnswer = xApplicationDHCPHook( eDHCPPhasePreDiscover, xNetworkAddressing.ulDefaultIPAddress );
 
-					*ipLOCAL_IP_ADDRESS_POINTER = 0UL;
+                    if( eAnswer == eDHCPContinue )
+                #endif /* ipconfigUSE_DHCP_HOOK */
+                {
+                    /* Initial state.  Create the DHCP socket, timer, etc. if they
+                     * have not already been created. */
+                    prvInitialiseDHCP();
 
-					/* Send the first discover request. */
-					EP_DHCPData.xDHCPTxTime = xTaskGetTickCount();
-					prvSendDHCPDiscover();
-					EP_DHCPData.eDHCPState = eWaitingOffer;
-				}
-			}
-		#if( ipconfigUSE_DHCP_HOOK != 0 )
-			else
-			{
-				if( eAnswer == eDHCPUseDefaults )
-				{
-					( void ) memcpy( &( xNetworkAddressing ), &( xDefaultAddressing ), sizeof( xNetworkAddressing ) );
-				}
+                    /* See if prvInitialiseDHCP() has creates a socket. */
+                    if( xDHCPSocket == NULL )
+                    {
+                        xGivingUp = pdTRUE;
+                    }
+                    else
+                    {
+                        *ipLOCAL_IP_ADDRESS_POINTER = 0UL;
 
-				/* The user indicates that the DHCP process does not continue. */
-				xGivingUp = pdTRUE;
-			}
-		#endif	/* ipconfigUSE_DHCP_HOOK */
-			break;
+                        /* Send the first discover request. */
+                        EP_DHCPData.xDHCPTxTime = xTaskGetTickCount();
+                        prvSendDHCPDiscover();
+                        EP_DHCPData.eDHCPState = eWaitingOffer;
+                    }
+                }
 
-		case eWaitingOffer :
+                #if ( ipconfigUSE_DHCP_HOOK != 0 )
+                    else
+                    {
+                        if( eAnswer == eDHCPUseDefaults )
+                        {
+                            ( void ) memcpy( &( xNetworkAddressing ), &( xDefaultAddressing ), sizeof( xNetworkAddressing ) );
+                        }
 
-			xGivingUp = pdFALSE;
+                        /* The user indicates that the DHCP process does not continue. */
+                        xGivingUp = pdTRUE;
+                    }
+                #endif /* ipconfigUSE_DHCP_HOOK */
+                break;
 
-			/* Look for offers coming in. */
-			if( prvProcessDHCPReplies( dhcpMESSAGE_TYPE_OFFER ) == pdPASS )
-			{
-			#if( ipconfigUSE_DHCP_HOOK != 0 )
-				/* Ask the user if a DHCP request is required. */
-				eAnswer = xApplicationDHCPHook( eDHCPPhasePreRequest, EP_DHCPData.ulOfferedIPAddress );
+            case eWaitingOffer:
 
-				if( eAnswer == eDHCPContinue )
-			#endif	/* ipconfigUSE_DHCP_HOOK */
-				{
-					/* An offer has been made, the user wants to continue,
-					generate the request. */
-					EP_DHCPData.xDHCPTxTime = xTaskGetTickCount();
-					EP_DHCPData.xDHCPTxPeriod = dhcpINITIAL_DHCP_TX_PERIOD;
-					prvSendDHCPRequest();
-					EP_DHCPData.eDHCPState = eWaitingAcknowledge;
-					break;
-				}
+                xGivingUp = pdFALSE;
 
-			#if( ipconfigUSE_DHCP_HOOK != 0 )
-				if( eAnswer == eDHCPUseDefaults )
-				{
-					( void ) memcpy( &( xNetworkAddressing ), &( xDefaultAddressing ), sizeof( xNetworkAddressing ) );
-				}
+                /* Look for offers coming in. */
+                if( prvProcessDHCPReplies( dhcpMESSAGE_TYPE_OFFER ) == pdPASS )
+                {
+                    #if ( ipconfigUSE_DHCP_HOOK != 0 )
+                        /* Ask the user if a DHCP request is required. */
+                        eAnswer = xApplicationDHCPHook( eDHCPPhasePreRequest, EP_DHCPData.ulOfferedIPAddress );
 
-				/* The user indicates that the DHCP process does not continue. */
-				xGivingUp = pdTRUE;
-			#endif	/* ipconfigUSE_DHCP_HOOK */
-			}
+                        if( eAnswer == eDHCPContinue )
+                    #endif /* ipconfigUSE_DHCP_HOOK */
+                    {
+                        /* An offer has been made, the user wants to continue,
+                         * generate the request. */
+                        EP_DHCPData.xDHCPTxTime = xTaskGetTickCount();
+                        EP_DHCPData.xDHCPTxPeriod = dhcpINITIAL_DHCP_TX_PERIOD;
+                        prvSendDHCPRequest();
+                        EP_DHCPData.eDHCPState = eWaitingAcknowledge;
+                        break;
+                    }
 
-			/* Is it time to send another Discover? */
-			else if( ( xTaskGetTickCount() - EP_DHCPData.xDHCPTxTime ) > EP_DHCPData.xDHCPTxPeriod )
-			{
-				/* It is time to send another Discover.  Increase the time
-				period, and if it has not got to the point of giving up - send
-				another discovery. */
-				EP_DHCPData.xDHCPTxPeriod <<= 1;
+                    #if ( ipconfigUSE_DHCP_HOOK != 0 )
+                        if( eAnswer == eDHCPUseDefaults )
+                        {
+                            ( void ) memcpy( &( xNetworkAddressing ), &( xDefaultAddressing ), sizeof( xNetworkAddressing ) );
+                        }
 
-				if( EP_DHCPData.xDHCPTxPeriod <= ( TickType_t ) ipconfigMAXIMUM_DISCOVER_TX_PERIOD )
-				{
-					if( xApplicationGetRandomNumber( &( EP_DHCPData.ulTransactionId ) ) != pdFALSE )
-					{
-						EP_DHCPData.xDHCPTxTime = xTaskGetTickCount();
-						if( EP_DHCPData.xUseBroadcast != pdFALSE )
-						{
-							EP_DHCPData.xUseBroadcast = pdFALSE;
-						}
-						else
-						{
-							EP_DHCPData.xUseBroadcast = pdTRUE;
-						}
-						prvSendDHCPDiscover();
-						FreeRTOS_debug_printf( ( "vDHCPProcess: timeout %lu ticks\n", EP_DHCPData.xDHCPTxPeriod ) );
-					}
-					else
-					{
-						FreeRTOS_debug_printf( ( "vDHCPProcess: failed to generate a random Transaction ID\n" ) );
-					}
-				}
-				else
-				{
-					FreeRTOS_debug_printf( ( "vDHCPProcess: giving up %lu > %lu ticks\n", EP_DHCPData.xDHCPTxPeriod, ipconfigMAXIMUM_DISCOVER_TX_PERIOD ) );
+                        /* The user indicates that the DHCP process does not continue. */
+                        xGivingUp = pdTRUE;
+                    #endif /* ipconfigUSE_DHCP_HOOK */
+                }
 
-					#if( ipconfigDHCP_FALL_BACK_AUTO_IP != 0 )
-					{
-						/* Only use a fake Ack if the default IP address == 0x00
-						and the link local addressing is used.  Start searching
-						a free LinkLayer IP-address.  Next state will be
-						'eGetLinkLayerAddress'. */
-						prvPrepareLinkLayerIPLookUp();
+                /* Is it time to send another Discover? */
+                else if( ( xTaskGetTickCount() - EP_DHCPData.xDHCPTxTime ) > EP_DHCPData.xDHCPTxPeriod )
+                {
+                    /* It is time to send another Discover.  Increase the time
+                     * period, and if it has not got to the point of giving up - send
+                     * another discovery. */
+                    EP_DHCPData.xDHCPTxPeriod <<= 1;
 
-						/* Setting an IP address manually so set to not using
-						leased address mode. */
-						EP_DHCPData.eDHCPState = eGetLinkLayerAddress;
-					}
-					#else
-					{
-						xGivingUp = pdTRUE;
-					}
-					#endif /* ipconfigDHCP_FALL_BACK_AUTO_IP */
-				}
-			}
-			else
-			{
-				/* There was no DHCP reply, there was no time-out, just keep on waiting. */
-			}
-			break;
+                    if( EP_DHCPData.xDHCPTxPeriod <= ( TickType_t ) ipconfigMAXIMUM_DISCOVER_TX_PERIOD )
+                    {
+                        if( xApplicationGetRandomNumber( &( EP_DHCPData.ulTransactionId ) ) != pdFALSE )
+                        {
+                            EP_DHCPData.xDHCPTxTime = xTaskGetTickCount();
 
-		case eWaitingAcknowledge :
+                            if( EP_DHCPData.xUseBroadcast != pdFALSE )
+                            {
+                                EP_DHCPData.xUseBroadcast = pdFALSE;
+                            }
+                            else
+                            {
+                                EP_DHCPData.xUseBroadcast = pdTRUE;
+                            }
 
-			/* Look for acks coming in. */
-			if( prvProcessDHCPReplies( dhcpMESSAGE_TYPE_ACK ) == pdPASS )
-			{
-				FreeRTOS_debug_printf( ( "vDHCPProcess: acked %lxip\n", FreeRTOS_ntohl( EP_DHCPData.ulOfferedIPAddress ) ) );
+                            prvSendDHCPDiscover();
+                            FreeRTOS_debug_printf( ( "vDHCPProcess: timeout %lu ticks\n", EP_DHCPData.xDHCPTxPeriod ) );
+                        }
+                        else
+                        {
+                            FreeRTOS_debug_printf( ( "vDHCPProcess: failed to generate a random Transaction ID\n" ) );
+                        }
+                    }
+                    else
+                    {
+                        FreeRTOS_debug_printf( ( "vDHCPProcess: giving up %lu > %lu ticks\n", EP_DHCPData.xDHCPTxPeriod, ipconfigMAXIMUM_DISCOVER_TX_PERIOD ) );
 
-				/* DHCP completed.  The IP address can now be used, and the
-				timer set to the lease timeout time. */
-				*ipLOCAL_IP_ADDRESS_POINTER = EP_DHCPData.ulOfferedIPAddress;
+                        #if ( ipconfigDHCP_FALL_BACK_AUTO_IP != 0 )
+                            {
+                                /* Only use a fake Ack if the default IP address == 0x00
+                                 * and the link local addressing is used.  Start searching
+                                 * a free LinkLayer IP-address.  Next state will be
+                                 * 'eGetLinkLayerAddress'. */
+                                prvPrepareLinkLayerIPLookUp();
 
-				/* Setting the 'local' broadcast address, something like
-				'192.168.1.255'. */
-				EP_IPv4_SETTINGS.ulBroadcastAddress = ( EP_DHCPData.ulOfferedIPAddress & xNetworkAddressing.ulNetMask ) |  ~xNetworkAddressing.ulNetMask;
-				EP_DHCPData.eDHCPState = eLeasedAddress;
+                                /* Setting an IP address manually so set to not using
+                                 * leased address mode. */
+                                EP_DHCPData.eDHCPState = eGetLinkLayerAddress;
+                            }
+                        #else
+                            {
+                                xGivingUp = pdTRUE;
+                            }
+                        #endif /* ipconfigDHCP_FALL_BACK_AUTO_IP */
+                    }
+                }
+                else
+                {
+                    /* There was no DHCP reply, there was no time-out, just keep on waiting. */
+                }
 
-				iptraceDHCP_SUCCEDEED( EP_DHCPData.ulOfferedIPAddress );
+                break;
 
-				/* DHCP failed, the default configured IP-address will be used
-				Now call vIPNetworkUpCalls() to send the network-up event and
-				start the ARP timer. */
-				vIPNetworkUpCalls();
+            case eWaitingAcknowledge:
 
-				/* Close socket to ensure packets don't queue on it. */
-				prvCloseDHCPSocket();
+                /* Look for acks coming in. */
+                if( prvProcessDHCPReplies( dhcpMESSAGE_TYPE_ACK ) == pdPASS )
+                {
+                    FreeRTOS_debug_printf( ( "vDHCPProcess: acked %lxip\n", FreeRTOS_ntohl( EP_DHCPData.ulOfferedIPAddress ) ) );
 
-				if( EP_DHCPData.ulLeaseTime == 0UL )
-				{
-					EP_DHCPData.ulLeaseTime = ( uint32_t ) dhcpDEFAULT_LEASE_TIME;
-				}
-				else if( EP_DHCPData.ulLeaseTime < dhcpMINIMUM_LEASE_TIME )
-				{
-					EP_DHCPData.ulLeaseTime = dhcpMINIMUM_LEASE_TIME;
-				}
-				else
-				{
-					/* The lease time is already valid. */
-				}
+                    /* DHCP completed.  The IP address can now be used, and the
+                     * timer set to the lease timeout time. */
+                    *ipLOCAL_IP_ADDRESS_POINTER = EP_DHCPData.ulOfferedIPAddress;
 
-				/* Check for clashes. */
-				vARPSendGratuitous();
-				vIPReloadDHCPTimer( EP_DHCPData.ulLeaseTime );
-			}
-			else
-			{
-				/* Is it time to send another Discover? */
-				if( ( xTaskGetTickCount() - EP_DHCPData.xDHCPTxTime ) > EP_DHCPData.xDHCPTxPeriod )
-				{
-					/* Increase the time period, and if it has not got to the
-					point of giving up - send another request. */
-					EP_DHCPData.xDHCPTxPeriod <<= 1;
+                    /* Setting the 'local' broadcast address, something like
+                     * '192.168.1.255'. */
+                    EP_IPv4_SETTINGS.ulBroadcastAddress = ( EP_DHCPData.ulOfferedIPAddress & xNetworkAddressing.ulNetMask ) | ~xNetworkAddressing.ulNetMask;
+                    EP_DHCPData.eDHCPState = eLeasedAddress;
 
-					if( EP_DHCPData.xDHCPTxPeriod <= ( TickType_t ) ipconfigMAXIMUM_DISCOVER_TX_PERIOD )
-					{
-						EP_DHCPData.xDHCPTxTime = xTaskGetTickCount();
-						prvSendDHCPRequest();
-					}
-					else
-					{
-						/* Give up, start again. */
-						EP_DHCPData.eDHCPState = eWaitingSendFirstDiscover;
-					}
-				}
-			}
-			break;
+                    iptraceDHCP_SUCCEDEED( EP_DHCPData.ulOfferedIPAddress );
 
-	#if( ipconfigDHCP_FALL_BACK_AUTO_IP != 0 )
-		case eGetLinkLayerAddress:
-			if( ( xTaskGetTickCount() - EP_DHCPData.xDHCPTxTime ) > EP_DHCPData.xDHCPTxPeriod )
-			{
-				if( xARPHadIPClash == pdFALSE )
-				{
-					/* ARP OK. proceed. */
-					iptraceDHCP_SUCCEDEED( EP_DHCPData.ulOfferedIPAddress );
+                    /* DHCP failed, the default configured IP-address will be used
+                     * Now call vIPNetworkUpCalls() to send the network-up event and
+                     * start the ARP timer. */
+                    vIPNetworkUpCalls();
 
-					/* Auto-IP succeeded, the default configured IP-address will
-					be used.  Now call vIPNetworkUpCalls() to send the
-					network-up event and start the ARP timer. */
-					vIPNetworkUpCalls();
-					EP_DHCPData.eDHCPState = eNotUsingLeasedAddress;
-				}
-				else
-				{
-					/* ARP clashed - try another IP address. */
-					prvPrepareLinkLayerIPLookUp();
+                    /* Close socket to ensure packets don't queue on it. */
+                    prvCloseDHCPSocket();
 
-					/* Setting an IP address manually so set to not using leased
-					address mode. */
-					EP_DHCPData.eDHCPState = eGetLinkLayerAddress;
-				}
-			}
-			break;
-	#endif	/* ipconfigDHCP_FALL_BACK_AUTO_IP */
+                    if( EP_DHCPData.ulLeaseTime == 0UL )
+                    {
+                        EP_DHCPData.ulLeaseTime = ( uint32_t ) dhcpDEFAULT_LEASE_TIME;
+                    }
+                    else if( EP_DHCPData.ulLeaseTime < dhcpMINIMUM_LEASE_TIME )
+                    {
+                        EP_DHCPData.ulLeaseTime = dhcpMINIMUM_LEASE_TIME;
+                    }
+                    else
+                    {
+                        /* The lease time is already valid. */
+                    }
 
-		case eLeasedAddress :
+                    /* Check for clashes. */
+                    vARPSendGratuitous();
+                    vIPReloadDHCPTimer( EP_DHCPData.ulLeaseTime );
+                }
+                else
+                {
+                    /* Is it time to send another Discover? */
+                    if( ( xTaskGetTickCount() - EP_DHCPData.xDHCPTxTime ) > EP_DHCPData.xDHCPTxPeriod )
+                    {
+                        /* Increase the time period, and if it has not got to the
+                         * point of giving up - send another request. */
+                        EP_DHCPData.xDHCPTxPeriod <<= 1;
 
-			if( FreeRTOS_IsNetworkUp() != 0 )
-			{
-				/* Resend the request at the appropriate time to renew the lease. */
-				prvCreateDHCPSocket();
+                        if( EP_DHCPData.xDHCPTxPeriod <= ( TickType_t ) ipconfigMAXIMUM_DISCOVER_TX_PERIOD )
+                        {
+                            EP_DHCPData.xDHCPTxTime = xTaskGetTickCount();
+                            prvSendDHCPRequest();
+                        }
+                        else
+                        {
+                            /* Give up, start again. */
+                            EP_DHCPData.eDHCPState = eWaitingSendFirstDiscover;
+                        }
+                    }
+                }
 
-				if( xDHCPSocket != NULL )
-				{
-					EP_DHCPData.xDHCPTxTime = xTaskGetTickCount();
-					EP_DHCPData.xDHCPTxPeriod = dhcpINITIAL_DHCP_TX_PERIOD;
-					prvSendDHCPRequest();
-					EP_DHCPData.eDHCPState = eWaitingAcknowledge;
+                break;
 
-					/* From now on, we should be called more often */
-					vIPReloadDHCPTimer( dhcpINITIAL_TIMER_PERIOD );
-				}
-			}
-			else
-			{
-				/* See PR #53 on github/freertos/freertos */
-				FreeRTOS_printf( ( "DHCP: lease time finished but network is down\n" ) );
-				vIPReloadDHCPTimer( pdMS_TO_TICKS( 5000U ) );
-			}
-			break;
+                #if ( ipconfigDHCP_FALL_BACK_AUTO_IP != 0 )
+                    case eGetLinkLayerAddress:
 
-		case eNotUsingLeasedAddress:
+                        if( ( xTaskGetTickCount() - EP_DHCPData.xDHCPTxTime ) > EP_DHCPData.xDHCPTxPeriod )
+                        {
+                            if( xARPHadIPClash == pdFALSE )
+                            {
+                                /* ARP OK. proceed. */
+                                iptraceDHCP_SUCCEDEED( EP_DHCPData.ulOfferedIPAddress );
 
-			vIPSetDHCPTimerEnableState( pdFALSE );
-			break;
+                                /* Auto-IP succeeded, the default configured IP-address will
+                                 * be used.  Now call vIPNetworkUpCalls() to send the
+                                 * network-up event and start the ARP timer. */
+                                vIPNetworkUpCalls();
+                                EP_DHCPData.eDHCPState = eNotUsingLeasedAddress;
+                            }
+                            else
+                            {
+                                /* ARP clashed - try another IP address. */
+                                prvPrepareLinkLayerIPLookUp();
 
-		default:
-			/* Lint: all options are included. */
-			break;
-	}
+                                /* Setting an IP address manually so set to not using leased
+                                 * address mode. */
+                                EP_DHCPData.eDHCPState = eGetLinkLayerAddress;
+                            }
+                        }
+                        break;
+                #endif /* ipconfigDHCP_FALL_BACK_AUTO_IP */
 
-	if( xGivingUp != pdFALSE )
-	{
-		/* xGivingUp became true either because of a time-out, or because
-		xApplicationDHCPHook() returned another value than 'eDHCPContinue',
-		meaning that the conversion is cancelled from here. */
+            case eLeasedAddress:
 
-		/* Revert to static IP address. */
-		taskENTER_CRITICAL();
-		{
-			*ipLOCAL_IP_ADDRESS_POINTER = xNetworkAddressing.ulDefaultIPAddress;
-			iptraceDHCP_REQUESTS_FAILED_USING_DEFAULT_IP_ADDRESS( xNetworkAddressing.ulDefaultIPAddress );
-		}
-		taskEXIT_CRITICAL();
+                if( FreeRTOS_IsNetworkUp() != 0 )
+                {
+                    /* Resend the request at the appropriate time to renew the lease. */
+                    prvCreateDHCPSocket();
 
-		EP_DHCPData.eDHCPState = eNotUsingLeasedAddress;
-		vIPSetDHCPTimerEnableState( pdFALSE );
+                    if( xDHCPSocket != NULL )
+                    {
+                        EP_DHCPData.xDHCPTxTime = xTaskGetTickCount();
+                        EP_DHCPData.xDHCPTxPeriod = dhcpINITIAL_DHCP_TX_PERIOD;
+                        prvSendDHCPRequest();
+                        EP_DHCPData.eDHCPState = eWaitingAcknowledge;
 
-		/* DHCP failed, the default configured IP-address will be used.  Now
-		call vIPNetworkUpCalls() to send the network-up event and start the ARP
-		timer. */
-		vIPNetworkUpCalls();
+                        /* From now on, we should be called more often */
+                        vIPReloadDHCPTimer( dhcpINITIAL_TIMER_PERIOD );
+                    }
+                }
+                else
+                {
+                    /* See PR #53 on github/freertos/freertos */
+                    FreeRTOS_printf( ( "DHCP: lease time finished but network is down\n" ) );
+                    vIPReloadDHCPTimer( pdMS_TO_TICKS( 5000U ) );
+                }
 
-		prvCloseDHCPSocket();
-	}
-}
+                break;
+
+            case eNotUsingLeasedAddress:
+
+                vIPSetDHCPTimerEnableState( pdFALSE );
+                break;
+
+            default:
+                /* Lint: all options are included. */
+                break;
+        }
+
+        if( xGivingUp != pdFALSE )
+        {
+            /* xGivingUp became true either because of a time-out, or because
+             * xApplicationDHCPHook() returned another value than 'eDHCPContinue',
+             * meaning that the conversion is cancelled from here. */
+
+            /* Revert to static IP address. */
+            taskENTER_CRITICAL();
+            {
+                *ipLOCAL_IP_ADDRESS_POINTER = xNetworkAddressing.ulDefaultIPAddress;
+                iptraceDHCP_REQUESTS_FAILED_USING_DEFAULT_IP_ADDRESS( xNetworkAddressing.ulDefaultIPAddress );
+            }
+            taskEXIT_CRITICAL();
+
+            EP_DHCPData.eDHCPState = eNotUsingLeasedAddress;
+            vIPSetDHCPTimerEnableState( pdFALSE );
+
+            /* DHCP failed, the default configured IP-address will be used.  Now
+             * call vIPNetworkUpCalls() to send the network-up event and start the ARP
+             * timer. */
+            vIPNetworkUpCalls();
+
+            prvCloseDHCPSocket();
+        }
+    }
 /*-----------------------------------------------------------*/
 
-static void prvCloseDHCPSocket( void )
-{
-	if( xDHCPSocket != NULL )
-	{
-		/* This modules runs from the IP-task. Use the internal
-		function 'vSocketClose()` to close the socket. */
-		( void ) vSocketClose( xDHCPSocket );
-		xDHCPSocket = NULL;
-	}
-}
+    static void prvCloseDHCPSocket( void )
+    {
+        if( xDHCPSocket != NULL )
+        {
+            /* This modules runs from the IP-task. Use the internal
+             * function 'vSocketClose()` to close the socket. */
+            ( void ) vSocketClose( xDHCPSocket );
+            xDHCPSocket = NULL;
+        }
+    }
 /*-----------------------------------------------------------*/
 
-static void prvCreateDHCPSocket( void )
-{
-struct freertos_sockaddr xAddress;
-BaseType_t xReturn;
-TickType_t xTimeoutTime = ( TickType_t ) 0;
+    static void prvCreateDHCPSocket( void )
+    {
+        struct freertos_sockaddr xAddress;
+        BaseType_t xReturn;
+        TickType_t xTimeoutTime = ( TickType_t ) 0;
 
-	/* Create the socket, if it has not already been created. */
-	if( xDHCPSocket == NULL )
-	{
-		xDHCPSocket = FreeRTOS_socket( FREERTOS_AF_INET, FREERTOS_SOCK_DGRAM, FREERTOS_IPPROTO_UDP );
-		if( xDHCPSocket != FREERTOS_INVALID_SOCKET )
-		{
+        /* Create the socket, if it has not already been created. */
+        if( xDHCPSocket == NULL )
+        {
+            xDHCPSocket = FreeRTOS_socket( FREERTOS_AF_INET, FREERTOS_SOCK_DGRAM, FREERTOS_IPPROTO_UDP );
 
-			/* Ensure the Rx and Tx timeouts are zero as the DHCP executes in the
-			context of the IP task. */
-			( void ) FreeRTOS_setsockopt( xDHCPSocket, 0, FREERTOS_SO_RCVTIMEO, &( xTimeoutTime ), sizeof( TickType_t ) );
-			( void ) FreeRTOS_setsockopt( xDHCPSocket, 0, FREERTOS_SO_SNDTIMEO, &( xTimeoutTime ), sizeof( TickType_t ) );
+            if( xDHCPSocket != FREERTOS_INVALID_SOCKET )
+            {
+                /* Ensure the Rx and Tx timeouts are zero as the DHCP executes in the
+                 * context of the IP task. */
+                ( void ) FreeRTOS_setsockopt( xDHCPSocket, 0, FREERTOS_SO_RCVTIMEO, &( xTimeoutTime ), sizeof( TickType_t ) );
+                ( void ) FreeRTOS_setsockopt( xDHCPSocket, 0, FREERTOS_SO_SNDTIMEO, &( xTimeoutTime ), sizeof( TickType_t ) );
 
-			/* Bind to the standard DHCP client port. */
-			xAddress.sin_port = ( uint16_t ) dhcpCLIENT_PORT_IPv4;
-			xReturn = vSocketBind( xDHCPSocket, &xAddress, sizeof( xAddress ), pdFALSE );
-			if( xReturn != 0 )
-			{
-				/* Binding failed, close the socket again. */
-				prvCloseDHCPSocket();
-			}
-		}
-		else
-		{
-			/* Change to NULL for easier testing. */
-			xDHCPSocket = NULL;
-		}
-	}
-}
+                /* Bind to the standard DHCP client port. */
+                xAddress.sin_port = ( uint16_t ) dhcpCLIENT_PORT_IPv4;
+                xReturn = vSocketBind( xDHCPSocket, &xAddress, sizeof( xAddress ), pdFALSE );
+
+                if( xReturn != 0 )
+                {
+                    /* Binding failed, close the socket again. */
+                    prvCloseDHCPSocket();
+                }
+            }
+            else
+            {
+                /* Change to NULL for easier testing. */
+                xDHCPSocket = NULL;
+            }
+        }
+    }
 /*-----------------------------------------------------------*/
 
-static void prvInitialiseDHCP( void )
-{
-	/* Initialise the parameters that will be set by the DHCP process. Per
-	https://www.ietf.org/rfc/rfc2131.txt, Transaction ID should be a random
-	value chosen by the client. */
+    static void prvInitialiseDHCP( void )
+    {
+        /* Initialise the parameters that will be set by the DHCP process. Per
+         * https://www.ietf.org/rfc/rfc2131.txt, Transaction ID should be a random
+         * value chosen by the client. */
 
-	/* Check for random number generator API failure. */
-	if( xApplicationGetRandomNumber( &( EP_DHCPData.ulTransactionId ) ) != pdFALSE )
-	{
-		EP_DHCPData.xUseBroadcast = 0;
-		EP_DHCPData.ulOfferedIPAddress = 0UL;
-		EP_DHCPData.ulDHCPServerAddress = 0UL;
-		EP_DHCPData.xDHCPTxPeriod = dhcpINITIAL_DHCP_TX_PERIOD;
+        /* Check for random number generator API failure. */
+        if( xApplicationGetRandomNumber( &( EP_DHCPData.ulTransactionId ) ) != pdFALSE )
+        {
+            EP_DHCPData.xUseBroadcast = 0;
+            EP_DHCPData.ulOfferedIPAddress = 0UL;
+            EP_DHCPData.ulDHCPServerAddress = 0UL;
+            EP_DHCPData.xDHCPTxPeriod = dhcpINITIAL_DHCP_TX_PERIOD;
 
-		/* Create the DHCP socket if it has not already been created. */
-		prvCreateDHCPSocket();
-		FreeRTOS_debug_printf( ( "prvInitialiseDHCP: start after %lu ticks\n", dhcpINITIAL_TIMER_PERIOD ) );
-		vIPReloadDHCPTimer( dhcpINITIAL_TIMER_PERIOD );
-	}
-	else
-	{
-		/* There was a problem with the randomiser. */
-	}
-}
+            /* Create the DHCP socket if it has not already been created. */
+            prvCreateDHCPSocket();
+            FreeRTOS_debug_printf( ( "prvInitialiseDHCP: start after %lu ticks\n", dhcpINITIAL_TIMER_PERIOD ) );
+            vIPReloadDHCPTimer( dhcpINITIAL_TIMER_PERIOD );
+        }
+        else
+        {
+            /* There was a problem with the randomiser. */
+        }
+    }
 /*-----------------------------------------------------------*/
 
-static BaseType_t prvProcessDHCPReplies( BaseType_t xExpectedMessageType )
-{
-uint8_t *pucUDPPayload;
-int32_t lBytes;
-const DHCPMessage_IPv4_t *pxDHCPMessage;
-const uint8_t *pucByte;
-uint8_t ucOptionCode;
-uint32_t ulProcessed, ulParameter;
-BaseType_t xReturn = pdFALSE;
-const uint32_t ulMandatoryOptions = 2UL; /* DHCP server address, and the correct DHCP message type must be present in the options. */
+    static BaseType_t prvProcessDHCPReplies( BaseType_t xExpectedMessageType )
+    {
+        uint8_t * pucUDPPayload;
+        int32_t lBytes;
+        const DHCPMessage_IPv4_t * pxDHCPMessage;
+        const uint8_t * pucByte;
+        uint8_t ucOptionCode;
+        uint32_t ulProcessed, ulParameter;
+        BaseType_t xReturn = pdFALSE;
+        const uint32_t ulMandatoryOptions = 2UL; /* DHCP server address, and the correct DHCP message type must be present in the options. */
 
-	/* Passing the address of a pointer (pucUDPPayload) because FREERTOS_ZERO_COPY is used. */
-	lBytes = FreeRTOS_recvfrom( xDHCPSocket, &pucUDPPayload, 0UL, FREERTOS_ZERO_COPY, NULL, NULL );
+        /* Passing the address of a pointer (pucUDPPayload) because FREERTOS_ZERO_COPY is used. */
+        lBytes = FreeRTOS_recvfrom( xDHCPSocket, &pucUDPPayload, 0UL, FREERTOS_ZERO_COPY, NULL, NULL );
 
-	if( lBytes > 0 )
-	{
-		/* Map a DHCP structure onto the received data. */
-		pxDHCPMessage = ipPOINTER_CAST( const DHCPMessage_IPv4_t *, pucUDPPayload );
+        if( lBytes > 0 )
+        {
+            /* Map a DHCP structure onto the received data. */
+            pxDHCPMessage = ipPOINTER_CAST( const DHCPMessage_IPv4_t *, pucUDPPayload );
 
-		/* Sanity check. */
-		if( lBytes < ( int32_t ) sizeof( DHCPMessage_IPv4_t ) )
-		{
-			/* Not enough bytes. */
-		}
-		else if( ( pxDHCPMessage->ulDHCPCookie != ( uint32_t ) dhcpCOOKIE ) ||
-			( pxDHCPMessage->ucOpcode != ( uint8_t ) dhcpREPLY_OPCODE ) )
-		{
-			/* Invalid cookie or unexpected opcode. */
-		}
-		else if( ( pxDHCPMessage->ulTransactionID != FreeRTOS_htonl( EP_DHCPData.ulTransactionId ) ) )
-		{
-			/* Transaction ID does not match. */
-		}
-		else /* Looks like a valid DHCP response, with the same transaction ID. */
-		{
-			if( memcmp( pxDHCPMessage->ucClientHardwareAddress,
-						ipLOCAL_MAC_ADDRESS,
-						sizeof( MACAddress_t ) ) != 0 )
-			{
-				/* Target MAC address doesn't match. */
-			}
-			else
-			{
-			size_t uxIndex, uxPayloadDataLength, uxLength;
+            /* Sanity check. */
+            if( lBytes < ( int32_t ) sizeof( DHCPMessage_IPv4_t ) )
+            {
+                /* Not enough bytes. */
+            }
+            else if( ( pxDHCPMessage->ulDHCPCookie != ( uint32_t ) dhcpCOOKIE ) ||
+                     ( pxDHCPMessage->ucOpcode != ( uint8_t ) dhcpREPLY_OPCODE ) )
+            {
+                /* Invalid cookie or unexpected opcode. */
+            }
+            else if( ( pxDHCPMessage->ulTransactionID != FreeRTOS_htonl( EP_DHCPData.ulTransactionId ) ) )
+            {
+                /* Transaction ID does not match. */
+            }
+            else /* Looks like a valid DHCP response, with the same transaction ID. */
+            {
+                if( memcmp( pxDHCPMessage->ucClientHardwareAddress,
+                            ipLOCAL_MAC_ADDRESS,
+                            sizeof( MACAddress_t ) ) != 0 )
+                {
+                    /* Target MAC address doesn't match. */
+                }
+                else
+                {
+                    size_t uxIndex, uxPayloadDataLength, uxLength;
 
-				/* None of the essential options have been processed yet. */
-				ulProcessed = 0UL;
+                    /* None of the essential options have been processed yet. */
+                    ulProcessed = 0UL;
 
-				/* Walk through the options until the dhcpOPTION_END_BYTE byte
-				is found, taking care not to walk off the end of the options. */
-				pucByte = &( pucUDPPayload[ sizeof( DHCPMessage_IPv4_t ) ] );
-				uxIndex = 0;
-				uxPayloadDataLength = ( ( size_t ) lBytes ) - sizeof( DHCPMessage_IPv4_t );
+                    /* Walk through the options until the dhcpOPTION_END_BYTE byte
+                     * is found, taking care not to walk off the end of the options. */
+                    pucByte = &( pucUDPPayload[ sizeof( DHCPMessage_IPv4_t ) ] );
+                    uxIndex = 0;
+                    uxPayloadDataLength = ( ( size_t ) lBytes ) - sizeof( DHCPMessage_IPv4_t );
 
-				while( uxIndex < uxPayloadDataLength )
-				{
-					ucOptionCode = pucByte[ uxIndex ];
-					if( ucOptionCode == ( uint8_t ) dhcpOPTION_END_BYTE )
-					{
-						/* Ready, the last byte has been seen. */
-						/* coverity[break_stmt] : Break statement terminating the loop */
-						break;
-					}
-					if( ucOptionCode == ( uint8_t ) dhcpIPv4_ZERO_PAD_OPTION_CODE )
-					{
-						/* The value zero is used as a pad byte,
-						it is not followed by a length byte. */
-						uxIndex = uxIndex + 1U;
-						continue;
-					}
+                    while( uxIndex < uxPayloadDataLength )
+                    {
+                        ucOptionCode = pucByte[ uxIndex ];
 
-					/* Stop if the response is malformed. */
-					if( ( uxIndex + 1U ) < uxPayloadDataLength )
-					{
-						/* Fetch the length byte. */
-						uxLength = ( size_t ) pucByte[ uxIndex + 1U ];
-						uxIndex = uxIndex + 2U;
+                        if( ucOptionCode == ( uint8_t ) dhcpOPTION_END_BYTE )
+                        {
+                            /* Ready, the last byte has been seen. */
+                            /* coverity[break_stmt] : Break statement terminating the loop */
+                            break;
+                        }
 
-						if( !( ( ( uxIndex + uxLength ) - 1U ) < uxPayloadDataLength ) )
-						{
-							/* There are not as many bytes left as there should be. */
-							break;
-						}
-					}
-					else
-					{
-						/* The length byte is missing. */
-						break;
-					}
+                        if( ucOptionCode == ( uint8_t ) dhcpIPv4_ZERO_PAD_OPTION_CODE )
+                        {
+                            /* The value zero is used as a pad byte,
+                             * it is not followed by a length byte. */
+                            uxIndex = uxIndex + 1U;
+                            continue;
+                        }
 
-					/* In most cases, a 4-byte network-endian parameter follows,
-					just get it once here and use later. */
-					if( uxLength >= sizeof( ulParameter ) )
-					{
-						( void ) memcpy( &( ulParameter ),
-										 &( pucByte[ uxIndex ] ),
-										 ( size_t ) sizeof( ulParameter ) );
-						/* 'uxIndex' will be increased at the end of this loop. */
-					}
-					else
-					{
-						ulParameter = 0;
-					}
+                        /* Stop if the response is malformed. */
+                        if( ( uxIndex + 1U ) < uxPayloadDataLength )
+                        {
+                            /* Fetch the length byte. */
+                            uxLength = ( size_t ) pucByte[ uxIndex + 1U ];
+                            uxIndex = uxIndex + 2U;
 
-					/* Confirm uxIndex is still a valid index after adjustments to uxIndex above */
-					if( !( uxIndex < uxPayloadDataLength ) )
-					{
-						break;
-					}
+                            if( !( ( ( uxIndex + uxLength ) - 1U ) < uxPayloadDataLength ) )
+                            {
+                                /* There are not as many bytes left as there should be. */
+                                break;
+                            }
+                        }
+                        else
+                        {
+                            /* The length byte is missing. */
+                            break;
+                        }
 
-					/* Option-specific handling. */
-					switch( ucOptionCode )
-					{
-						case dhcpIPv4_MESSAGE_TYPE_OPTION_CODE	:
+                        /* In most cases, a 4-byte network-endian parameter follows,
+                         * just get it once here and use later. */
+                        if( uxLength >= sizeof( ulParameter ) )
+                        {
+                            ( void ) memcpy( &( ulParameter ),
+                                             &( pucByte[ uxIndex ] ),
+                                             ( size_t ) sizeof( ulParameter ) );
+                            /* 'uxIndex' will be increased at the end of this loop. */
+                        }
+                        else
+                        {
+                            ulParameter = 0;
+                        }
 
-							if( pucByte[ uxIndex ] == ( uint8_t ) xExpectedMessageType )
-							{
-								/* The message type is the message type the
-								state machine is expecting. */
-								ulProcessed++;
-							}
-							else
-							{
-								if( pucByte[ uxIndex ] == ( uint8_t ) dhcpMESSAGE_TYPE_NACK )
-								{
-									if( xExpectedMessageType == ( BaseType_t ) dhcpMESSAGE_TYPE_ACK )
-									{
-										/* Start again. */
-										EP_DHCPData.eDHCPState = eWaitingSendFirstDiscover;
-									}
-								}
-								/* Stop processing further options. */
-								uxLength = 0;
-							}
-							break;
+                        /* Confirm uxIndex is still a valid index after adjustments to uxIndex above */
+                        if( !( uxIndex < uxPayloadDataLength ) )
+                        {
+                            break;
+                        }
 
-						case dhcpIPv4_SUBNET_MASK_OPTION_CODE :
+                        /* Option-specific handling. */
+                        switch( ucOptionCode )
+                        {
+                            case dhcpIPv4_MESSAGE_TYPE_OPTION_CODE:
 
-							if( uxLength == sizeof( uint32_t ) )
-							{
-								EP_IPv4_SETTINGS.ulNetMask = ulParameter;
-							}
-							break;
+                                if( pucByte[ uxIndex ] == ( uint8_t ) xExpectedMessageType )
+                                {
+                                    /* The message type is the message type the
+                                     * state machine is expecting. */
+                                    ulProcessed++;
+                                }
+                                else
+                                {
+                                    if( pucByte[ uxIndex ] == ( uint8_t ) dhcpMESSAGE_TYPE_NACK )
+                                    {
+                                        if( xExpectedMessageType == ( BaseType_t ) dhcpMESSAGE_TYPE_ACK )
+                                        {
+                                            /* Start again. */
+                                            EP_DHCPData.eDHCPState = eWaitingSendFirstDiscover;
+                                        }
+                                    }
 
-						case dhcpIPv4_GATEWAY_OPTION_CODE :
-							/* The DHCP server may send more than 1 gateway addresses. */
-							if( uxLength >= sizeof( uint32_t ) )
-							{
-								/* ulProcessed is not incremented in this case
-								because the gateway is not essential. */
-								EP_IPv4_SETTINGS.ulGatewayAddress = ulParameter;
-							}
-							break;
+                                    /* Stop processing further options. */
+                                    uxLength = 0;
+                                }
 
-						case dhcpIPv4_DNS_SERVER_OPTIONS_CODE :
+                                break;
 
-							/* ulProcessed is not incremented in this case
-							because the DNS server is not essential.  Only the
-							first DNS server address is taken. */
-							EP_IPv4_SETTINGS.ulDNSServerAddress = ulParameter;
-							break;
+                            case dhcpIPv4_SUBNET_MASK_OPTION_CODE:
 
-						case dhcpIPv4_SERVER_IP_ADDRESS_OPTION_CODE :
+                                if( uxLength == sizeof( uint32_t ) )
+                                {
+                                    EP_IPv4_SETTINGS.ulNetMask = ulParameter;
+                                }
 
-							if( uxLength == sizeof( uint32_t ) )
-							{
-								if( xExpectedMessageType == ( BaseType_t ) dhcpMESSAGE_TYPE_OFFER )
-								{
-									/* Offers state the replying server. */
-									ulProcessed++;
-									EP_DHCPData.ulDHCPServerAddress = ulParameter;
-								}
-								else
-								{
-									/* The ack must come from the expected server. */
-									if( EP_DHCPData.ulDHCPServerAddress == ulParameter )
-									{
-										ulProcessed++;
-									}
-								}
-							}
-							break;
+                                break;
 
-						case dhcpIPv4_LEASE_TIME_OPTION_CODE :
+                            case dhcpIPv4_GATEWAY_OPTION_CODE:
 
-							if( uxLength == sizeof( EP_DHCPData.ulLeaseTime ) )
-							{
-								/* ulProcessed is not incremented in this case
-								because the lease time is not essential. */
-								/* The DHCP parameter is in seconds, convert
-								to host-endian format. */
-								EP_DHCPData.ulLeaseTime = FreeRTOS_ntohl( ulParameter );
+                                /* The DHCP server may send more than 1 gateway addresses. */
+                                if( uxLength >= sizeof( uint32_t ) )
+                                {
+                                    /* ulProcessed is not incremented in this case
+                                     * because the gateway is not essential. */
+                                    EP_IPv4_SETTINGS.ulGatewayAddress = ulParameter;
+                                }
 
-								/* Divide the lease time by two to ensure a renew
-								request is sent before the lease actually expires. */
-								EP_DHCPData.ulLeaseTime >>= 1UL;
+                                break;
 
-								/* Multiply with configTICK_RATE_HZ to get clock ticks. */
-								EP_DHCPData.ulLeaseTime = ( uint32_t ) configTICK_RATE_HZ * ( uint32_t ) EP_DHCPData.ulLeaseTime;
-							}
-							break;
+                            case dhcpIPv4_DNS_SERVER_OPTIONS_CODE:
 
-						default :
+                                /* ulProcessed is not incremented in this case
+                                 * because the DNS server is not essential.  Only the
+                                 * first DNS server address is taken. */
+                                EP_IPv4_SETTINGS.ulDNSServerAddress = ulParameter;
+                                break;
 
-							/* Not interested in this field. */
+                            case dhcpIPv4_SERVER_IP_ADDRESS_OPTION_CODE:
 
-							break;
-					}
+                                if( uxLength == sizeof( uint32_t ) )
+                                {
+                                    if( xExpectedMessageType == ( BaseType_t ) dhcpMESSAGE_TYPE_OFFER )
+                                    {
+                                        /* Offers state the replying server. */
+                                        ulProcessed++;
+                                        EP_DHCPData.ulDHCPServerAddress = ulParameter;
+                                    }
+                                    else
+                                    {
+                                        /* The ack must come from the expected server. */
+                                        if( EP_DHCPData.ulDHCPServerAddress == ulParameter )
+                                        {
+                                            ulProcessed++;
+                                        }
+                                    }
+                                }
 
-					/* Jump over the data to find the next option code. */
-					if( uxLength == 0U )
-					{
-						break;
-					}
-					uxIndex = uxIndex + uxLength;
-				}
+                                break;
 
-				/* Were all the mandatory options received? */
-				if( ulProcessed >= ulMandatoryOptions )
-				{
-					/* HT:endian: used to be network order */
-					EP_DHCPData.ulOfferedIPAddress = pxDHCPMessage->ulYourIPAddress_yiaddr;
-					FreeRTOS_printf( ( "vDHCPProcess: offer %lxip\n", FreeRTOS_ntohl( EP_DHCPData.ulOfferedIPAddress ) ) );
-					xReturn = pdPASS;
-				}
-			}
-		}
+                            case dhcpIPv4_LEASE_TIME_OPTION_CODE:
 
-		FreeRTOS_ReleaseUDPPayloadBuffer( pucUDPPayload );
-	} /* if( lBytes > 0 ) */
+                                if( uxLength == sizeof( EP_DHCPData.ulLeaseTime ) )
+                                {
+                                    /* ulProcessed is not incremented in this case
+                                     * because the lease time is not essential. */
+                                    /* The DHCP parameter is in seconds, convert
+                                     * to host-endian format. */
+                                    EP_DHCPData.ulLeaseTime = FreeRTOS_ntohl( ulParameter );
 
-	return xReturn;
-}
+                                    /* Divide the lease time by two to ensure a renew
+                                     * request is sent before the lease actually expires. */
+                                    EP_DHCPData.ulLeaseTime >>= 1UL;
+
+                                    /* Multiply with configTICK_RATE_HZ to get clock ticks. */
+                                    EP_DHCPData.ulLeaseTime = ( uint32_t ) configTICK_RATE_HZ * ( uint32_t ) EP_DHCPData.ulLeaseTime;
+                                }
+
+                                break;
+
+                            default:
+
+                                /* Not interested in this field. */
+
+                                break;
+                        }
+
+                        /* Jump over the data to find the next option code. */
+                        if( uxLength == 0U )
+                        {
+                            break;
+                        }
+
+                        uxIndex = uxIndex + uxLength;
+                    }
+
+                    /* Were all the mandatory options received? */
+                    if( ulProcessed >= ulMandatoryOptions )
+                    {
+                        /* HT:endian: used to be network order */
+                        EP_DHCPData.ulOfferedIPAddress = pxDHCPMessage->ulYourIPAddress_yiaddr;
+                        FreeRTOS_printf( ( "vDHCPProcess: offer %lxip\n", FreeRTOS_ntohl( EP_DHCPData.ulOfferedIPAddress ) ) );
+                        xReturn = pdPASS;
+                    }
+                }
+            }
+
+            FreeRTOS_ReleaseUDPPayloadBuffer( pucUDPPayload );
+        } /* if( lBytes > 0 ) */
+
+        return xReturn;
+    }
 /*-----------------------------------------------------------*/
 
-static uint8_t *prvCreatePartDHCPMessage( struct freertos_sockaddr *pxAddress,
-										  BaseType_t xOpcode,
-										  const uint8_t * const pucOptionsArray,
-										  size_t *pxOptionsArraySize )
-{
-DHCPMessage_IPv4_t *pxDHCPMessage;
-size_t uxRequiredBufferSize = sizeof( DHCPMessage_IPv4_t ) + *pxOptionsArraySize;
-const NetworkBufferDescriptor_t *pxNetworkBuffer;
-uint8_t *pucUDPPayloadBuffer;
+    static uint8_t * prvCreatePartDHCPMessage( struct freertos_sockaddr * pxAddress,
+                                               BaseType_t xOpcode,
+                                               const uint8_t * const pucOptionsArray,
+                                               size_t * pxOptionsArraySize )
+    {
+        DHCPMessage_IPv4_t * pxDHCPMessage;
+        size_t uxRequiredBufferSize = sizeof( DHCPMessage_IPv4_t ) + *pxOptionsArraySize;
+        const NetworkBufferDescriptor_t * pxNetworkBuffer;
+        uint8_t * pucUDPPayloadBuffer;
 
-#if( ipconfigDHCP_REGISTER_HOSTNAME == 1 )
-	const char *pucHostName = pcApplicationHostnameHook ();
-	size_t uxNameLength = strlen( pucHostName );
-	uint8_t *pucPtr;
+        #if ( ipconfigDHCP_REGISTER_HOSTNAME == 1 )
+            const char * pucHostName = pcApplicationHostnameHook();
+            size_t uxNameLength = strlen( pucHostName );
+            uint8_t * pucPtr;
 
-	/* Two extra bytes for option code and length. */
-	uxRequiredBufferSize += ( 2U + uxNameLength );
-#endif
+            /* Two extra bytes for option code and length. */
+            uxRequiredBufferSize += ( 2U + uxNameLength );
+        #endif
 
-	/* Get a buffer.  This uses a maximum delay, but the delay will be capped
-	to ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS so the return value still needs to
-	be test. */
-	do
-	{
-		/* Obtain a network buffer with the required amount of storage. */
-		pxNetworkBuffer = pxGetNetworkBufferWithDescriptor( sizeof( UDPPacket_t ) + uxRequiredBufferSize, portMAX_DELAY );
-	} while( pxNetworkBuffer == NULL );
+        /* Get a buffer.  This uses a maximum delay, but the delay will be capped
+         * to ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS so the return value still needs to
+         * be test. */
+        do
+        {
+            /* Obtain a network buffer with the required amount of storage. */
+            pxNetworkBuffer = pxGetNetworkBufferWithDescriptor( sizeof( UDPPacket_t ) + uxRequiredBufferSize, portMAX_DELAY );
+        } while( pxNetworkBuffer == NULL );
 
-	/* Leave space for the UPD header. */
-	pucUDPPayloadBuffer = &( pxNetworkBuffer->pucEthernetBuffer[ ipUDP_PAYLOAD_OFFSET_IPv4 ] );
-	pxDHCPMessage = ipPOINTER_CAST( DHCPMessage_IPv4_t *, pucUDPPayloadBuffer );
+        /* Leave space for the UPD header. */
+        pucUDPPayloadBuffer = &( pxNetworkBuffer->pucEthernetBuffer[ ipUDP_PAYLOAD_OFFSET_IPv4 ] );
+        pxDHCPMessage = ipPOINTER_CAST( DHCPMessage_IPv4_t *, pucUDPPayloadBuffer );
 
-	/* Most fields need to be zero. */
-	( void ) memset( pxDHCPMessage, 0x00, sizeof( DHCPMessage_IPv4_t ) );
+        /* Most fields need to be zero. */
+        ( void ) memset( pxDHCPMessage, 0x00, sizeof( DHCPMessage_IPv4_t ) );
 
-	/* Create the message. */
-	pxDHCPMessage->ucOpcode = ( uint8_t ) xOpcode;
-	pxDHCPMessage->ucAddressType = ( uint8_t ) dhcpADDRESS_TYPE_ETHERNET;
-	pxDHCPMessage->ucAddressLength = ( uint8_t ) dhcpETHERNET_ADDRESS_LENGTH;
-	pxDHCPMessage->ulTransactionID = FreeRTOS_htonl( EP_DHCPData.ulTransactionId );
-	pxDHCPMessage->ulDHCPCookie = ( uint32_t ) dhcpCOOKIE;
-	if( EP_DHCPData.xUseBroadcast != pdFALSE )
-	{
-		pxDHCPMessage->usFlags = ( uint16_t ) dhcpBROADCAST;
-	}
-	else
-	{
-		pxDHCPMessage->usFlags = 0U;
-	}
+        /* Create the message. */
+        pxDHCPMessage->ucOpcode = ( uint8_t ) xOpcode;
+        pxDHCPMessage->ucAddressType = ( uint8_t ) dhcpADDRESS_TYPE_ETHERNET;
+        pxDHCPMessage->ucAddressLength = ( uint8_t ) dhcpETHERNET_ADDRESS_LENGTH;
+        pxDHCPMessage->ulTransactionID = FreeRTOS_htonl( EP_DHCPData.ulTransactionId );
+        pxDHCPMessage->ulDHCPCookie = ( uint32_t ) dhcpCOOKIE;
 
-	( void ) memcpy( &( pxDHCPMessage->ucClientHardwareAddress[ 0 ] ), ipLOCAL_MAC_ADDRESS, sizeof( MACAddress_t ) );
+        if( EP_DHCPData.xUseBroadcast != pdFALSE )
+        {
+            pxDHCPMessage->usFlags = ( uint16_t ) dhcpBROADCAST;
+        }
+        else
+        {
+            pxDHCPMessage->usFlags = 0U;
+        }
 
-	/* Copy in the const part of the options options. */
-	( void ) memcpy( &( pucUDPPayloadBuffer[ dhcpFIRST_OPTION_BYTE_OFFSET ] ), pucOptionsArray, *pxOptionsArraySize );
+        ( void ) memcpy( &( pxDHCPMessage->ucClientHardwareAddress[ 0 ] ), ipLOCAL_MAC_ADDRESS, sizeof( MACAddress_t ) );
 
-	#if( ipconfigDHCP_REGISTER_HOSTNAME == 1 )
-	{
-		/* With this option, the hostname can be registered as well which makes
-		it easier to lookup a device in a router's list of DHCP clients. */
+        /* Copy in the const part of the options options. */
+        ( void ) memcpy( &( pucUDPPayloadBuffer[ dhcpFIRST_OPTION_BYTE_OFFSET ] ), pucOptionsArray, *pxOptionsArraySize );
 
-		/* Point to where the OPTION_END was stored to add data. */
-		pucPtr = &( pucUDPPayloadBuffer[ dhcpFIRST_OPTION_BYTE_OFFSET + ( *pxOptionsArraySize - 1U ) ] );
-		pucPtr[ 0U ] = dhcpIPv4_DNS_HOSTNAME_OPTIONS_CODE;
-		pucPtr[ 1U ] = ( uint8_t ) uxNameLength;
-		( void ) memcpy( &( pucPtr[ 2U ] ), pucHostName, uxNameLength );
-		pucPtr[ 2U + uxNameLength ] = ( uint8_t ) dhcpOPTION_END_BYTE;
-		*pxOptionsArraySize += ( size_t ) ( 2U + uxNameLength );
-	}
-	#endif
+        #if ( ipconfigDHCP_REGISTER_HOSTNAME == 1 )
+            {
+                /* With this option, the hostname can be registered as well which makes
+                 * it easier to lookup a device in a router's list of DHCP clients. */
 
-	/* Map in the client identifier. */
-	( void ) memcpy( &( pucUDPPayloadBuffer[ dhcpFIRST_OPTION_BYTE_OFFSET + dhcpCLIENT_IDENTIFIER_OFFSET ] ),
-		ipLOCAL_MAC_ADDRESS, sizeof( MACAddress_t ) );
+                /* Point to where the OPTION_END was stored to add data. */
+                pucPtr = &( pucUDPPayloadBuffer[ dhcpFIRST_OPTION_BYTE_OFFSET + ( *pxOptionsArraySize - 1U ) ] );
+                pucPtr[ 0U ] = dhcpIPv4_DNS_HOSTNAME_OPTIONS_CODE;
+                pucPtr[ 1U ] = ( uint8_t ) uxNameLength;
+                ( void ) memcpy( &( pucPtr[ 2U ] ), pucHostName, uxNameLength );
+                pucPtr[ 2U + uxNameLength ] = ( uint8_t ) dhcpOPTION_END_BYTE;
+                *pxOptionsArraySize += ( size_t ) ( 2U + uxNameLength );
+            }
+        #endif /* if ( ipconfigDHCP_REGISTER_HOSTNAME == 1 ) */
 
-	/* Set the addressing. */
-	pxAddress->sin_addr = ipBROADCAST_IP_ADDRESS;
-	pxAddress->sin_port = ( uint16_t ) dhcpSERVER_PORT_IPv4;
+        /* Map in the client identifier. */
+        ( void ) memcpy( &( pucUDPPayloadBuffer[ dhcpFIRST_OPTION_BYTE_OFFSET + dhcpCLIENT_IDENTIFIER_OFFSET ] ),
+                         ipLOCAL_MAC_ADDRESS, sizeof( MACAddress_t ) );
 
-	return pucUDPPayloadBuffer;
-}
+        /* Set the addressing. */
+        pxAddress->sin_addr = ipBROADCAST_IP_ADDRESS;
+        pxAddress->sin_port = ( uint16_t ) dhcpSERVER_PORT_IPv4;
+
+        return pucUDPPayloadBuffer;
+    }
 /*-----------------------------------------------------------*/
 
-static void prvSendDHCPRequest( void )
-{
-uint8_t *pucUDPPayloadBuffer;
-struct freertos_sockaddr xAddress;
-static const uint8_t ucDHCPRequestOptions[] =
-{
-	/* Do not change the ordering without also changing
-	dhcpCLIENT_IDENTIFIER_OFFSET, dhcpREQUESTED_IP_ADDRESS_OFFSET and
-	dhcpDHCP_SERVER_IP_ADDRESS_OFFSET. */
-	dhcpIPv4_MESSAGE_TYPE_OPTION_CODE, 1, dhcpMESSAGE_TYPE_REQUEST,		/* Message type option. */
-	dhcpIPv4_CLIENT_IDENTIFIER_OPTION_CODE, 7, 1, 0, 0, 0, 0, 0, 0,		/* Client identifier. */
-	dhcpIPv4_REQUEST_IP_ADDRESS_OPTION_CODE, 4, 0, 0, 0, 0,				/* The IP address being requested. */
-	dhcpIPv4_SERVER_IP_ADDRESS_OPTION_CODE, 4, 0, 0, 0, 0,				/* The IP address of the DHCP server. */
-	dhcpOPTION_END_BYTE
-};
-size_t uxOptionsLength = sizeof( ucDHCPRequestOptions );
+    static void prvSendDHCPRequest( void )
+    {
+        uint8_t * pucUDPPayloadBuffer;
+        struct freertos_sockaddr xAddress;
+        static const uint8_t ucDHCPRequestOptions[] =
+        {
+            /* Do not change the ordering without also changing
+             * dhcpCLIENT_IDENTIFIER_OFFSET, dhcpREQUESTED_IP_ADDRESS_OFFSET and
+             * dhcpDHCP_SERVER_IP_ADDRESS_OFFSET. */
+            dhcpIPv4_MESSAGE_TYPE_OPTION_CODE,       1, dhcpMESSAGE_TYPE_REQUEST, /* Message type option. */
+            dhcpIPv4_CLIENT_IDENTIFIER_OPTION_CODE,  7, 1, 0, 0, 0, 0, 0, 0,      /* Client identifier. */
+            dhcpIPv4_REQUEST_IP_ADDRESS_OPTION_CODE, 4, 0, 0, 0, 0,               /* The IP address being requested. */
+            dhcpIPv4_SERVER_IP_ADDRESS_OPTION_CODE,  4, 0, 0, 0, 0,               /* The IP address of the DHCP server. */
+            dhcpOPTION_END_BYTE
+        };
+        size_t uxOptionsLength = sizeof( ucDHCPRequestOptions );
 
-	pucUDPPayloadBuffer = prvCreatePartDHCPMessage( &xAddress,
-													( BaseType_t ) dhcpREQUEST_OPCODE,
-													ucDHCPRequestOptions,
-													&( uxOptionsLength ) );
+        pucUDPPayloadBuffer = prvCreatePartDHCPMessage( &xAddress,
+                                                        ( BaseType_t ) dhcpREQUEST_OPCODE,
+                                                        ucDHCPRequestOptions,
+                                                        &( uxOptionsLength ) );
 
-	/* Copy in the IP address being requested. */
-	( void ) memcpy( &( pucUDPPayloadBuffer[ dhcpFIRST_OPTION_BYTE_OFFSET + dhcpREQUESTED_IP_ADDRESS_OFFSET ] ),
-					 &( EP_DHCPData.ulOfferedIPAddress ),
-					 sizeof( EP_DHCPData.ulOfferedIPAddress ) );
+        /* Copy in the IP address being requested. */
+        ( void ) memcpy( &( pucUDPPayloadBuffer[ dhcpFIRST_OPTION_BYTE_OFFSET + dhcpREQUESTED_IP_ADDRESS_OFFSET ] ),
+                         &( EP_DHCPData.ulOfferedIPAddress ),
+                         sizeof( EP_DHCPData.ulOfferedIPAddress ) );
 
-	/* Copy in the address of the DHCP server being used. */
-	( void ) memcpy( &( pucUDPPayloadBuffer[ dhcpFIRST_OPTION_BYTE_OFFSET + dhcpDHCP_SERVER_IP_ADDRESS_OFFSET ] ),
-					 &( EP_DHCPData.ulDHCPServerAddress ),
-					 sizeof( EP_DHCPData.ulDHCPServerAddress ) );
+        /* Copy in the address of the DHCP server being used. */
+        ( void ) memcpy( &( pucUDPPayloadBuffer[ dhcpFIRST_OPTION_BYTE_OFFSET + dhcpDHCP_SERVER_IP_ADDRESS_OFFSET ] ),
+                         &( EP_DHCPData.ulDHCPServerAddress ),
+                         sizeof( EP_DHCPData.ulDHCPServerAddress ) );
 
-	FreeRTOS_debug_printf( ( "vDHCPProcess: reply %lxip\n", FreeRTOS_ntohl( EP_DHCPData.ulOfferedIPAddress ) ) );
-	iptraceSENDING_DHCP_REQUEST();
+        FreeRTOS_debug_printf( ( "vDHCPProcess: reply %lxip\n", FreeRTOS_ntohl( EP_DHCPData.ulOfferedIPAddress ) ) );
+        iptraceSENDING_DHCP_REQUEST();
 
-	if( FreeRTOS_sendto( xDHCPSocket, pucUDPPayloadBuffer, sizeof( DHCPMessage_IPv4_t ) + uxOptionsLength, FREERTOS_ZERO_COPY, &xAddress, sizeof( xAddress ) ) == 0 )
-	{
-		/* The packet was not successfully queued for sending and must be
-		returned to the stack. */
-		FreeRTOS_ReleaseUDPPayloadBuffer( pucUDPPayloadBuffer );
-	}
-}
+        if( FreeRTOS_sendto( xDHCPSocket, pucUDPPayloadBuffer, sizeof( DHCPMessage_IPv4_t ) + uxOptionsLength, FREERTOS_ZERO_COPY, &xAddress, sizeof( xAddress ) ) == 0 )
+        {
+            /* The packet was not successfully queued for sending and must be
+             * returned to the stack. */
+            FreeRTOS_ReleaseUDPPayloadBuffer( pucUDPPayloadBuffer );
+        }
+    }
 /*-----------------------------------------------------------*/
 
-static void prvSendDHCPDiscover( void )
-{
-uint8_t const * pucUDPPayloadBuffer;
-struct freertos_sockaddr xAddress;
-static const uint8_t ucDHCPDiscoverOptions[] =
-{
-	/* Do not change the ordering without also changing dhcpCLIENT_IDENTIFIER_OFFSET. */
-	dhcpIPv4_MESSAGE_TYPE_OPTION_CODE, 1, dhcpMESSAGE_TYPE_DISCOVER,					/* Message type option. */
-	dhcpIPv4_CLIENT_IDENTIFIER_OPTION_CODE, 7, 1, 0, 0, 0, 0, 0, 0,						/* Client identifier. */
-	dhcpIPv4_PARAMETER_REQUEST_OPTION_CODE, 3, dhcpIPv4_SUBNET_MASK_OPTION_CODE, dhcpIPv4_GATEWAY_OPTION_CODE, dhcpIPv4_DNS_SERVER_OPTIONS_CODE,	/* Parameter request option. */
-	dhcpOPTION_END_BYTE
-};
-size_t uxOptionsLength = sizeof( ucDHCPDiscoverOptions );
+    static void prvSendDHCPDiscover( void )
+    {
+        uint8_t const * pucUDPPayloadBuffer;
+        struct freertos_sockaddr xAddress;
+        static const uint8_t ucDHCPDiscoverOptions[] =
+        {
+            /* Do not change the ordering without also changing dhcpCLIENT_IDENTIFIER_OFFSET. */
+            dhcpIPv4_MESSAGE_TYPE_OPTION_CODE,      1, dhcpMESSAGE_TYPE_DISCOVER,                                                                        /* Message type option. */
+            dhcpIPv4_CLIENT_IDENTIFIER_OPTION_CODE, 7, 1,                                0,                            0, 0, 0, 0, 0,                    /* Client identifier. */
+            dhcpIPv4_PARAMETER_REQUEST_OPTION_CODE, 3, dhcpIPv4_SUBNET_MASK_OPTION_CODE, dhcpIPv4_GATEWAY_OPTION_CODE, dhcpIPv4_DNS_SERVER_OPTIONS_CODE, /* Parameter request option. */
+            dhcpOPTION_END_BYTE
+        };
+        size_t uxOptionsLength = sizeof( ucDHCPDiscoverOptions );
 
-	pucUDPPayloadBuffer = prvCreatePartDHCPMessage( &xAddress,
-													( BaseType_t ) dhcpREQUEST_OPCODE,
-													ucDHCPDiscoverOptions,
-													&( uxOptionsLength ) );
+        pucUDPPayloadBuffer = prvCreatePartDHCPMessage( &xAddress,
+                                                        ( BaseType_t ) dhcpREQUEST_OPCODE,
+                                                        ucDHCPDiscoverOptions,
+                                                        &( uxOptionsLength ) );
 
-	FreeRTOS_debug_printf( ( "vDHCPProcess: discover\n" ) );
-	iptraceSENDING_DHCP_DISCOVER();
+        FreeRTOS_debug_printf( ( "vDHCPProcess: discover\n" ) );
+        iptraceSENDING_DHCP_DISCOVER();
 
-	if( FreeRTOS_sendto( xDHCPSocket,
-						 pucUDPPayloadBuffer,
-						 sizeof( DHCPMessage_IPv4_t ) + uxOptionsLength,
-						 FREERTOS_ZERO_COPY,
-						 &( xAddress ),
-						 sizeof( xAddress ) ) == 0 )
-	{
-		/* The packet was not successfully queued for sending and must be
-		returned to the stack. */
-		FreeRTOS_ReleaseUDPPayloadBuffer( pucUDPPayloadBuffer );
-	}
-}
+        if( FreeRTOS_sendto( xDHCPSocket,
+                             pucUDPPayloadBuffer,
+                             sizeof( DHCPMessage_IPv4_t ) + uxOptionsLength,
+                             FREERTOS_ZERO_COPY,
+                             &( xAddress ),
+                             sizeof( xAddress ) ) == 0 )
+        {
+            /* The packet was not successfully queued for sending and must be
+             * returned to the stack. */
+            FreeRTOS_ReleaseUDPPayloadBuffer( pucUDPPayloadBuffer );
+        }
+    }
 /*-----------------------------------------------------------*/
 
-#if( ipconfigDHCP_FALL_BACK_AUTO_IP != 0 )
+    #if ( ipconfigDHCP_FALL_BACK_AUTO_IP != 0 )
 
-	static void prvPrepareLinkLayerIPLookUp( void )
-	{
-	uint8_t ucLinkLayerIPAddress[ 2 ];
-	uint32_t ulNumbers[ 2 ];
+        static void prvPrepareLinkLayerIPLookUp( void )
+        {
+            uint8_t ucLinkLayerIPAddress[ 2 ];
+            uint32_t ulNumbers[ 2 ];
 
-		/* After DHCP has failed to answer, prepare everything to start
-		trying-out LinkLayer IP-addresses, using the random method. */
-		EP_DHCPData.xDHCPTxTime = xTaskGetTickCount();
+            /* After DHCP has failed to answer, prepare everything to start
+             * trying-out LinkLayer IP-addresses, using the random method. */
+            EP_DHCPData.xDHCPTxTime = xTaskGetTickCount();
 
-		xApplicationGetRandomNumber( &( ulNumbers[ 0 ] ) );
-		xApplicationGetRandomNumber( &( ulNumbers[ 1 ] ) );
-		ucLinkLayerIPAddress[ 0 ] = ( uint8_t )1 + ( uint8_t )( ulNumbers[ 0 ] % 0xFDU );		/* get value 1..254 for IP-address 3rd byte of IP address to try. */
-		ucLinkLayerIPAddress[ 1 ] = ( uint8_t )1 + ( uint8_t )( ulNumbers[ 1 ] % 0xFDU );		/* get value 1..254 for IP-address 4th byte of IP address to try. */
+            xApplicationGetRandomNumber( &( ulNumbers[ 0 ] ) );
+            xApplicationGetRandomNumber( &( ulNumbers[ 1 ] ) );
+            ucLinkLayerIPAddress[ 0 ] = ( uint8_t ) 1 + ( uint8_t ) ( ulNumbers[ 0 ] % 0xFDU ); /* get value 1..254 for IP-address 3rd byte of IP address to try. */
+            ucLinkLayerIPAddress[ 1 ] = ( uint8_t ) 1 + ( uint8_t ) ( ulNumbers[ 1 ] % 0xFDU ); /* get value 1..254 for IP-address 4th byte of IP address to try. */
 
-		EP_IPv4_SETTINGS.ulGatewayAddress = 0UL;
+            EP_IPv4_SETTINGS.ulGatewayAddress = 0UL;
 
-		/* prepare xDHCPData with data to test. */
-		EP_DHCPData.ulOfferedIPAddress =
-			FreeRTOS_inet_addr_quick( LINK_LAYER_ADDRESS_0, LINK_LAYER_ADDRESS_1, ucLinkLayerIPAddress[ 0 ], ucLinkLayerIPAddress[ 1 ] );
+            /* prepare xDHCPData with data to test. */
+            EP_DHCPData.ulOfferedIPAddress =
+                FreeRTOS_inet_addr_quick( LINK_LAYER_ADDRESS_0, LINK_LAYER_ADDRESS_1, ucLinkLayerIPAddress[ 0 ], ucLinkLayerIPAddress[ 1 ] );
 
-		EP_DHCPData.ulLeaseTime = dhcpDEFAULT_LEASE_TIME;	 /*  don't care about lease time. just put anything. */
+            EP_DHCPData.ulLeaseTime = dhcpDEFAULT_LEASE_TIME; /*  don't care about lease time. just put anything. */
 
-		EP_IPv4_SETTINGS.ulNetMask =
-			FreeRTOS_inet_addr_quick( LINK_LAYER_NETMASK_0, LINK_LAYER_NETMASK_1, LINK_LAYER_NETMASK_2, LINK_LAYER_NETMASK_3 );
+            EP_IPv4_SETTINGS.ulNetMask =
+                FreeRTOS_inet_addr_quick( LINK_LAYER_NETMASK_0, LINK_LAYER_NETMASK_1, LINK_LAYER_NETMASK_2, LINK_LAYER_NETMASK_3 );
 
-		/* DHCP completed.  The IP address can now be used, and the
-		timer set to the lease timeout time. */
-		*( ipLOCAL_IP_ADDRESS_POINTER ) = EP_DHCPData.ulOfferedIPAddress;
+            /* DHCP completed.  The IP address can now be used, and the
+             * timer set to the lease timeout time. */
+            *( ipLOCAL_IP_ADDRESS_POINTER ) = EP_DHCPData.ulOfferedIPAddress;
 
-		/* Setting the 'local' broadcast address, something like 192.168.1.255' */
-		EP_IPv4_SETTINGS.ulBroadcastAddress = ( EP_DHCPData.ulOfferedIPAddress & EP_IPv4_SETTINGS.ulNetMask ) |  ~EP_IPv4_SETTINGS.ulNetMask;
+            /* Setting the 'local' broadcast address, something like 192.168.1.255' */
+            EP_IPv4_SETTINGS.ulBroadcastAddress = ( EP_DHCPData.ulOfferedIPAddress & EP_IPv4_SETTINGS.ulNetMask ) | ~EP_IPv4_SETTINGS.ulNetMask;
 
-		/* Close socket to ensure packets don't queue on it. not needed anymore as DHCP failed. but still need timer for ARP testing. */
-		prvCloseDHCPSocket();
+            /* Close socket to ensure packets don't queue on it. not needed anymore as DHCP failed. but still need timer for ARP testing. */
+            prvCloseDHCPSocket();
 
-		xApplicationGetRandomNumber( &( ulNumbers[ 0 ] ) );
-		EP_DHCPData.xDHCPTxPeriod = pdMS_TO_TICKS( 3000UL + ( ulNumbers[ 0 ] & 0x3ffUL ) ); /*  do ARP test every (3 + 0-1024mS) seconds. */
+            xApplicationGetRandomNumber( &( ulNumbers[ 0 ] ) );
+            EP_DHCPData.xDHCPTxPeriod = pdMS_TO_TICKS( 3000UL + ( ulNumbers[ 0 ] & 0x3ffUL ) ); /*  do ARP test every (3 + 0-1024mS) seconds. */
 
-		xARPHadIPClash = pdFALSE;	   /* reset flag that shows if have ARP clash. */
-		vARPSendGratuitous();
-	}
+            xARPHadIPClash = pdFALSE;                                                           /* reset flag that shows if have ARP clash. */
+            vARPSendGratuitous();
+        }
 
-#endif /* ipconfigDHCP_FALL_BACK_AUTO_IP */
+    #endif /* ipconfigDHCP_FALL_BACK_AUTO_IP */
 /*-----------------------------------------------------------*/
 
 #endif /* ipconfigUSE_DHCP != 0 */

--- a/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/FreeRTOS_DNS.c
+++ b/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/FreeRTOS_DNS.c
@@ -43,1723 +43,1744 @@
 #include "NetworkInterface.h"
 
 /* Exclude the entire file if DNS is not enabled. */
-#if( ipconfigUSE_DNS != 0 )
+#if ( ipconfigUSE_DNS != 0 )
 
-#if( ipconfigBYTE_ORDER == pdFREERTOS_LITTLE_ENDIAN )
-	#define dnsDNS_PORT						0x3500U
-	#define dnsONE_QUESTION					0x0100U
-	#define dnsOUTGOING_FLAGS				0x0001U /* Standard query. */
-	#define dnsRX_FLAGS_MASK				0x0f80U /* The bits of interest in the flags field of incoming DNS messages. */
-	#define dnsEXPECTED_RX_FLAGS			0x0080U /* Should be a response, without any errors. */
-#else
-	#define dnsDNS_PORT						0x0035U
-	#define dnsONE_QUESTION					0x0001U
-	#define dnsOUTGOING_FLAGS				0x0100U /* Standard query. */
-	#define dnsRX_FLAGS_MASK				0x800fU /* The bits of interest in the flags field of incoming DNS messages. */
-	#define dnsEXPECTED_RX_FLAGS			0x8000U /* Should be a response, without any errors. */
+    #if ( ipconfigBYTE_ORDER == pdFREERTOS_LITTLE_ENDIAN )
+        #define dnsDNS_PORT             0x3500U
+        #define dnsONE_QUESTION         0x0100U
+        #define dnsOUTGOING_FLAGS       0x0001U     /* Standard query. */
+        #define dnsRX_FLAGS_MASK        0x0f80U     /* The bits of interest in the flags field of incoming DNS messages. */
+        #define dnsEXPECTED_RX_FLAGS    0x0080U     /* Should be a response, without any errors. */
+    #else
+        #define dnsDNS_PORT             0x0035U
+        #define dnsONE_QUESTION         0x0001U
+        #define dnsOUTGOING_FLAGS       0x0100U     /* Standard query. */
+        #define dnsRX_FLAGS_MASK        0x800fU     /* The bits of interest in the flags field of incoming DNS messages. */
+        #define dnsEXPECTED_RX_FLAGS    0x8000U     /* Should be a response, without any errors. */
 
-#endif /* ipconfigBYTE_ORDER */
+    #endif /* ipconfigBYTE_ORDER */
 
 /* The maximum number of times a DNS request should be sent out if a response
-is not received, before giving up. */
-#ifndef ipconfigDNS_REQUEST_ATTEMPTS
-	#define ipconfigDNS_REQUEST_ATTEMPTS		5
-#endif
+ * is not received, before giving up. */
+    #ifndef ipconfigDNS_REQUEST_ATTEMPTS
+        #define ipconfigDNS_REQUEST_ATTEMPTS    5
+    #endif
 
 /* If the top two bits in the first character of a name field are set then the
-name field is an offset to the string, rather than the string itself. */
-#define dnsNAME_IS_OFFSET					( ( uint8_t ) 0xc0 )
+ * name field is an offset to the string, rather than the string itself. */
+    #define dnsNAME_IS_OFFSET    ( ( uint8_t ) 0xc0 )
 
 /* NBNS flags. */
-#if( ipconfigUSE_NBNS == 1 )
-	#define dnsNBNS_FLAGS_RESPONSE				0x8000U
-	#define dnsNBNS_FLAGS_OPCODE_MASK			0x7800U
-	#define dnsNBNS_FLAGS_OPCODE_QUERY			0x0000U
-#endif	/* ( ipconfigUSE_NBNS == 1 ) */
+    #if ( ipconfigUSE_NBNS == 1 )
+        #define dnsNBNS_FLAGS_RESPONSE        0x8000U
+        #define dnsNBNS_FLAGS_OPCODE_MASK     0x7800U
+        #define dnsNBNS_FLAGS_OPCODE_QUERY    0x0000U
+    #endif /* ( ipconfigUSE_NBNS == 1 ) */
 
 /* Host types. */
-#define dnsTYPE_A_HOST							0x01U
-#define dnsCLASS_IN								0x01U
+    #define dnsTYPE_A_HOST    0x01U
+    #define dnsCLASS_IN       0x01U
 
-#ifndef _lint
-	/* LLMNR constants. */
-	#define dnsLLMNR_TTL_VALUE					300000UL
-	#define dnsLLMNR_FLAGS_IS_REPONSE			0x8000U
-#endif	/* _lint */
+    #ifndef _lint
+        /* LLMNR constants. */
+        #define dnsLLMNR_TTL_VALUE           300000UL
+        #define dnsLLMNR_FLAGS_IS_REPONSE    0x8000U
+    #endif /* _lint */
 
 /* NBNS constants. */
-#if( ipconfigUSE_NBNS != 0 )
-	#define dnsNBNS_TTL_VALUE					3600UL /* 1 hour valid */
-	#define dnsNBNS_TYPE_NET_BIOS				0x0020U
-	#define dnsNBNS_CLASS_IN					0x01U
-	#define dnsNBNS_NAME_FLAGS					0x6000U
-	#define dnsNBNS_ENCODED_NAME_LENGTH			32
+    #if ( ipconfigUSE_NBNS != 0 )
+        #define dnsNBNS_TTL_VALUE               3600UL /* 1 hour valid */
+        #define dnsNBNS_TYPE_NET_BIOS           0x0020U
+        #define dnsNBNS_CLASS_IN                0x01U
+        #define dnsNBNS_NAME_FLAGS              0x6000U
+        #define dnsNBNS_ENCODED_NAME_LENGTH     32
 
-	/* If the queried NBNS name matches with the device's name,
-	the query will be responded to with these flags: */
-	#define dnsNBNS_QUERY_RESPONSE_FLAGS		( 0x8500U )
-#endif	/* ( ipconfigUSE_NBNS != 0 ) */
+        /* If the queried NBNS name matches with the device's name,
+         * the query will be responded to with these flags: */
+        #define dnsNBNS_QUERY_RESPONSE_FLAGS    ( 0x8500U )
+    #endif /* ( ipconfigUSE_NBNS != 0 ) */
 
 /* Flag DNS parsing errors in situations where an IPv4 address is the return
-type. */
-#define dnsPARSE_ERROR							0UL
+ * type. */
+    #define dnsPARSE_ERROR    0UL
 
-#ifndef _lint
-	#if( ipconfigUSE_DNS_CACHE == 0 )
-		#if( ipconfigDNS_CACHE_ADDRESSES_PER_ENTRY != 1 )
-			#error When DNS caching is disabled, please make ipconfigDNS_CACHE_ADDRESSES_PER_ENTRY equal to 1.
-		#endif
-	#endif
-#endif
+    #ifndef _lint
+        #if ( ipconfigUSE_DNS_CACHE == 0 )
+            #if ( ipconfigDNS_CACHE_ADDRESSES_PER_ENTRY != 1 )
+                #error When DNS caching is disabled, please make ipconfigDNS_CACHE_ADDRESSES_PER_ENTRY equal to 1.
+            #endif
+        #endif
+    #endif
 
 /*
  * Create a socket and bind it to the standard DNS port number.  Return the
  * the created socket - or NULL if the socket could not be created or bound.
  */
-static Socket_t prvCreateDNSSocket( void );
+    static Socket_t prvCreateDNSSocket( void );
 
 /*
  * Create the DNS message in the zero copy buffer passed in the first parameter.
  */
-static size_t prvCreateDNSMessage( uint8_t *pucUDPPayloadBuffer,
-								   const char *pcHostName,
-								   TickType_t uxIdentifier );
+    static size_t prvCreateDNSMessage( uint8_t * pucUDPPayloadBuffer,
+                                       const char * pcHostName,
+                                       TickType_t uxIdentifier );
 
 /*
  * Simple routine that jumps over the NAME field of a resource record.
  * It returns the number of bytes read.
  */
-static size_t prvSkipNameField( const uint8_t *pucByte,
-								size_t uxLength );
+    static size_t prvSkipNameField( const uint8_t * pucByte,
+                                    size_t uxLength );
 
 /*
  * Process a response packet from a DNS server.
  * The parameter 'xExpected' indicates whether the identifier in the reply
  * was expected, and thus if the DNS cache may be updated with the reply.
  */
-static uint32_t prvParseDNSReply( uint8_t *pucUDPPayloadBuffer,
-								  size_t uxBufferLength,
-								  BaseType_t xExpected );
+    static uint32_t prvParseDNSReply( uint8_t * pucUDPPayloadBuffer,
+                                      size_t uxBufferLength,
+                                      BaseType_t xExpected );
 
 /*
  * Check if hostname is already known. If not, call prvGetHostByName() to send a DNS request.
  */
-#if( ipconfigDNS_USE_CALLBACKS == 1 )
-	static uint32_t prvPrepareLookup( const char *pcHostName,
-									  FOnDNSEvent pCallback,
-									  void *pvSearchID,
-									  TickType_t uxTimeout );
-#else
-	static uint32_t prvPrepareLookup( const char *pcHostName );
-#endif
+    #if ( ipconfigDNS_USE_CALLBACKS == 1 )
+        static uint32_t prvPrepareLookup( const char * pcHostName,
+                                          FOnDNSEvent pCallback,
+                                          void * pvSearchID,
+                                          TickType_t uxTimeout );
+    #else
+        static uint32_t prvPrepareLookup( const char * pcHostName );
+    #endif
 
 /*
  * Prepare and send a message to a DNS server.  'uxReadTimeOut_ticks' will be passed as
  * zero, in case the user has supplied a call-back function.
  */
-static uint32_t prvGetHostByName( const char *pcHostName,
-								  TickType_t uxIdentifier,
-								  TickType_t uxReadTimeOut_ticks );
+    static uint32_t prvGetHostByName( const char * pcHostName,
+                                      TickType_t uxIdentifier,
+                                      TickType_t uxReadTimeOut_ticks );
 
-#if( ipconfigDNS_USE_CALLBACKS != 0 )
-	static void vDNSSetCallBack( const char *pcHostName,
-								 void *pvSearchID,
-								 FOnDNSEvent pCallbackFunction,
-								 TickType_t uxTimeout,
-								 TickType_t uxIdentifier );
-#endif	/* ipconfigDNS_USE_CALLBACKS */
+    #if ( ipconfigDNS_USE_CALLBACKS != 0 )
+        static void vDNSSetCallBack( const char * pcHostName,
+                                     void * pvSearchID,
+                                     FOnDNSEvent pCallbackFunction,
+                                     TickType_t uxTimeout,
+                                     TickType_t uxIdentifier );
+    #endif /* ipconfigDNS_USE_CALLBACKS */
 
-#if( ipconfigDNS_USE_CALLBACKS != 0 )
-	static BaseType_t xDNSDoCallback( TickType_t uxIdentifier,
-									  const char *pcName,
-									  uint32_t ulIPAddress );
-#endif	/* ipconfigDNS_USE_CALLBACKS */
+    #if ( ipconfigDNS_USE_CALLBACKS != 0 )
+        static BaseType_t xDNSDoCallback( TickType_t uxIdentifier,
+                                          const char * pcName,
+                                          uint32_t ulIPAddress );
+    #endif /* ipconfigDNS_USE_CALLBACKS */
 
 /*
  * The NBNS and the LLMNR protocol share this reply function.
  */
-#if( ( ipconfigUSE_NBNS == 1 ) || ( ipconfigUSE_LLMNR == 1 ) )
-	static void prvReplyDNSMessage( NetworkBufferDescriptor_t *pxNetworkBuffer,
-									BaseType_t lNetLength );
-#endif
+    #if ( ( ipconfigUSE_NBNS == 1 ) || ( ipconfigUSE_LLMNR == 1 ) )
+        static void prvReplyDNSMessage( NetworkBufferDescriptor_t * pxNetworkBuffer,
+                                        BaseType_t lNetLength );
+    #endif
 
-#if( ipconfigUSE_NBNS == 1 )
-	static portINLINE void prvTreatNBNS( uint8_t *pucPayload,
-										 size_t uxBufferLength,
-										 uint32_t ulIPAddress );
-#endif /* ipconfigUSE_NBNS */
+    #if ( ipconfigUSE_NBNS == 1 )
+        static portINLINE void prvTreatNBNS( uint8_t * pucPayload,
+                                             size_t uxBufferLength,
+                                             uint32_t ulIPAddress );
+    #endif /* ipconfigUSE_NBNS */
 
 
-#if( ipconfigUSE_DNS_CACHE == 1 ) || ( ipconfigDNS_USE_CALLBACKS == 1 )
-	static size_t prvReadNameField( const uint8_t *pucByte,
-									size_t uxRemainingBytes,
-									char *pcName,
-									size_t uxDestLen );
-#endif	/* ipconfigUSE_DNS_CACHE || ipconfigDNS_USE_CALLBACKS */
+    #if ( ipconfigUSE_DNS_CACHE == 1 ) || ( ipconfigDNS_USE_CALLBACKS == 1 )
+        static size_t prvReadNameField( const uint8_t * pucByte,
+                                        size_t uxRemainingBytes,
+                                        char * pcName,
+                                        size_t uxDestLen );
+    #endif /* ipconfigUSE_DNS_CACHE || ipconfigDNS_USE_CALLBACKS */
 
-#if( ipconfigUSE_DNS_CACHE == 1 )
-	static BaseType_t prvProcessDNSCache( const char *pcName,
-										  uint32_t *pulIP,
-										  uint32_t ulTTL,
-										  BaseType_t xLookUp );
+    #if ( ipconfigUSE_DNS_CACHE == 1 )
+        static BaseType_t prvProcessDNSCache( const char * pcName,
+                                              uint32_t * pulIP,
+                                              uint32_t ulTTL,
+                                              BaseType_t xLookUp );
 
-	typedef struct xDNS_CACHE_TABLE_ROW
-	{
-		uint32_t ulIPAddresses[ ipconfigDNS_CACHE_ADDRESSES_PER_ENTRY ]; /* The IP address(es) of an ARP cache entry. */
-		char pcName[ ipconfigDNS_CACHE_NAME_LENGTH ]; /* The name of the host */
-		uint32_t ulTTL;                               /* Time-to-Live (in seconds) from the DNS server. */
-		uint32_t ulTimeWhenAddedInSeconds;
-#if( ipconfigDNS_CACHE_ADDRESSES_PER_ENTRY > 1 )
-		uint8_t  ucNumIPAddresses;
-		uint8_t  ucCurrentIPAddress;
-#endif
-	} DNSCacheRow_t;
+        typedef struct xDNS_CACHE_TABLE_ROW
+        {
+            uint32_t ulIPAddresses[ ipconfigDNS_CACHE_ADDRESSES_PER_ENTRY ]; /* The IP address(es) of an ARP cache entry. */
+            char pcName[ ipconfigDNS_CACHE_NAME_LENGTH ];                    /* The name of the host */
+            uint32_t ulTTL;                                                  /* Time-to-Live (in seconds) from the DNS server. */
+            uint32_t ulTimeWhenAddedInSeconds;
+            #if ( ipconfigDNS_CACHE_ADDRESSES_PER_ENTRY > 1 )
+                uint8_t ucNumIPAddresses;
+                uint8_t ucCurrentIPAddress;
+            #endif
+        } DNSCacheRow_t;
 
-	static DNSCacheRow_t xDNSCache[ ipconfigDNS_CACHE_ENTRIES ];
+        static DNSCacheRow_t xDNSCache[ ipconfigDNS_CACHE_ENTRIES ];
 
-	/* MISRA c 2012 rule 8.7: Below function may be used by 
-	external callees as well			        */
-	void FreeRTOS_dnsclear( void )
-	{
-		( void ) memset( xDNSCache, 0x0, sizeof( xDNSCache ) );
-	}
-#endif /* ipconfigUSE_DNS_CACHE == 1 */
+        /* MISRA c 2012 rule 8.7: Below function may be used by
+         * external callees as well			        */
+        void FreeRTOS_dnsclear( void )
+        {
+            ( void ) memset( xDNSCache, 0x0, sizeof( xDNSCache ) );
+        }
+    #endif /* ipconfigUSE_DNS_CACHE == 1 */
 
-#if( ipconfigUSE_LLMNR == 1 )
-	const MACAddress_t xLLMNR_MacAdress = { { 0x01, 0x00, 0x5e, 0x00, 0x00, 0xfc } };
-#endif /* ipconfigUSE_LLMNR == 1 */
+    #if ( ipconfigUSE_LLMNR == 1 )
+        const MACAddress_t xLLMNR_MacAdress = { { 0x01, 0x00, 0x5e, 0x00, 0x00, 0xfc } };
+    #endif /* ipconfigUSE_LLMNR == 1 */
 
 /*-----------------------------------------------------------*/
 
-/* Below #include just tells the compiler to pack the structure. 
+/* Below #include just tells the compiler to pack the structure.
  * It is included in to make the code more readable */
-#include "pack_struct_start.h"
-struct xDNSMessage
-{
-	uint16_t usIdentifier;
-	uint16_t usFlags;
-	uint16_t usQuestions;
-	uint16_t usAnswers;
-	uint16_t usAuthorityRRs;
-	uint16_t usAdditionalRRs;
-}
-#include "pack_struct_end.h"
-typedef struct xDNSMessage DNSMessage_t;
+    #include "pack_struct_start.h"
+    struct xDNSMessage
+    {
+        uint16_t usIdentifier;
+        uint16_t usFlags;
+        uint16_t usQuestions;
+        uint16_t usAnswers;
+        uint16_t usAuthorityRRs;
+        uint16_t usAdditionalRRs;
+    }
+    #include "pack_struct_end.h"
+    typedef struct xDNSMessage DNSMessage_t;
 
 /* A DNS query consists of a header, as described in 'struct xDNSMessage'
-It is followed by 1 or more queries, each one consisting of a name and a tail,
-with two fields: type and class
-*/
-#include "pack_struct_start.h"
-struct xDNSTail
-{
-	uint16_t usType;
-	uint16_t usClass;
-}
-#include "pack_struct_end.h"
-typedef struct xDNSTail DNSTail_t;
+ * It is followed by 1 or more queries, each one consisting of a name and a tail,
+ * with two fields: type and class
+ */
+    #include "pack_struct_start.h"
+    struct xDNSTail
+    {
+        uint16_t usType;
+        uint16_t usClass;
+    }
+    #include "pack_struct_end.h"
+    typedef struct xDNSTail DNSTail_t;
 
 /* DNS answer record header. */
-#include "pack_struct_start.h"
-struct xDNSAnswerRecord
-{
-	uint16_t usType;
-	uint16_t usClass;
-	uint32_t ulTTL;
-	uint16_t usDataLength;
-}
-#include "pack_struct_end.h"
-typedef struct xDNSAnswerRecord DNSAnswerRecord_t;
+    #include "pack_struct_start.h"
+    struct xDNSAnswerRecord
+    {
+        uint16_t usType;
+        uint16_t usClass;
+        uint32_t ulTTL;
+        uint16_t usDataLength;
+    }
+    #include "pack_struct_end.h"
+    typedef struct xDNSAnswerRecord DNSAnswerRecord_t;
 
-#if( ipconfigUSE_LLMNR == 1 )
+    #if ( ipconfigUSE_LLMNR == 1 )
 
-	#include "pack_struct_start.h"
-	struct xLLMNRAnswer
-	{
-		uint8_t ucNameCode;
-		uint8_t ucNameOffset;   /* The name is not repeated in the answer, only the offset is given with "0xc0 <offs>" */
-		uint16_t usType;
-		uint16_t usClass;
-		uint32_t ulTTL;
-		uint16_t usDataLength;
-		uint32_t ulIPAddress;
-	}
-	#include "pack_struct_end.h"
-	typedef struct xLLMNRAnswer LLMNRAnswer_t;
+        #include "pack_struct_start.h"
+        struct xLLMNRAnswer
+        {
+            uint8_t ucNameCode;
+            uint8_t ucNameOffset; /* The name is not repeated in the answer, only the offset is given with "0xc0 <offs>" */
+            uint16_t usType;
+            uint16_t usClass;
+            uint32_t ulTTL;
+            uint16_t usDataLength;
+            uint32_t ulIPAddress;
+        }
+        #include "pack_struct_end.h"
+        typedef struct xLLMNRAnswer LLMNRAnswer_t;
 
-#endif /* ipconfigUSE_LLMNR == 1 */
+    #endif /* ipconfigUSE_LLMNR == 1 */
 
-#if( ipconfigUSE_NBNS == 1 )
+    #if ( ipconfigUSE_NBNS == 1 )
 
-	#include "pack_struct_start.h"
-	struct xNBNSRequest
-	{
-		uint16_t usRequestId;
-		uint16_t usFlags;
-		uint16_t ulRequestCount;
-		uint16_t usAnswerRSS;
-		uint16_t usAuthRSS;
-		uint16_t usAdditionalRSS;
-		uint8_t ucNameSpace;
-		uint8_t ucName[ dnsNBNS_ENCODED_NAME_LENGTH ];
-		uint8_t ucNameZero;
-		uint16_t usType;
-		uint16_t usClass;
-	}
-	#include "pack_struct_end.h"
-	typedef struct xNBNSRequest NBNSRequest_t;
+        #include "pack_struct_start.h"
+        struct xNBNSRequest
+        {
+            uint16_t usRequestId;
+            uint16_t usFlags;
+            uint16_t ulRequestCount;
+            uint16_t usAnswerRSS;
+            uint16_t usAuthRSS;
+            uint16_t usAdditionalRSS;
+            uint8_t ucNameSpace;
+            uint8_t ucName[ dnsNBNS_ENCODED_NAME_LENGTH ];
+            uint8_t ucNameZero;
+            uint16_t usType;
+            uint16_t usClass;
+        }
+        #include "pack_struct_end.h"
+        typedef struct xNBNSRequest NBNSRequest_t;
 
-	#include "pack_struct_start.h"
-	struct xNBNSAnswer
-	{
-		uint16_t usType;
-		uint16_t usClass;
-		uint32_t ulTTL;
-		uint16_t usDataLength;
-		uint16_t usNbFlags;     /* NetBIOS flags 0x6000 : IP-address, big-endian */
-		uint32_t ulIPAddress;
-	}
-	#include "pack_struct_end.h"
-	typedef struct xNBNSAnswer NBNSAnswer_t;
+        #include "pack_struct_start.h"
+        struct xNBNSAnswer
+        {
+            uint16_t usType;
+            uint16_t usClass;
+            uint32_t ulTTL;
+            uint16_t usDataLength;
+            uint16_t usNbFlags; /* NetBIOS flags 0x6000 : IP-address, big-endian */
+            uint32_t ulIPAddress;
+        }
+        #include "pack_struct_end.h"
+        typedef struct xNBNSAnswer NBNSAnswer_t;
 
-	#endif /* ipconfigUSE_NBNS == 1 */
+    #endif /* ipconfigUSE_NBNS == 1 */
 
 /*-----------------------------------------------------------*/
 
-#if( ipconfigUSE_DNS_CACHE == 1 )
+    #if ( ipconfigUSE_DNS_CACHE == 1 )
 
-	/* MISRA c 2012 rule 8.7: Below function may be used by 
-	external callees as well			        */
-	uint32_t FreeRTOS_dnslookup( const char *pcHostName )
-	{
-	uint32_t ulIPAddress = 0UL;
+        /* MISRA c 2012 rule 8.7: Below function may be used by
+         * external callees as well			        */
+        uint32_t FreeRTOS_dnslookup( const char * pcHostName )
+        {
+            uint32_t ulIPAddress = 0UL;
 
-		( void ) prvProcessDNSCache( pcHostName, &ulIPAddress, 0, pdTRUE );
-		return ulIPAddress;
-	}
-#endif /* ipconfigUSE_DNS_CACHE == 1 */
+            ( void ) prvProcessDNSCache( pcHostName, &ulIPAddress, 0, pdTRUE );
+            return ulIPAddress;
+        }
+    #endif /* ipconfigUSE_DNS_CACHE == 1 */
 /*-----------------------------------------------------------*/
 
-#if( ipconfigDNS_USE_CALLBACKS == 1 )
+    #if ( ipconfigDNS_USE_CALLBACKS == 1 )
 
-	typedef struct xDNS_Callback
-	{
-		TickType_t uxRemaningTime;		/* Timeout in ms */
-		FOnDNSEvent pCallbackFunction;	/* Function to be called when the address has been found or when a timeout has beeen reached */
-		TimeOut_t uxTimeoutState;
-		void *pvSearchID;
-		struct xLIST_ITEM xListItem;
-		char pcName[ 1 ];
-	} DNSCallback_t;
+        typedef struct xDNS_Callback
+        {
+            TickType_t uxRemaningTime;     /* Timeout in ms */
+            FOnDNSEvent pCallbackFunction; /* Function to be called when the address has been found or when a timeout has beeen reached */
+            TimeOut_t uxTimeoutState;
+            void * pvSearchID;
+            struct xLIST_ITEM xListItem;
+            char pcName[ 1 ];
+        } DNSCallback_t;
 
-	static List_t xCallbackList;
+        static List_t xCallbackList;
 
-	/* Define FreeRTOS_gethostbyname() as a normal blocking call. */
-	uint32_t FreeRTOS_gethostbyname( const char *pcHostName )
-	{
-		return FreeRTOS_gethostbyname_a( pcHostName, NULL, ( void * ) NULL, 0 );
-	}
-	/*-----------------------------------------------------------*/
+        /* Define FreeRTOS_gethostbyname() as a normal blocking call. */
+        uint32_t FreeRTOS_gethostbyname( const char * pcHostName )
+        {
+            return FreeRTOS_gethostbyname_a( pcHostName, NULL, ( void * ) NULL, 0 );
+        }
+        /*-----------------------------------------------------------*/
 
-	/* Initialise the list of call-back structures. */
-	void vDNSInitialise( void )
-	{
-		vListInitialise( &xCallbackList );
-	}
-	/*-----------------------------------------------------------*/
+        /* Initialise the list of call-back structures. */
+        void vDNSInitialise( void )
+        {
+            vListInitialise( &xCallbackList );
+        }
+        /*-----------------------------------------------------------*/
 
-	/* Iterate through the list of call-back structures and remove
-	old entries which have reached a timeout.
-	As soon as the list hase become empty, the DNS timer will be stopped
-	In case pvSearchID is supplied, the user wants to cancel a DNS request
-	*/
-	void vDNSCheckCallBack( void *pvSearchID )
-	{
-	const ListItem_t * pxIterator;
-	const ListItem_t * xEnd = ipPOINTER_CAST( const ListItem_t *, listGET_END_MARKER( &xCallbackList ) );
+        /* Iterate through the list of call-back structures and remove
+         * old entries which have reached a timeout.
+         * As soon as the list hase become empty, the DNS timer will be stopped
+         * In case pvSearchID is supplied, the user wants to cancel a DNS request
+         */
+        void vDNSCheckCallBack( void * pvSearchID )
+        {
+            const ListItem_t * pxIterator;
+            const ListItem_t * xEnd = ipPOINTER_CAST( const ListItem_t *, listGET_END_MARKER( &xCallbackList ) );
 
-		vTaskSuspendAll();
-		{
-			for( pxIterator  = ( const ListItem_t * ) listGET_NEXT( xEnd );
-				 pxIterator != xEnd;
-				 )
-			{
-				DNSCallback_t *pxCallback = ipPOINTER_CAST( DNSCallback_t *, listGET_LIST_ITEM_OWNER( pxIterator ) );
-				/* Move to the next item because we might remove this item */
-				pxIterator = ( const ListItem_t * ) listGET_NEXT( pxIterator );
-				if( ( pvSearchID != NULL ) && ( pvSearchID == pxCallback->pvSearchID ) )
-				{
-					( void ) uxListRemove( &( pxCallback->xListItem ) );
-					vPortFree( pxCallback );
-				}
-				else if( xTaskCheckForTimeOut( &pxCallback->uxTimeoutState, &pxCallback->uxRemaningTime ) != pdFALSE )
-				{
-					pxCallback->pCallbackFunction( pxCallback->pcName, pxCallback->pvSearchID, 0 );
-					( void ) uxListRemove( &( pxCallback->xListItem ) );
-					vPortFree( pxCallback );
-				}
-				else
-				{
-					/* This call-back is still waiting for a reply or a time-out. */
-				}
-			}
-		}
-		( void ) xTaskResumeAll();
+            vTaskSuspendAll();
+            {
+                for( pxIterator = ( const ListItem_t * ) listGET_NEXT( xEnd );
+                     pxIterator != xEnd;
+                     )
+                {
+                    DNSCallback_t * pxCallback = ipPOINTER_CAST( DNSCallback_t *, listGET_LIST_ITEM_OWNER( pxIterator ) );
+                    /* Move to the next item because we might remove this item */
+                    pxIterator = ( const ListItem_t * ) listGET_NEXT( pxIterator );
 
-		if( listLIST_IS_EMPTY( &xCallbackList ) != pdFALSE )
-		{
-			vIPSetDnsTimerEnableState( pdFALSE );
-		}
-	}
-	/*-----------------------------------------------------------*/
+                    if( ( pvSearchID != NULL ) && ( pvSearchID == pxCallback->pvSearchID ) )
+                    {
+                        ( void ) uxListRemove( &( pxCallback->xListItem ) );
+                        vPortFree( pxCallback );
+                    }
+                    else if( xTaskCheckForTimeOut( &pxCallback->uxTimeoutState, &pxCallback->uxRemaningTime ) != pdFALSE )
+                    {
+                        pxCallback->pCallbackFunction( pxCallback->pcName, pxCallback->pvSearchID, 0 );
+                        ( void ) uxListRemove( &( pxCallback->xListItem ) );
+                        vPortFree( pxCallback );
+                    }
+                    else
+                    {
+                        /* This call-back is still waiting for a reply or a time-out. */
+                    }
+                }
+            }
+            ( void ) xTaskResumeAll();
 
-	void FreeRTOS_gethostbyname_cancel( void *pvSearchID )
-	{
-		/* _HT_ Should better become a new API call to have the IP-task remove the callback */
-		vDNSCheckCallBack( pvSearchID );
-	}
-	/*-----------------------------------------------------------*/
+            if( listLIST_IS_EMPTY( &xCallbackList ) != pdFALSE )
+            {
+                vIPSetDnsTimerEnableState( pdFALSE );
+            }
+        }
+        /*-----------------------------------------------------------*/
 
-	/* FreeRTOS_gethostbyname_a() was called along with callback parameters.
-	Store them in a list for later reference. */
-	static void vDNSSetCallBack( const char *pcHostName,
-								 void *pvSearchID,
-								 FOnDNSEvent pCallbackFunction,
-								 TickType_t uxTimeout,
-								 TickType_t uxIdentifier )
-	{
-	size_t lLength = strlen( pcHostName );
-	DNSCallback_t *pxCallback = ipPOINTER_CAST( DNSCallback_t *, pvPortMalloc( sizeof( *pxCallback ) + lLength ) );
+        void FreeRTOS_gethostbyname_cancel( void * pvSearchID )
+        {
+            /* _HT_ Should better become a new API call to have the IP-task remove the callback */
+            vDNSCheckCallBack( pvSearchID );
+        }
+        /*-----------------------------------------------------------*/
 
-		/* Translate from ms to number of clock ticks. */
-		uxTimeout /= portTICK_PERIOD_MS;
+        /* FreeRTOS_gethostbyname_a() was called along with callback parameters.
+         * Store them in a list for later reference. */
+        static void vDNSSetCallBack( const char * pcHostName,
+                                     void * pvSearchID,
+                                     FOnDNSEvent pCallbackFunction,
+                                     TickType_t uxTimeout,
+                                     TickType_t uxIdentifier )
+        {
+            size_t lLength = strlen( pcHostName );
+            DNSCallback_t * pxCallback = ipPOINTER_CAST( DNSCallback_t *, pvPortMalloc( sizeof( *pxCallback ) + lLength ) );
 
-		if( pxCallback != NULL )
-		{
-			if( listLIST_IS_EMPTY( &xCallbackList ) != pdFALSE )
-			{
-				/* This is the first one, start the DNS timer to check for timeouts */
-				vIPReloadDNSTimer( FreeRTOS_min_uint32( 1000U, uxTimeout ) );
-			}
+            /* Translate from ms to number of clock ticks. */
+            uxTimeout /= portTICK_PERIOD_MS;
 
-			( void ) strcpy( pxCallback->pcName, pcHostName );
-			pxCallback->pCallbackFunction = pCallbackFunction;
-			pxCallback->pvSearchID = pvSearchID;
-			pxCallback->uxRemaningTime = uxTimeout;
-			vTaskSetTimeOutState( &pxCallback->uxTimeoutState );
-			listSET_LIST_ITEM_OWNER( &( pxCallback->xListItem ), ipPOINTER_CAST( void *, pxCallback ) );
-			listSET_LIST_ITEM_VALUE( &( pxCallback->xListItem ), uxIdentifier );
-			vTaskSuspendAll();
-			{
-				vListInsertEnd( &xCallbackList, &pxCallback->xListItem );
-			}
-			( void ) xTaskResumeAll();
-		}
-	}
-	/*-----------------------------------------------------------*/
+            if( pxCallback != NULL )
+            {
+                if( listLIST_IS_EMPTY( &xCallbackList ) != pdFALSE )
+                {
+                    /* This is the first one, start the DNS timer to check for timeouts */
+                    vIPReloadDNSTimer( FreeRTOS_min_uint32( 1000U, uxTimeout ) );
+                }
 
-	/* A DNS reply was received, see if there is any matching entry and
-	call the handler.  Returns pdTRUE if uxIdentifier was recognised. */
-	static BaseType_t xDNSDoCallback( TickType_t uxIdentifier,
-									  const char *pcName,
-									  uint32_t ulIPAddress )
-	{
-	BaseType_t xResult = pdFALSE;
-	const ListItem_t * pxIterator;
-	const ListItem_t * xEnd = ipPOINTER_CAST( const ListItem_t *, listGET_END_MARKER( &xCallbackList ) );
+                ( void ) strcpy( pxCallback->pcName, pcHostName );
+                pxCallback->pCallbackFunction = pCallbackFunction;
+                pxCallback->pvSearchID = pvSearchID;
+                pxCallback->uxRemaningTime = uxTimeout;
+                vTaskSetTimeOutState( &pxCallback->uxTimeoutState );
+                listSET_LIST_ITEM_OWNER( &( pxCallback->xListItem ), ipPOINTER_CAST( void *, pxCallback ) );
+                listSET_LIST_ITEM_VALUE( &( pxCallback->xListItem ), uxIdentifier );
+                vTaskSuspendAll();
+                {
+                    vListInsertEnd( &xCallbackList, &pxCallback->xListItem );
+                }
+                ( void ) xTaskResumeAll();
+            }
+        }
+        /*-----------------------------------------------------------*/
 
-		vTaskSuspendAll();
-		{
-			for( pxIterator  = ( const ListItem_t * ) listGET_NEXT( xEnd );
-				 pxIterator != ( const ListItem_t * ) xEnd;
-				 pxIterator  = ( const ListItem_t * ) listGET_NEXT( pxIterator ) )
-			{
-				if( listGET_LIST_ITEM_VALUE( pxIterator ) == uxIdentifier )
-				{
-				DNSCallback_t *pxCallback = ipPOINTER_CAST( DNSCallback_t *, listGET_LIST_ITEM_OWNER( pxIterator ) );
+        /* A DNS reply was received, see if there is any matching entry and
+         * call the handler.  Returns pdTRUE if uxIdentifier was recognised. */
+        static BaseType_t xDNSDoCallback( TickType_t uxIdentifier,
+                                          const char * pcName,
+                                          uint32_t ulIPAddress )
+        {
+            BaseType_t xResult = pdFALSE;
+            const ListItem_t * pxIterator;
+            const ListItem_t * xEnd = ipPOINTER_CAST( const ListItem_t *, listGET_END_MARKER( &xCallbackList ) );
 
-					pxCallback->pCallbackFunction( pcName, pxCallback->pvSearchID, ulIPAddress );
-					( void ) uxListRemove( &pxCallback->xListItem );
-					vPortFree( pxCallback );
+            vTaskSuspendAll();
+            {
+                for( pxIterator = ( const ListItem_t * ) listGET_NEXT( xEnd );
+                     pxIterator != ( const ListItem_t * ) xEnd;
+                     pxIterator = ( const ListItem_t * ) listGET_NEXT( pxIterator ) )
+                {
+                    if( listGET_LIST_ITEM_VALUE( pxIterator ) == uxIdentifier )
+                    {
+                        DNSCallback_t * pxCallback = ipPOINTER_CAST( DNSCallback_t *, listGET_LIST_ITEM_OWNER( pxIterator ) );
 
-					if( listLIST_IS_EMPTY( &xCallbackList ) != pdFALSE )
-					{
-						/* The list of outstanding requests is empty. No need for periodic polling. */
-						vIPSetDnsTimerEnableState( pdFALSE );
-					}
+                        pxCallback->pCallbackFunction( pcName, pxCallback->pvSearchID, ulIPAddress );
+                        ( void ) uxListRemove( &pxCallback->xListItem );
+                        vPortFree( pxCallback );
 
-					xResult = pdTRUE;
-					break;
-				}
-			}
-		}
-		( void ) xTaskResumeAll();
-		return xResult;
-	}
+                        if( listLIST_IS_EMPTY( &xCallbackList ) != pdFALSE )
+                        {
+                            /* The list of outstanding requests is empty. No need for periodic polling. */
+                            vIPSetDnsTimerEnableState( pdFALSE );
+                        }
 
-#endif /* ipconfigDNS_USE_CALLBACKS == 1 */
+                        xResult = pdTRUE;
+                        break;
+                    }
+                }
+            }
+            ( void ) xTaskResumeAll();
+            return xResult;
+        }
+
+    #endif /* ipconfigDNS_USE_CALLBACKS == 1 */
 /*-----------------------------------------------------------*/
 
-#if( ipconfigDNS_USE_CALLBACKS == 0 )
-	/* MISRA c 2012 rule 8.7 ralxed since this function can
-	be called from external sources as well             */
-	uint32_t FreeRTOS_gethostbyname( const char *pcHostName )
-	{
-		return prvPrepareLookup( pcHostName );
-	}
-#else
-	uint32_t FreeRTOS_gethostbyname_a( const char *pcHostName,
-									   FOnDNSEvent pCallback,
-									   void *pvSearchID,
-									   TickType_t uxTimeout )
-	{
-		return prvPrepareLookup( pcHostName, pCallback, pvSearchID, uxTimeout );
-	}
-#endif
+    #if ( ipconfigDNS_USE_CALLBACKS == 0 )
 
-#if( ipconfigDNS_USE_CALLBACKS == 1 )
-	static uint32_t prvPrepareLookup( const char *pcHostName,
-									  FOnDNSEvent pCallback,
-									  void *pvSearchID,
-									  TickType_t uxTimeout )
-#else
-	static uint32_t prvPrepareLookup( const char *pcHostName )
-#endif
-{
-uint32_t ulIPAddress = 0UL;
-TickType_t uxReadTimeOut_ticks = ipconfigDNS_RECEIVE_BLOCK_TIME_TICKS;
+        /* MISRA c 2012 rule 8.7 ralxed since this function can
+         * be called from external sources as well             */
+        uint32_t FreeRTOS_gethostbyname( const char * pcHostName )
+        {
+            return prvPrepareLookup( pcHostName );
+        }
+    #else
+        uint32_t FreeRTOS_gethostbyname_a( const char * pcHostName,
+                                           FOnDNSEvent pCallback,
+                                           void * pvSearchID,
+                                           TickType_t uxTimeout )
+        {
+            return prvPrepareLookup( pcHostName, pCallback, pvSearchID, uxTimeout );
+        }
+    #endif /* if ( ipconfigDNS_USE_CALLBACKS == 0 ) */
+
+    #if ( ipconfigDNS_USE_CALLBACKS == 1 )
+        static uint32_t prvPrepareLookup( const char * pcHostName,
+                                          FOnDNSEvent pCallback,
+                                          void * pvSearchID,
+                                          TickType_t uxTimeout )
+    #else
+        static uint32_t prvPrepareLookup( const char * pcHostName )
+    #endif
+    {
+        uint32_t ulIPAddress = 0UL;
+        TickType_t uxReadTimeOut_ticks = ipconfigDNS_RECEIVE_BLOCK_TIME_TICKS;
+
 /* Generate a unique identifier for this query. Keep it in a local variable
- as gethostbyname() may be called from different threads */
-BaseType_t xHasRandom = pdFALSE;
-TickType_t uxIdentifier = 0U;
+ * as gethostbyname() may be called from different threads */
+        BaseType_t xHasRandom = pdFALSE;
+        TickType_t uxIdentifier = 0U;
 
-	if( pcHostName != NULL )
-	{
-		/* If the supplied hostname is IP address, convert it to uint32_t
-		and return. */
-		#if( ipconfigINCLUDE_FULL_INET_ADDR == 1 )
-		{
-			ulIPAddress = FreeRTOS_inet_addr( pcHostName );
-		}
-		#endif /* ipconfigINCLUDE_FULL_INET_ADDR == 1 */
+        if( pcHostName != NULL )
+        {
+            /* If the supplied hostname is IP address, convert it to uint32_t
+             * and return. */
+            #if ( ipconfigINCLUDE_FULL_INET_ADDR == 1 )
+                {
+                    ulIPAddress = FreeRTOS_inet_addr( pcHostName );
+                }
+            #endif /* ipconfigINCLUDE_FULL_INET_ADDR == 1 */
 
-		/* If a DNS cache is used then check the cache before issuing another DNS
-		request. */
-		#if( ipconfigUSE_DNS_CACHE == 1 )
-		{
-			if( ulIPAddress == 0UL )
-			{
-				ulIPAddress = FreeRTOS_dnslookup( pcHostName );
+            /* If a DNS cache is used then check the cache before issuing another DNS
+             * request. */
+            #if ( ipconfigUSE_DNS_CACHE == 1 )
+                {
+                    if( ulIPAddress == 0UL )
+                    {
+                        ulIPAddress = FreeRTOS_dnslookup( pcHostName );
 
-				if( ulIPAddress != 0UL )
-				{
-					FreeRTOS_debug_printf( ( "FreeRTOS_gethostbyname: found '%s' in cache: %lxip\n", pcHostName, ulIPAddress ) );
-				}
-				else
-				{
-					/* prvGetHostByName will be called to start a DNS lookup. */
-				}
-			}
-		}
-		#endif /* ipconfigUSE_DNS_CACHE == 1 */
+                        if( ulIPAddress != 0UL )
+                        {
+                            FreeRTOS_debug_printf( ( "FreeRTOS_gethostbyname: found '%s' in cache: %lxip\n", pcHostName, ulIPAddress ) );
+                        }
+                        else
+                        {
+                            /* prvGetHostByName will be called to start a DNS lookup. */
+                        }
+                    }
+                }
+            #endif /* ipconfigUSE_DNS_CACHE == 1 */
 
-		/* Generate a unique identifier. */
-		if( ulIPAddress == 0UL )
-		{
-		uint32_t ulNumber;
+            /* Generate a unique identifier. */
+            if( ulIPAddress == 0UL )
+            {
+                uint32_t ulNumber;
 
-			xHasRandom = xApplicationGetRandomNumber( &( ulNumber ) );
-			/* DNS identifiers are 16-bit. */
-			uxIdentifier = ( TickType_t ) ( ulNumber & 0xffffU );
-		}
+                xHasRandom = xApplicationGetRandomNumber( &( ulNumber ) );
+                /* DNS identifiers are 16-bit. */
+                uxIdentifier = ( TickType_t ) ( ulNumber & 0xffffU );
+            }
 
-		#if( ipconfigDNS_USE_CALLBACKS == 1 )
-		{
-			if( pCallback != NULL )
-			{
-				if( ulIPAddress == 0UL )
-				{
-					/* The user has provided a callback function, so do not block on recvfrom() */
-					if( xHasRandom != pdFALSE )
-					{
-						uxReadTimeOut_ticks = 0U;
-						vDNSSetCallBack( pcHostName, pvSearchID, pCallback, uxTimeout, uxIdentifier );
-					}
-				}
-				else
-				{
-					/* The IP address is known, do the call-back now. */
-					pCallback( pcHostName, pvSearchID, ulIPAddress );
-				}
-			}
-		}
-		#endif /* if ( ipconfigDNS_USE_CALLBACKS == 1 ) */
+            #if ( ipconfigDNS_USE_CALLBACKS == 1 )
+                {
+                    if( pCallback != NULL )
+                    {
+                        if( ulIPAddress == 0UL )
+                        {
+                            /* The user has provided a callback function, so do not block on recvfrom() */
+                            if( xHasRandom != pdFALSE )
+                            {
+                                uxReadTimeOut_ticks = 0U;
+                                vDNSSetCallBack( pcHostName, pvSearchID, pCallback, uxTimeout, uxIdentifier );
+                            }
+                        }
+                        else
+                        {
+                            /* The IP address is known, do the call-back now. */
+                            pCallback( pcHostName, pvSearchID, ulIPAddress );
+                        }
+                    }
+                }
+            #endif /* if ( ipconfigDNS_USE_CALLBACKS == 1 ) */
 
-		if( ( ulIPAddress == 0UL ) && ( xHasRandom != pdFALSE ) )
-		{
-			ulIPAddress = prvGetHostByName( pcHostName, uxIdentifier, uxReadTimeOut_ticks );
-		}
-	}
-	return ulIPAddress;
-}
+            if( ( ulIPAddress == 0UL ) && ( xHasRandom != pdFALSE ) )
+            {
+                ulIPAddress = prvGetHostByName( pcHostName, uxIdentifier, uxReadTimeOut_ticks );
+            }
+        }
+
+        return ulIPAddress;
+    }
 /*-----------------------------------------------------------*/
 
-static uint32_t prvGetHostByName( const char *pcHostName,
-								  TickType_t uxIdentifier,
-								  TickType_t uxReadTimeOut_ticks )
-{
-struct freertos_sockaddr xAddress;
-Socket_t xDNSSocket;
-uint32_t ulIPAddress = 0UL;
-uint32_t ulAddressLength = sizeof( struct freertos_sockaddr );
-BaseType_t xAttempt;
-int32_t lBytes;
-size_t uxPayloadLength, uxExpectedPayloadLength;
-TickType_t uxWriteTimeOut_ticks = ipconfigDNS_SEND_BLOCK_TIME_TICKS;
+    static uint32_t prvGetHostByName( const char * pcHostName,
+                                      TickType_t uxIdentifier,
+                                      TickType_t uxReadTimeOut_ticks )
+    {
+        struct freertos_sockaddr xAddress;
+        Socket_t xDNSSocket;
+        uint32_t ulIPAddress = 0UL;
+        uint32_t ulAddressLength = sizeof( struct freertos_sockaddr );
+        BaseType_t xAttempt;
+        int32_t lBytes;
+        size_t uxPayloadLength, uxExpectedPayloadLength;
+        TickType_t uxWriteTimeOut_ticks = ipconfigDNS_SEND_BLOCK_TIME_TICKS;
 
-#if( ipconfigUSE_LLMNR == 1 )
-	BaseType_t bHasDot = pdFALSE;
-#endif /* ipconfigUSE_LLMNR == 1 */
+        #if ( ipconfigUSE_LLMNR == 1 )
+            BaseType_t bHasDot = pdFALSE;
+        #endif /* ipconfigUSE_LLMNR == 1 */
 
-	/* If LLMNR is being used then determine if the host name includes a '.' -
-	if not then LLMNR can be used as the lookup method. */
-	#if( ipconfigUSE_LLMNR == 1 )
-	{
-	const char *pucPtr;
+        /* If LLMNR is being used then determine if the host name includes a '.' -
+         * if not then LLMNR can be used as the lookup method. */
+        #if ( ipconfigUSE_LLMNR == 1 )
+            {
+                const char * pucPtr;
 
-		for( pucPtr = pcHostName; *pucPtr != ( char ) 0; pucPtr++ )
-		{
-			if( *pucPtr == '.' )
-			{
-				bHasDot = pdTRUE;
-				break;
-			}
-		}
-	}
-	#endif /* ipconfigUSE_LLMNR == 1 */
+                for( pucPtr = pcHostName; *pucPtr != ( char ) 0; pucPtr++ )
+                {
+                    if( *pucPtr == '.' )
+                    {
+                        bHasDot = pdTRUE;
+                        break;
+                    }
+                }
+            }
+        #endif /* ipconfigUSE_LLMNR == 1 */
 
-	/* Two is added at the end for the count of characters in the first
-	subdomain part and the string end byte. */
-	uxExpectedPayloadLength = sizeof( DNSMessage_t ) + strlen( pcHostName ) + sizeof( uint16_t ) + sizeof( uint16_t ) + 2U;
+        /* Two is added at the end for the count of characters in the first
+         * subdomain part and the string end byte. */
+        uxExpectedPayloadLength = sizeof( DNSMessage_t ) + strlen( pcHostName ) + sizeof( uint16_t ) + sizeof( uint16_t ) + 2U;
 
-	xDNSSocket = prvCreateDNSSocket();
+        xDNSSocket = prvCreateDNSSocket();
 
-	if( xDNSSocket != NULL )
-	{
-		/* Ideally we should check for the return value. But since we are passing
-		correect parameters, and xDNSSocket is != NULL, the return value is 
-		going to be '0' i.e. success. Thus, return value is discarded */
-		( void ) FreeRTOS_setsockopt( xDNSSocket, 0, FREERTOS_SO_SNDTIMEO, &( uxWriteTimeOut_ticks ), sizeof( TickType_t ) );
-		( void ) FreeRTOS_setsockopt( xDNSSocket, 0, FREERTOS_SO_RCVTIMEO, &( uxReadTimeOut_ticks ),  sizeof( TickType_t ) );
+        if( xDNSSocket != NULL )
+        {
+            /* Ideally we should check for the return value. But since we are passing
+             * correect parameters, and xDNSSocket is != NULL, the return value is
+             * going to be '0' i.e. success. Thus, return value is discarded */
+            ( void ) FreeRTOS_setsockopt( xDNSSocket, 0, FREERTOS_SO_SNDTIMEO, &( uxWriteTimeOut_ticks ), sizeof( TickType_t ) );
+            ( void ) FreeRTOS_setsockopt( xDNSSocket, 0, FREERTOS_SO_RCVTIMEO, &( uxReadTimeOut_ticks ), sizeof( TickType_t ) );
 
-		for( xAttempt = 0; xAttempt < ipconfigDNS_REQUEST_ATTEMPTS; xAttempt++ )
-		{
-		size_t uxHeaderBytes;
-		NetworkBufferDescriptor_t *pxNetworkBuffer;
-		uint8_t *pucUDPPayloadBuffer = NULL, *pucReceiveBuffer;
+            for( xAttempt = 0; xAttempt < ipconfigDNS_REQUEST_ATTEMPTS; xAttempt++ )
+            {
+                size_t uxHeaderBytes;
+                NetworkBufferDescriptor_t * pxNetworkBuffer;
+                uint8_t * pucUDPPayloadBuffer = NULL, * pucReceiveBuffer;
 
-			/* Get a buffer.  This uses a maximum delay, but the delay will be
-			capped to ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS so the return value
-			still needs to be tested. */
+                /* Get a buffer.  This uses a maximum delay, but the delay will be
+                 * capped to ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS so the return value
+                 * still needs to be tested. */
 
-			uxHeaderBytes = ipSIZE_OF_ETH_HEADER + ipSIZE_OF_IPv4_HEADER + ipSIZE_OF_UDP_HEADER;
+                uxHeaderBytes = ipSIZE_OF_ETH_HEADER + ipSIZE_OF_IPv4_HEADER + ipSIZE_OF_UDP_HEADER;
 
-			pxNetworkBuffer = pxGetNetworkBufferWithDescriptor( uxHeaderBytes + uxExpectedPayloadLength, 0UL );
-			if( pxNetworkBuffer != NULL )
-			{
-				pucUDPPayloadBuffer = &( pxNetworkBuffer->pucEthernetBuffer[ uxHeaderBytes ] );
-			}
+                pxNetworkBuffer = pxGetNetworkBufferWithDescriptor( uxHeaderBytes + uxExpectedPayloadLength, 0UL );
 
-			if( pucUDPPayloadBuffer != NULL )
-			{
-				/* Create the message in the obtained buffer. */
-				uxPayloadLength = prvCreateDNSMessage( pucUDPPayloadBuffer, pcHostName, uxIdentifier );
+                if( pxNetworkBuffer != NULL )
+                {
+                    pucUDPPayloadBuffer = &( pxNetworkBuffer->pucEthernetBuffer[ uxHeaderBytes ] );
+                }
 
-				iptraceSENDING_DNS_REQUEST();
+                if( pucUDPPayloadBuffer != NULL )
+                {
+                    /* Create the message in the obtained buffer. */
+                    uxPayloadLength = prvCreateDNSMessage( pucUDPPayloadBuffer, pcHostName, uxIdentifier );
 
-				/* Obtain the DNS server address. */
-				FreeRTOS_GetAddressConfiguration( NULL, NULL, NULL, &ulIPAddress );
+                    iptraceSENDING_DNS_REQUEST();
 
-				/* Send the DNS message. */
-#if( ipconfigUSE_LLMNR == 1 )
-				if( bHasDot == pdFALSE )
-				{
-					/* Use LLMNR addressing. */
-					( ipPOINTER_CAST( DNSMessage_t *, pucUDPPayloadBuffer ) )->usFlags = 0;
-					xAddress.sin_addr = ipLLMNR_IP_ADDR; /* Is in network byte order. */
-					xAddress.sin_port = ipLLMNR_PORT;
-					xAddress.sin_port = FreeRTOS_ntohs( xAddress.sin_port );
-				}
-				else
-#endif
-				{
-					/* Use DNS server. */
-					xAddress.sin_addr = ulIPAddress;
-					xAddress.sin_port = dnsDNS_PORT;
-				}
+                    /* Obtain the DNS server address. */
+                    FreeRTOS_GetAddressConfiguration( NULL, NULL, NULL, &ulIPAddress );
 
-				ulIPAddress = 0UL;
+                    /* Send the DNS message. */
+                    #if ( ipconfigUSE_LLMNR == 1 )
+                        if( bHasDot == pdFALSE )
+                        {
+                            /* Use LLMNR addressing. */
+                            ( ipPOINTER_CAST( DNSMessage_t *, pucUDPPayloadBuffer ) )->usFlags = 0;
+                            xAddress.sin_addr = ipLLMNR_IP_ADDR; /* Is in network byte order. */
+                            xAddress.sin_port = ipLLMNR_PORT;
+                            xAddress.sin_port = FreeRTOS_ntohs( xAddress.sin_port );
+                        }
+                        else
+                    #endif
+                    {
+                        /* Use DNS server. */
+                        xAddress.sin_addr = ulIPAddress;
+                        xAddress.sin_port = dnsDNS_PORT;
+                    }
 
-				if( FreeRTOS_sendto( xDNSSocket, pucUDPPayloadBuffer, uxPayloadLength, FREERTOS_ZERO_COPY, &xAddress, sizeof( xAddress ) ) != 0 )
-				{
-					/* Wait for the reply. */
-					lBytes = FreeRTOS_recvfrom( xDNSSocket, &pucReceiveBuffer, 0, FREERTOS_ZERO_COPY, &xAddress, &ulAddressLength );
+                    ulIPAddress = 0UL;
 
-					if( lBytes > 0 )
-					{
-					BaseType_t xExpected;
-					const DNSMessage_t *pxDNSMessageHeader = ipPOINTER_CAST( DNSMessage_t *, pucReceiveBuffer );
+                    if( FreeRTOS_sendto( xDNSSocket, pucUDPPayloadBuffer, uxPayloadLength, FREERTOS_ZERO_COPY, &xAddress, sizeof( xAddress ) ) != 0 )
+                    {
+                        /* Wait for the reply. */
+                        lBytes = FreeRTOS_recvfrom( xDNSSocket, &pucReceiveBuffer, 0, FREERTOS_ZERO_COPY, &xAddress, &ulAddressLength );
 
-						/* See if the identifiers match. */
-						if( uxIdentifier == ( TickType_t ) pxDNSMessageHeader->usIdentifier )
-						{
-							xExpected = pdTRUE;
-						}
-						else
-						{
-							/* The reply was not expected. */
-							xExpected = pdFALSE;
-						}
+                        if( lBytes > 0 )
+                        {
+                            BaseType_t xExpected;
+                            const DNSMessage_t * pxDNSMessageHeader = ipPOINTER_CAST( DNSMessage_t *, pucReceiveBuffer );
 
-						/* The reply was received.  Process it. */
-					#if( ipconfigDNS_USE_CALLBACKS == 0 )
-						/* It is useless to analyse the unexpected reply
-						unless asynchronous look-ups are enabled. */
-						if( xExpected != pdFALSE )
-					#endif /* ipconfigDNS_USE_CALLBACKS == 0 */
-						{
-							ulIPAddress = prvParseDNSReply( pucReceiveBuffer, ( size_t ) lBytes, xExpected );
-						}
+                            /* See if the identifiers match. */
+                            if( uxIdentifier == ( TickType_t ) pxDNSMessageHeader->usIdentifier )
+                            {
+                                xExpected = pdTRUE;
+                            }
+                            else
+                            {
+                                /* The reply was not expected. */
+                                xExpected = pdFALSE;
+                            }
 
-						/* Finished with the buffer.  The zero copy interface
-						is being used, so the buffer must be freed by the
-						task. */
-						FreeRTOS_ReleaseUDPPayloadBuffer( pucReceiveBuffer );
+                            /* The reply was received.  Process it. */
+                            #if ( ipconfigDNS_USE_CALLBACKS == 0 )
+                                /* It is useless to analyse the unexpected reply
+                                 * unless asynchronous look-ups are enabled. */
+                                if( xExpected != pdFALSE )
+                            #endif /* ipconfigDNS_USE_CALLBACKS == 0 */
+                            {
+                                ulIPAddress = prvParseDNSReply( pucReceiveBuffer, ( size_t ) lBytes, xExpected );
+                            }
 
-						if( ulIPAddress != 0UL )
-						{
-							/* All done. */
-							/* coverity[break_stmt] : Break statement terminating the loop */
-							break;
-						}
-					}
-				}
-				else
-				{
-					/* The message was not sent so the stack will not be
-					releasing the zero copy - it must be released here. */
-					vReleaseNetworkBufferAndDescriptor( pxNetworkBuffer );
-				}
-			}
+                            /* Finished with the buffer.  The zero copy interface
+                             * is being used, so the buffer must be freed by the
+                             * task. */
+                            FreeRTOS_ReleaseUDPPayloadBuffer( pucReceiveBuffer );
 
-			if( uxReadTimeOut_ticks == 0U )
-			{
-				/* This DNS lookup is asynchronous, using a call-back:
-				send the request only once. */
-				break;
-			}
-		}
+                            if( ulIPAddress != 0UL )
+                            {
+                                /* All done. */
+                                /* coverity[break_stmt] : Break statement terminating the loop */
+                                break;
+                            }
+                        }
+                    }
+                    else
+                    {
+                        /* The message was not sent so the stack will not be
+                         * releasing the zero copy - it must be released here. */
+                        vReleaseNetworkBufferAndDescriptor( pxNetworkBuffer );
+                    }
+                }
 
-		/* Finished with the socket. */
-		( void ) FreeRTOS_closesocket( xDNSSocket );
-	}
+                if( uxReadTimeOut_ticks == 0U )
+                {
+                    /* This DNS lookup is asynchronous, using a call-back:
+                     * send the request only once. */
+                    break;
+                }
+            }
 
-	return ulIPAddress;
-}
+            /* Finished with the socket. */
+            ( void ) FreeRTOS_closesocket( xDNSSocket );
+        }
+
+        return ulIPAddress;
+    }
 /*-----------------------------------------------------------*/
 
-static size_t prvCreateDNSMessage( uint8_t *pucUDPPayloadBuffer,
-								   const char *pcHostName,
-								   TickType_t uxIdentifier )
-{
-DNSMessage_t *pxDNSMessageHeader;
-uint8_t *pucStart, *pucByte;
-DNSTail_t const * pxTail;
-static const DNSMessage_t xDefaultPartDNSHeader =
-{
-	0,                 /* The identifier will be overwritten. */
-	dnsOUTGOING_FLAGS, /* Flags set for standard query. */
-	dnsONE_QUESTION,   /* One question is being asked. */
-	0,                 /* No replies are included. */
-	0,                 /* No authorities. */
-	0                  /* No additional authorities. */
-};
+    static size_t prvCreateDNSMessage( uint8_t * pucUDPPayloadBuffer,
+                                       const char * pcHostName,
+                                       TickType_t uxIdentifier )
+    {
+        DNSMessage_t * pxDNSMessageHeader;
+        uint8_t * pucStart, * pucByte;
+        DNSTail_t const * pxTail;
+        static const DNSMessage_t xDefaultPartDNSHeader =
+        {
+            0,                 /* The identifier will be overwritten. */
+            dnsOUTGOING_FLAGS, /* Flags set for standard query. */
+            dnsONE_QUESTION,   /* One question is being asked. */
+            0,                 /* No replies are included. */
+            0,                 /* No authorities. */
+            0                  /* No additional authorities. */
+        };
 
-	/* Copy in the const part of the header. */
-	( void ) memcpy( pucUDPPayloadBuffer, &( xDefaultPartDNSHeader ), sizeof( xDefaultPartDNSHeader ) );
+        /* Copy in the const part of the header. */
+        ( void ) memcpy( pucUDPPayloadBuffer, &( xDefaultPartDNSHeader ), sizeof( xDefaultPartDNSHeader ) );
 
-	/* Write in a unique identifier. */
-	pxDNSMessageHeader = ipPOINTER_CAST( DNSMessage_t *, pucUDPPayloadBuffer );
-	pxDNSMessageHeader->usIdentifier = ( uint16_t ) uxIdentifier;
+        /* Write in a unique identifier. */
+        pxDNSMessageHeader = ipPOINTER_CAST( DNSMessage_t *, pucUDPPayloadBuffer );
+        pxDNSMessageHeader->usIdentifier = ( uint16_t ) uxIdentifier;
 
-	/* Create the resource record at the end of the header.  First
-	find the end of the header. */
-	pucStart = &( pucUDPPayloadBuffer[ sizeof( xDefaultPartDNSHeader ) ] );
+        /* Create the resource record at the end of the header.  First
+         * find the end of the header. */
+        pucStart = &( pucUDPPayloadBuffer[ sizeof( xDefaultPartDNSHeader ) ] );
 
-	/* Leave a gap for the first length bytes. */
-	pucByte = &( pucStart[ 1 ] );
+        /* Leave a gap for the first length bytes. */
+        pucByte = &( pucStart[ 1 ] );
 
-	/* Copy in the host name. */
-	( void ) strcpy( ( char * ) pucByte, pcHostName );
+        /* Copy in the host name. */
+        ( void ) strcpy( ( char * ) pucByte, pcHostName );
 
-	/* Mark the end of the string. */
-	pucByte = &( pucByte[ strlen( pcHostName ) ] );
-	*pucByte = 0x00U;
+        /* Mark the end of the string. */
+        pucByte = &( pucByte[ strlen( pcHostName ) ] );
+        *pucByte = 0x00U;
 
-	/* Walk the string to replace the '.' characters with byte counts.
-	pucStart holds the address of the byte count.  Walking the string
-	starts after the byte count position. */
-	pucByte = pucStart;
+        /* Walk the string to replace the '.' characters with byte counts.
+         * pucStart holds the address of the byte count.  Walking the string
+         * starts after the byte count position. */
+        pucByte = pucStart;
 
-	do
-	{
-		pucByte++;
+        do
+        {
+            pucByte++;
 
-		/* MISRA c 2012 rule 10.4 relaxed for increased readability.
-		Not writing 46U instead of '.' */
-		while( ( *pucByte != ( uint8_t ) 0U ) && ( *pucByte != ( uint8_t ) '.' ) )
-		{
-			pucByte++;
-		}
+            /* MISRA c 2012 rule 10.4 relaxed for increased readability.
+             * Not writing 46U instead of '.' */
+            while( ( *pucByte != ( uint8_t ) 0U ) && ( *pucByte != ( uint8_t ) '.' ) )
+            {
+                pucByte++;
+            }
 
-		/* Fill in the byte count, then move the pucStart pointer up to
-		the found byte position. */
-		*pucStart = ( uint8_t ) ( ( uint32_t ) pucByte - ( uint32_t ) pucStart );
-		( *pucStart )--;
+            /* Fill in the byte count, then move the pucStart pointer up to
+             * the found byte position. */
+            *pucStart = ( uint8_t ) ( ( uint32_t ) pucByte - ( uint32_t ) pucStart );
+            ( *pucStart )--;
 
-		pucStart = pucByte;
-	} while( *pucByte != ( uint8_t ) 0U );
+            pucStart = pucByte;
+        } while( *pucByte != ( uint8_t ) 0U );
 
-	/* Finish off the record. */
-	pxTail = ipPOINTER_CAST(DNSTail_t *, &( pucByte[ 1 ] ) );
+        /* Finish off the record. */
+        pxTail = ipPOINTER_CAST( DNSTail_t *, &( pucByte[ 1 ] ) );
 
-	#if defined( _lint ) || defined( __COVERITY__ )
-	( void ) pxTail;
-	#else
-	vSetField16( pxTail, DNSTail_t, usType, dnsTYPE_A_HOST );
-	vSetField16( pxTail, DNSTail_t, usClass, dnsCLASS_IN );
-	#endif
+        #if defined( _lint ) || defined( __COVERITY__ )
+            ( void ) pxTail;
+        #else
+            vSetField16( pxTail, DNSTail_t, usType, dnsTYPE_A_HOST );
+            vSetField16( pxTail, DNSTail_t, usClass, dnsCLASS_IN );
+        #endif
 
-	/* Return the total size of the generated message, which is the space from
-	the last written byte to the beginning of the buffer. */
-	return ( ( uint32_t ) pucByte - ( uint32_t ) pucUDPPayloadBuffer + 1U ) + sizeof( DNSTail_t );
-}
+        /* Return the total size of the generated message, which is the space from
+         * the last written byte to the beginning of the buffer. */
+        return ( ( uint32_t ) pucByte - ( uint32_t ) pucUDPPayloadBuffer + 1U ) + sizeof( DNSTail_t );
+    }
 /*-----------------------------------------------------------*/
 
-#if( ipconfigUSE_DNS_CACHE == 1 ) || ( ipconfigDNS_USE_CALLBACKS == 1 )
+    #if ( ipconfigUSE_DNS_CACHE == 1 ) || ( ipconfigDNS_USE_CALLBACKS == 1 )
 
-	static size_t prvReadNameField( const uint8_t *pucByte,
-									size_t uxRemainingBytes,
-									char *pcName,
-									size_t uxDestLen )
-	{
-	size_t uxNameLen = 0U;
-	size_t uxIndex = 0U;
-	size_t uxSourceLen = uxRemainingBytes;
+        static size_t prvReadNameField( const uint8_t * pucByte,
+                                        size_t uxRemainingBytes,
+                                        char * pcName,
+                                        size_t uxDestLen )
+        {
+            size_t uxNameLen = 0U;
+            size_t uxIndex = 0U;
+            size_t uxSourceLen = uxRemainingBytes;
 
-	/* uxCount gets the valus from pucByte and counts down to 0.
-	No need to have a different type than that of pucByte */
-	size_t uxCount;  
+            /* uxCount gets the valus from pucByte and counts down to 0.
+             * No need to have a different type than that of pucByte */
+            size_t uxCount;
 
-		if( uxSourceLen == ( size_t ) 0U )
-		{
-			/* Return 0 value in case of error. */
-			uxIndex = 0U;
-		}
-		/* Determine if the name is the fully coded name, or an offset to the name
-		elsewhere in the message. */
-		else if( ( pucByte[ uxIndex ] & dnsNAME_IS_OFFSET ) == dnsNAME_IS_OFFSET )
-		{
-			/* Jump over the two byte offset. */
-			if( uxSourceLen > sizeof( uint16_t ) )
-			{
-				uxIndex += sizeof( uint16_t );
-			}
-			else
-			{
-				uxIndex = 0U;
-			}
-		}
-		else
-		{
-			/* 'uxIndex' points to the full name. Walk over the string. */
-			while( ( uxIndex < uxSourceLen ) && ( pucByte[ uxIndex ] != ( uint8_t )0x00U ) )
-			{
-				/* If this is not the first time through the loop, then add a
-				separator in the output. */
-				if( ( uxNameLen > 0U ) )
-				{
-					if( uxNameLen >= uxDestLen )
-					{
-						uxIndex = 0U;
-						/* coverity[break_stmt] : Break statement terminating the loop */
-						break;
-					}
-					pcName[ uxNameLen ] = '.';
-					uxNameLen++;
-				}
+            if( uxSourceLen == ( size_t ) 0U )
+            {
+                /* Return 0 value in case of error. */
+                uxIndex = 0U;
+            }
 
-				/* Process the first/next sub-string. */
-				uxCount = ( size_t ) pucByte[ uxIndex ];
-				uxIndex++;
-				if( ( uxIndex + uxCount ) > uxSourceLen )
-				{
-					uxIndex = 0U;
-					break;
-				}
+            /* Determine if the name is the fully coded name, or an offset to the name
+             * elsewhere in the message. */
+            else if( ( pucByte[ uxIndex ] & dnsNAME_IS_OFFSET ) == dnsNAME_IS_OFFSET )
+            {
+                /* Jump over the two byte offset. */
+                if( uxSourceLen > sizeof( uint16_t ) )
+                {
+                    uxIndex += sizeof( uint16_t );
+                }
+                else
+                {
+                    uxIndex = 0U;
+                }
+            }
+            else
+            {
+                /* 'uxIndex' points to the full name. Walk over the string. */
+                while( ( uxIndex < uxSourceLen ) && ( pucByte[ uxIndex ] != ( uint8_t ) 0x00U ) )
+                {
+                    /* If this is not the first time through the loop, then add a
+                     * separator in the output. */
+                    if( ( uxNameLen > 0U ) )
+                    {
+                        if( uxNameLen >= uxDestLen )
+                        {
+                            uxIndex = 0U;
+                            /* coverity[break_stmt] : Break statement terminating the loop */
+                            break;
+                        }
 
-				while( ( uxCount-- != 0U ) && ( uxIndex < uxSourceLen ) )
-				{
-					if( uxNameLen >= uxDestLen )
-					{
-						uxIndex = 0U;
-						break;
-						/* break out of inner loop here
-						break out of outer loop at the test uxNameLen >= uxDestLen. */
-					}
-					pcName[ uxNameLen ] = ( char ) pucByte[ uxIndex ];
-					uxNameLen++;
-					uxIndex++;
-				}
-			}
+                        pcName[ uxNameLen ] = '.';
+                        uxNameLen++;
+                    }
 
-			/* Confirm that a fully formed name was found. */
-			if( uxIndex > 0U )
-			{
-				if( ( uxNameLen < uxDestLen ) && ( uxIndex < uxSourceLen ) && ( pucByte[ uxIndex ] == 0U ) )
-				{
-					pcName[ uxNameLen ] = '\0';
-					uxIndex++;
-				}
-				else
-				{
-					uxIndex = 0U;
-				}
-			}
-		}
+                    /* Process the first/next sub-string. */
+                    uxCount = ( size_t ) pucByte[ uxIndex ];
+                    uxIndex++;
 
-		return uxIndex;
-	}
-#endif	/* ipconfigUSE_DNS_CACHE || ipconfigDNS_USE_CALLBACKS */
+                    if( ( uxIndex + uxCount ) > uxSourceLen )
+                    {
+                        uxIndex = 0U;
+                        break;
+                    }
+
+                    while( ( uxCount-- != 0U ) && ( uxIndex < uxSourceLen ) )
+                    {
+                        if( uxNameLen >= uxDestLen )
+                        {
+                            uxIndex = 0U;
+                            break;
+
+                            /* break out of inner loop here
+                             * break out of outer loop at the test uxNameLen >= uxDestLen. */
+                        }
+
+                        pcName[ uxNameLen ] = ( char ) pucByte[ uxIndex ];
+                        uxNameLen++;
+                        uxIndex++;
+                    }
+                }
+
+                /* Confirm that a fully formed name was found. */
+                if( uxIndex > 0U )
+                {
+                    if( ( uxNameLen < uxDestLen ) && ( uxIndex < uxSourceLen ) && ( pucByte[ uxIndex ] == 0U ) )
+                    {
+                        pcName[ uxNameLen ] = '\0';
+                        uxIndex++;
+                    }
+                    else
+                    {
+                        uxIndex = 0U;
+                    }
+                }
+            }
+
+            return uxIndex;
+        }
+    #endif /* ipconfigUSE_DNS_CACHE || ipconfigDNS_USE_CALLBACKS */
 /*-----------------------------------------------------------*/
 
-static size_t prvSkipNameField( const uint8_t *pucByte,
-								size_t uxLength )
-{
-size_t uxChunkLength;
-size_t uxSourceLenCpy = uxLength;
-size_t uxIndex = 0U;
+    static size_t prvSkipNameField( const uint8_t * pucByte,
+                                    size_t uxLength )
+    {
+        size_t uxChunkLength;
+        size_t uxSourceLenCpy = uxLength;
+        size_t uxIndex = 0U;
 
-	if( uxSourceLenCpy == 0U )
-	{
-		uxIndex = 0U;
-	}
-	/* Determine if the name is the fully coded name, or an offset to the name
-	elsewhere in the message. */
-	else if( ( pucByte[ uxIndex ] & dnsNAME_IS_OFFSET ) == dnsNAME_IS_OFFSET )
-	{
-		/* Jump over the two byte offset. */
-		if( uxSourceLenCpy > sizeof( uint16_t ) )
-		{
-			uxIndex += sizeof( uint16_t );
-		}
-		else
-		{
-			uxIndex = 0U;
-		}
-	}
-	else
-	{
-		/* pucByte points to the full name. Walk over the string. */
-		while( ( pucByte[ uxIndex ] != 0U ) && ( uxSourceLenCpy > 1U ) )
-		{
-			/* Conversion to size_t causes addition to be done
-			in size_t */
-			uxChunkLength = ( ( size_t ) pucByte[ uxIndex ] ) + 1U;
+        if( uxSourceLenCpy == 0U )
+        {
+            uxIndex = 0U;
+        }
 
-			if( uxSourceLenCpy > uxChunkLength )
-			{
-				uxSourceLenCpy -= uxChunkLength;
-				uxIndex += uxChunkLength;
-			}
-			else
-			{
-				uxIndex = 0U;
-				break;
-			}
-		}
+        /* Determine if the name is the fully coded name, or an offset to the name
+         * elsewhere in the message. */
+        else if( ( pucByte[ uxIndex ] & dnsNAME_IS_OFFSET ) == dnsNAME_IS_OFFSET )
+        {
+            /* Jump over the two byte offset. */
+            if( uxSourceLenCpy > sizeof( uint16_t ) )
+            {
+                uxIndex += sizeof( uint16_t );
+            }
+            else
+            {
+                uxIndex = 0U;
+            }
+        }
+        else
+        {
+            /* pucByte points to the full name. Walk over the string. */
+            while( ( pucByte[ uxIndex ] != 0U ) && ( uxSourceLenCpy > 1U ) )
+            {
+                /* Conversion to size_t causes addition to be done
+                 * in size_t */
+                uxChunkLength = ( ( size_t ) pucByte[ uxIndex ] ) + 1U;
 
-		/* Confirm that a fully formed name was found. */
-		if( uxIndex > 0U )
-		{
-			if( pucByte[ uxIndex ] == 0U )
-			{
-				uxIndex++;
-			}
-			else
-			{
-				uxIndex = 0U;
-			}
-		}
-	}
+                if( uxSourceLenCpy > uxChunkLength )
+                {
+                    uxSourceLenCpy -= uxChunkLength;
+                    uxIndex += uxChunkLength;
+                }
+                else
+                {
+                    uxIndex = 0U;
+                    break;
+                }
+            }
 
-	return uxIndex;
-}
+            /* Confirm that a fully formed name was found. */
+            if( uxIndex > 0U )
+            {
+                if( pucByte[ uxIndex ] == 0U )
+                {
+                    uxIndex++;
+                }
+                else
+                {
+                    uxIndex = 0U;
+                }
+            }
+        }
+
+        return uxIndex;
+    }
 /*-----------------------------------------------------------*/
 
 /* The function below will only be called :
-when ipconfigDNS_USE_CALLBACKS == 1
-when ipconfigUSE_LLMNR == 1
-for testing purposes, by the module iot_test_freertos_tcp.c
-*/
+ * when ipconfigDNS_USE_CALLBACKS == 1
+ * when ipconfigUSE_LLMNR == 1
+ * for testing purposes, by the module iot_test_freertos_tcp.c
+ */
 
 /* MISRA c 2012 rule 8.7: Function below may be used by external
-callees as well. */
-uint32_t ulDNSHandlePacket( const NetworkBufferDescriptor_t *pxNetworkBuffer )
-{
-DNSMessage_t *pxDNSMessageHeader;
-size_t uxPayloadSize;
+ * callees as well. */
+    uint32_t ulDNSHandlePacket( const NetworkBufferDescriptor_t * pxNetworkBuffer )
+    {
+        DNSMessage_t * pxDNSMessageHeader;
+        size_t uxPayloadSize;
 
-	/* Only proceed if the payload length indicated in the header
-	appears to be valid. */
-	if( pxNetworkBuffer->xDataLength >= sizeof( UDPPacket_t ) )
-	{
-		uxPayloadSize = pxNetworkBuffer->xDataLength - sizeof( UDPPacket_t );
+        /* Only proceed if the payload length indicated in the header
+         * appears to be valid. */
+        if( pxNetworkBuffer->xDataLength >= sizeof( UDPPacket_t ) )
+        {
+            uxPayloadSize = pxNetworkBuffer->xDataLength - sizeof( UDPPacket_t );
 
-		if( uxPayloadSize >= sizeof( DNSMessage_t ) )
-		{
-			pxDNSMessageHeader =
-				ipPOINTER_CAST( DNSMessage_t *, &( pxNetworkBuffer->pucEthernetBuffer [ sizeof( UDPPacket_t ) ] ) );
+            if( uxPayloadSize >= sizeof( DNSMessage_t ) )
+            {
+                pxDNSMessageHeader =
+                    ipPOINTER_CAST( DNSMessage_t *, &( pxNetworkBuffer->pucEthernetBuffer[ sizeof( UDPPacket_t ) ] ) );
 
-			/* The parameter pdFALSE indicates that the reply was not expected. */
-			( void ) prvParseDNSReply( ( uint8_t * ) pxDNSMessageHeader,
-				uxPayloadSize,
-				pdFALSE );
-		}
-	}
+                /* The parameter pdFALSE indicates that the reply was not expected. */
+                ( void ) prvParseDNSReply( ( uint8_t * ) pxDNSMessageHeader,
+                                           uxPayloadSize,
+                                           pdFALSE );
+            }
+        }
 
-	/* The packet was not consumed. */
-	return pdFAIL;
-}
+        /* The packet was not consumed. */
+        return pdFAIL;
+    }
 /*-----------------------------------------------------------*/
 
-#if( ipconfigUSE_NBNS == 1 )
+    #if ( ipconfigUSE_NBNS == 1 )
 
-	uint32_t ulNBNSHandlePacket( NetworkBufferDescriptor_t * pxNetworkBuffer )
-	{
-	UDPPacket_t *pxUDPPacket = ipPOINTER_CAST( UDPPacket_t *, pxNetworkBuffer->pucEthernetBuffer );
-	uint8_t *pucUDPPayloadBuffer = &( pxNetworkBuffer->pucEthernetBuffer[ sizeof( *pxUDPPacket ) ] );
+        uint32_t ulNBNSHandlePacket( NetworkBufferDescriptor_t * pxNetworkBuffer )
+        {
+            UDPPacket_t * pxUDPPacket = ipPOINTER_CAST( UDPPacket_t *, pxNetworkBuffer->pucEthernetBuffer );
+            uint8_t * pucUDPPayloadBuffer = &( pxNetworkBuffer->pucEthernetBuffer[ sizeof( *pxUDPPacket ) ] );
 
-		prvTreatNBNS( pucUDPPayloadBuffer,
-					  pxNetworkBuffer->xDataLength,
-					  pxUDPPacket->xIPHeader.ulSourceIPAddress );
+            prvTreatNBNS( pucUDPPayloadBuffer,
+                          pxNetworkBuffer->xDataLength,
+                          pxUDPPacket->xIPHeader.ulSourceIPAddress );
 
-		/* The packet was not consumed. */
-		return pdFAIL;
-	}
+            /* The packet was not consumed. */
+            return pdFAIL;
+        }
 
-#endif /* ipconfigUSE_NBNS */
+    #endif /* ipconfigUSE_NBNS */
 /*-----------------------------------------------------------*/
 
-static uint32_t prvParseDNSReply( uint8_t *pucUDPPayloadBuffer,
-								  size_t uxBufferLength,
-								  BaseType_t xExpected )
-{
-DNSMessage_t *pxDNSMessageHeader;
+    static uint32_t prvParseDNSReply( uint8_t * pucUDPPayloadBuffer,
+                                      size_t uxBufferLength,
+                                      BaseType_t xExpected )
+    {
+        DNSMessage_t * pxDNSMessageHeader;
 /* This pointer is not used to modify anything */
-const DNSAnswerRecord_t *pxDNSAnswerRecord; 
-uint32_t ulIPAddress = 0UL;
-#if( ipconfigUSE_LLMNR == 1 )
-	char *pcRequestedName = NULL;
-#endif
-uint8_t *pucByte;
-size_t uxSourceBytesRemaining;
-uint16_t x, usDataLength, usQuestions;
-uint16_t usType = 0U;
-#if( ipconfigUSE_LLMNR == 1 )
-	uint16_t usClass = 0U;
-#endif
-#if( ipconfigUSE_DNS_CACHE == 1 ) || ( ipconfigDNS_USE_CALLBACKS == 1 )
-	BaseType_t xDoStore = xExpected;
-	char pcName[ ipconfigDNS_CACHE_NAME_LENGTH ] = "";
-#endif
+        const DNSAnswerRecord_t * pxDNSAnswerRecord;
+        uint32_t ulIPAddress = 0UL;
 
-	/* Ensure that the buffer is of at least minimal DNS message length. */
-	if( uxBufferLength < sizeof( DNSMessage_t ) )
-	{
-		return dnsPARSE_ERROR;
-	}
+        #if ( ipconfigUSE_LLMNR == 1 )
+            char * pcRequestedName = NULL;
+        #endif
+        uint8_t * pucByte;
+        size_t uxSourceBytesRemaining;
+        uint16_t x, usDataLength, usQuestions;
+        uint16_t usType = 0U;
+        #if ( ipconfigUSE_LLMNR == 1 )
+            uint16_t usClass = 0U;
+        #endif
+        #if ( ipconfigUSE_DNS_CACHE == 1 ) || ( ipconfigDNS_USE_CALLBACKS == 1 )
+            BaseType_t xDoStore = xExpected;
+            char pcName[ ipconfigDNS_CACHE_NAME_LENGTH ] = "";
+        #endif
 
-	uxSourceBytesRemaining = uxBufferLength;
+        /* Ensure that the buffer is of at least minimal DNS message length. */
+        if( uxBufferLength < sizeof( DNSMessage_t ) )
+        {
+            return dnsPARSE_ERROR;
+        }
 
-	/* Parse the DNS message header.
-	MISRA c 2012 rule 11.3 relaxed to make byte by byte traversal easier */
-	pxDNSMessageHeader = ipPOINTER_CAST( DNSMessage_t *, pucUDPPayloadBuffer );
+        uxSourceBytesRemaining = uxBufferLength;
 
-	/* Introduce a do {} while (0) to allow the use of breaks. */
-	do
-	{
-	size_t uxBytesRead = 0U;
-	size_t uxResult;
+        /* Parse the DNS message header.
+         * MISRA c 2012 rule 11.3 relaxed to make byte by byte traversal easier */
+        pxDNSMessageHeader = ipPOINTER_CAST( DNSMessage_t *, pucUDPPayloadBuffer );
 
-		/* Start at the first byte after the header. */
-		pucByte = &( pucUDPPayloadBuffer [ sizeof( DNSMessage_t ) ] );
-		uxSourceBytesRemaining -= sizeof( DNSMessage_t );
+        /* Introduce a do {} while (0) to allow the use of breaks. */
+        do
+        {
+            size_t uxBytesRead = 0U;
+            size_t uxResult;
 
-		/* Skip any question records. */
-		usQuestions = FreeRTOS_ntohs( pxDNSMessageHeader->usQuestions );
+            /* Start at the first byte after the header. */
+            pucByte = &( pucUDPPayloadBuffer[ sizeof( DNSMessage_t ) ] );
+            uxSourceBytesRemaining -= sizeof( DNSMessage_t );
 
-		for( x = 0U; x < usQuestions; x++ )
-		{
-			#if( ipconfigUSE_LLMNR == 1 )
-			{
-				if( x == 0U )
-				{
-					pcRequestedName = ( char * ) pucByte;
-				}
-			}
-			#endif
+            /* Skip any question records. */
+            usQuestions = FreeRTOS_ntohs( pxDNSMessageHeader->usQuestions );
 
-#if( ipconfigUSE_DNS_CACHE == 1 ) || ( ipconfigDNS_USE_CALLBACKS == 1 )
-			if( x == 0U )
-			{
-				uxResult = prvReadNameField( pucByte,
-											 uxSourceBytesRemaining,
-											 pcName,
-											 sizeof( pcName ) );
+            for( x = 0U; x < usQuestions; x++ )
+            {
+                #if ( ipconfigUSE_LLMNR == 1 )
+                    {
+                        if( x == 0U )
+                        {
+                            pcRequestedName = ( char * ) pucByte;
+                        }
+                    }
+                #endif
 
-				/* Check for a malformed response. */
-				if( uxResult == 0U )
-				{
-					return dnsPARSE_ERROR;
-				}
-				uxBytesRead += uxResult;
-				pucByte = &( pucByte[ uxResult ] );
-				uxSourceBytesRemaining -= uxResult;
-			}
-			else
-#endif /* ipconfigUSE_DNS_CACHE || ipconfigDNS_USE_CALLBACKS */
-			{
-				/* Skip the variable length pcName field. */
-				uxResult = prvSkipNameField( pucByte,
-											 uxSourceBytesRemaining );
+                #if ( ipconfigUSE_DNS_CACHE == 1 ) || ( ipconfigDNS_USE_CALLBACKS == 1 )
+                    if( x == 0U )
+                    {
+                        uxResult = prvReadNameField( pucByte,
+                                                     uxSourceBytesRemaining,
+                                                     pcName,
+                                                     sizeof( pcName ) );
 
-				/* Check for a malformed response. */
-				if( uxResult == 0U )
-				{
-					return dnsPARSE_ERROR;
-				}
-				uxBytesRead += uxResult;
-				pucByte = &( pucByte[ uxResult ] );
-				uxSourceBytesRemaining -= uxResult;
-			}
+                        /* Check for a malformed response. */
+                        if( uxResult == 0U )
+                        {
+                            return dnsPARSE_ERROR;
+                        }
 
-			/* Check the remaining buffer size. */
-			if( uxSourceBytesRemaining >= sizeof( uint32_t ) )
-			{
-				#if( ipconfigUSE_LLMNR == 1 )
-				{
-					/* usChar2u16 returns value in host endianness. */
-					usType = usChar2u16( pucByte );
-					usClass = usChar2u16( &( pucByte[ 2 ] ) );
-				}
-				#endif /* ipconfigUSE_LLMNR */
+                        uxBytesRead += uxResult;
+                        pucByte = &( pucByte[ uxResult ] );
+                        uxSourceBytesRemaining -= uxResult;
+                    }
+                    else
+                #endif /* ipconfigUSE_DNS_CACHE || ipconfigDNS_USE_CALLBACKS */
+                {
+                    /* Skip the variable length pcName field. */
+                    uxResult = prvSkipNameField( pucByte,
+                                                 uxSourceBytesRemaining );
 
-				/* Skip the type and class fields. */
-				pucByte = &( pucByte[ sizeof( uint32_t ) ] );
-				uxSourceBytesRemaining -= sizeof( uint32_t );
-			}
-			else
-			{
-				return dnsPARSE_ERROR;
-			}
-		}
+                    /* Check for a malformed response. */
+                    if( uxResult == 0U )
+                    {
+                        return dnsPARSE_ERROR;
+                    }
 
-		/* Search through the answer records. */
-		pxDNSMessageHeader->usAnswers = FreeRTOS_ntohs( pxDNSMessageHeader->usAnswers );
+                    uxBytesRead += uxResult;
+                    pucByte = &( pucByte[ uxResult ] );
+                    uxSourceBytesRemaining -= uxResult;
+                }
 
-		if( ( pxDNSMessageHeader->usFlags & dnsRX_FLAGS_MASK ) == dnsEXPECTED_RX_FLAGS )
-		{
-			const uint16_t usCount = ( uint16_t ) ipconfigDNS_CACHE_ADDRESSES_PER_ENTRY;
+                /* Check the remaining buffer size. */
+                if( uxSourceBytesRemaining >= sizeof( uint32_t ) )
+                {
+                    #if ( ipconfigUSE_LLMNR == 1 )
+                        {
+                            /* usChar2u16 returns value in host endianness. */
+                            usType = usChar2u16( pucByte );
+                            usClass = usChar2u16( &( pucByte[ 2 ] ) );
+                        }
+                    #endif /* ipconfigUSE_LLMNR */
 
-			for( x = 0U; ( x < pxDNSMessageHeader->usAnswers ) && ( x < usCount ); x++ )
-			{
-			BaseType_t xDoAccept;
+                    /* Skip the type and class fields. */
+                    pucByte = &( pucByte[ sizeof( uint32_t ) ] );
+                    uxSourceBytesRemaining -= sizeof( uint32_t );
+                }
+                else
+                {
+                    return dnsPARSE_ERROR;
+                }
+            }
 
-				uxResult = prvSkipNameField( pucByte,
-											 uxSourceBytesRemaining );
+            /* Search through the answer records. */
+            pxDNSMessageHeader->usAnswers = FreeRTOS_ntohs( pxDNSMessageHeader->usAnswers );
 
-				/* Check for a malformed response. */
-				if( uxResult == 0U )
-				{
-					return dnsPARSE_ERROR;
-				}
+            if( ( pxDNSMessageHeader->usFlags & dnsRX_FLAGS_MASK ) == dnsEXPECTED_RX_FLAGS )
+            {
+                const uint16_t usCount = ( uint16_t ) ipconfigDNS_CACHE_ADDRESSES_PER_ENTRY;
 
-				uxBytesRead += uxResult;
-				pucByte = &( pucByte[ uxResult ] );
-				uxSourceBytesRemaining -= uxResult;
+                for( x = 0U; ( x < pxDNSMessageHeader->usAnswers ) && ( x < usCount ); x++ )
+                {
+                    BaseType_t xDoAccept;
 
-				/* Is there enough data for an IPv4 A record answer and, if so,
-				is this an A record? */
-				if( uxSourceBytesRemaining < sizeof( uint16_t ) )
-				{
-					return dnsPARSE_ERROR;
-				}
-				usType = usChar2u16( pucByte );
+                    uxResult = prvSkipNameField( pucByte,
+                                                 uxSourceBytesRemaining );
 
-				if( usType == ( uint16_t ) dnsTYPE_A_HOST )
-				{
-					if( uxSourceBytesRemaining >= ( sizeof( DNSAnswerRecord_t ) + ipSIZE_OF_IPv4_ADDRESS ) )
-					{
-						xDoAccept = pdTRUE;
-					}
-					else
-					{
-						xDoAccept = pdFALSE;
-					}
-				}
-				else
-				{
-					/* Unknown host type. */
-					xDoAccept = pdFALSE;
-				}
-				if( xDoAccept != pdFALSE )
-				{
-					/* This is the required record type and is of sufficient size. */
-					/* MISRA c 2012 rule 11.3 relaxed. pucByte is used for byte-by-byte
-					traversal. */
-					pxDNSAnswerRecord = ipPOINTER_CAST( DNSAnswerRecord_t *, pucByte );
+                    /* Check for a malformed response. */
+                    if( uxResult == 0U )
+                    {
+                        return dnsPARSE_ERROR;
+                    }
 
-					/* Sanity check the data length of an IPv4 answer. */
-					if( FreeRTOS_ntohs( pxDNSAnswerRecord->usDataLength ) == ( uint16_t ) sizeof( uint32_t ) )
-					{
-						/* Copy the IP address out of the record. */
-						/* MISRA c 2012 rule 21.15 relaxed here since this seems
-						to be the least cumbersome way to get the IP address
-						from the record. */
-						( void ) memcpy( &( ulIPAddress ),
-										 &( pucByte[ sizeof( DNSAnswerRecord_t ) ] ),
-										 sizeof( uint32_t ) );
+                    uxBytesRead += uxResult;
+                    pucByte = &( pucByte[ uxResult ] );
+                    uxSourceBytesRemaining -= uxResult;
 
-						#if( ipconfigDNS_USE_CALLBACKS == 1 )
-						{
-							/* See if any asynchronous call was made to FreeRTOS_gethostbyname_a() */
-							if( xDNSDoCallback( ( TickType_t ) pxDNSMessageHeader->usIdentifier, pcName, ulIPAddress ) != pdFALSE )
-							{
-								/* This device has requested this DNS look-up.
-								The result may be stored in the DNS cache. */
-								xDoStore = pdTRUE;
-							}
-						}
-						#endif	/* ipconfigDNS_USE_CALLBACKS == 1 */
-						#if( ipconfigUSE_DNS_CACHE == 1 )
-						{
-							/* The reply will only be stored in the DNS cache when the
-							request was issued by this device. */
-							if( xDoStore != pdFALSE )
-							{
-								( void ) prvProcessDNSCache( pcName, &ulIPAddress, pxDNSAnswerRecord->ulTTL, pdFALSE );
-							}
+                    /* Is there enough data for an IPv4 A record answer and, if so,
+                     * is this an A record? */
+                    if( uxSourceBytesRemaining < sizeof( uint16_t ) )
+                    {
+                        return dnsPARSE_ERROR;
+                    }
 
-							/* Show what has happened. */
-							FreeRTOS_printf( ( "DNS[0x%04lX]: The answer to '%s' (%lxip) will%s be stored\n",
-											   ( UBaseType_t ) pxDNSMessageHeader->usIdentifier,
-											   pcName,
-											   ( UBaseType_t ) FreeRTOS_ntohl( ulIPAddress ),
-											   ( xDoStore != 0 ) ? "" : " NOT" ) );
-						}
-						#endif /* ipconfigUSE_DNS_CACHE */
-					}
+                    usType = usChar2u16( pucByte );
 
-					pucByte = &( pucByte[ sizeof( DNSAnswerRecord_t ) + sizeof( uint32_t ) ] );
-					uxSourceBytesRemaining -= ( sizeof( DNSAnswerRecord_t ) + sizeof( uint32_t ) );
-				}
-				else if( uxSourceBytesRemaining >= sizeof( DNSAnswerRecord_t ) )
-				{
-					/* It's not an A record, so skip it. Get the header location
-					and then jump over the header. */
+                    if( usType == ( uint16_t ) dnsTYPE_A_HOST )
+                    {
+                        if( uxSourceBytesRemaining >= ( sizeof( DNSAnswerRecord_t ) + ipSIZE_OF_IPv4_ADDRESS ) )
+                        {
+                            xDoAccept = pdTRUE;
+                        }
+                        else
+                        {
+                            xDoAccept = pdFALSE;
+                        }
+                    }
+                    else
+                    {
+                        /* Unknown host type. */
+                        xDoAccept = pdFALSE;
+                    }
 
-					/* MISRA c 2012 rule 11.3 relaxed as pucByte is being used in
-					various places to point to various parts of the DNS records */
-					pxDNSAnswerRecord = ipPOINTER_CAST( DNSAnswerRecord_t *, pucByte );
+                    if( xDoAccept != pdFALSE )
+                    {
+                        /* This is the required record type and is of sufficient size. */
 
-					pucByte = &( pucByte[ sizeof( DNSAnswerRecord_t ) ] );
-					uxSourceBytesRemaining -= sizeof( DNSAnswerRecord_t );
+                        /* MISRA c 2012 rule 11.3 relaxed. pucByte is used for byte-by-byte
+                         * traversal. */
+                        pxDNSAnswerRecord = ipPOINTER_CAST( DNSAnswerRecord_t *, pucByte );
 
-					/* Determine the length of the answer data from the header. */
-					usDataLength = FreeRTOS_ntohs( pxDNSAnswerRecord->usDataLength );
+                        /* Sanity check the data length of an IPv4 answer. */
+                        if( FreeRTOS_ntohs( pxDNSAnswerRecord->usDataLength ) == ( uint16_t ) sizeof( uint32_t ) )
+                        {
+                            /* Copy the IP address out of the record. */
 
-					/* Jump over the answer. */
-					if( uxSourceBytesRemaining >= usDataLength )
-					{
-						pucByte = &( pucByte[ usDataLength ] );
-						uxSourceBytesRemaining -= usDataLength;
-					}
-					else
-					{
-						/* Malformed response. */
-						return dnsPARSE_ERROR;
-					}
-				}
-				else
-				{
-					/* Do nothing */
-				}
-			}
-		}
+                            /* MISRA c 2012 rule 21.15 relaxed here since this seems
+                             * to be the least cumbersome way to get the IP address
+                             * from the record. */
+                            ( void ) memcpy( &( ulIPAddress ),
+                                             &( pucByte[ sizeof( DNSAnswerRecord_t ) ] ),
+                                             sizeof( uint32_t ) );
 
-#if( ipconfigUSE_LLMNR == 1 )
-		else if( ( usQuestions != ( uint16_t ) 0U ) && ( usType == dnsTYPE_A_HOST ) && ( usClass == dnsCLASS_IN ) && ( pcRequestedName != NULL ) )
-		{
-			/* If this is not a reply to our DNS request, it might an LLMNR
-			request. */
-			if( xApplicationDNSQueryHook( &( pcRequestedName[ 1 ] ) )  != pdFALSE )
-			{
-			int16_t usLength;
-			NetworkBufferDescriptor_t *pxNewBuffer = NULL;
-			NetworkBufferDescriptor_t *pxNetworkBuffer = pxUDPPayloadBuffer_to_NetworkBuffer( pucUDPPayloadBuffer );
-			LLMNRAnswer_t *pxAnswer;
-			uint8_t *pucNewBuffer = NULL;
+                            #if ( ipconfigDNS_USE_CALLBACKS == 1 )
+                                {
+                                    /* See if any asynchronous call was made to FreeRTOS_gethostbyname_a() */
+                                    if( xDNSDoCallback( ( TickType_t ) pxDNSMessageHeader->usIdentifier, pcName, ulIPAddress ) != pdFALSE )
+                                    {
+                                        /* This device has requested this DNS look-up.
+                                         * The result may be stored in the DNS cache. */
+                                        xDoStore = pdTRUE;
+                                    }
+                                }
+                            #endif /* ipconfigDNS_USE_CALLBACKS == 1 */
+                            #if ( ipconfigUSE_DNS_CACHE == 1 )
+                                {
+                                    /* The reply will only be stored in the DNS cache when the
+                                     * request was issued by this device. */
+                                    if( xDoStore != pdFALSE )
+                                    {
+                                        ( void ) prvProcessDNSCache( pcName, &ulIPAddress, pxDNSAnswerRecord->ulTTL, pdFALSE );
+                                    }
 
-				if( ( xBufferAllocFixedSize == pdFALSE ) && ( pxNetworkBuffer != NULL ) )
-				{
-				size_t uxDataLength = uxBufferLength + sizeof( UDPHeader_t ) + sizeof( EthernetHeader_t ) + sizeof( IPHeader_t );
+                                    /* Show what has happened. */
+                                    FreeRTOS_printf( ( "DNS[0x%04lX]: The answer to '%s' (%lxip) will%s be stored\n",
+                                                       ( UBaseType_t ) pxDNSMessageHeader->usIdentifier,
+                                                       pcName,
+                                                       ( UBaseType_t ) FreeRTOS_ntohl( ulIPAddress ),
+                                                       ( xDoStore != 0 ) ? "" : " NOT" ) );
+                                }
+                            #endif /* ipconfigUSE_DNS_CACHE */
+                        }
 
-					/* Set the size of the outgoing packet. */
-					pxNetworkBuffer->xDataLength = uxDataLength;
-					pxNewBuffer = pxDuplicateNetworkBufferWithDescriptor( pxNetworkBuffer, uxDataLength + sizeof( LLMNRAnswer_t ) );
+                        pucByte = &( pucByte[ sizeof( DNSAnswerRecord_t ) + sizeof( uint32_t ) ] );
+                        uxSourceBytesRemaining -= ( sizeof( DNSAnswerRecord_t ) + sizeof( uint32_t ) );
+                    }
+                    else if( uxSourceBytesRemaining >= sizeof( DNSAnswerRecord_t ) )
+                    {
+                        /* It's not an A record, so skip it. Get the header location
+                         * and then jump over the header. */
 
-					if( pxNewBuffer != NULL )
-					{
-					BaseType_t xOffset1, xOffset2;
+                        /* MISRA c 2012 rule 11.3 relaxed as pucByte is being used in
+                         * various places to point to various parts of the DNS records */
+                        pxDNSAnswerRecord = ipPOINTER_CAST( DNSAnswerRecord_t *, pucByte );
 
-						xOffset1 = ( BaseType_t ) ( pucByte - pucUDPPayloadBuffer );
-						xOffset2 = ( BaseType_t ) ( ( ( uint8_t * ) pcRequestedName ) - pucUDPPayloadBuffer );
+                        pucByte = &( pucByte[ sizeof( DNSAnswerRecord_t ) ] );
+                        uxSourceBytesRemaining -= sizeof( DNSAnswerRecord_t );
 
-						pxNetworkBuffer = pxNewBuffer;
-						pucNewBuffer = &( pxNetworkBuffer->pucEthernetBuffer[ ipUDP_PAYLOAD_OFFSET_IPv4 ] );
+                        /* Determine the length of the answer data from the header. */
+                        usDataLength = FreeRTOS_ntohs( pxDNSAnswerRecord->usDataLength );
 
-						pucByte = &( pucNewBuffer[ xOffset1 ] );
-						pcRequestedName = ( char * ) &( pucNewBuffer[ xOffset2 ] );
-						pxDNSMessageHeader = ipPOINTER_CAST( DNSMessage_t *, pucNewBuffer );
-					}
-					else
-					{
-						/* Just to indicate that the message may not be answered. */
-						pxNetworkBuffer = NULL;
-					}
-				}
+                        /* Jump over the answer. */
+                        if( uxSourceBytesRemaining >= usDataLength )
+                        {
+                            pucByte = &( pucByte[ usDataLength ] );
+                            uxSourceBytesRemaining -= usDataLength;
+                        }
+                        else
+                        {
+                            /* Malformed response. */
+                            return dnsPARSE_ERROR;
+                        }
+                    }
+                    else
+                    {
+                        /* Do nothing */
+                    }
+                }
+            }
 
-				/* The test on 'pucNewBuffer' is only to satisfy lint. */
-				if( ( pxNetworkBuffer != NULL ) && ( pucNewBuffer != NULL ) )
-				{
-					pxAnswer = ipPOINTER_CAST( LLMNRAnswer_t *, pucByte );
+            #if ( ipconfigUSE_LLMNR == 1 )
+                else if( ( usQuestions != ( uint16_t ) 0U ) && ( usType == dnsTYPE_A_HOST ) && ( usClass == dnsCLASS_IN ) && ( pcRequestedName != NULL ) )
+                {
+                    /* If this is not a reply to our DNS request, it might an LLMNR
+                     * request. */
+                    if( xApplicationDNSQueryHook( &( pcRequestedName[ 1 ] ) ) != pdFALSE )
+                    {
+                        int16_t usLength;
+                        NetworkBufferDescriptor_t * pxNewBuffer = NULL;
+                        NetworkBufferDescriptor_t * pxNetworkBuffer = pxUDPPayloadBuffer_to_NetworkBuffer( pucUDPPayloadBuffer );
+                        LLMNRAnswer_t * pxAnswer;
+                        uint8_t * pucNewBuffer = NULL;
 
-					/* We leave 'usIdentifier' and 'usQuestions' untouched */
-					#ifndef _lint
-					vSetField16( pxDNSMessageHeader, DNSMessage_t, usFlags, dnsLLMNR_FLAGS_IS_REPONSE ); /* Set the response flag */
-					vSetField16( pxDNSMessageHeader, DNSMessage_t, usAnswers, 1 );                       /* Provide a single answer */
-					vSetField16( pxDNSMessageHeader, DNSMessage_t, usAuthorityRRs, 0 );                  /* No authority */
-					vSetField16( pxDNSMessageHeader, DNSMessage_t, usAdditionalRRs, 0 );                 /* No additional info */
-					#endif /* lint */
+                        if( ( xBufferAllocFixedSize == pdFALSE ) && ( pxNetworkBuffer != NULL ) )
+                        {
+                            size_t uxDataLength = uxBufferLength + sizeof( UDPHeader_t ) + sizeof( EthernetHeader_t ) + sizeof( IPHeader_t );
 
-					pxAnswer->ucNameCode = dnsNAME_IS_OFFSET;
-					pxAnswer->ucNameOffset = ( uint8_t ) ( pcRequestedName - ( char * ) pucNewBuffer );
+                            /* Set the size of the outgoing packet. */
+                            pxNetworkBuffer->xDataLength = uxDataLength;
+                            pxNewBuffer = pxDuplicateNetworkBufferWithDescriptor( pxNetworkBuffer, uxDataLength + sizeof( LLMNRAnswer_t ) );
 
-					#ifndef _lint
-					vSetField16( pxAnswer, LLMNRAnswer_t, usType, dnsTYPE_A_HOST ); /* Type A: host */
-					vSetField16( pxAnswer, LLMNRAnswer_t, usClass, dnsCLASS_IN );   /* 1: Class IN */
-					vSetField32( pxAnswer, LLMNRAnswer_t, ulTTL, dnsLLMNR_TTL_VALUE );
-					vSetField16( pxAnswer, LLMNRAnswer_t, usDataLength, 4 );
-					vSetField32( pxAnswer, LLMNRAnswer_t, ulIPAddress, FreeRTOS_ntohl( *ipLOCAL_IP_ADDRESS_POINTER ) );
-					#endif /* lint */
-					usLength = ( int16_t ) ( sizeof( *pxAnswer ) + ( size_t ) ( pucByte - pucNewBuffer ) );
+                            if( pxNewBuffer != NULL )
+                            {
+                                BaseType_t xOffset1, xOffset2;
 
-					prvReplyDNSMessage( pxNetworkBuffer, usLength );
+                                xOffset1 = ( BaseType_t ) ( pucByte - pucUDPPayloadBuffer );
+                                xOffset2 = ( BaseType_t ) ( ( ( uint8_t * ) pcRequestedName ) - pucUDPPayloadBuffer );
 
-					if( pxNewBuffer != NULL )
-					{
-						vReleaseNetworkBufferAndDescriptor( pxNewBuffer );
-					}
-				}
-			}
-		}
-		else
-		{
-			/* Not an expected reply. */
-		}
-#endif /* ipconfigUSE_LLMNR == 1 */
-		( void ) uxBytesRead;
-	} while( ipFALSE_BOOL );
+                                pxNetworkBuffer = pxNewBuffer;
+                                pucNewBuffer = &( pxNetworkBuffer->pucEthernetBuffer[ ipUDP_PAYLOAD_OFFSET_IPv4 ] );
 
-	if( xExpected == pdFALSE )
-	{
-		/* Do not return a valid IP-address in case the reply was not expected. */
-		ulIPAddress = 0UL;
-	}
-	#if( ipconfigUSE_DNS_CACHE == 1 ) || ( ipconfigDNS_USE_CALLBACKS == 1 )
-	( void ) xDoStore;
-	#endif
+                                pucByte = &( pucNewBuffer[ xOffset1 ] );
+                                pcRequestedName = ( char * ) &( pucNewBuffer[ xOffset2 ] );
+                                pxDNSMessageHeader = ipPOINTER_CAST( DNSMessage_t *, pucNewBuffer );
+                            }
+                            else
+                            {
+                                /* Just to indicate that the message may not be answered. */
+                                pxNetworkBuffer = NULL;
+                            }
+                        }
 
-	return ulIPAddress;
-}
+                        /* The test on 'pucNewBuffer' is only to satisfy lint. */
+                        if( ( pxNetworkBuffer != NULL ) && ( pucNewBuffer != NULL ) )
+                        {
+                            pxAnswer = ipPOINTER_CAST( LLMNRAnswer_t *, pucByte );
+
+                            /* We leave 'usIdentifier' and 'usQuestions' untouched */
+                            #ifndef _lint
+                                vSetField16( pxDNSMessageHeader, DNSMessage_t, usFlags, dnsLLMNR_FLAGS_IS_REPONSE ); /* Set the response flag */
+                                vSetField16( pxDNSMessageHeader, DNSMessage_t, usAnswers, 1 );                       /* Provide a single answer */
+                                vSetField16( pxDNSMessageHeader, DNSMessage_t, usAuthorityRRs, 0 );                  /* No authority */
+                                vSetField16( pxDNSMessageHeader, DNSMessage_t, usAdditionalRRs, 0 );                 /* No additional info */
+                            #endif /* lint */
+
+                            pxAnswer->ucNameCode = dnsNAME_IS_OFFSET;
+                            pxAnswer->ucNameOffset = ( uint8_t ) ( pcRequestedName - ( char * ) pucNewBuffer );
+
+                            #ifndef _lint
+                                vSetField16( pxAnswer, LLMNRAnswer_t, usType, dnsTYPE_A_HOST ); /* Type A: host */
+                                vSetField16( pxAnswer, LLMNRAnswer_t, usClass, dnsCLASS_IN );   /* 1: Class IN */
+                                vSetField32( pxAnswer, LLMNRAnswer_t, ulTTL, dnsLLMNR_TTL_VALUE );
+                                vSetField16( pxAnswer, LLMNRAnswer_t, usDataLength, 4 );
+                                vSetField32( pxAnswer, LLMNRAnswer_t, ulIPAddress, FreeRTOS_ntohl( *ipLOCAL_IP_ADDRESS_POINTER ) );
+                            #endif /* lint */
+                            usLength = ( int16_t ) ( sizeof( *pxAnswer ) + ( size_t ) ( pucByte - pucNewBuffer ) );
+
+                            prvReplyDNSMessage( pxNetworkBuffer, usLength );
+
+                            if( pxNewBuffer != NULL )
+                            {
+                                vReleaseNetworkBufferAndDescriptor( pxNewBuffer );
+                            }
+                        }
+                    }
+                }
+                else
+                {
+                    /* Not an expected reply. */
+                }
+            #endif /* ipconfigUSE_LLMNR == 1 */
+            ( void ) uxBytesRead;
+        } while( ipFALSE_BOOL );
+
+        if( xExpected == pdFALSE )
+        {
+            /* Do not return a valid IP-address in case the reply was not expected. */
+            ulIPAddress = 0UL;
+        }
+
+        #if ( ipconfigUSE_DNS_CACHE == 1 ) || ( ipconfigDNS_USE_CALLBACKS == 1 )
+            ( void ) xDoStore;
+        #endif
+
+        return ulIPAddress;
+    }
 /*-----------------------------------------------------------*/
 
-#if( ipconfigUSE_NBNS == 1 )
+    #if ( ipconfigUSE_NBNS == 1 )
 
-	static void prvTreatNBNS( uint8_t *pucPayload,
-							  size_t uxBufferLength,
-							  uint32_t ulIPAddress )
-	{
-	uint16_t usFlags, usType, usClass;
-	uint8_t *pucSource, *pucTarget;
-	uint8_t ucByte;
-	uint8_t ucNBNSName[ 17 ];
-	uint8_t *pucUDPPayloadBuffer = pucPayload;
-	NetworkBufferDescriptor_t *pxNetworkBuffer;
-	size_t uxBytesNeeded = sizeof( UDPPacket_t ) + sizeof( NBNSRequest_t );
+        static void prvTreatNBNS( uint8_t * pucPayload,
+                                  size_t uxBufferLength,
+                                  uint32_t ulIPAddress )
+        {
+            uint16_t usFlags, usType, usClass;
+            uint8_t * pucSource, * pucTarget;
+            uint8_t ucByte;
+            uint8_t ucNBNSName[ 17 ];
+            uint8_t * pucUDPPayloadBuffer = pucPayload;
+            NetworkBufferDescriptor_t * pxNetworkBuffer;
+            size_t uxBytesNeeded = sizeof( UDPPacket_t ) + sizeof( NBNSRequest_t );
 
-		/* Check for minimum buffer size. */
-		if( uxBufferLength < uxBytesNeeded )
-		{
-			return;
-		}
+            /* Check for minimum buffer size. */
+            if( uxBufferLength < uxBytesNeeded )
+            {
+                return;
+            }
 
-		/* Read the request flags in host endianness. */
-		usFlags = usChar2u16( &( pucUDPPayloadBuffer[ offsetof( NBNSRequest_t, usFlags ) ] ) );
+            /* Read the request flags in host endianness. */
+            usFlags = usChar2u16( &( pucUDPPayloadBuffer[ offsetof( NBNSRequest_t, usFlags ) ] ) );
 
-		if( ( usFlags & dnsNBNS_FLAGS_OPCODE_MASK ) == dnsNBNS_FLAGS_OPCODE_QUERY )
-		{
-			usType  = usChar2u16( &( pucUDPPayloadBuffer[ offsetof( NBNSRequest_t, usType ) ] ) );
-			usClass = usChar2u16( &( pucUDPPayloadBuffer[ offsetof( NBNSRequest_t, usClass ) ] ) );
+            if( ( usFlags & dnsNBNS_FLAGS_OPCODE_MASK ) == dnsNBNS_FLAGS_OPCODE_QUERY )
+            {
+                usType = usChar2u16( &( pucUDPPayloadBuffer[ offsetof( NBNSRequest_t, usType ) ] ) );
+                usClass = usChar2u16( &( pucUDPPayloadBuffer[ offsetof( NBNSRequest_t, usClass ) ] ) );
 
-			/* Not used for now */
-			( void ) usClass;
+                /* Not used for now */
+                ( void ) usClass;
 
-			/* For NBNS a name is 16 bytes long, written with capitals only.
-			Make sure that the copy is terminated with a zero. */
-			pucTarget = &( ucNBNSName[ sizeof( ucNBNSName ) - 2U ] );
-			pucTarget[ 1 ] = ( uint8_t ) 0U;
+                /* For NBNS a name is 16 bytes long, written with capitals only.
+                 * Make sure that the copy is terminated with a zero. */
+                pucTarget = &( ucNBNSName[ sizeof( ucNBNSName ) - 2U ] );
+                pucTarget[ 1 ] = ( uint8_t ) 0U;
 
-			/* Start with decoding the last 2 bytes. */
-			pucSource = &( pucUDPPayloadBuffer[ ( dnsNBNS_ENCODED_NAME_LENGTH - 2 ) + offsetof( NBNSRequest_t, ucName ) ] );
+                /* Start with decoding the last 2 bytes. */
+                pucSource = &( pucUDPPayloadBuffer[ ( dnsNBNS_ENCODED_NAME_LENGTH - 2 ) + offsetof( NBNSRequest_t, ucName ) ] );
 
-			for( ;; )
-			{
-			const uint8_t ucCharA = ( uint8_t ) 0x41U;
+                for( ; ; )
+                {
+                    const uint8_t ucCharA = ( uint8_t ) 0x41U;
 
-				ucByte = ( ( uint8_t ) ( ( pucSource[ 0 ] - ucCharA ) << 4 ) ) | ( pucSource[ 1 ] - ucCharA );
+                    ucByte = ( ( uint8_t ) ( ( pucSource[ 0 ] - ucCharA ) << 4 ) ) | ( pucSource[ 1 ] - ucCharA );
 
-				/* Make sure there are no trailing spaces in the name. */
-				if( ( ucByte == ( uint8_t ) ' ' ) && ( pucTarget[ 1 ] == 0U ) )
-				{
-					ucByte = 0U;
-				}
+                    /* Make sure there are no trailing spaces in the name. */
+                    if( ( ucByte == ( uint8_t ) ' ' ) && ( pucTarget[ 1 ] == 0U ) )
+                    {
+                        ucByte = 0U;
+                    }
 
-				*pucTarget = ucByte;
+                    *pucTarget = ucByte;
 
-				if( pucTarget == ucNBNSName )
-				{
-					break;
-				}
+                    if( pucTarget == ucNBNSName )
+                    {
+                        break;
+                    }
 
-				pucTarget -= 1;
-				pucSource -= 2;
-			}
+                    pucTarget -= 1;
+                    pucSource -= 2;
+                }
 
-			#if( ipconfigUSE_DNS_CACHE == 1 )
-			{
-				if( ( usFlags & dnsNBNS_FLAGS_RESPONSE ) != 0U )
-				{
-					/* If this is a response from another device,
-					add the name to the DNS cache */
-					( void ) prvProcessDNSCache( ( char * ) ucNBNSName, &( ulIPAddress ), 0, pdFALSE );
-				}
-			}
-			#else
-			{
-				/* Avoid compiler warnings. */
-				( void ) ulIPAddress;
-			}
-			#endif /* ipconfigUSE_DNS_CACHE */
+                #if ( ipconfigUSE_DNS_CACHE == 1 )
+                    {
+                        if( ( usFlags & dnsNBNS_FLAGS_RESPONSE ) != 0U )
+                        {
+                            /* If this is a response from another device,
+                             * add the name to the DNS cache */
+                            ( void ) prvProcessDNSCache( ( char * ) ucNBNSName, &( ulIPAddress ), 0, pdFALSE );
+                        }
+                    }
+                #else
+                    {
+                        /* Avoid compiler warnings. */
+                        ( void ) ulIPAddress;
+                    }
+                #endif /* ipconfigUSE_DNS_CACHE */
 
-			if( ( ( usFlags & dnsNBNS_FLAGS_RESPONSE ) == 0U ) &&
-				( usType == dnsNBNS_TYPE_NET_BIOS ) &&
-				( xApplicationDNSQueryHook( ( const char * ) ucNBNSName ) != pdFALSE ) )
-			{
-			uint16_t usLength;
-			DNSMessage_t *pxMessage;
-			NBNSAnswer_t *pxAnswer;
+                if( ( ( usFlags & dnsNBNS_FLAGS_RESPONSE ) == 0U ) &&
+                    ( usType == dnsNBNS_TYPE_NET_BIOS ) &&
+                    ( xApplicationDNSQueryHook( ( const char * ) ucNBNSName ) != pdFALSE ) )
+                {
+                    uint16_t usLength;
+                    DNSMessage_t * pxMessage;
+                    NBNSAnswer_t * pxAnswer;
 
-				/* Someone is looking for a device with ucNBNSName,
-				prepare a positive reply. */
-				pxNetworkBuffer = pxUDPPayloadBuffer_to_NetworkBuffer( pucUDPPayloadBuffer );
+                    /* Someone is looking for a device with ucNBNSName,
+                     * prepare a positive reply. */
+                    pxNetworkBuffer = pxUDPPayloadBuffer_to_NetworkBuffer( pucUDPPayloadBuffer );
 
-				if( ( xBufferAllocFixedSize == pdFALSE ) && ( pxNetworkBuffer != NULL ) )
-				{
-				NetworkBufferDescriptor_t *pxNewBuffer;
+                    if( ( xBufferAllocFixedSize == pdFALSE ) && ( pxNetworkBuffer != NULL ) )
+                    {
+                        NetworkBufferDescriptor_t * pxNewBuffer;
 
-					/* The field xDataLength was set to the total length of the UDP packet,
-					i.e. the payload size plus sizeof( UDPPacket_t ). */
-					pxNewBuffer = pxDuplicateNetworkBufferWithDescriptor( pxNetworkBuffer, pxNetworkBuffer->xDataLength + sizeof( NBNSAnswer_t ) );
+                        /* The field xDataLength was set to the total length of the UDP packet,
+                         * i.e. the payload size plus sizeof( UDPPacket_t ). */
+                        pxNewBuffer = pxDuplicateNetworkBufferWithDescriptor( pxNetworkBuffer, pxNetworkBuffer->xDataLength + sizeof( NBNSAnswer_t ) );
 
-					if( pxNewBuffer != NULL )
-					{
-						pucUDPPayloadBuffer = &( pxNewBuffer->pucEthernetBuffer[ sizeof( UDPPacket_t ) ] );
-						pxNetworkBuffer = pxNewBuffer;
-					}
-					else
-					{
-						/* Just prevent that a reply will be sent */
-						pxNetworkBuffer = NULL;
-					}
-				}
+                        if( pxNewBuffer != NULL )
+                        {
+                            pucUDPPayloadBuffer = &( pxNewBuffer->pucEthernetBuffer[ sizeof( UDPPacket_t ) ] );
+                            pxNetworkBuffer = pxNewBuffer;
+                        }
+                        else
+                        {
+                            /* Just prevent that a reply will be sent */
+                            pxNetworkBuffer = NULL;
+                        }
+                    }
 
-				/* Should not occur: pucUDPPayloadBuffer is part of a xNetworkBufferDescriptor */
-				if( pxNetworkBuffer != NULL )
-				{
-					pxMessage = ipPOINTER_CAST( DNSMessage_t *, pucUDPPayloadBuffer );
+                    /* Should not occur: pucUDPPayloadBuffer is part of a xNetworkBufferDescriptor */
+                    if( pxNetworkBuffer != NULL )
+                    {
+                        pxMessage = ipPOINTER_CAST( DNSMessage_t *, pucUDPPayloadBuffer );
 
-					/* As the fields in the structures are not word-aligned, we have to
-					copy the values byte-by-byte using macro's vSetField16() and vSetField32() */
-					#ifndef _lint
-					vSetField16( pxMessage, DNSMessage_t, usFlags, dnsNBNS_QUERY_RESPONSE_FLAGS ); /* 0x8500 */
-					vSetField16( pxMessage, DNSMessage_t, usQuestions, 0 );
-					vSetField16( pxMessage, DNSMessage_t, usAnswers, 1 );
-					vSetField16( pxMessage, DNSMessage_t, usAuthorityRRs, 0 );
-					vSetField16( pxMessage, DNSMessage_t, usAdditionalRRs, 0 );
-					#else
-					( void ) pxMessage;
-					#endif
+                        /* As the fields in the structures are not word-aligned, we have to
+                         * copy the values byte-by-byte using macro's vSetField16() and vSetField32() */
+                        #ifndef _lint
+                            vSetField16( pxMessage, DNSMessage_t, usFlags, dnsNBNS_QUERY_RESPONSE_FLAGS ); /* 0x8500 */
+                            vSetField16( pxMessage, DNSMessage_t, usQuestions, 0 );
+                            vSetField16( pxMessage, DNSMessage_t, usAnswers, 1 );
+                            vSetField16( pxMessage, DNSMessage_t, usAuthorityRRs, 0 );
+                            vSetField16( pxMessage, DNSMessage_t, usAdditionalRRs, 0 );
+                        #else
+                            ( void ) pxMessage;
+                        #endif
 
-					pxAnswer = ipPOINTER_CAST( NBNSAnswer_t *, &( pucUDPPayloadBuffer[ offsetof( NBNSRequest_t, usType ) ] ) );
+                        pxAnswer = ipPOINTER_CAST( NBNSAnswer_t *, &( pucUDPPayloadBuffer[ offsetof( NBNSRequest_t, usType ) ] ) );
 
-					#ifndef _lint
-					vSetField16( pxAnswer, NBNSAnswer_t, usType, usType );            /* Type */
-					vSetField16( pxAnswer, NBNSAnswer_t, usClass, dnsNBNS_CLASS_IN ); /* Class */
-					vSetField32( pxAnswer, NBNSAnswer_t, ulTTL, dnsNBNS_TTL_VALUE );
-					vSetField16( pxAnswer, NBNSAnswer_t, usDataLength, 6 );           /* 6 bytes including the length field */
-					vSetField16( pxAnswer, NBNSAnswer_t, usNbFlags, dnsNBNS_NAME_FLAGS );
-					vSetField32( pxAnswer, NBNSAnswer_t, ulIPAddress, FreeRTOS_ntohl( *ipLOCAL_IP_ADDRESS_POINTER ) );
-					#else
-					( void ) pxAnswer;
-					#endif
+                        #ifndef _lint
+                            vSetField16( pxAnswer, NBNSAnswer_t, usType, usType );            /* Type */
+                            vSetField16( pxAnswer, NBNSAnswer_t, usClass, dnsNBNS_CLASS_IN ); /* Class */
+                            vSetField32( pxAnswer, NBNSAnswer_t, ulTTL, dnsNBNS_TTL_VALUE );
+                            vSetField16( pxAnswer, NBNSAnswer_t, usDataLength, 6 );           /* 6 bytes including the length field */
+                            vSetField16( pxAnswer, NBNSAnswer_t, usNbFlags, dnsNBNS_NAME_FLAGS );
+                            vSetField32( pxAnswer, NBNSAnswer_t, ulIPAddress, FreeRTOS_ntohl( *ipLOCAL_IP_ADDRESS_POINTER ) );
+                        #else
+                            ( void ) pxAnswer;
+                        #endif
 
-					usLength = ( uint16_t ) ( sizeof( NBNSAnswer_t ) + ( size_t ) offsetof( NBNSRequest_t, usType ) );
+                        usLength = ( uint16_t ) ( sizeof( NBNSAnswer_t ) + ( size_t ) offsetof( NBNSRequest_t, usType ) );
 
-					prvReplyDNSMessage( pxNetworkBuffer, ( BaseType_t ) usLength );
-				}
-			}
-		}
-	}
+                        prvReplyDNSMessage( pxNetworkBuffer, ( BaseType_t ) usLength );
+                    }
+                }
+            }
+        }
 
-#endif /* ipconfigUSE_NBNS */
+    #endif /* ipconfigUSE_NBNS */
 /*-----------------------------------------------------------*/
 
-static Socket_t prvCreateDNSSocket( void )
-{
-Socket_t xSocket;
-struct freertos_sockaddr xAddress;
-BaseType_t xReturn;
+    static Socket_t prvCreateDNSSocket( void )
+    {
+        Socket_t xSocket;
+        struct freertos_sockaddr xAddress;
+        BaseType_t xReturn;
 
-	/* This must be the first time this function has been called.  Create
-	the socket. */
-	xSocket = FreeRTOS_socket( FREERTOS_AF_INET, FREERTOS_SOCK_DGRAM, FREERTOS_IPPROTO_UDP );
-	if( ( xSocket == FREERTOS_INVALID_SOCKET ) || ( xSocket == NULL ) )
-	{
-		return NULL;
-	}
+        /* This must be the first time this function has been called.  Create
+         * the socket. */
+        xSocket = FreeRTOS_socket( FREERTOS_AF_INET, FREERTOS_SOCK_DGRAM, FREERTOS_IPPROTO_UDP );
 
-	/* Auto bind the port. */
-	xAddress.sin_port = 0U;
-	xReturn = FreeRTOS_bind( xSocket, &xAddress, sizeof( xAddress ) );
+        if( ( xSocket == FREERTOS_INVALID_SOCKET ) || ( xSocket == NULL ) )
+        {
+            return NULL;
+        }
 
-	/* Check the bind was successful, and clean up if not. */
-	if( xReturn != 0 )
-	{
-		( void ) FreeRTOS_closesocket( xSocket );
-		xSocket = NULL;
-	}
-	else
-	{
-		/* The send and receive timeouts will be set later on. */
-	}
+        /* Auto bind the port. */
+        xAddress.sin_port = 0U;
+        xReturn = FreeRTOS_bind( xSocket, &xAddress, sizeof( xAddress ) );
 
-	return xSocket;
-}
+        /* Check the bind was successful, and clean up if not. */
+        if( xReturn != 0 )
+        {
+            ( void ) FreeRTOS_closesocket( xSocket );
+            xSocket = NULL;
+        }
+        else
+        {
+            /* The send and receive timeouts will be set later on. */
+        }
+
+        return xSocket;
+    }
 /*-----------------------------------------------------------*/
 
-#if( ( ipconfigUSE_NBNS == 1 ) || ( ipconfigUSE_LLMNR == 1 ) )
+    #if ( ( ipconfigUSE_NBNS == 1 ) || ( ipconfigUSE_LLMNR == 1 ) )
 
-	static void prvReplyDNSMessage( NetworkBufferDescriptor_t *pxNetworkBuffer,
-									BaseType_t lNetLength )
-	{
-	UDPPacket_t *pxUDPPacket;
-	IPHeader_t *pxIPHeader;
-	UDPHeader_t *pxUDPHeader;
-	size_t uxDataLength;
+        static void prvReplyDNSMessage( NetworkBufferDescriptor_t * pxNetworkBuffer,
+                                        BaseType_t lNetLength )
+        {
+            UDPPacket_t * pxUDPPacket;
+            IPHeader_t * pxIPHeader;
+            UDPHeader_t * pxUDPHeader;
+            size_t uxDataLength;
 
-		pxUDPPacket = ipPOINTER_CAST( UDPPacket_t *, pxNetworkBuffer->pucEthernetBuffer );
-		pxIPHeader = &pxUDPPacket->xIPHeader;
-		pxUDPHeader = &pxUDPPacket->xUDPHeader;
-		/* HT: started using defines like 'ipSIZE_OF_xxx' */
-			pxIPHeader->usLength				= FreeRTOS_htons( ( uint16_t ) lNetLength + ipSIZE_OF_IPv4_HEADER + ipSIZE_OF_UDP_HEADER );
-		/* HT:endian: should not be translated, copying from packet to packet */
-		pxIPHeader->ulDestinationIPAddress = pxIPHeader->ulSourceIPAddress;
-		pxIPHeader->ulSourceIPAddress	   = *ipLOCAL_IP_ADDRESS_POINTER;
-		pxIPHeader->ucTimeToLive		   = ipconfigUDP_TIME_TO_LIVE;
-		pxIPHeader->usIdentification	   = FreeRTOS_htons( usPacketIdentifier );
-		usPacketIdentifier++;
-		pxUDPHeader->usLength			   = FreeRTOS_htons( ( uint32_t ) lNetLength + ipSIZE_OF_UDP_HEADER );
-		vFlip_16( pxUDPHeader->usSourcePort, pxUDPHeader->usDestinationPort );
+            pxUDPPacket = ipPOINTER_CAST( UDPPacket_t *, pxNetworkBuffer->pucEthernetBuffer );
+            pxIPHeader = &pxUDPPacket->xIPHeader;
+            pxUDPHeader = &pxUDPPacket->xUDPHeader;
+            /* HT: started using defines like 'ipSIZE_OF_xxx' */
+            pxIPHeader->usLength = FreeRTOS_htons( ( uint16_t ) lNetLength + ipSIZE_OF_IPv4_HEADER + ipSIZE_OF_UDP_HEADER );
+            /* HT:endian: should not be translated, copying from packet to packet */
+            pxIPHeader->ulDestinationIPAddress = pxIPHeader->ulSourceIPAddress;
+            pxIPHeader->ulSourceIPAddress = *ipLOCAL_IP_ADDRESS_POINTER;
+            pxIPHeader->ucTimeToLive = ipconfigUDP_TIME_TO_LIVE;
+            pxIPHeader->usIdentification = FreeRTOS_htons( usPacketIdentifier );
+            usPacketIdentifier++;
+            pxUDPHeader->usLength = FreeRTOS_htons( ( uint32_t ) lNetLength + ipSIZE_OF_UDP_HEADER );
+            vFlip_16( pxUDPHeader->usSourcePort, pxUDPHeader->usDestinationPort );
 
-		/* Important: tell NIC driver how many bytes must be sent */
-		uxDataLength = ( ( size_t ) lNetLength ) + ipSIZE_OF_IPv4_HEADER + ipSIZE_OF_UDP_HEADER + ipSIZE_OF_ETH_HEADER;
+            /* Important: tell NIC driver how many bytes must be sent */
+            uxDataLength = ( ( size_t ) lNetLength ) + ipSIZE_OF_IPv4_HEADER + ipSIZE_OF_UDP_HEADER + ipSIZE_OF_ETH_HEADER;
 
-		#if( ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM == 0 )
-		{
-			/* calculate the IP header checksum */
-			pxIPHeader->usHeaderChecksum = 0U;
-			pxIPHeader->usHeaderChecksum = usGenerateChecksum( 0U, ( uint8_t * ) &( pxIPHeader->ucVersionHeaderLength ), ipSIZE_OF_IPv4_HEADER );
-			pxIPHeader->usHeaderChecksum = ~FreeRTOS_htons( pxIPHeader->usHeaderChecksum );
+            #if ( ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM == 0 )
+                {
+                    /* calculate the IP header checksum */
+                    pxIPHeader->usHeaderChecksum = 0U;
+                    pxIPHeader->usHeaderChecksum = usGenerateChecksum( 0U, ( uint8_t * ) &( pxIPHeader->ucVersionHeaderLength ), ipSIZE_OF_IPv4_HEADER );
+                    pxIPHeader->usHeaderChecksum = ~FreeRTOS_htons( pxIPHeader->usHeaderChecksum );
 
-			/* calculate the UDP checksum for outgoing package */
-			( void ) usGenerateProtocolChecksum( ( uint8_t * ) pxUDPPacket, uxDataLength, pdTRUE );
-		}
-		#endif
+                    /* calculate the UDP checksum for outgoing package */
+                    ( void ) usGenerateProtocolChecksum( ( uint8_t * ) pxUDPPacket, uxDataLength, pdTRUE );
+                }
+            #endif
 
-		/* Important: tell NIC driver how many bytes must be sent */
-		pxNetworkBuffer->xDataLength = uxDataLength;
+            /* Important: tell NIC driver how many bytes must be sent */
+            pxNetworkBuffer->xDataLength = uxDataLength;
 
-		/* This function will fill in the eth addresses and send the packet */
-		vReturnEthernetFrame( pxNetworkBuffer, pdFALSE );
-	}
+            /* This function will fill in the eth addresses and send the packet */
+            vReturnEthernetFrame( pxNetworkBuffer, pdFALSE );
+        }
 
-#endif /* ipconfigUSE_NBNS == 1 || ipconfigUSE_LLMNR == 1 */
+    #endif /* ipconfigUSE_NBNS == 1 || ipconfigUSE_LLMNR == 1 */
 /*-----------------------------------------------------------*/
 
-#if( ipconfigUSE_DNS_CACHE == 1 )
+    #if ( ipconfigUSE_DNS_CACHE == 1 )
 
-	static BaseType_t prvProcessDNSCache( const char *pcName,
-									uint32_t *pulIP,
-									uint32_t ulTTL,
-									BaseType_t xLookUp )
-	{
-	BaseType_t x;
-	BaseType_t xFound = pdFALSE;
-	uint32_t ulCurrentTimeSeconds = ( xTaskGetTickCount() / portTICK_PERIOD_MS ) / 1000U;
-	uint32_t ulIPAddressIndex = 0;
-	static BaseType_t xFreeEntry = 0;
+        static BaseType_t prvProcessDNSCache( const char * pcName,
+                                              uint32_t * pulIP,
+                                              uint32_t ulTTL,
+                                              BaseType_t xLookUp )
+        {
+            BaseType_t x;
+            BaseType_t xFound = pdFALSE;
+            uint32_t ulCurrentTimeSeconds = ( xTaskGetTickCount() / portTICK_PERIOD_MS ) / 1000U;
+            uint32_t ulIPAddressIndex = 0;
+            static BaseType_t xFreeEntry = 0;
 
-		/* MISRA advisory rule 1.2 Relaxed in case of 
-		configASSERT as using __FUNCTION__ makes 
-		debugging easier 			   */
-		configASSERT( ( pcName != NULL ) );
+            /* MISRA advisory rule 1.2 Relaxed in case of
+             * configASSERT as using __FUNCTION__ makes
+             * debugging easier                */
+            configASSERT( ( pcName != NULL ) );
 
-		/* For each entry in the DNS cache table. */
-		for( x = 0; x < ipconfigDNS_CACHE_ENTRIES; x++ )
-		{
-			if( xDNSCache[ x ].pcName[ 0 ] == ( char ) 0 )
-			{
-				continue;
-			}
+            /* For each entry in the DNS cache table. */
+            for( x = 0; x < ipconfigDNS_CACHE_ENTRIES; x++ )
+            {
+                if( xDNSCache[ x ].pcName[ 0 ] == ( char ) 0 )
+                {
+                    continue;
+                }
 
-			if( strcmp( xDNSCache[ x ].pcName, pcName ) == 0 )
-			{
-				/* Is this function called for a lookup or to add/update an IP address? */
-				if( xLookUp != pdFALSE )
-				{
-					/* Confirm that the record is still fresh. */
-					if( ulCurrentTimeSeconds < ( xDNSCache[ x ].ulTimeWhenAddedInSeconds + FreeRTOS_ntohl( xDNSCache[ x ].ulTTL ) ) )
-					{
-#if( ipconfigDNS_CACHE_ADDRESSES_PER_ENTRY > 1 )
-					uint8_t ucIndex;
-						/* The ucCurrentIPAddress value increments without bound and will rollover, */
-						/*  modulo it by the number of IP addresses to keep it in range.     */
-						/*  Also perform a final modulo by the max number of IP addresses    */
-						/*  per DNS cache entry to prevent out-of-bounds access in the event */
-						/*  that ucNumIPAddresses has been corrupted.                        */
-						ucIndex = xDNSCache[ x ].ucCurrentIPAddress % xDNSCache[ x ].ucNumIPAddresses;
-						ucIndex = ucIndex % ( uint8_t ) ipconfigDNS_CACHE_ADDRESSES_PER_ENTRY;
-						ulIPAddressIndex = ucIndex;
+                if( strcmp( xDNSCache[ x ].pcName, pcName ) == 0 )
+                {
+                    /* Is this function called for a lookup or to add/update an IP address? */
+                    if( xLookUp != pdFALSE )
+                    {
+                        /* Confirm that the record is still fresh. */
+                        if( ulCurrentTimeSeconds < ( xDNSCache[ x ].ulTimeWhenAddedInSeconds + FreeRTOS_ntohl( xDNSCache[ x ].ulTTL ) ) )
+                        {
+                            #if ( ipconfigDNS_CACHE_ADDRESSES_PER_ENTRY > 1 )
+                                uint8_t ucIndex;
+                                /* The ucCurrentIPAddress value increments without bound and will rollover, */
+                                /*  modulo it by the number of IP addresses to keep it in range.     */
+                                /*  Also perform a final modulo by the max number of IP addresses    */
+                                /*  per DNS cache entry to prevent out-of-bounds access in the event */
+                                /*  that ucNumIPAddresses has been corrupted.                        */
+                                ucIndex = xDNSCache[ x ].ucCurrentIPAddress % xDNSCache[ x ].ucNumIPAddresses;
+                                ucIndex = ucIndex % ( uint8_t ) ipconfigDNS_CACHE_ADDRESSES_PER_ENTRY;
+                                ulIPAddressIndex = ucIndex;
 
-						xDNSCache[ x ].ucCurrentIPAddress++;
-#endif
-						*pulIP = xDNSCache[ x ].ulIPAddresses[ ulIPAddressIndex ];
-					}
-					else
-					{
-						/* Age out the old cached record. */
-						xDNSCache[ x ].pcName[ 0 ] = ( char ) 0;
-					}
-				}
-				else
-				{
-#if( ipconfigDNS_CACHE_ADDRESSES_PER_ENTRY > 1 )
-					if ( xDNSCache[ x ].ucNumIPAddresses < ( uint8_t ) ipconfigDNS_CACHE_ADDRESSES_PER_ENTRY )
-					{
-						/* If more answers exist than there are IP address storage slots */
-						/* they will overwrite entry 0 */
+                                xDNSCache[ x ].ucCurrentIPAddress++;
+                            #endif /* if ( ipconfigDNS_CACHE_ADDRESSES_PER_ENTRY > 1 ) */
+                            *pulIP = xDNSCache[ x ].ulIPAddresses[ ulIPAddressIndex ];
+                        }
+                        else
+                        {
+                            /* Age out the old cached record. */
+                            xDNSCache[ x ].pcName[ 0 ] = ( char ) 0;
+                        }
+                    }
+                    else
+                    {
+                        #if ( ipconfigDNS_CACHE_ADDRESSES_PER_ENTRY > 1 )
+                            if( xDNSCache[ x ].ucNumIPAddresses < ( uint8_t ) ipconfigDNS_CACHE_ADDRESSES_PER_ENTRY )
+                            {
+                                /* If more answers exist than there are IP address storage slots */
+                                /* they will overwrite entry 0 */
 
-						ulIPAddressIndex = xDNSCache[ x ].ucNumIPAddresses;
-						xDNSCache[ x ].ucNumIPAddresses++;
-					}
-#endif
-					xDNSCache[ x ].ulIPAddresses[ ulIPAddressIndex ] = *pulIP;
-					xDNSCache[ x ].ulTTL = ulTTL;
-					xDNSCache[ x ].ulTimeWhenAddedInSeconds = ulCurrentTimeSeconds;
-				}
+                                ulIPAddressIndex = xDNSCache[ x ].ucNumIPAddresses;
+                                xDNSCache[ x ].ucNumIPAddresses++;
+                            }
+                        #endif
+                        xDNSCache[ x ].ulIPAddresses[ ulIPAddressIndex ] = *pulIP;
+                        xDNSCache[ x ].ulTTL = ulTTL;
+                        xDNSCache[ x ].ulTimeWhenAddedInSeconds = ulCurrentTimeSeconds;
+                    }
 
-				xFound = pdTRUE;
-				break;
-			}
-		}
+                    xFound = pdTRUE;
+                    break;
+                }
+            }
 
-		if( xFound == pdFALSE )
-		{
-			if( xLookUp != pdFALSE )
-			{
-				*pulIP = 0UL;
-			}
-			else
-			{
-				/* Add or update the item. */
-				if( strlen( pcName ) < ( size_t ) ipconfigDNS_CACHE_NAME_LENGTH )
-				{
-					( void ) strcpy( xDNSCache[ xFreeEntry ].pcName, pcName );
+            if( xFound == pdFALSE )
+            {
+                if( xLookUp != pdFALSE )
+                {
+                    *pulIP = 0UL;
+                }
+                else
+                {
+                    /* Add or update the item. */
+                    if( strlen( pcName ) < ( size_t ) ipconfigDNS_CACHE_NAME_LENGTH )
+                    {
+                        ( void ) strcpy( xDNSCache[ xFreeEntry ].pcName, pcName );
 
-					xDNSCache[ xFreeEntry ].ulIPAddresses[ 0 ] = *pulIP;
-					xDNSCache[ xFreeEntry ].ulTTL = ulTTL;
-					xDNSCache[ xFreeEntry ].ulTimeWhenAddedInSeconds = ulCurrentTimeSeconds;
-#if( ipconfigDNS_CACHE_ADDRESSES_PER_ENTRY > 1 )
-					xDNSCache[ xFreeEntry ].ucNumIPAddresses = 1;
-					xDNSCache[ xFreeEntry ].ucCurrentIPAddress = 0;
+                        xDNSCache[ xFreeEntry ].ulIPAddresses[ 0 ] = *pulIP;
+                        xDNSCache[ xFreeEntry ].ulTTL = ulTTL;
+                        xDNSCache[ xFreeEntry ].ulTimeWhenAddedInSeconds = ulCurrentTimeSeconds;
+                        #if ( ipconfigDNS_CACHE_ADDRESSES_PER_ENTRY > 1 )
+                            xDNSCache[ xFreeEntry ].ucNumIPAddresses = 1;
+                            xDNSCache[ xFreeEntry ].ucCurrentIPAddress = 0;
 
-					/* Initialize all remaining IP addresses in this entry to 0 */
-					memset( &xDNSCache[ xFreeEntry ].ulIPAddresses[ 1 ],
-							0,
-							sizeof( xDNSCache[ xFreeEntry ].ulIPAddresses[ 1 ] ) *
-								( ( uint32_t ) ipconfigDNS_CACHE_ADDRESSES_PER_ENTRY - 1U ) );
-#endif
+                            /* Initialize all remaining IP addresses in this entry to 0 */
+                            memset( &xDNSCache[ xFreeEntry ].ulIPAddresses[ 1 ],
+                                    0,
+                                    sizeof( xDNSCache[ xFreeEntry ].ulIPAddresses[ 1 ] ) *
+                                    ( ( uint32_t ) ipconfigDNS_CACHE_ADDRESSES_PER_ENTRY - 1U ) );
+                        #endif
 
-					xFreeEntry++;
+                        xFreeEntry++;
 
-					if( xFreeEntry == ipconfigDNS_CACHE_ENTRIES )
-					{
-						xFreeEntry = 0;
-					}
-				}
-			}
-		}
+                        if( xFreeEntry == ipconfigDNS_CACHE_ENTRIES )
+                        {
+                            xFreeEntry = 0;
+                        }
+                    }
+                }
+            }
 
-		if( ( xLookUp == 0 ) || ( *pulIP != 0UL ) )
-		{
-			FreeRTOS_debug_printf( ( "prvProcessDNSCache: %s: '%s' @ %lxip\n", ( xLookUp != 0 ) ? "look-up" : "add", pcName, FreeRTOS_ntohl( *pulIP ) ) );
-		}
-		return xFound;
-	}
+            if( ( xLookUp == 0 ) || ( *pulIP != 0UL ) )
+            {
+                FreeRTOS_debug_printf( ( "prvProcessDNSCache: %s: '%s' @ %lxip\n", ( xLookUp != 0 ) ? "look-up" : "add", pcName, FreeRTOS_ntohl( *pulIP ) ) );
+            }
 
-#endif /* ipconfigUSE_DNS_CACHE */
+            return xFound;
+        }
+
+    #endif /* ipconfigUSE_DNS_CACHE */
 
 #endif /* ipconfigUSE_DNS != 0 */
 
@@ -1767,5 +1788,5 @@ BaseType_t xReturn;
 
 /* Provide access to private members for testing. */
 #ifdef FREERTOS_ENABLE_UNIT_TESTS
-	#include "freertos_tcp_test_access_dns_define.h"
+    #include "freertos_tcp_test_access_dns_define.h"
 #endif

--- a/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/FreeRTOS_IP.c
+++ b/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/FreeRTOS_IP.c
@@ -47,108 +47,109 @@
 
 
 /* Used to ensure the structure packing is having the desired effect.  The
-'volatile' is used to prevent compiler warnings about comparing a constant with
-a constant. */
+ * 'volatile' is used to prevent compiler warnings about comparing a constant with
+ * a constant. */
 #ifndef _lint
-	#define ipEXPECTED_EthernetHeader_t_SIZE	( ( size_t ) 14 )
-	#define ipEXPECTED_ARPHeader_t_SIZE			( ( size_t ) 28 )
-	#define ipEXPECTED_IPHeader_t_SIZE			( ( size_t ) 20 )
-	#define ipEXPECTED_IGMPHeader_t_SIZE		( ( size_t ) 8 )
-	#define ipEXPECTED_ICMPHeader_t_SIZE		( ( size_t ) 8 )
-	#define ipEXPECTED_UDPHeader_t_SIZE			( ( size_t ) 8 )
-	#define ipEXPECTED_TCPHeader_t_SIZE			( ( size_t ) 20 )
+    #define ipEXPECTED_EthernetHeader_t_SIZE    ( ( size_t ) 14 )
+    #define ipEXPECTED_ARPHeader_t_SIZE         ( ( size_t ) 28 )
+    #define ipEXPECTED_IPHeader_t_SIZE          ( ( size_t ) 20 )
+    #define ipEXPECTED_IGMPHeader_t_SIZE        ( ( size_t ) 8 )
+    #define ipEXPECTED_ICMPHeader_t_SIZE        ( ( size_t ) 8 )
+    #define ipEXPECTED_UDPHeader_t_SIZE         ( ( size_t ) 8 )
+    #define ipEXPECTED_TCPHeader_t_SIZE         ( ( size_t ) 20 )
 #endif
 
 /* ICMP protocol definitions. */
-#define ipICMP_ECHO_REQUEST				( ( uint8_t ) 8 )
-#define ipICMP_ECHO_REPLY				( ( uint8_t ) 0 )
+#define ipICMP_ECHO_REQUEST        ( ( uint8_t ) 8 )
+#define ipICMP_ECHO_REPLY          ( ( uint8_t ) 0 )
 
 /* IPv4 multi-cast addresses range from 224.0.0.0.0 to 240.0.0.0. */
-#define	ipFIRST_MULTI_CAST_IPv4		0xE0000000UL
-#define	ipLAST_MULTI_CAST_IPv4		0xF0000000UL
+#define ipFIRST_MULTI_CAST_IPv4    0xE0000000UL
+#define ipLAST_MULTI_CAST_IPv4     0xF0000000UL
 
 /* Time delay between repeated attempts to initialise the network hardware. */
 #ifndef ipINITIALISATION_RETRY_DELAY
-	#define ipINITIALISATION_RETRY_DELAY	( pdMS_TO_TICKS( 3000U ) )
+    #define ipINITIALISATION_RETRY_DELAY    ( pdMS_TO_TICKS( 3000U ) )
 #endif
 
 /* Defines how often the ARP timer callback function is executed.  The time is
-shorted in the Windows simulator as simulated time is not real time. */
-#ifndef	ipARP_TIMER_PERIOD_MS
-	#ifdef _WINDOWS_
-		#define ipARP_TIMER_PERIOD_MS	( 500U ) /* For windows simulator builds. */
-	#else
-		#define ipARP_TIMER_PERIOD_MS	( 10000U )
-	#endif
+ * shorted in the Windows simulator as simulated time is not real time. */
+#ifndef ipARP_TIMER_PERIOD_MS
+    #ifdef _WINDOWS_
+        #define ipARP_TIMER_PERIOD_MS    ( 500U ) /* For windows simulator builds. */
+    #else
+        #define ipARP_TIMER_PERIOD_MS    ( 10000U )
+    #endif
 #endif
 
 #ifndef iptraceIP_TASK_STARTING
-	#define	iptraceIP_TASK_STARTING()	do {} while( ipFALSE_BOOL )
+    #define iptraceIP_TASK_STARTING()    do {} while( ipFALSE_BOOL )
 #endif
 
-#if( ( ipconfigUSE_TCP == 1 ) && !defined( ipTCP_TIMER_PERIOD_MS ) )
-	/* When initialising the TCP timer,
-	give it an initial time-out of 1 second. */
-	#define ipTCP_TIMER_PERIOD_MS	( 1000U )
+#if ( ( ipconfigUSE_TCP == 1 ) && !defined( ipTCP_TIMER_PERIOD_MS ) )
+
+    /* When initialising the TCP timer,
+     * give it an initial time-out of 1 second. */
+    #define ipTCP_TIMER_PERIOD_MS    ( 1000U )
 #endif
 
 /* If ipconfigETHERNET_DRIVER_FILTERS_FRAME_TYPES is set to 1, then the Ethernet
-driver will filter incoming packets and only pass the stack those packets it
-considers need processing.  In this case ipCONSIDER_FRAME_FOR_PROCESSING() can
-be #defined away.  If ipconfigETHERNET_DRIVER_FILTERS_FRAME_TYPES is set to 0
-then the Ethernet driver will pass all received packets to the stack, and the
-stack must do the filtering itself.  In this case ipCONSIDER_FRAME_FOR_PROCESSING
-needs to call eConsiderFrameForProcessing. */
+ * driver will filter incoming packets and only pass the stack those packets it
+ * considers need processing.  In this case ipCONSIDER_FRAME_FOR_PROCESSING() can
+ * be #defined away.  If ipconfigETHERNET_DRIVER_FILTERS_FRAME_TYPES is set to 0
+ * then the Ethernet driver will pass all received packets to the stack, and the
+ * stack must do the filtering itself.  In this case ipCONSIDER_FRAME_FOR_PROCESSING
+ * needs to call eConsiderFrameForProcessing. */
 #if ipconfigETHERNET_DRIVER_FILTERS_FRAME_TYPES == 0
-	#define ipCONSIDER_FRAME_FOR_PROCESSING( pucEthernetBuffer ) eConsiderFrameForProcessing( ( pucEthernetBuffer ) )
+    #define ipCONSIDER_FRAME_FOR_PROCESSING( pucEthernetBuffer )    eConsiderFrameForProcessing( ( pucEthernetBuffer ) )
 #else
-	#define ipCONSIDER_FRAME_FOR_PROCESSING( pucEthernetBuffer ) eProcessBuffer
+    #define ipCONSIDER_FRAME_FOR_PROCESSING( pucEthernetBuffer )    eProcessBuffer
 #endif
 
-#if( ipconfigETHERNET_DRIVER_FILTERS_PACKETS == 0 )
-	#if( ipconfigBYTE_ORDER == pdFREERTOS_LITTLE_ENDIAN )
-		/* The bits in the two byte IP header field that make up the fragment offset value. */
-		#define ipFRAGMENT_OFFSET_BIT_MASK				( ( uint16_t ) 0xff0f )
-	#else
-		/* The bits in the two byte IP header field that make up the fragment offset value. */
-		#define ipFRAGMENT_OFFSET_BIT_MASK				( ( uint16_t ) 0x0fff )
-	#endif /* ipconfigBYTE_ORDER */
+#if ( ipconfigETHERNET_DRIVER_FILTERS_PACKETS == 0 )
+    #if ( ipconfigBYTE_ORDER == pdFREERTOS_LITTLE_ENDIAN )
+        /* The bits in the two byte IP header field that make up the fragment offset value. */
+        #define ipFRAGMENT_OFFSET_BIT_MASK    ( ( uint16_t ) 0xff0f )
+    #else
+        /* The bits in the two byte IP header field that make up the fragment offset value. */
+        #define ipFRAGMENT_OFFSET_BIT_MASK    ( ( uint16_t ) 0x0fff )
+    #endif /* ipconfigBYTE_ORDER */
 #endif /* ipconfigETHERNET_DRIVER_FILTERS_PACKETS */
 
 /* The maximum time the IP task is allowed to remain in the Blocked state if no
-events are posted to the network event queue. */
-#ifndef	ipconfigMAX_IP_TASK_SLEEP_TIME
-	#define ipconfigMAX_IP_TASK_SLEEP_TIME ( pdMS_TO_TICKS( 10000UL ) )
+ * events are posted to the network event queue. */
+#ifndef ipconfigMAX_IP_TASK_SLEEP_TIME
+    #define ipconfigMAX_IP_TASK_SLEEP_TIME    ( pdMS_TO_TICKS( 10000UL ) )
 #endif
 
 /* Returned as the (invalid) checksum when the protocol being checked is not
-handled.  The value is chosen simply to be easy to spot when debugging. */
-#define ipUNHANDLED_PROTOCOL		0x4321U
+* handled.  The value is chosen simply to be easy to spot when debugging. */
+#define ipUNHANDLED_PROTOCOL    0x4321U
 
 /* Returned to indicate a valid checksum when the checksum does not need to be
-calculated. */
-#define ipCORRECT_CRC				0xffffU
+ * calculated. */
+#define ipCORRECT_CRC           0xffffU
 
 /* Returned as the (invalid) checksum when the length of the data being checked
-had an invalid length. */
-#define ipINVALID_LENGTH			0x1234U
+ * had an invalid length. */
+#define ipINVALID_LENGTH        0x1234U
 
 /*-----------------------------------------------------------*/
 
 /* Used in checksum calculation. */
 typedef union _xUnion32
 {
-	uint32_t u32;
-	uint16_t u16[ 2 ];
-	uint8_t u8[ 4 ];
+    uint32_t u32;
+    uint16_t u16[ 2 ];
+    uint8_t u8[ 4 ];
 } xUnion32;
 
 /* Used in checksum calculation. */
 typedef union _xUnionPtr
 {
-	uint32_t *u32ptr;
-	uint16_t *u16ptr;
-	uint8_t *u8ptr;
+    uint32_t * u32ptr;
+    uint16_t * u16ptr;
+    uint8_t * u8ptr;
 } xUnionPtr;
 
 /*-----------------------------------------------------------*/
@@ -158,7 +159,7 @@ typedef union _xUnionPtr
  * from the network hardware drivers and tasks that are using sockets.  It also
  * maintains a set of protocol timers.
  */
-static void prvIPTask( void *pvParameters );
+static void prvIPTask( void * pvParameters );
 
 /*
  * Called when new data is available from the network interface.
@@ -168,20 +169,22 @@ static void prvProcessEthernetPacket( NetworkBufferDescriptor_t * const pxNetwor
 /*
  * Process incoming IP packets.
  */
-static eFrameProcessingResult_t prvProcessIPPacket( IPPacket_t * pxIPPacket, NetworkBufferDescriptor_t * const pxNetworkBuffer );
+static eFrameProcessingResult_t prvProcessIPPacket( IPPacket_t * pxIPPacket,
+                                                    NetworkBufferDescriptor_t * const pxNetworkBuffer );
 
 #if ( ipconfigREPLY_TO_INCOMING_PINGS == 1 ) || ( ipconfigSUPPORT_OUTGOING_PINGS == 1 )
-	/*
-	 * Process incoming ICMP packets.
-	 */
-	static eFrameProcessingResult_t prvProcessICMPPacket( ICMPPacket_t * const pxICMPPacket );
+
+    /*
+     * Process incoming ICMP packets.
+     */
+    static eFrameProcessingResult_t prvProcessICMPPacket( ICMPPacket_t * const pxICMPPacket );
 #endif /* ( ipconfigREPLY_TO_INCOMING_PINGS == 1 ) || ( ipconfigSUPPORT_OUTGOING_PINGS == 1 ) */
 
 /*
  * Turns around an incoming ping request to convert it into a ping reply.
  */
 #if ( ipconfigREPLY_TO_INCOMING_PINGS == 1 )
-	static eFrameProcessingResult_t prvProcessICMPEchoRequest( ICMPPacket_t * const pxICMPPacket );
+    static eFrameProcessingResult_t prvProcessICMPEchoRequest( ICMPPacket_t * const pxICMPPacket );
 #endif /* ipconfigREPLY_TO_INCOMING_PINGS */
 
 /*
@@ -189,7 +192,7 @@ static eFrameProcessingResult_t prvProcessIPPacket( IPPacket_t * pxIPPacket, Net
  * vApplicationPingReplyHook() is called with the results.
  */
 #if ( ipconfigSUPPORT_OUTGOING_PINGS == 1 )
-	static void prvProcessICMPEchoReply( ICMPPacket_t * const pxICMPPacket );
+    static void prvProcessICMPEchoReply( ICMPPacket_t * const pxICMPPacket );
 #endif /* ipconfigSUPPORT_OUTGOING_PINGS */
 
 /*
@@ -214,19 +217,21 @@ static TickType_t prvCalculateSleepTime( void );
  * The network card driver has received a packet.  In the case that it is part
  * of a linked packet chain, walk through it to handle every message.
  */
-static void prvHandleEthernetPacket( NetworkBufferDescriptor_t *pxBuffer );
+static void prvHandleEthernetPacket( NetworkBufferDescriptor_t * pxBuffer );
 
 /*
  * Utility functions for the light weight IP timers.
  */
-static void prvIPTimerStart( IPTimer_t *pxTimer, TickType_t xTime );
-static BaseType_t prvIPTimerCheck( IPTimer_t *pxTimer );
-static void prvIPTimerReload( IPTimer_t *pxTimer, TickType_t xTime );
+static void prvIPTimerStart( IPTimer_t * pxTimer,
+                             TickType_t xTime );
+static BaseType_t prvIPTimerCheck( IPTimer_t * pxTimer );
+static void prvIPTimerReload( IPTimer_t * pxTimer,
+                              TickType_t xTime );
 
 /* The function 'prvAllowIPPacket()' checks if a packets should be processed. */
 static eFrameProcessingResult_t prvAllowIPPacket( const IPPacket_t * const pxIPPacket,
-												  const NetworkBufferDescriptor_t * const pxNetworkBuffer,
-												  UBaseType_t uxHeaderLength );
+                                                  const NetworkBufferDescriptor_t * const pxNetworkBuffer,
+                                                  UBaseType_t uxHeaderLength );
 
 /*-----------------------------------------------------------*/
 
@@ -237,56 +242,57 @@ QueueHandle_t xNetworkEventQueue = NULL;
 uint16_t usPacketIdentifier = 0U;
 
 /* For convenience, a MAC address of all 0xffs is defined const for quick
-reference. */
+ * reference. */
 const MACAddress_t xBroadcastMACAddress = { { 0xff, 0xff, 0xff, 0xff, 0xff, 0xff } };
 
 /* Structure that stores the netmask, gateway address and DNS server addresses. */
 NetworkAddressingParameters_t xNetworkAddressing = { 0, 0, 0, 0, 0 };
 
 /* Default values for the above struct in case DHCP
-does not lead to a confirmed request. */
+ * does not lead to a confirmed request. */
 /* coverity[misra_c_2012_rule_8_9_violation] */
 /* "xDefaultAddressing" should be defined at block scope. */
 NetworkAddressingParameters_t xDefaultAddressing = { 0, 0, 0, 0, 0 };
 
 /* Used to ensure network down events cannot be missed when they cannot be
-posted to the network event queue because the network event queue is already
-full. */
+ * posted to the network event queue because the network event queue is already
+ * full. */
 static volatile BaseType_t xNetworkDownEventPending = pdFALSE;
 
 /* Stores the handle of the task that handles the stack.  The handle is used
-(indirectly) by some utility function to determine if the utility function is
-being called by a task (in which case it is ok to block) or by the IP task
-itself (in which case it is not ok to block). */
+ * (indirectly) by some utility function to determine if the utility function is
+ * being called by a task (in which case it is ok to block) or by the IP task
+ * itself (in which case it is not ok to block). */
 static TaskHandle_t xIPTaskHandle = NULL;
 
-#if( ipconfigUSE_TCP != 0 )
-	/* Set to a non-zero value if one or more TCP message have been processed
-	within the last round. */
-	static BaseType_t xProcessedTCPMessage;
+#if ( ipconfigUSE_TCP != 0 )
+
+    /* Set to a non-zero value if one or more TCP message have been processed
+     * within the last round. */
+    static BaseType_t xProcessedTCPMessage;
 #endif
 
 /* Simple set to pdTRUE or pdFALSE depending on whether the network is up or
-down (connected, not connected) respectively. */
+ * down (connected, not connected) respectively. */
 static BaseType_t xNetworkUp = pdFALSE;
 
 /*
-A timer for each of the following processes, all of which need attention on a
-regular basis:
-	1. ARP, to check its table entries
-	2. DPHC, to send requests and to renew a reservation
-	3. TCP, to check for timeouts, resends
-	4. DNS, to check for timeouts when looking-up a domain.
+ * A timer for each of the following processes, all of which need attention on a
+ * regular basis:
+ *  1. ARP, to check its table entries
+ *  2. DPHC, to send requests and to renew a reservation
+ *  3. TCP, to check for timeouts, resends
+ *  4. DNS, to check for timeouts when looking-up a domain.
  */
 static IPTimer_t xARPTimer;
-#if( ipconfigUSE_DHCP != 0 )
-	static IPTimer_t xDHCPTimer;
+#if ( ipconfigUSE_DHCP != 0 )
+    static IPTimer_t xDHCPTimer;
 #endif
-#if( ipconfigUSE_TCP != 0 )
-	static IPTimer_t xTCPTimer;
+#if ( ipconfigUSE_TCP != 0 )
+    static IPTimer_t xTCPTimer;
 #endif
-#if( ipconfigDNS_USE_CALLBACKS != 0 )
-	static IPTimer_t xDNSTimer;
+#if ( ipconfigDNS_USE_CALLBACKS != 0 )
+    static IPTimer_t xDNSTimer;
 #endif
 
 /* Set to pdTRUE when the IP task is ready to start processing packets. */
@@ -294,1851 +300,1871 @@ static IPTimer_t xARPTimer;
 /* "xIPTaskInitialised" should be defined at block scope. */
 static BaseType_t xIPTaskInitialised = pdFALSE;
 
-#if( ipconfigCHECK_IP_QUEUE_SPACE != 0 )
-	/* Keep track of the lowest amount of space in 'xNetworkEventQueue'. */
-	static UBaseType_t uxQueueMinimumSpace = ipconfigEVENT_QUEUE_LENGTH;
+#if ( ipconfigCHECK_IP_QUEUE_SPACE != 0 )
+    /* Keep track of the lowest amount of space in 'xNetworkEventQueue'. */
+    static UBaseType_t uxQueueMinimumSpace = ipconfigEVENT_QUEUE_LENGTH;
 #endif
 
 /*-----------------------------------------------------------*/
 
 /* Coverity want to make pvParameters const, which would make it incompatible. */
 /* coverity[misra_c_2012_rule_8_13_violation] */
-static void prvIPTask( void *pvParameters )
+static void prvIPTask( void * pvParameters )
 {
-IPStackEvent_t xReceivedEvent;
-TickType_t xNextIPSleep;
-FreeRTOS_Socket_t *pxSocket;
-struct freertos_sockaddr xAddress;
+    IPStackEvent_t xReceivedEvent;
+    TickType_t xNextIPSleep;
+    FreeRTOS_Socket_t * pxSocket;
+    struct freertos_sockaddr xAddress;
 
-	/* Just to prevent compiler warnings about unused parameters. */
-	( void ) pvParameters;
+    /* Just to prevent compiler warnings about unused parameters. */
+    ( void ) pvParameters;
 
-	/* A possibility to set some additional task properties. */
-	iptraceIP_TASK_STARTING();
+    /* A possibility to set some additional task properties. */
+    iptraceIP_TASK_STARTING();
 
-	/* Generate a dummy message to say that the network connection has gone
-	down.  This will cause this task to initialise the network interface.  After
-	this it is the responsibility of the network interface hardware driver to
-	send this message if a previously connected network is disconnected. */
-	FreeRTOS_NetworkDown();
+    /* Generate a dummy message to say that the network connection has gone
+     *  down.  This will cause this task to initialise the network interface.  After
+     *  this it is the responsibility of the network interface hardware driver to
+     *  send this message if a previously connected network is disconnected. */
+    FreeRTOS_NetworkDown();
 
-	#if( ipconfigUSE_TCP == 1 )
-	{
-		/* Initialise the TCP timer. */
-		prvIPTimerReload( &xTCPTimer, pdMS_TO_TICKS( ipTCP_TIMER_PERIOD_MS ) );
-	}
-	#endif
+    #if ( ipconfigUSE_TCP == 1 )
+        {
+            /* Initialise the TCP timer. */
+            prvIPTimerReload( &xTCPTimer, pdMS_TO_TICKS( ipTCP_TIMER_PERIOD_MS ) );
+        }
+    #endif
 
-	/* Initialisation is complete and events can now be processed. */
-	xIPTaskInitialised = pdTRUE;
+    /* Initialisation is complete and events can now be processed. */
+    xIPTaskInitialised = pdTRUE;
 
-	FreeRTOS_debug_printf( ( "prvIPTask started\n" ) );
+    FreeRTOS_debug_printf( ( "prvIPTask started\n" ) );
 
-	/* Loop, processing IP events. */
-	for( ;; )
-	{
-		ipconfigWATCHDOG_TIMER();
+    /* Loop, processing IP events. */
+    for( ; ; )
+    {
+        ipconfigWATCHDOG_TIMER();
 
-		/* Check the ARP, DHCP and TCP timers to see if there is any periodic
-		or timeout processing to perform. */
-		prvCheckNetworkTimers();
+        /* Check the ARP, DHCP and TCP timers to see if there is any periodic
+         * or timeout processing to perform. */
+        prvCheckNetworkTimers();
 
-		/* Calculate the acceptable maximum sleep time. */
-		xNextIPSleep = prvCalculateSleepTime();
+        /* Calculate the acceptable maximum sleep time. */
+        xNextIPSleep = prvCalculateSleepTime();
 
-		/* Wait until there is something to do. If the following call exits
-		 * due to a time out rather than a message being received, set a
-		 * 'NoEvent' value. */
-		if ( xQueueReceive( xNetworkEventQueue, ipPOINTER_CAST( void *, &xReceivedEvent ), xNextIPSleep ) == pdFALSE ) 
-		{
-			xReceivedEvent.eEventType = eNoEvent;
-		}
+        /* Wait until there is something to do. If the following call exits
+         * due to a time out rather than a message being received, set a
+         * 'NoEvent' value. */
+        if( xQueueReceive( xNetworkEventQueue, ipPOINTER_CAST( void *, &xReceivedEvent ), xNextIPSleep ) == pdFALSE )
+        {
+            xReceivedEvent.eEventType = eNoEvent;
+        }
 
-		#if( ipconfigCHECK_IP_QUEUE_SPACE != 0 )
-		{
-			if( xReceivedEvent.eEventType != eNoEvent )
-			{
-			UBaseType_t uxCount;
+        #if ( ipconfigCHECK_IP_QUEUE_SPACE != 0 )
+            {
+                if( xReceivedEvent.eEventType != eNoEvent )
+                {
+                    UBaseType_t uxCount;
 
-				uxCount = uxQueueSpacesAvailable( xNetworkEventQueue );
-				if( uxQueueMinimumSpace > uxCount )
-				{
-					uxQueueMinimumSpace = uxCount;
-				}
-			}
-		}
-		#endif /* ipconfigCHECK_IP_QUEUE_SPACE */
+                    uxCount = uxQueueSpacesAvailable( xNetworkEventQueue );
 
-		iptraceNETWORK_EVENT_RECEIVED( xReceivedEvent.eEventType );
+                    if( uxQueueMinimumSpace > uxCount )
+                    {
+                        uxQueueMinimumSpace = uxCount;
+                    }
+                }
+            }
+        #endif /* ipconfigCHECK_IP_QUEUE_SPACE */
 
-		switch( xReceivedEvent.eEventType )
-		{
-			case eNetworkDownEvent :
-				/* Attempt to establish a connection. */
-				xNetworkUp = pdFALSE;
-				prvProcessNetworkDownEvent();
-				break;
+        iptraceNETWORK_EVENT_RECEIVED( xReceivedEvent.eEventType );
 
-			case eNetworkRxEvent:
-				/* The network hardware driver has received a new packet.  A
-				pointer to the received buffer is located in the pvData member
-				of the received event structure. */
-				prvHandleEthernetPacket( ipPOINTER_CAST( NetworkBufferDescriptor_t *, xReceivedEvent.pvData ) );
-				break;
+        switch( xReceivedEvent.eEventType )
+        {
+            case eNetworkDownEvent:
+                /* Attempt to establish a connection. */
+                xNetworkUp = pdFALSE;
+                prvProcessNetworkDownEvent();
+                break;
 
-			case eNetworkTxEvent:
-				/* Send a network packet. The ownership will  be transferred to
-				the driver, which will release it after delivery. */
-				( void ) xNetworkInterfaceOutput( ipPOINTER_CAST( NetworkBufferDescriptor_t *, xReceivedEvent.pvData ), pdTRUE );
-				break;
+            case eNetworkRxEvent:
+                /* The network hardware driver has received a new packet.  A
+                 * pointer to the received buffer is located in the pvData member
+                 * of the received event structure. */
+                prvHandleEthernetPacket( ipPOINTER_CAST( NetworkBufferDescriptor_t *, xReceivedEvent.pvData ) );
+                break;
 
-			case eARPTimerEvent :
-				/* The ARP timer has expired, process the ARP cache. */
-				vARPAgeCache();
-				break;
+            case eNetworkTxEvent:
+                /* Send a network packet. The ownership will  be transferred to
+                 * the driver, which will release it after delivery. */
+                ( void ) xNetworkInterfaceOutput( ipPOINTER_CAST( NetworkBufferDescriptor_t *, xReceivedEvent.pvData ), pdTRUE );
+                break;
 
-			case eSocketBindEvent:
-				/* FreeRTOS_bind (a user API) wants the IP-task to bind a socket
-				to a port. The port number is communicated in the socket field
-				usLocalPort. vSocketBind() will actually bind the socket and the
-				API will unblock as soon as the eSOCKET_BOUND event is
-				triggered. */
-				pxSocket = ipPOINTER_CAST( FreeRTOS_Socket_t *, xReceivedEvent.pvData );
-				xAddress.sin_addr = 0U;	/* For the moment. */
-				xAddress.sin_port = FreeRTOS_ntohs( pxSocket->usLocalPort );
-				pxSocket->usLocalPort = 0U;
-				( void ) vSocketBind( pxSocket, &xAddress, sizeof( xAddress ), pdFALSE );
+            case eARPTimerEvent:
+                /* The ARP timer has expired, process the ARP cache. */
+                vARPAgeCache();
+                break;
 
-				/* Before 'eSocketBindEvent' was sent it was tested that
-				( xEventGroup != NULL ) so it can be used now to wake up the
-				user. */
-				pxSocket->xEventBits |= ( EventBits_t ) eSOCKET_BOUND;
-				vSocketWakeUpUser( pxSocket );
-				break;
+            case eSocketBindEvent:
+                /* FreeRTOS_bind (a user API) wants the IP-task to bind a socket
+                 * to a port. The port number is communicated in the socket field
+                 * usLocalPort. vSocketBind() will actually bind the socket and the
+                 * API will unblock as soon as the eSOCKET_BOUND event is
+                 * triggered. */
+                pxSocket = ipPOINTER_CAST( FreeRTOS_Socket_t *, xReceivedEvent.pvData );
+                xAddress.sin_addr = 0U; /* For the moment. */
+                xAddress.sin_port = FreeRTOS_ntohs( pxSocket->usLocalPort );
+                pxSocket->usLocalPort = 0U;
+                ( void ) vSocketBind( pxSocket, &xAddress, sizeof( xAddress ), pdFALSE );
 
-			case eSocketCloseEvent :
-				/* The user API FreeRTOS_closesocket() has sent a message to the
-				IP-task to actually close a socket. This is handled in
-				vSocketClose().  As the socket gets closed, there is no way to
-				report back to the API, so the API won't wait for the result */
-				( void ) vSocketClose( ipPOINTER_CAST( FreeRTOS_Socket_t *, xReceivedEvent.pvData ) );
-				break;
+                /* Before 'eSocketBindEvent' was sent it was tested that
+                 * ( xEventGroup != NULL ) so it can be used now to wake up the
+                 * user. */
+                pxSocket->xEventBits |= ( EventBits_t ) eSOCKET_BOUND;
+                vSocketWakeUpUser( pxSocket );
+                break;
 
-			case eStackTxEvent :
-				/* The network stack has generated a packet to send.  A
-				pointer to the generated buffer is located in the pvData
-				member of the received event structure. */
-				vProcessGeneratedUDPPacket( ipPOINTER_CAST( NetworkBufferDescriptor_t *, xReceivedEvent.pvData ) );
-				break;
+            case eSocketCloseEvent:
+                /* The user API FreeRTOS_closesocket() has sent a message to the
+                 * IP-task to actually close a socket. This is handled in
+                 * vSocketClose().  As the socket gets closed, there is no way to
+                 * report back to the API, so the API won't wait for the result */
+                ( void ) vSocketClose( ipPOINTER_CAST( FreeRTOS_Socket_t *, xReceivedEvent.pvData ) );
+                break;
 
-			case eDHCPEvent:
-				/* The DHCP state machine needs processing. */
-				#if( ipconfigUSE_DHCP == 1 )
-				{
-					/* Process DHCP messages for a given end-point. */
-					vDHCPProcess( pdFALSE );
-				}
-				#endif /* ipconfigUSE_DHCP */
-				break;
+            case eStackTxEvent:
+                /* The network stack has generated a packet to send.  A
+                 * pointer to the generated buffer is located in the pvData
+                 * member of the received event structure. */
+                vProcessGeneratedUDPPacket( ipPOINTER_CAST( NetworkBufferDescriptor_t *, xReceivedEvent.pvData ) );
+                break;
 
-			case eSocketSelectEvent :
-				/* FreeRTOS_select() has got unblocked by a socket event,
-				vSocketSelect() will check which sockets actually have an event
-				and update the socket field xSocketBits. */
-				#if( ipconfigSUPPORT_SELECT_FUNCTION == 1 )
-				{
-					#if( ipconfigSELECT_USES_NOTIFY != 0 )
-					{
-						SocketSelectMessage_t *pxMessage = ipPOINTER_CAST( SocketSelectMessage_t *, xReceivedEvent.pvData );
-						vSocketSelect( pxMessage->pxSocketSet );
-						( void ) xTaskNotifyGive( pxMessage->xTaskhandle );
-					}
-					#else
-					{
-						vSocketSelect( ipPOINTER_CAST( SocketSelect_t *, xReceivedEvent.pvData ) );
-					}
-					#endif	/* ( ipconfigSELECT_USES_NOTIFY != 0 ) */
-				}
-				#endif /* ipconfigSUPPORT_SELECT_FUNCTION == 1 */
-				break;
+            case eDHCPEvent:
+                /* The DHCP state machine needs processing. */
+                #if ( ipconfigUSE_DHCP == 1 )
+                    /* Process DHCP messages for a given end-point. */
+                    vDHCPProcess( pdFALSE );
+                #endif /* ipconfigUSE_DHCP */
+                break;
 
-			case eSocketSignalEvent :
-				#if( ipconfigSUPPORT_SIGNALS != 0 )
-				{
-					/* Some task wants to signal the user of this socket in
-					order to interrupt a call to recv() or a call to select(). */
-					( void ) FreeRTOS_SignalSocket( ipPOINTER_CAST( Socket_t, xReceivedEvent.pvData ) );
-				}
-				#endif /* ipconfigSUPPORT_SIGNALS */
-				break;
+            case eSocketSelectEvent:
+                /* FreeRTOS_select() has got unblocked by a socket event,
+                 * vSocketSelect() will check which sockets actually have an event
+                 * and update the socket field xSocketBits. */
+                #if ( ipconfigSUPPORT_SELECT_FUNCTION == 1 )
+                    #if ( ipconfigSELECT_USES_NOTIFY != 0 )
+                       {
+                           SocketSelectMessage_t * pxMessage = ipPOINTER_CAST( SocketSelectMessage_t *, xReceivedEvent.pvData );
+                           vSocketSelect( pxMessage->pxSocketSet );
+                           ( void ) xTaskNotifyGive( pxMessage->xTaskhandle );
+                       }
+                    #else
+                        {
+                            vSocketSelect( ipPOINTER_CAST( SocketSelect_t *, xReceivedEvent.pvData ) );
+                        }
+                    #endif /* ( ipconfigSELECT_USES_NOTIFY != 0 ) */
+                #endif /* ipconfigSUPPORT_SELECT_FUNCTION == 1 */
+                break;
 
-			case eTCPTimerEvent :
-				#if( ipconfigUSE_TCP == 1 )
-				{
-					/* Simply mark the TCP timer as expired so it gets processed
-					the next time prvCheckNetworkTimers() is called. */
-					xTCPTimer.bExpired = pdTRUE_UNSIGNED;
-				}
-				#endif /* ipconfigUSE_TCP */
-				break;
+            case eSocketSignalEvent:
+                #if ( ipconfigSUPPORT_SIGNALS != 0 )
+                    /* Some task wants to signal the user of this socket in
+                     * order to interrupt a call to recv() or a call to select(). */
+                    ( void ) FreeRTOS_SignalSocket( ipPOINTER_CAST( Socket_t, xReceivedEvent.pvData ) );
+                #endif /* ipconfigSUPPORT_SIGNALS */
+                break;
 
-			case eTCPAcceptEvent:
-				/* The API FreeRTOS_accept() was called, the IP-task will now
-				check if the listening socket (communicated in pvData) actually
-				received a new connection. */
-				#if( ipconfigUSE_TCP == 1 )
-				{
-					pxSocket = ipPOINTER_CAST( FreeRTOS_Socket_t *, xReceivedEvent.pvData );
+            case eTCPTimerEvent:
+                #if ( ipconfigUSE_TCP == 1 )
+                    /* Simply mark the TCP timer as expired so it gets processed
+                     * the next time prvCheckNetworkTimers() is called. */
+                    xTCPTimer.bExpired = pdTRUE_UNSIGNED;
+                #endif /* ipconfigUSE_TCP */
+                break;
 
-					if( xTCPCheckNewClient( pxSocket ) != pdFALSE )
-					{
-						pxSocket->xEventBits |= ( EventBits_t ) eSOCKET_ACCEPT;
-						vSocketWakeUpUser( pxSocket );
-					}
-				}
-				#endif /* ipconfigUSE_TCP */
-				break;
+            case eTCPAcceptEvent:
+                /* The API FreeRTOS_accept() was called, the IP-task will now
+                 * check if the listening socket (communicated in pvData) actually
+                 * received a new connection. */
+                #if ( ipconfigUSE_TCP == 1 )
+                    pxSocket = ipPOINTER_CAST( FreeRTOS_Socket_t *, xReceivedEvent.pvData );
 
-			case eTCPNetStat:
-				/* FreeRTOS_netstat() was called to have the IP-task print an
-				overview of all sockets and their connections */
-				#if( ( ipconfigUSE_TCP == 1 ) && ( ipconfigHAS_PRINTF == 1 ) )
-				{
-					vTCPNetStat();
-				}
-				#endif /* ipconfigUSE_TCP */
-				break;
+                    if( xTCPCheckNewClient( pxSocket ) != pdFALSE )
+                    {
+                        pxSocket->xEventBits |= ( EventBits_t ) eSOCKET_ACCEPT;
+                        vSocketWakeUpUser( pxSocket );
+                    }
+                #endif /* ipconfigUSE_TCP */
+                break;
 
-			case eNoEvent:
-				/* xQueueReceive() returned because of a normal time-out. */
-				break;
+            case eTCPNetStat:
+                /* FreeRTOS_netstat() was called to have the IP-task print an
+                 * overview of all sockets and their connections */
+                #if ( ( ipconfigUSE_TCP == 1 ) && ( ipconfigHAS_PRINTF == 1 ) )
+                    vTCPNetStat();
+                #endif /* ipconfigUSE_TCP */
+                break;
 
-			default :
-				/* Should not get here. */
-				break;
-		}
+            case eNoEvent:
+                /* xQueueReceive() returned because of a normal time-out. */
+                break;
 
-		if( xNetworkDownEventPending != pdFALSE )
-		{
-			/* A network down event could not be posted to the network event
-			queue because the queue was full.
-			As this code runs in the IP-task, it can be done directly by
-			calling prvProcessNetworkDownEvent(). */
-			prvProcessNetworkDownEvent();
-		}
-	}
+            default:
+                /* Should not get here. */
+                break;
+        }
+
+        if( xNetworkDownEventPending != pdFALSE )
+        {
+            /* A network down event could not be posted to the network event
+             * queue because the queue was full.
+             * As this code runs in the IP-task, it can be done directly by
+             * calling prvProcessNetworkDownEvent(). */
+            prvProcessNetworkDownEvent();
+        }
+    }
 }
 /*-----------------------------------------------------------*/
 
 BaseType_t xIsCallingFromIPTask( void )
 {
-BaseType_t xReturn;
+    BaseType_t xReturn;
 
-	if( xTaskGetCurrentTaskHandle() == xIPTaskHandle )
-	{
-		xReturn = pdTRUE;
-	}
-	else
-	{
-		xReturn = pdFALSE;
-	}
+    if( xTaskGetCurrentTaskHandle() == xIPTaskHandle )
+    {
+        xReturn = pdTRUE;
+    }
+    else
+    {
+        xReturn = pdFALSE;
+    }
 
-	return xReturn;
+    return xReturn;
 }
 /*-----------------------------------------------------------*/
 
-static void prvHandleEthernetPacket( NetworkBufferDescriptor_t *pxBuffer )
+static void prvHandleEthernetPacket( NetworkBufferDescriptor_t * pxBuffer )
 {
-	#if( ipconfigUSE_LINKED_RX_MESSAGES == 0 )
-	{
-		/* When ipconfigUSE_LINKED_RX_MESSAGES is not set to 0 then only one
-		buffer will be sent at a time.  This is the default way for +TCP to pass
-		messages from the MAC to the TCP/IP stack. */
-		prvProcessEthernetPacket( pxBuffer );
-	}
-	#else /* ipconfigUSE_LINKED_RX_MESSAGES */
-	{
-	NetworkBufferDescriptor_t *pxNextBuffer;
+    #if ( ipconfigUSE_LINKED_RX_MESSAGES == 0 )
+        {
+            /* When ipconfigUSE_LINKED_RX_MESSAGES is not set to 0 then only one
+             * buffer will be sent at a time.  This is the default way for +TCP to pass
+             * messages from the MAC to the TCP/IP stack. */
+            prvProcessEthernetPacket( pxBuffer );
+        }
+    #else /* ipconfigUSE_LINKED_RX_MESSAGES */
+        {
+            NetworkBufferDescriptor_t * pxNextBuffer;
 
-		/* An optimisation that is useful when there is high network traffic.
-		Instead of passing received packets into the IP task one at a time the
-		network interface can chain received packets together and pass them into
-		the IP task in one go.  The packets are chained using the pxNextBuffer
-		member.  The loop below walks through the chain processing each packet
-		in the chain in turn. */
-		do
-		{
-			/* Store a pointer to the buffer after pxBuffer for use later on. */
-			pxNextBuffer = pxBuffer->pxNextBuffer;
+            /* An optimisation that is useful when there is high network traffic.
+             * Instead of passing received packets into the IP task one at a time the
+             * network interface can chain received packets together and pass them into
+             * the IP task in one go.  The packets are chained using the pxNextBuffer
+             * member.  The loop below walks through the chain processing each packet
+             * in the chain in turn. */
+            do
+            {
+                /* Store a pointer to the buffer after pxBuffer for use later on. */
+                pxNextBuffer = pxBuffer->pxNextBuffer;
 
-			/* Make it NULL to avoid using it later on. */
-			pxBuffer->pxNextBuffer = NULL;
+                /* Make it NULL to avoid using it later on. */
+                pxBuffer->pxNextBuffer = NULL;
 
-			prvProcessEthernetPacket( pxBuffer );
-			pxBuffer = pxNextBuffer;
+                prvProcessEthernetPacket( pxBuffer );
+                pxBuffer = pxNextBuffer;
 
-		/* While there is another packet in the chain. */
-		} while( pxBuffer != NULL );
-	}
-	#endif /* ipconfigUSE_LINKED_RX_MESSAGES */
+                /* While there is another packet in the chain. */
+            } while( pxBuffer != NULL );
+        }
+    #endif /* ipconfigUSE_LINKED_RX_MESSAGES */
 }
 /*-----------------------------------------------------------*/
 
 static TickType_t prvCalculateSleepTime( void )
 {
-TickType_t xMaximumSleepTime;
+    TickType_t xMaximumSleepTime;
 
-	/* Start with the maximum sleep time, then check this against the remaining
-	time in any other timers that are active. */
-	xMaximumSleepTime = ipconfigMAX_IP_TASK_SLEEP_TIME;
+    /* Start with the maximum sleep time, then check this against the remaining
+     * time in any other timers that are active. */
+    xMaximumSleepTime = ipconfigMAX_IP_TASK_SLEEP_TIME;
 
-	if( xARPTimer.bActive != pdFALSE_UNSIGNED )
-	{
-		if( xARPTimer.ulRemainingTime < xMaximumSleepTime )
-		{
-			xMaximumSleepTime = xARPTimer.ulReloadTime;
-		}
-	}
+    if( xARPTimer.bActive != pdFALSE_UNSIGNED )
+    {
+        if( xARPTimer.ulRemainingTime < xMaximumSleepTime )
+        {
+            xMaximumSleepTime = xARPTimer.ulReloadTime;
+        }
+    }
 
-	#if( ipconfigUSE_DHCP == 1 )
-	{
-		if( xDHCPTimer.bActive != pdFALSE_UNSIGNED )
-		{
-			if( xDHCPTimer.ulRemainingTime < xMaximumSleepTime )
-			{
-				xMaximumSleepTime = xDHCPTimer.ulRemainingTime;
-			}
-		}
-	}
-	#endif /* ipconfigUSE_DHCP */
+    #if ( ipconfigUSE_DHCP == 1 )
+        {
+            if( xDHCPTimer.bActive != pdFALSE_UNSIGNED )
+            {
+                if( xDHCPTimer.ulRemainingTime < xMaximumSleepTime )
+                {
+                    xMaximumSleepTime = xDHCPTimer.ulRemainingTime;
+                }
+            }
+        }
+    #endif /* ipconfigUSE_DHCP */
 
-	#if( ipconfigUSE_TCP == 1 )
-	{
-		if( xTCPTimer.ulRemainingTime < xMaximumSleepTime )
-		{
-			xMaximumSleepTime = xTCPTimer.ulRemainingTime;
-		}
-	}
-	#endif
+    #if ( ipconfigUSE_TCP == 1 )
+        {
+            if( xTCPTimer.ulRemainingTime < xMaximumSleepTime )
+            {
+                xMaximumSleepTime = xTCPTimer.ulRemainingTime;
+            }
+        }
+    #endif
 
-	#if( ipconfigDNS_USE_CALLBACKS != 0 )
-	{
-		if( xDNSTimer.bActive != pdFALSE_UNSIGNED )
-		{
-			if( xDNSTimer.ulRemainingTime < xMaximumSleepTime )
-			{
-				xMaximumSleepTime = xDNSTimer.ulRemainingTime;
-			}
-		}
-	}
-	#endif
+    #if ( ipconfigDNS_USE_CALLBACKS != 0 )
+        {
+            if( xDNSTimer.bActive != pdFALSE_UNSIGNED )
+            {
+                if( xDNSTimer.ulRemainingTime < xMaximumSleepTime )
+                {
+                    xMaximumSleepTime = xDNSTimer.ulRemainingTime;
+                }
+            }
+        }
+    #endif
 
-	return xMaximumSleepTime;
+    return xMaximumSleepTime;
 }
 /*-----------------------------------------------------------*/
 
 static void prvCheckNetworkTimers( void )
 {
-	/* Is it time for ARP processing? */
-	if( prvIPTimerCheck( &xARPTimer ) != pdFALSE )
-	{
-		( void ) xSendEventToIPTask( eARPTimerEvent );
-	}
+    /* Is it time for ARP processing? */
+    if( prvIPTimerCheck( &xARPTimer ) != pdFALSE )
+    {
+        ( void ) xSendEventToIPTask( eARPTimerEvent );
+    }
 
-	#if( ipconfigUSE_DHCP == 1 )
-	{
-		/* Is it time for DHCP processing? */
-		if( prvIPTimerCheck( &xDHCPTimer ) != pdFALSE )
-		{
-			( void ) xSendEventToIPTask( eDHCPEvent );
-		}
-	}
-	#endif /* ipconfigUSE_DHCP */
+    #if ( ipconfigUSE_DHCP == 1 )
+        {
+            /* Is it time for DHCP processing? */
+            if( prvIPTimerCheck( &xDHCPTimer ) != pdFALSE )
+            {
+                ( void ) xSendEventToIPTask( eDHCPEvent );
+            }
+        }
+    #endif /* ipconfigUSE_DHCP */
 
-	#if( ipconfigDNS_USE_CALLBACKS != 0 )
-	{
-		/* Is it time for DNS processing? */
-		if( prvIPTimerCheck( &xDNSTimer ) != pdFALSE )
-		{
-			vDNSCheckCallBack( NULL );
-		}
-	}
-	#endif /* ipconfigDNS_USE_CALLBACKS */
+    #if ( ipconfigDNS_USE_CALLBACKS != 0 )
+        {
+            /* Is it time for DNS processing? */
+            if( prvIPTimerCheck( &xDNSTimer ) != pdFALSE )
+            {
+                vDNSCheckCallBack( NULL );
+            }
+        }
+    #endif /* ipconfigDNS_USE_CALLBACKS */
 
-	#if( ipconfigUSE_TCP == 1 )
-	{
-	BaseType_t xWillSleep;
-	TickType_t xNextTime;
-	BaseType_t xCheckTCPSockets;
+    #if ( ipconfigUSE_TCP == 1 )
+        {
+            BaseType_t xWillSleep;
+            TickType_t xNextTime;
+            BaseType_t xCheckTCPSockets;
 
-		/* If the IP task has messages waiting to be processed then
-		it will not sleep in any case. */
-		if( uxQueueMessagesWaiting( xNetworkEventQueue ) == 0U )
-		{
-			xWillSleep = pdTRUE;
-		}
-		else
-		{
-			xWillSleep = pdFALSE;
-		}
+            /* If the IP task has messages waiting to be processed then
+             * it will not sleep in any case. */
+            if( uxQueueMessagesWaiting( xNetworkEventQueue ) == 0U )
+            {
+                xWillSleep = pdTRUE;
+            }
+            else
+            {
+                xWillSleep = pdFALSE;
+            }
 
-		/* Sockets need to be checked if the TCP timer has expired. */
-		xCheckTCPSockets = prvIPTimerCheck( &xTCPTimer );
+            /* Sockets need to be checked if the TCP timer has expired. */
+            xCheckTCPSockets = prvIPTimerCheck( &xTCPTimer );
 
-		/* Sockets will also be checked if there are TCP messages but the
-		message queue is empty (indicated by xWillSleep being true). */
-		if( ( xProcessedTCPMessage != pdFALSE ) && ( xWillSleep != pdFALSE ) )
-		{
-			xCheckTCPSockets = pdTRUE;
-		}
+            /* Sockets will also be checked if there are TCP messages but the
+            * message queue is empty (indicated by xWillSleep being true). */
+            if( ( xProcessedTCPMessage != pdFALSE ) && ( xWillSleep != pdFALSE ) )
+            {
+                xCheckTCPSockets = pdTRUE;
+            }
 
-		if( xCheckTCPSockets != pdFALSE )
-		{
-			/* Attend to the sockets, returning the period after which the
-			check must be repeated. */
-			xNextTime = xTCPTimerCheck( xWillSleep );
-			prvIPTimerStart( &xTCPTimer, xNextTime );
-			xProcessedTCPMessage = 0;
-		}
-	}
-	#endif /* ipconfigUSE_TCP == 1 */
+            if( xCheckTCPSockets != pdFALSE )
+            {
+                /* Attend to the sockets, returning the period after which the
+                 * check must be repeated. */
+                xNextTime = xTCPTimerCheck( xWillSleep );
+                prvIPTimerStart( &xTCPTimer, xNextTime );
+                xProcessedTCPMessage = 0;
+            }
+        }
+    #endif /* ipconfigUSE_TCP == 1 */
 }
 /*-----------------------------------------------------------*/
 
-static void prvIPTimerStart( IPTimer_t *pxTimer, TickType_t xTime )
+static void prvIPTimerStart( IPTimer_t * pxTimer,
+                             TickType_t xTime )
 {
-	vTaskSetTimeOutState( &pxTimer->xTimeOut );
-	pxTimer->ulRemainingTime = xTime;
+    vTaskSetTimeOutState( &pxTimer->xTimeOut );
+    pxTimer->ulRemainingTime = xTime;
 
-	if( xTime == ( TickType_t ) 0 )
-	{
-		pxTimer->bExpired = pdTRUE_UNSIGNED;
-	}
-	else
-	{
-		pxTimer->bExpired = pdFALSE_UNSIGNED;
-	}
+    if( xTime == ( TickType_t ) 0 )
+    {
+        pxTimer->bExpired = pdTRUE_UNSIGNED;
+    }
+    else
+    {
+        pxTimer->bExpired = pdFALSE_UNSIGNED;
+    }
 
-	pxTimer->bActive = pdTRUE_UNSIGNED;
+    pxTimer->bActive = pdTRUE_UNSIGNED;
 }
 /*-----------------------------------------------------------*/
 
-static void prvIPTimerReload( IPTimer_t *pxTimer, TickType_t xTime )
+static void prvIPTimerReload( IPTimer_t * pxTimer,
+                              TickType_t xTime )
 {
-	pxTimer->ulReloadTime = xTime;
-	prvIPTimerStart( pxTimer, xTime );
+    pxTimer->ulReloadTime = xTime;
+    prvIPTimerStart( pxTimer, xTime );
 }
 /*-----------------------------------------------------------*/
 
-static BaseType_t prvIPTimerCheck( IPTimer_t *pxTimer )
+static BaseType_t prvIPTimerCheck( IPTimer_t * pxTimer )
 {
-BaseType_t xReturn;
+    BaseType_t xReturn;
 
-	if( pxTimer->bActive == pdFALSE_UNSIGNED )
-	{
-		/* The timer is not enabled. */
-		xReturn = pdFALSE;
-	}
-	else
-	{
-		/* The timer might have set the bExpired flag already, if not, check the
-		value of xTimeOut against ulRemainingTime. */
-		if( pxTimer->bExpired == pdFALSE_UNSIGNED )
-		{
-			if( xTaskCheckForTimeOut( &( pxTimer->xTimeOut ), &( pxTimer->ulRemainingTime ) ) != pdFALSE )
-			{
-				pxTimer->bExpired = pdTRUE_UNSIGNED;
-			}
-		}
-		if( pxTimer->bExpired != pdFALSE_UNSIGNED )
-		{
-			prvIPTimerStart( pxTimer, pxTimer->ulReloadTime );
-			xReturn = pdTRUE;
-		}
-		else
-		{
-			xReturn = pdFALSE;
-		}
-	}
+    if( pxTimer->bActive == pdFALSE_UNSIGNED )
+    {
+        /* The timer is not enabled. */
+        xReturn = pdFALSE;
+    }
+    else
+    {
+        /* The timer might have set the bExpired flag already, if not, check the
+         * value of xTimeOut against ulRemainingTime. */
+        if( pxTimer->bExpired == pdFALSE_UNSIGNED )
+        {
+            if( xTaskCheckForTimeOut( &( pxTimer->xTimeOut ), &( pxTimer->ulRemainingTime ) ) != pdFALSE )
+            {
+                pxTimer->bExpired = pdTRUE_UNSIGNED;
+            }
+        }
 
-	return xReturn;
+        if( pxTimer->bExpired != pdFALSE_UNSIGNED )
+        {
+            prvIPTimerStart( pxTimer, pxTimer->ulReloadTime );
+            xReturn = pdTRUE;
+        }
+        else
+        {
+            xReturn = pdFALSE;
+        }
+    }
+
+    return xReturn;
 }
 /*-----------------------------------------------------------*/
 
 void FreeRTOS_NetworkDown( void )
 {
-static const IPStackEvent_t xNetworkDownEvent = { eNetworkDownEvent, NULL };
-const TickType_t xDontBlock = ( TickType_t ) 0;
+    static const IPStackEvent_t xNetworkDownEvent = { eNetworkDownEvent, NULL };
+    const TickType_t xDontBlock = ( TickType_t ) 0;
 
-	/* Simply send the network task the appropriate event. */
-	if( xSendEventStructToIPTask( &xNetworkDownEvent, xDontBlock ) != pdPASS )
-	{
-		/* Could not send the message, so it is still pending. */
-		xNetworkDownEventPending = pdTRUE;
-	}
-	else
-	{
-		/* Message was sent so it is not pending. */
-		xNetworkDownEventPending = pdFALSE;
-	}
+    /* Simply send the network task the appropriate event. */
+    if( xSendEventStructToIPTask( &xNetworkDownEvent, xDontBlock ) != pdPASS )
+    {
+        /* Could not send the message, so it is still pending. */
+        xNetworkDownEventPending = pdTRUE;
+    }
+    else
+    {
+        /* Message was sent so it is not pending. */
+        xNetworkDownEventPending = pdFALSE;
+    }
 
-	iptraceNETWORK_DOWN();
+    iptraceNETWORK_DOWN();
 }
 /*-----------------------------------------------------------*/
 
 BaseType_t FreeRTOS_NetworkDownFromISR( void )
 {
-static const IPStackEvent_t xNetworkDownEvent = { eNetworkDownEvent, NULL };
-BaseType_t xHigherPriorityTaskWoken = pdFALSE;
+    static const IPStackEvent_t xNetworkDownEvent = { eNetworkDownEvent, NULL };
+    BaseType_t xHigherPriorityTaskWoken = pdFALSE;
 
-	/* Simply send the network task the appropriate event. */
-	if( xQueueSendToBackFromISR( xNetworkEventQueue, &xNetworkDownEvent, &xHigherPriorityTaskWoken ) != pdPASS )
-	{
-		xNetworkDownEventPending = pdTRUE;
-	}
-	else
-	{
-		xNetworkDownEventPending = pdFALSE;
-	}
+    /* Simply send the network task the appropriate event. */
+    if( xQueueSendToBackFromISR( xNetworkEventQueue, &xNetworkDownEvent, &xHigherPriorityTaskWoken ) != pdPASS )
+    {
+        xNetworkDownEventPending = pdTRUE;
+    }
+    else
+    {
+        xNetworkDownEventPending = pdFALSE;
+    }
 
-	iptraceNETWORK_DOWN();
+    iptraceNETWORK_DOWN();
 
-	return xHigherPriorityTaskWoken;
+    return xHigherPriorityTaskWoken;
 }
 /*-----------------------------------------------------------*/
 
-void *FreeRTOS_GetUDPPayloadBuffer( size_t uxRequestedSizeBytes, TickType_t uxBlockTimeTicks )
+void * FreeRTOS_GetUDPPayloadBuffer( size_t uxRequestedSizeBytes,
+                                     TickType_t uxBlockTimeTicks )
 {
-NetworkBufferDescriptor_t *pxNetworkBuffer;
-void *pvReturn;
-TickType_t uxBlockTime = uxBlockTimeTicks;
+    NetworkBufferDescriptor_t * pxNetworkBuffer;
+    void * pvReturn;
+    TickType_t uxBlockTime = uxBlockTimeTicks;
 
-	/* Cap the block time.  The reason for this is explained where
-	ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS is defined (assuming an official
-	FreeRTOSIPConfig.h header file is being used). */
-	if( uxBlockTime > ( ( TickType_t ) ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS ) )
-	{
-		uxBlockTime = ( ( TickType_t ) ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS );
-	}
+    /* Cap the block time.  The reason for this is explained where
+     * ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS is defined (assuming an official
+     * FreeRTOSIPConfig.h header file is being used). */
+    if( uxBlockTime > ( ( TickType_t ) ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS ) )
+    {
+        uxBlockTime = ( ( TickType_t ) ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS );
+    }
 
-	/* Obtain a network buffer with the required amount of storage. */
-	pxNetworkBuffer = pxGetNetworkBufferWithDescriptor( sizeof( UDPPacket_t ) + uxRequestedSizeBytes, uxBlockTime );
+    /* Obtain a network buffer with the required amount of storage. */
+    pxNetworkBuffer = pxGetNetworkBufferWithDescriptor( sizeof( UDPPacket_t ) + uxRequestedSizeBytes, uxBlockTime );
 
-	if( pxNetworkBuffer != NULL )
-	{
-		/* Set the actual packet size in case a bigger buffer was returned. */
-		pxNetworkBuffer->xDataLength = sizeof( UDPPacket_t ) + uxRequestedSizeBytes;
-		/* Skip 3 headers. */
-		pvReturn = &( pxNetworkBuffer->pucEthernetBuffer[ sizeof( UDPPacket_t ) ] );
-	}
-	else
-	{
-		pvReturn = NULL;
-	}
+    if( pxNetworkBuffer != NULL )
+    {
+        /* Set the actual packet size in case a bigger buffer was returned. */
+        pxNetworkBuffer->xDataLength = sizeof( UDPPacket_t ) + uxRequestedSizeBytes;
+        /* Skip 3 headers. */
+        pvReturn = &( pxNetworkBuffer->pucEthernetBuffer[ sizeof( UDPPacket_t ) ] );
+    }
+    else
+    {
+        pvReturn = NULL;
+    }
 
-	return ( void * ) pvReturn;
+    return ( void * ) pvReturn;
 }
 /*-----------------------------------------------------------*/
 
-NetworkBufferDescriptor_t *pxDuplicateNetworkBufferWithDescriptor( const NetworkBufferDescriptor_t * const pxNetworkBuffer,
-	size_t uxNewLength )
+NetworkBufferDescriptor_t * pxDuplicateNetworkBufferWithDescriptor( const NetworkBufferDescriptor_t * const pxNetworkBuffer,
+                                                                    size_t uxNewLength )
 {
-NetworkBufferDescriptor_t * pxNewBuffer;
+    NetworkBufferDescriptor_t * pxNewBuffer;
 
-	/* This function is only used when 'ipconfigZERO_COPY_TX_DRIVER' is set to 1.
-	The transmit routine wants to have ownership of the network buffer
-	descriptor, because it will pass the buffer straight to DMA. */
-	pxNewBuffer = pxGetNetworkBufferWithDescriptor( uxNewLength, ( TickType_t ) 0 );
+    /* This function is only used when 'ipconfigZERO_COPY_TX_DRIVER' is set to 1.
+     * The transmit routine wants to have ownership of the network buffer
+     * descriptor, because it will pass the buffer straight to DMA. */
+    pxNewBuffer = pxGetNetworkBufferWithDescriptor( uxNewLength, ( TickType_t ) 0 );
 
-	if( pxNewBuffer != NULL )
-	{
-		/* Set the actual packet size in case a bigger buffer than requested
-		was returned. */
-		pxNewBuffer->xDataLength = uxNewLength;
+    if( pxNewBuffer != NULL )
+    {
+        /* Set the actual packet size in case a bigger buffer than requested
+         * was returned. */
+        pxNewBuffer->xDataLength = uxNewLength;
 
-		/* Copy the original packet information. */
-		pxNewBuffer->ulIPAddress = pxNetworkBuffer->ulIPAddress;
-		pxNewBuffer->usPort = pxNetworkBuffer->usPort;
-		pxNewBuffer->usBoundPort = pxNetworkBuffer->usBoundPort;
-		( void ) memcpy( pxNewBuffer->pucEthernetBuffer, pxNetworkBuffer->pucEthernetBuffer, pxNetworkBuffer->xDataLength );
-	}
+        /* Copy the original packet information. */
+        pxNewBuffer->ulIPAddress = pxNetworkBuffer->ulIPAddress;
+        pxNewBuffer->usPort = pxNetworkBuffer->usPort;
+        pxNewBuffer->usBoundPort = pxNetworkBuffer->usBoundPort;
+        ( void ) memcpy( pxNewBuffer->pucEthernetBuffer, pxNetworkBuffer->pucEthernetBuffer, pxNetworkBuffer->xDataLength );
+    }
 
-	return pxNewBuffer;
+    return pxNewBuffer;
 }
 /*-----------------------------------------------------------*/
 
-#if( ipconfigZERO_COPY_TX_DRIVER != 0 ) || ( ipconfigZERO_COPY_RX_DRIVER != 0 )
+#if ( ipconfigZERO_COPY_TX_DRIVER != 0 ) || ( ipconfigZERO_COPY_RX_DRIVER != 0 )
 
-	NetworkBufferDescriptor_t *pxPacketBuffer_to_NetworkBuffer( const void *pvBuffer )
-	{
-	const uint8_t *pucBuffer;
-	NetworkBufferDescriptor_t *pxResult;
+    NetworkBufferDescriptor_t * pxPacketBuffer_to_NetworkBuffer( const void * pvBuffer )
+    {
+        const uint8_t * pucBuffer;
+        NetworkBufferDescriptor_t * pxResult;
 
-		if( pvBuffer == NULL )
-		{
-			pxResult = NULL;
-		}
-		else
-		{
-			/* Obtain the network buffer from the zero copy pointer. */
-			pucBuffer = ipPOINTER_CAST( const uint8_t *, pvBuffer );
+        if( pvBuffer == NULL )
+        {
+            pxResult = NULL;
+        }
+        else
+        {
+            /* Obtain the network buffer from the zero copy pointer. */
+            pucBuffer = ipPOINTER_CAST( const uint8_t *, pvBuffer );
 
-			/* The input here is a pointer to a payload buffer.  Subtract the
-			size of the header in the network buffer, usually 8 + 2 bytes. */
-			pucBuffer -= ipBUFFER_PADDING;
+            /* The input here is a pointer to a payload buffer.  Subtract the
+             *  size of the header in the network buffer, usually 8 + 2 bytes. */
+            pucBuffer -= ipBUFFER_PADDING;
 
-			/* Here a pointer was placed to the network descriptor.  As a
-			pointer is dereferenced, make sure it is well aligned. */
-			if( ( ( ( size_t ) pucBuffer ) & ( sizeof( pucBuffer ) - 1U ) ) == ( size_t ) 0U )
-			{
-				pxResult = * ( ipPOINTER_CAST( NetworkBufferDescriptor_t **, pucBuffer ) );
-			}
-			else
-			{
-				pxResult = NULL;
-			}
-		}
+            /* Here a pointer was placed to the network descriptor.  As a
+             * pointer is dereferenced, make sure it is well aligned. */
+            if( ( ( ( size_t ) pucBuffer ) & ( sizeof( pucBuffer ) - 1U ) ) == ( size_t ) 0U )
+            {
+                pxResult = *( ipPOINTER_CAST( NetworkBufferDescriptor_t * *, pucBuffer ) );
+            }
+            else
+            {
+                pxResult = NULL;
+            }
+        }
 
-		return pxResult;
-	}
+        return pxResult;
+    }
 
 #endif /* ipconfigZERO_COPY_TX_DRIVER != 0 */
 /*-----------------------------------------------------------*/
 
-NetworkBufferDescriptor_t *pxUDPPayloadBuffer_to_NetworkBuffer( const void * pvBuffer )
+NetworkBufferDescriptor_t * pxUDPPayloadBuffer_to_NetworkBuffer( const void * pvBuffer )
 {
-const uint8_t *pucBuffer;
-NetworkBufferDescriptor_t *pxResult;
+    const uint8_t * pucBuffer;
+    NetworkBufferDescriptor_t * pxResult;
 
-	if( pvBuffer == NULL )
-	{
-		pxResult = NULL;
-	}
-	else
-	{
-		/* Obtain the network buffer from the zero copy pointer. */
-		pucBuffer = ipPOINTER_CAST( const uint8_t *, pvBuffer );
+    if( pvBuffer == NULL )
+    {
+        pxResult = NULL;
+    }
+    else
+    {
+        /* Obtain the network buffer from the zero copy pointer. */
+        pucBuffer = ipPOINTER_CAST( const uint8_t *, pvBuffer );
 
-		/* The input here is a pointer to a payload buffer.  Subtract
-		the total size of a UDP/IP header plus the size of the header in
-		the network buffer, usually 8 + 2 bytes. */
-		pucBuffer -= ( sizeof( UDPPacket_t ) + ( ( size_t ) ipBUFFER_PADDING ) );
+        /* The input here is a pointer to a payload buffer.  Subtract
+         * the total size of a UDP/IP header plus the size of the header in
+         * the network buffer, usually 8 + 2 bytes. */
+        pucBuffer -= ( sizeof( UDPPacket_t ) + ( ( size_t ) ipBUFFER_PADDING ) );
 
-		/* Here a pointer was placed to the network descriptor,
-		As a pointer is dereferenced, make sure it is well aligned */
-		if( ( ( ( size_t ) pucBuffer ) & ( sizeof( pucBuffer ) - 1U ) ) == 0U )
-		{
-			/* The following statement may trigger a:
-			warning: cast increases required alignment of target type [-Wcast-align].
-			It has been confirmed though that the alignment is suitable. */
-			pxResult = * ( ipPOINTER_CAST( NetworkBufferDescriptor_t **, pucBuffer ) );
-		}
-		else
-		{
-			pxResult = NULL;
-		}
-	}
+        /* Here a pointer was placed to the network descriptor,
+         * As a pointer is dereferenced, make sure it is well aligned */
+        if( ( ( ( size_t ) pucBuffer ) & ( sizeof( pucBuffer ) - 1U ) ) == 0U )
+        {
+            /* The following statement may trigger a:
+             * warning: cast increases required alignment of target type [-Wcast-align].
+             * It has been confirmed though that the alignment is suitable. */
+            pxResult = *( ipPOINTER_CAST( NetworkBufferDescriptor_t * *, pucBuffer ) );
+        }
+        else
+        {
+            pxResult = NULL;
+        }
+    }
 
-	return pxResult;
+    return pxResult;
 }
 /*-----------------------------------------------------------*/
 
 void FreeRTOS_ReleaseUDPPayloadBuffer( void const * pvBuffer )
 {
-	vReleaseNetworkBufferAndDescriptor( pxUDPPayloadBuffer_to_NetworkBuffer( pvBuffer ) );
+    vReleaseNetworkBufferAndDescriptor( pxUDPPayloadBuffer_to_NetworkBuffer( pvBuffer ) );
 }
 /*-----------------------------------------------------------*/
 
 /*_RB_ Should we add an error or assert if the task priorities are set such that the servers won't function as expected? */
+
 /*_HT_ There was a bug in FreeRTOS_TCP_IP.c that only occurred when the applications' priority was too high.
- As that bug has been repaired, there is not an urgent reason to warn.
- It is better though to use the advised priority scheme. */
-BaseType_t FreeRTOS_IPInit( const uint8_t ucIPAddress[ ipIP_ADDRESS_LENGTH_BYTES ], const uint8_t ucNetMask[ ipIP_ADDRESS_LENGTH_BYTES ], const uint8_t ucGatewayAddress[ ipIP_ADDRESS_LENGTH_BYTES ], const uint8_t ucDNSServerAddress[ ipIP_ADDRESS_LENGTH_BYTES ], const uint8_t ucMACAddress[ ipMAC_ADDRESS_LENGTH_BYTES ] )
+ * As that bug has been repaired, there is not an urgent reason to warn.
+ * It is better though to use the advised priority scheme. */
+BaseType_t FreeRTOS_IPInit( const uint8_t ucIPAddress[ ipIP_ADDRESS_LENGTH_BYTES ],
+                            const uint8_t ucNetMask[ ipIP_ADDRESS_LENGTH_BYTES ],
+                            const uint8_t ucGatewayAddress[ ipIP_ADDRESS_LENGTH_BYTES ],
+                            const uint8_t ucDNSServerAddress[ ipIP_ADDRESS_LENGTH_BYTES ],
+                            const uint8_t ucMACAddress[ ipMAC_ADDRESS_LENGTH_BYTES ] )
 {
-BaseType_t xReturn = pdFALSE;
+    BaseType_t xReturn = pdFALSE;
 
-	/* This function should only be called once. */
-	configASSERT( xIPIsNetworkTaskReady() == pdFALSE );
-	configASSERT( xNetworkEventQueue == NULL );
-	configASSERT( xIPTaskHandle == NULL );
+    /* This function should only be called once. */
+    configASSERT( xIPIsNetworkTaskReady() == pdFALSE );
+    configASSERT( xNetworkEventQueue == NULL );
+    configASSERT( xIPTaskHandle == NULL );
 
-	#ifndef _lint
-	{
-		/* Check if MTU is big enough. */
-		configASSERT( ( ( size_t ) ipconfigNETWORK_MTU ) >= ( ipSIZE_OF_IPv4_HEADER + ipSIZE_OF_TCP_HEADER + ipconfigTCP_MSS ) );
-		/* Check structure packing is correct. */
-		configASSERT( sizeof( EthernetHeader_t ) == ipEXPECTED_EthernetHeader_t_SIZE );
-		configASSERT( sizeof( ARPHeader_t ) == ipEXPECTED_ARPHeader_t_SIZE );
-		configASSERT( sizeof( IPHeader_t ) == ipEXPECTED_IPHeader_t_SIZE );
-		configASSERT( sizeof( ICMPHeader_t ) == ipEXPECTED_ICMPHeader_t_SIZE );
-		configASSERT( sizeof( UDPHeader_t ) == ipEXPECTED_UDPHeader_t_SIZE );
-	}
-	#endif
-	/* Attempt to create the queue used to communicate with the IP task. */
-	xNetworkEventQueue = xQueueCreate( ( UBaseType_t ) ipconfigEVENT_QUEUE_LENGTH, ( UBaseType_t ) sizeof( IPStackEvent_t ) );
-	configASSERT( xNetworkEventQueue != NULL );
+    #ifndef _lint
+        {
+            /* Check if MTU is big enough. */
+            configASSERT( ( ( size_t ) ipconfigNETWORK_MTU ) >= ( ipSIZE_OF_IPv4_HEADER + ipSIZE_OF_TCP_HEADER + ipconfigTCP_MSS ) );
+            /* Check structure packing is correct. */
+            configASSERT( sizeof( EthernetHeader_t ) == ipEXPECTED_EthernetHeader_t_SIZE );
+            configASSERT( sizeof( ARPHeader_t ) == ipEXPECTED_ARPHeader_t_SIZE );
+            configASSERT( sizeof( IPHeader_t ) == ipEXPECTED_IPHeader_t_SIZE );
+            configASSERT( sizeof( ICMPHeader_t ) == ipEXPECTED_ICMPHeader_t_SIZE );
+            configASSERT( sizeof( UDPHeader_t ) == ipEXPECTED_UDPHeader_t_SIZE );
+        }
+    #endif /* ifndef _lint */
+    /* Attempt to create the queue used to communicate with the IP task. */
+    xNetworkEventQueue = xQueueCreate( ( UBaseType_t ) ipconfigEVENT_QUEUE_LENGTH, ( UBaseType_t ) sizeof( IPStackEvent_t ) );
+    configASSERT( xNetworkEventQueue != NULL );
 
-	if( xNetworkEventQueue != NULL )
-	{
-		#if ( configQUEUE_REGISTRY_SIZE > 0 )
-		{
-			/* A queue registry is normally used to assist a kernel aware
-			debugger.  If one is in use then it will be helpful for the debugger
-			to show information about the network event queue. */
-			vQueueAddToRegistry( xNetworkEventQueue, "NetEvnt" );
-		}
-		#endif /* configQUEUE_REGISTRY_SIZE */
+    if( xNetworkEventQueue != NULL )
+    {
+        #if ( configQUEUE_REGISTRY_SIZE > 0 )
+            {
+                /* A queue registry is normally used to assist a kernel aware
+                 * debugger.  If one is in use then it will be helpful for the debugger
+                 * to show information about the network event queue. */
+                vQueueAddToRegistry( xNetworkEventQueue, "NetEvnt" );
+            }
+        #endif /* configQUEUE_REGISTRY_SIZE */
 
-		if( xNetworkBuffersInitialise() == pdPASS )
-		{
-			/* Store the local IP and MAC address. */
-			xNetworkAddressing.ulDefaultIPAddress = FreeRTOS_inet_addr_quick( ucIPAddress[ 0 ], ucIPAddress[ 1 ], ucIPAddress[ 2 ], ucIPAddress[ 3 ] );
-			xNetworkAddressing.ulNetMask = FreeRTOS_inet_addr_quick( ucNetMask[ 0 ], ucNetMask[ 1 ], ucNetMask[ 2 ], ucNetMask[ 3 ] );
-			xNetworkAddressing.ulGatewayAddress = FreeRTOS_inet_addr_quick( ucGatewayAddress[ 0 ], ucGatewayAddress[ 1 ], ucGatewayAddress[ 2 ], ucGatewayAddress[ 3 ] );
-			xNetworkAddressing.ulDNSServerAddress = FreeRTOS_inet_addr_quick( ucDNSServerAddress[ 0 ], ucDNSServerAddress[ 1 ], ucDNSServerAddress[ 2 ], ucDNSServerAddress[ 3 ] );
-			xNetworkAddressing.ulBroadcastAddress = ( xNetworkAddressing.ulDefaultIPAddress & xNetworkAddressing.ulNetMask ) |  ~xNetworkAddressing.ulNetMask;
+        if( xNetworkBuffersInitialise() == pdPASS )
+        {
+            /* Store the local IP and MAC address. */
+            xNetworkAddressing.ulDefaultIPAddress = FreeRTOS_inet_addr_quick( ucIPAddress[ 0 ], ucIPAddress[ 1 ], ucIPAddress[ 2 ], ucIPAddress[ 3 ] );
+            xNetworkAddressing.ulNetMask = FreeRTOS_inet_addr_quick( ucNetMask[ 0 ], ucNetMask[ 1 ], ucNetMask[ 2 ], ucNetMask[ 3 ] );
+            xNetworkAddressing.ulGatewayAddress = FreeRTOS_inet_addr_quick( ucGatewayAddress[ 0 ], ucGatewayAddress[ 1 ], ucGatewayAddress[ 2 ], ucGatewayAddress[ 3 ] );
+            xNetworkAddressing.ulDNSServerAddress = FreeRTOS_inet_addr_quick( ucDNSServerAddress[ 0 ], ucDNSServerAddress[ 1 ], ucDNSServerAddress[ 2 ], ucDNSServerAddress[ 3 ] );
+            xNetworkAddressing.ulBroadcastAddress = ( xNetworkAddressing.ulDefaultIPAddress & xNetworkAddressing.ulNetMask ) | ~xNetworkAddressing.ulNetMask;
 
-			( void ) memcpy( &xDefaultAddressing, &xNetworkAddressing, sizeof( xDefaultAddressing ) );
+            ( void ) memcpy( &xDefaultAddressing, &xNetworkAddressing, sizeof( xDefaultAddressing ) );
 
-			#if ipconfigUSE_DHCP == 1
-			{
-				/* The IP address is not set until DHCP completes. */
-				*ipLOCAL_IP_ADDRESS_POINTER = 0x00UL;
-			}
-			#else
-			{
-				/* The IP address is set from the value passed in. */
-				*ipLOCAL_IP_ADDRESS_POINTER = xNetworkAddressing.ulDefaultIPAddress;
+            #if ipconfigUSE_DHCP == 1
+                {
+                    /* The IP address is not set until DHCP completes. */
+                    *ipLOCAL_IP_ADDRESS_POINTER = 0x00UL;
+                }
+            #else
+                {
+                    /* The IP address is set from the value passed in. */
+                    *ipLOCAL_IP_ADDRESS_POINTER = xNetworkAddressing.ulDefaultIPAddress;
 
-				/* Added to prevent ARP flood to gateway.  Ensure the
-				gateway is on the same subnet as the IP	address. */
-				if( xNetworkAddressing.ulGatewayAddress != 0UL )
-				{
-					configASSERT( ( ( *ipLOCAL_IP_ADDRESS_POINTER ) & xNetworkAddressing.ulNetMask ) == ( xNetworkAddressing.ulGatewayAddress & xNetworkAddressing.ulNetMask ) );
-				}
-			}
-			#endif /* ipconfigUSE_DHCP == 1 */
+                    /* Added to prevent ARP flood to gateway.  Ensure the
+                    * gateway is on the same subnet as the IP	address. */
+                    if( xNetworkAddressing.ulGatewayAddress != 0UL )
+                    {
+                        configASSERT( ( ( *ipLOCAL_IP_ADDRESS_POINTER ) & xNetworkAddressing.ulNetMask ) == ( xNetworkAddressing.ulGatewayAddress & xNetworkAddressing.ulNetMask ) );
+                    }
+                }
+            #endif /* ipconfigUSE_DHCP == 1 */
 
-			/* The MAC address is stored in the start of the default packet
-			header fragment, which is used when sending UDP packets. */
-			( void ) memcpy( ipLOCAL_MAC_ADDRESS, ucMACAddress, ( size_t ) ipMAC_ADDRESS_LENGTH_BYTES );
+            /* The MAC address is stored in the start of the default packet
+             * header fragment, which is used when sending UDP packets. */
+            ( void ) memcpy( ipLOCAL_MAC_ADDRESS, ucMACAddress, ( size_t ) ipMAC_ADDRESS_LENGTH_BYTES );
 
-			/* Prepare the sockets interface. */
-			vNetworkSocketsInit();
+            /* Prepare the sockets interface. */
+            vNetworkSocketsInit();
 
-			/* Create the task that processes Ethernet and stack events. */
-			xReturn = xTaskCreate( prvIPTask,
-								   "IP-task",
-								   ( uint16_t )ipconfigIP_TASK_STACK_SIZE_WORDS,
-								   NULL,
-								   ( UBaseType_t )ipconfigIP_TASK_PRIORITY,
-								   &( xIPTaskHandle ) );
-		}
-		else
-		{
-			FreeRTOS_debug_printf( ( "FreeRTOS_IPInit: xNetworkBuffersInitialise() failed\n") );
+            /* Create the task that processes Ethernet and stack events. */
+            xReturn = xTaskCreate( prvIPTask,
+                                   "IP-task",
+                                   ( uint16_t ) ipconfigIP_TASK_STACK_SIZE_WORDS,
+                                   NULL,
+                                   ( UBaseType_t ) ipconfigIP_TASK_PRIORITY,
+                                   &( xIPTaskHandle ) );
+        }
+        else
+        {
+            FreeRTOS_debug_printf( ( "FreeRTOS_IPInit: xNetworkBuffersInitialise() failed\n" ) );
 
-			/* Clean up. */
-			vQueueDelete( xNetworkEventQueue );
-			xNetworkEventQueue = NULL;
-		}
-	}
-	else
-	{
-		FreeRTOS_debug_printf( ( "FreeRTOS_IPInit: Network event queue could not be created\n") );
-	}
+            /* Clean up. */
+            vQueueDelete( xNetworkEventQueue );
+            xNetworkEventQueue = NULL;
+        }
+    }
+    else
+    {
+        FreeRTOS_debug_printf( ( "FreeRTOS_IPInit: Network event queue could not be created\n" ) );
+    }
 
-	return xReturn;
+    return xReturn;
 }
 /*-----------------------------------------------------------*/
 
-void FreeRTOS_GetAddressConfiguration( uint32_t *pulIPAddress,
-									   uint32_t *pulNetMask,
-									   uint32_t *pulGatewayAddress,
-									   uint32_t *pulDNSServerAddress )
+void FreeRTOS_GetAddressConfiguration( uint32_t * pulIPAddress,
+                                       uint32_t * pulNetMask,
+                                       uint32_t * pulGatewayAddress,
+                                       uint32_t * pulDNSServerAddress )
 {
-	/* Return the address configuration to the caller. */
+    /* Return the address configuration to the caller. */
 
-	if( pulIPAddress != NULL )
-	{
-		*pulIPAddress = *ipLOCAL_IP_ADDRESS_POINTER;
-	}
+    if( pulIPAddress != NULL )
+    {
+        *pulIPAddress = *ipLOCAL_IP_ADDRESS_POINTER;
+    }
 
-	if( pulNetMask != NULL )
-	{
-		*pulNetMask = xNetworkAddressing.ulNetMask;
-	}
+    if( pulNetMask != NULL )
+    {
+        *pulNetMask = xNetworkAddressing.ulNetMask;
+    }
 
-	if( pulGatewayAddress != NULL )
-	{
-		*pulGatewayAddress = xNetworkAddressing.ulGatewayAddress;
-	}
+    if( pulGatewayAddress != NULL )
+    {
+        *pulGatewayAddress = xNetworkAddressing.ulGatewayAddress;
+    }
 
-	if( pulDNSServerAddress != NULL )
-	{
-		*pulDNSServerAddress = xNetworkAddressing.ulDNSServerAddress;
-	}
+    if( pulDNSServerAddress != NULL )
+    {
+        *pulDNSServerAddress = xNetworkAddressing.ulDNSServerAddress;
+    }
 }
 /*-----------------------------------------------------------*/
 
-void FreeRTOS_SetAddressConfiguration( const uint32_t *pulIPAddress,
-									   const uint32_t *pulNetMask,
-									   const uint32_t *pulGatewayAddress,
-									   const uint32_t *pulDNSServerAddress )
+void FreeRTOS_SetAddressConfiguration( const uint32_t * pulIPAddress,
+                                       const uint32_t * pulNetMask,
+                                       const uint32_t * pulGatewayAddress,
+                                       const uint32_t * pulDNSServerAddress )
 {
-	/* Update the address configuration. */
+    /* Update the address configuration. */
 
-	if( pulIPAddress != NULL )
-	{
-		*ipLOCAL_IP_ADDRESS_POINTER = *pulIPAddress;
-	}
+    if( pulIPAddress != NULL )
+    {
+        *ipLOCAL_IP_ADDRESS_POINTER = *pulIPAddress;
+    }
 
-	if( pulNetMask != NULL )
-	{
-		xNetworkAddressing.ulNetMask = *pulNetMask;
-	}
+    if( pulNetMask != NULL )
+    {
+        xNetworkAddressing.ulNetMask = *pulNetMask;
+    }
 
-	if( pulGatewayAddress != NULL )
-	{
-		xNetworkAddressing.ulGatewayAddress = *pulGatewayAddress;
-	}
+    if( pulGatewayAddress != NULL )
+    {
+        xNetworkAddressing.ulGatewayAddress = *pulGatewayAddress;
+    }
 
-	if( pulDNSServerAddress != NULL )
-	{
-		xNetworkAddressing.ulDNSServerAddress = *pulDNSServerAddress;
-	}
+    if( pulDNSServerAddress != NULL )
+    {
+        xNetworkAddressing.ulDNSServerAddress = *pulDNSServerAddress;
+    }
 }
 /*-----------------------------------------------------------*/
 
 #if ( ipconfigSUPPORT_OUTGOING_PINGS == 1 )
 
-	BaseType_t FreeRTOS_SendPingRequest( uint32_t ulIPAddress, size_t uxNumberOfBytesToSend, TickType_t uxBlockTimeTicks )
-	{
-	NetworkBufferDescriptor_t *pxNetworkBuffer;
-	ICMPHeader_t *pxICMPHeader;
-	EthernetHeader_t *pxEthernetHeader;
-	BaseType_t xReturn = pdFAIL;
-	static uint16_t usSequenceNumber = 0;
-	uint8_t *pucChar;
-	size_t uxTotalLength;
-	IPStackEvent_t xStackTxEvent = { eStackTxEvent, NULL };
+    BaseType_t FreeRTOS_SendPingRequest( uint32_t ulIPAddress,
+                                         size_t uxNumberOfBytesToSend,
+                                         TickType_t uxBlockTimeTicks )
+    {
+        NetworkBufferDescriptor_t * pxNetworkBuffer;
+        ICMPHeader_t * pxICMPHeader;
+        EthernetHeader_t * pxEthernetHeader;
+        BaseType_t xReturn = pdFAIL;
+        static uint16_t usSequenceNumber = 0;
+        uint8_t * pucChar;
+        size_t uxTotalLength;
+        IPStackEvent_t xStackTxEvent = { eStackTxEvent, NULL };
 
-		uxTotalLength = uxNumberOfBytesToSend + sizeof( ICMPPacket_t );
-		pxNetworkBuffer = pxGetNetworkBufferWithDescriptor( uxTotalLength, uxBlockTimeTicks );
+        uxTotalLength = uxNumberOfBytesToSend + sizeof( ICMPPacket_t );
+        pxNetworkBuffer = pxGetNetworkBufferWithDescriptor( uxTotalLength, uxBlockTimeTicks );
 
-		if( pxNetworkBuffer != NULL )
-		{
-		BaseType_t xEnoughSpace;
+        if( pxNetworkBuffer != NULL )
+        {
+            BaseType_t xEnoughSpace;
 
-			if( uxNumberOfBytesToSend < ( ipconfigNETWORK_MTU - ( sizeof( IPHeader_t ) + sizeof( ICMPHeader_t ) ) ) )
-			{
-				xEnoughSpace = pdTRUE;
-			}
-			else
-			{
-				xEnoughSpace = pdFALSE;
-			}
-			if( ( uxGetNumberOfFreeNetworkBuffers() >= 3U ) && ( uxNumberOfBytesToSend >= 1U ) && ( xEnoughSpace != pdFALSE ) )
-			{
-				pxEthernetHeader = ipPOINTER_CAST( EthernetHeader_t *, pxNetworkBuffer->pucEthernetBuffer );
-				pxEthernetHeader->usFrameType = ipIPv4_FRAME_TYPE;
-				
+            if( uxNumberOfBytesToSend < ( ipconfigNETWORK_MTU - ( sizeof( IPHeader_t ) + sizeof( ICMPHeader_t ) ) ) )
+            {
+                xEnoughSpace = pdTRUE;
+            }
+            else
+            {
+                xEnoughSpace = pdFALSE;
+            }
 
-				pxICMPHeader = ipPOINTER_CAST( ICMPHeader_t *, &( pxNetworkBuffer->pucEthernetBuffer[ ipIP_PAYLOAD_OFFSET ] ) );
-				usSequenceNumber++;
+            if( ( uxGetNumberOfFreeNetworkBuffers() >= 3U ) && ( uxNumberOfBytesToSend >= 1U ) && ( xEnoughSpace != pdFALSE ) )
+            {
+                pxEthernetHeader = ipPOINTER_CAST( EthernetHeader_t *, pxNetworkBuffer->pucEthernetBuffer );
+                pxEthernetHeader->usFrameType = ipIPv4_FRAME_TYPE;
 
-				/* Fill in the basic header information. */
-				pxICMPHeader->ucTypeOfMessage = ipICMP_ECHO_REQUEST;
-				pxICMPHeader->ucTypeOfService = 0;
-				pxICMPHeader->usIdentifier = usSequenceNumber;
-				pxICMPHeader->usSequenceNumber = usSequenceNumber;
 
-				/* Find the start of the data. */
-				pucChar = ( uint8_t * ) pxICMPHeader;
-				pucChar = &(pucChar[ sizeof( ICMPHeader_t ) ] );
+                pxICMPHeader = ipPOINTER_CAST( ICMPHeader_t *, &( pxNetworkBuffer->pucEthernetBuffer[ ipIP_PAYLOAD_OFFSET ] ) );
+                usSequenceNumber++;
 
-				/* Just memset the data to a fixed value. */
-				( void ) memset( pucChar, ( int ) ipECHO_DATA_FILL_BYTE, uxNumberOfBytesToSend );
+                /* Fill in the basic header information. */
+                pxICMPHeader->ucTypeOfMessage = ipICMP_ECHO_REQUEST;
+                pxICMPHeader->ucTypeOfService = 0;
+                pxICMPHeader->usIdentifier = usSequenceNumber;
+                pxICMPHeader->usSequenceNumber = usSequenceNumber;
 
-				/* The message is complete, IP and checksum's are handled by
-				vProcessGeneratedUDPPacket */
-				pxNetworkBuffer->pucEthernetBuffer[ ipSOCKET_OPTIONS_OFFSET ] = FREERTOS_SO_UDPCKSUM_OUT;
-				pxNetworkBuffer->ulIPAddress = ulIPAddress;
-				pxNetworkBuffer->usPort = ipPACKET_CONTAINS_ICMP_DATA;
-				/* xDataLength is the size of the total packet, including the Ethernet header. */
-				pxNetworkBuffer->xDataLength = uxTotalLength;
+                /* Find the start of the data. */
+                pucChar = ( uint8_t * ) pxICMPHeader;
+                pucChar = &( pucChar[ sizeof( ICMPHeader_t ) ] );
 
-				/* Send to the stack. */
-				xStackTxEvent.pvData = pxNetworkBuffer;
+                /* Just memset the data to a fixed value. */
+                ( void ) memset( pucChar, ( int ) ipECHO_DATA_FILL_BYTE, uxNumberOfBytesToSend );
 
-				if( xSendEventStructToIPTask( &( xStackTxEvent ), uxBlockTimeTicks ) != pdPASS )
-				{
-					vReleaseNetworkBufferAndDescriptor( pxNetworkBuffer );
-					iptraceSTACK_TX_EVENT_LOST( ipSTACK_TX_EVENT );
-				}
-				else
-				{
-					xReturn = ( BaseType_t ) usSequenceNumber;
-				}
-			}
-		}
-		else
-		{
-			/* The requested number of bytes will not fit in the available space
-			in the network buffer. */
-		}
+                /* The message is complete, IP and checksum's are handled by
+                 * vProcessGeneratedUDPPacket */
+                pxNetworkBuffer->pucEthernetBuffer[ ipSOCKET_OPTIONS_OFFSET ] = FREERTOS_SO_UDPCKSUM_OUT;
+                pxNetworkBuffer->ulIPAddress = ulIPAddress;
+                pxNetworkBuffer->usPort = ipPACKET_CONTAINS_ICMP_DATA;
+                /* xDataLength is the size of the total packet, including the Ethernet header. */
+                pxNetworkBuffer->xDataLength = uxTotalLength;
 
-		return xReturn;
-	}
+                /* Send to the stack. */
+                xStackTxEvent.pvData = pxNetworkBuffer;
+
+                if( xSendEventStructToIPTask( &( xStackTxEvent ), uxBlockTimeTicks ) != pdPASS )
+                {
+                    vReleaseNetworkBufferAndDescriptor( pxNetworkBuffer );
+                    iptraceSTACK_TX_EVENT_LOST( ipSTACK_TX_EVENT );
+                }
+                else
+                {
+                    xReturn = ( BaseType_t ) usSequenceNumber;
+                }
+            }
+        }
+        else
+        {
+            /* The requested number of bytes will not fit in the available space
+             * in the network buffer. */
+        }
+
+        return xReturn;
+    }
 
 #endif /* ipconfigSUPPORT_OUTGOING_PINGS == 1 */
 /*-----------------------------------------------------------*/
 
 BaseType_t xSendEventToIPTask( eIPEvent_t eEvent )
 {
-IPStackEvent_t xEventMessage;
-const TickType_t xDontBlock = ( TickType_t ) 0;
+    IPStackEvent_t xEventMessage;
+    const TickType_t xDontBlock = ( TickType_t ) 0;
 
-	xEventMessage.eEventType = eEvent;
-	xEventMessage.pvData = ( void* )NULL;
+    xEventMessage.eEventType = eEvent;
+    xEventMessage.pvData = ( void * ) NULL;
 
-	return xSendEventStructToIPTask( &xEventMessage, xDontBlock );
+    return xSendEventStructToIPTask( &xEventMessage, xDontBlock );
 }
 /*-----------------------------------------------------------*/
 
-BaseType_t xSendEventStructToIPTask( const IPStackEvent_t *pxEvent, TickType_t uxTimeout )
+BaseType_t xSendEventStructToIPTask( const IPStackEvent_t * pxEvent,
+                                     TickType_t uxTimeout )
 {
-BaseType_t xReturn, xSendMessage;
-TickType_t uxUseTimeout = uxTimeout;
+    BaseType_t xReturn, xSendMessage;
+    TickType_t uxUseTimeout = uxTimeout;
 
-	if( ( xIPIsNetworkTaskReady() == pdFALSE ) && ( pxEvent->eEventType != eNetworkDownEvent ) )
-	{
-		/* Only allow eNetworkDownEvent events if the IP task is not ready
-		yet.  Not going to attempt to send the message so the send failed. */
-		xReturn = pdFAIL;
-	}
-	else
-	{
-		xSendMessage = pdTRUE;
+    if( ( xIPIsNetworkTaskReady() == pdFALSE ) && ( pxEvent->eEventType != eNetworkDownEvent ) )
+    {
+        /* Only allow eNetworkDownEvent events if the IP task is not ready
+         * yet.  Not going to attempt to send the message so the send failed. */
+        xReturn = pdFAIL;
+    }
+    else
+    {
+        xSendMessage = pdTRUE;
 
-		#if( ipconfigUSE_TCP == 1 )
-		{
-			if( pxEvent->eEventType == eTCPTimerEvent )
-			{
-				/* TCP timer events are sent to wake the timer task when
-				xTCPTimer has expired, but there is no point sending them if the
-				IP task is already awake processing other message. */
-				xTCPTimer.bExpired = pdTRUE_UNSIGNED;
+        #if ( ipconfigUSE_TCP == 1 )
+            {
+                if( pxEvent->eEventType == eTCPTimerEvent )
+                {
+                    /* TCP timer events are sent to wake the timer task when
+                     * xTCPTimer has expired, but there is no point sending them if the
+                     * IP task is already awake processing other message. */
+                    xTCPTimer.bExpired = pdTRUE_UNSIGNED;
 
-				if( uxQueueMessagesWaiting( xNetworkEventQueue ) != 0U )
-				{
-					/* Not actually going to send the message but this is not a
-					failure as the message didn't need to be sent. */
-					xSendMessage = pdFALSE;
-				}
-			}
-		}
-		#endif /* ipconfigUSE_TCP */
+                    if( uxQueueMessagesWaiting( xNetworkEventQueue ) != 0U )
+                    {
+                        /* Not actually going to send the message but this is not a
+                         * failure as the message didn't need to be sent. */
+                        xSendMessage = pdFALSE;
+                    }
+                }
+            }
+        #endif /* ipconfigUSE_TCP */
 
-		if( xSendMessage != pdFALSE )
-		{
-			/* The IP task cannot block itself while waiting for itself to
-			respond. */
-			if( ( xIsCallingFromIPTask() == pdTRUE ) && ( uxUseTimeout > ( TickType_t ) 0U ) )
-			{
-				uxUseTimeout = ( TickType_t ) 0;
-			}
+        if( xSendMessage != pdFALSE )
+        {
+            /* The IP task cannot block itself while waiting for itself to
+             * respond. */
+            if( ( xIsCallingFromIPTask() == pdTRUE ) && ( uxUseTimeout > ( TickType_t ) 0U ) )
+            {
+                uxUseTimeout = ( TickType_t ) 0;
+            }
 
-			xReturn = xQueueSendToBack( xNetworkEventQueue, pxEvent, uxUseTimeout );
+            xReturn = xQueueSendToBack( xNetworkEventQueue, pxEvent, uxUseTimeout );
 
-			if( xReturn == pdFAIL )
-			{
-				/* A message should have been sent to the IP task, but wasn't. */
-				FreeRTOS_debug_printf( ( "xSendEventStructToIPTask: CAN NOT ADD %d\n", pxEvent->eEventType ) );
-				iptraceSTACK_TX_EVENT_LOST( pxEvent->eEventType );
-			}
-		}
-		else
-		{
-			/* It was not necessary to send the message to process the event so
-			even though the message was not sent the call was successful. */
-			xReturn = pdPASS;
-		}
-	}
+            if( xReturn == pdFAIL )
+            {
+                /* A message should have been sent to the IP task, but wasn't. */
+                FreeRTOS_debug_printf( ( "xSendEventStructToIPTask: CAN NOT ADD %d\n", pxEvent->eEventType ) );
+                iptraceSTACK_TX_EVENT_LOST( pxEvent->eEventType );
+            }
+        }
+        else
+        {
+            /* It was not necessary to send the message to process the event so
+             * even though the message was not sent the call was successful. */
+            xReturn = pdPASS;
+        }
+    }
 
-	return xReturn;
+    return xReturn;
 }
 /*-----------------------------------------------------------*/
 
 eFrameProcessingResult_t eConsiderFrameForProcessing( const uint8_t * const pucEthernetBuffer )
 {
-eFrameProcessingResult_t eReturn;
-const EthernetHeader_t *pxEthernetHeader;
+    eFrameProcessingResult_t eReturn;
+    const EthernetHeader_t * pxEthernetHeader;
 
-	pxEthernetHeader = ipPOINTER_CAST( const EthernetHeader_t *, pucEthernetBuffer );
+    pxEthernetHeader = ipPOINTER_CAST( const EthernetHeader_t *, pucEthernetBuffer );
 
-	if( memcmp( ipLOCAL_MAC_ADDRESS, pxEthernetHeader->xDestinationAddress.ucBytes, sizeof( MACAddress_t ) ) == 0 )
-	{
-		/* The packet was directed to this node - process it. */
-		eReturn = eProcessBuffer;
-	}
-	else if( memcmp( xBroadcastMACAddress.ucBytes, pxEthernetHeader->xDestinationAddress.ucBytes, sizeof( MACAddress_t ) ) == 0 )
-	{
-		/* The packet was a broadcast - process it. */
-		eReturn = eProcessBuffer;
-	}
-	else
-#if( ipconfigUSE_LLMNR == 1 )
-	if( memcmp( xLLMNR_MacAdress.ucBytes, pxEthernetHeader->xDestinationAddress.ucBytes, sizeof( MACAddress_t ) ) == 0 )
-	{
-		/* The packet is a request for LLMNR - process it. */
-		eReturn = eProcessBuffer;
-	}
-	else
-#endif /* ipconfigUSE_LLMNR */
-	{
-		/* The packet was not a broadcast, or for this node, just release
-		the buffer without taking any other action. */
-		eReturn = eReleaseBuffer;
-	}
+    if( memcmp( ipLOCAL_MAC_ADDRESS, pxEthernetHeader->xDestinationAddress.ucBytes, sizeof( MACAddress_t ) ) == 0 )
+    {
+        /* The packet was directed to this node - process it. */
+        eReturn = eProcessBuffer;
+    }
+    else if( memcmp( xBroadcastMACAddress.ucBytes, pxEthernetHeader->xDestinationAddress.ucBytes, sizeof( MACAddress_t ) ) == 0 )
+    {
+        /* The packet was a broadcast - process it. */
+        eReturn = eProcessBuffer;
+    }
+    else
+    #if ( ipconfigUSE_LLMNR == 1 )
+        if( memcmp( xLLMNR_MacAdress.ucBytes, pxEthernetHeader->xDestinationAddress.ucBytes, sizeof( MACAddress_t ) ) == 0 )
+        {
+            /* The packet is a request for LLMNR - process it. */
+            eReturn = eProcessBuffer;
+        }
+        else
+    #endif /* ipconfigUSE_LLMNR */
+    {
+        /* The packet was not a broadcast, or for this node, just release
+         * the buffer without taking any other action. */
+        eReturn = eReleaseBuffer;
+    }
 
-	#if( ipconfigFILTER_OUT_NON_ETHERNET_II_FRAMES == 1 )
-	{
-	uint16_t usFrameType;
+    #if ( ipconfigFILTER_OUT_NON_ETHERNET_II_FRAMES == 1 )
+        {
+            uint16_t usFrameType;
 
-		if( eReturn == eProcessBuffer )
-		{
-			usFrameType = pxEthernetHeader->usFrameType;
-			usFrameType = FreeRTOS_ntohs( usFrameType );
+            if( eReturn == eProcessBuffer )
+            {
+                usFrameType = pxEthernetHeader->usFrameType;
+                usFrameType = FreeRTOS_ntohs( usFrameType );
 
-			if( usFrameType <= 0x600U )
-			{
-				/* Not an Ethernet II frame. */
-				eReturn = eReleaseBuffer;
-			}
-		}
-	}
-	#endif /* ipconfigFILTER_OUT_NON_ETHERNET_II_FRAMES == 1  */
+                if( usFrameType <= 0x600U )
+                {
+                    /* Not an Ethernet II frame. */
+                    eReturn = eReleaseBuffer;
+                }
+            }
+        }
+    #endif /* ipconfigFILTER_OUT_NON_ETHERNET_II_FRAMES == 1  */
 
-	return eReturn;
+    return eReturn;
 }
 /*-----------------------------------------------------------*/
 
 static void prvProcessNetworkDownEvent( void )
 {
-	/* Stop the ARP timer while there is no network. */
-	xARPTimer.bActive = pdFALSE_UNSIGNED;
+    /* Stop the ARP timer while there is no network. */
+    xARPTimer.bActive = pdFALSE_UNSIGNED;
 
-	#if ipconfigUSE_NETWORK_EVENT_HOOK == 1
-	{
-		static BaseType_t xCallEventHook = pdFALSE;
+    #if ipconfigUSE_NETWORK_EVENT_HOOK == 1
+        {
+            static BaseType_t xCallEventHook = pdFALSE;
 
-		/* The first network down event is generated by the IP stack itself to
-		initialise the network hardware, so do not call the network down event
-		the first time through. */
-		if( xCallEventHook == pdTRUE )
-		{
-			vApplicationIPNetworkEventHook( eNetworkDown );
-		}
-		xCallEventHook = pdTRUE;
-	}
-	#endif
+            /* The first network down event is generated by the IP stack itself to
+             * initialise the network hardware, so do not call the network down event
+             * the first time through. */
+            if( xCallEventHook == pdTRUE )
+            {
+                vApplicationIPNetworkEventHook( eNetworkDown );
+            }
 
-	/* Per the ARP Cache Validation section of https://tools.ietf.org/html/rfc1122, 
-	treat network down as a "delivery problem" and flush the ARP cache for this
-	interface. */
-	FreeRTOS_ClearARP( );
+            xCallEventHook = pdTRUE;
+        }
+    #endif /* if ipconfigUSE_NETWORK_EVENT_HOOK == 1 */
 
-	/* The network has been disconnected (or is being initialised for the first
-	time).  Perform whatever hardware processing is necessary to bring it up
-	again, or wait for it to be available again.  This is hardware dependent. */
-	if( xNetworkInterfaceInitialise() != pdPASS )
-	{
-		/* Ideally the network interface initialisation function will only
-		return when the network is available.  In case this is not the case,
-		wait a while before retrying the initialisation. */
-		vTaskDelay( ipINITIALISATION_RETRY_DELAY );
-		FreeRTOS_NetworkDown();
-	}
-	else
-	{
-		/* Set remaining time to 0 so it will become active immediately. */
-		#if ipconfigUSE_DHCP == 1
-		{
-			/* The network is not up until DHCP has completed. */
-			vDHCPProcess( pdTRUE );
-			( void ) xSendEventToIPTask( eDHCPEvent );
-		}
-		#else
-		{
-			/* Perform any necessary 'network up' processing. */
-			vIPNetworkUpCalls();
-		}
-		#endif
-	}
+    /* Per the ARP Cache Validation section of https://tools.ietf.org/html/rfc1122,
+     * treat network down as a "delivery problem" and flush the ARP cache for this
+     * interface. */
+    FreeRTOS_ClearARP();
+
+    /* The network has been disconnected (or is being initialised for the first
+     * time).  Perform whatever hardware processing is necessary to bring it up
+     * again, or wait for it to be available again.  This is hardware dependent. */
+    if( xNetworkInterfaceInitialise() != pdPASS )
+    {
+        /* Ideally the network interface initialisation function will only
+         * return when the network is available.  In case this is not the case,
+         * wait a while before retrying the initialisation. */
+        vTaskDelay( ipINITIALISATION_RETRY_DELAY );
+        FreeRTOS_NetworkDown();
+    }
+    else
+    {
+        /* Set remaining time to 0 so it will become active immediately. */
+        #if ipconfigUSE_DHCP == 1
+            {
+                /* The network is not up until DHCP has completed. */
+                vDHCPProcess( pdTRUE );
+                ( void ) xSendEventToIPTask( eDHCPEvent );
+            }
+        #else
+            {
+                /* Perform any necessary 'network up' processing. */
+                vIPNetworkUpCalls();
+            }
+        #endif
+    }
 }
 /*-----------------------------------------------------------*/
 
 void vIPNetworkUpCalls( void )
 {
-	xNetworkUp = pdTRUE;
+    xNetworkUp = pdTRUE;
 
-	#if( ipconfigUSE_NETWORK_EVENT_HOOK == 1 )
-	{
-		vApplicationIPNetworkEventHook( eNetworkUp );
-	}
-	#endif /* ipconfigUSE_NETWORK_EVENT_HOOK */
+    #if ( ipconfigUSE_NETWORK_EVENT_HOOK == 1 )
+        {
+            vApplicationIPNetworkEventHook( eNetworkUp );
+        }
+    #endif /* ipconfigUSE_NETWORK_EVENT_HOOK */
 
-	#if( ipconfigDNS_USE_CALLBACKS != 0 )
-	{
-		/* The following function is declared in FreeRTOS_DNS.c	and 'private' to
-		this library */
-		extern void vDNSInitialise( void );
-		vDNSInitialise();
-	}
-	#endif /* ipconfigDNS_USE_CALLBACKS != 0 */
+    #if ( ipconfigDNS_USE_CALLBACKS != 0 )
+        {
+            /* The following function is declared in FreeRTOS_DNS.c	and 'private' to
+             * this library */
+            extern void vDNSInitialise( void );
+            vDNSInitialise();
+        }
+    #endif /* ipconfigDNS_USE_CALLBACKS != 0 */
 
-	/* Set remaining time to 0 so it will become active immediately. */
-	prvIPTimerReload( &xARPTimer, pdMS_TO_TICKS( ipARP_TIMER_PERIOD_MS ) );
+    /* Set remaining time to 0 so it will become active immediately. */
+    prvIPTimerReload( &xARPTimer, pdMS_TO_TICKS( ipARP_TIMER_PERIOD_MS ) );
 }
 /*-----------------------------------------------------------*/
 
 static void prvProcessEthernetPacket( NetworkBufferDescriptor_t * const pxNetworkBuffer )
 {
-const EthernetHeader_t *pxEthernetHeader;
-eFrameProcessingResult_t eReturned = eReleaseBuffer;
+    const EthernetHeader_t * pxEthernetHeader;
+    eFrameProcessingResult_t eReturned = eReleaseBuffer;
 
-	configASSERT( pxNetworkBuffer != NULL );
+    configASSERT( pxNetworkBuffer != NULL );
 
-	/* Interpret the Ethernet frame. */
-	if( pxNetworkBuffer->xDataLength >= sizeof( EthernetHeader_t ) )
-	{
-		eReturned = ipCONSIDER_FRAME_FOR_PROCESSING( pxNetworkBuffer->pucEthernetBuffer );
-		pxEthernetHeader = ipPOINTER_CAST( const EthernetHeader_t *, pxNetworkBuffer->pucEthernetBuffer );
+    /* Interpret the Ethernet frame. */
+    if( pxNetworkBuffer->xDataLength >= sizeof( EthernetHeader_t ) )
+    {
+        eReturned = ipCONSIDER_FRAME_FOR_PROCESSING( pxNetworkBuffer->pucEthernetBuffer );
+        pxEthernetHeader = ipPOINTER_CAST( const EthernetHeader_t *, pxNetworkBuffer->pucEthernetBuffer );
 
-		/* The condition "eReturned == eProcessBuffer" must be true. */
-		#if( ipconfigETHERNET_DRIVER_FILTERS_FRAME_TYPES == 0 )
-		if( eReturned == eProcessBuffer )
-		#endif
-		{
-			/* Interpret the received Ethernet packet. */
-			switch( pxEthernetHeader->usFrameType )
-			{
-			case ipARP_FRAME_TYPE:
-				/* The Ethernet frame contains an ARP packet. */
-				if( pxNetworkBuffer->xDataLength >= sizeof( ARPPacket_t ) )
-				{
-					eReturned = eARPProcessPacket( ipPOINTER_CAST( ARPPacket_t *, pxNetworkBuffer->pucEthernetBuffer ) );
-				}
-				else
-				{
-					eReturned = eReleaseBuffer;
-				}
-				break;
+        /* The condition "eReturned == eProcessBuffer" must be true. */
+        #if ( ipconfigETHERNET_DRIVER_FILTERS_FRAME_TYPES == 0 )
+            if( eReturned == eProcessBuffer )
+        #endif
+        {
+            /* Interpret the received Ethernet packet. */
+            switch( pxEthernetHeader->usFrameType )
+            {
+                case ipARP_FRAME_TYPE:
 
-			case ipIPv4_FRAME_TYPE:
-				/* The Ethernet frame contains an IP packet. */
-				if( pxNetworkBuffer->xDataLength >= sizeof( IPPacket_t ) )
-				{
-					eReturned = prvProcessIPPacket( ipPOINTER_CAST( IPPacket_t *, pxNetworkBuffer->pucEthernetBuffer ), pxNetworkBuffer );
-				}
-				else
-				{
-					eReturned = eReleaseBuffer;
-				}
-				break;
+                    /* The Ethernet frame contains an ARP packet. */
+                    if( pxNetworkBuffer->xDataLength >= sizeof( ARPPacket_t ) )
+                    {
+                        eReturned = eARPProcessPacket( ipPOINTER_CAST( ARPPacket_t *, pxNetworkBuffer->pucEthernetBuffer ) );
+                    }
+                    else
+                    {
+                        eReturned = eReleaseBuffer;
+                    }
 
-			default:
-				/* No other packet types are handled.  Nothing to do. */
-				eReturned = eReleaseBuffer;
-				break;
-			}
-		}
-	}
+                    break;
 
-	/* Perform any actions that resulted from processing the Ethernet frame. */
-	switch( eReturned )
-	{
-		case eReturnEthernetFrame :
-			/* The Ethernet frame will have been updated (maybe it was
-			an ARP request or a PING request?) and should be sent back to
-			its source. */
-			vReturnEthernetFrame( pxNetworkBuffer, pdTRUE );
-			/* parameter pdTRUE: the buffer must be released once
-			the frame has been transmitted */
-			break;
+                case ipIPv4_FRAME_TYPE:
 
-		case eFrameConsumed :
-			/* The frame is in use somewhere, don't release the buffer
-			yet. */
-			break;
+                    /* The Ethernet frame contains an IP packet. */
+                    if( pxNetworkBuffer->xDataLength >= sizeof( IPPacket_t ) )
+                    {
+                        eReturned = prvProcessIPPacket( ipPOINTER_CAST( IPPacket_t *, pxNetworkBuffer->pucEthernetBuffer ), pxNetworkBuffer );
+                    }
+                    else
+                    {
+                        eReturned = eReleaseBuffer;
+                    }
 
-		case eReleaseBuffer :
-		case eProcessBuffer :
-		default :
-			/* The frame is not being used anywhere, and the
-			NetworkBufferDescriptor_t structure containing the frame should
-			just be	released back to the list of free buffers. */
-			vReleaseNetworkBufferAndDescriptor( pxNetworkBuffer );
-			break;
-	}
+                    break;
+
+                default:
+                    /* No other packet types are handled.  Nothing to do. */
+                    eReturned = eReleaseBuffer;
+                    break;
+            }
+        }
+    }
+
+    /* Perform any actions that resulted from processing the Ethernet frame. */
+    switch( eReturned )
+    {
+        case eReturnEthernetFrame:
+            /* The Ethernet frame will have been updated (maybe it was
+             * an ARP request or a PING request?) and should be sent back to
+             * its source. */
+            vReturnEthernetFrame( pxNetworkBuffer, pdTRUE );
+
+            /* parameter pdTRUE: the buffer must be released once
+             * the frame has been transmitted */
+            break;
+
+        case eFrameConsumed:
+            /* The frame is in use somewhere, don't release the buffer
+             * yet. */
+            break;
+
+        case eReleaseBuffer:
+        case eProcessBuffer:
+        default:
+            /* The frame is not being used anywhere, and the
+             * NetworkBufferDescriptor_t structure containing the frame should
+             * just be	released back to the list of free buffers. */
+            vReleaseNetworkBufferAndDescriptor( pxNetworkBuffer );
+            break;
+    }
 }
 /*-----------------------------------------------------------*/
 
 BaseType_t xIsIPv4Multicast( uint32_t ulIPAddress )
 {
-BaseType_t xReturn;
-uint32_t ulIP = FreeRTOS_ntohl( ulIPAddress );
+    BaseType_t xReturn;
+    uint32_t ulIP = FreeRTOS_ntohl( ulIPAddress );
 
-	if( ( ulIP >= ipFIRST_MULTI_CAST_IPv4 ) && ( ulIP < ipLAST_MULTI_CAST_IPv4 ) )
-	{
-		xReturn = pdTRUE;
-	}
-	else
-	{
-		xReturn = pdFALSE;
-	}
-	return xReturn;
+    if( ( ulIP >= ipFIRST_MULTI_CAST_IPv4 ) && ( ulIP < ipLAST_MULTI_CAST_IPv4 ) )
+    {
+        xReturn = pdTRUE;
+    }
+    else
+    {
+        xReturn = pdFALSE;
+    }
+
+    return xReturn;
 }
 /*-----------------------------------------------------------*/
 
-void vSetMultiCastIPv4MacAddress( uint32_t ulIPAddress, MACAddress_t *pxMACAddress )
+void vSetMultiCastIPv4MacAddress( uint32_t ulIPAddress,
+                                  MACAddress_t * pxMACAddress )
 {
-uint32_t ulIP = FreeRTOS_ntohl( ulIPAddress );
+    uint32_t ulIP = FreeRTOS_ntohl( ulIPAddress );
 
-	pxMACAddress->ucBytes[ 0 ] = ( uint8_t ) 0x01U;
-	pxMACAddress->ucBytes[ 1 ] = ( uint8_t ) 0x00U;
-	pxMACAddress->ucBytes[ 2 ] = ( uint8_t ) 0x5EU;
-	pxMACAddress->ucBytes[ 3 ] = ( uint8_t ) ( ( ulIP >> 16 ) & 0x7fU );	/* Use 7 bits. */
-	pxMACAddress->ucBytes[ 4 ] = ( uint8_t ) ( ( ulIP >>  8 ) & 0xffU );	/* Use 8 bits. */
-	pxMACAddress->ucBytes[ 5 ] = ( uint8_t ) ( ( ulIP       ) & 0xffU );	/* Use 8 bits. */
+    pxMACAddress->ucBytes[ 0 ] = ( uint8_t ) 0x01U;
+    pxMACAddress->ucBytes[ 1 ] = ( uint8_t ) 0x00U;
+    pxMACAddress->ucBytes[ 2 ] = ( uint8_t ) 0x5EU;
+    pxMACAddress->ucBytes[ 3 ] = ( uint8_t ) ( ( ulIP >> 16 ) & 0x7fU ); /* Use 7 bits. */
+    pxMACAddress->ucBytes[ 4 ] = ( uint8_t ) ( ( ulIP >> 8 ) & 0xffU );  /* Use 8 bits. */
+    pxMACAddress->ucBytes[ 5 ] = ( uint8_t ) ( ( ulIP ) & 0xffU );       /* Use 8 bits. */
 }
 /*-----------------------------------------------------------*/
 
 static eFrameProcessingResult_t prvAllowIPPacket( const IPPacket_t * const pxIPPacket,
-	const NetworkBufferDescriptor_t * const pxNetworkBuffer, UBaseType_t uxHeaderLength )
+                                                  const NetworkBufferDescriptor_t * const pxNetworkBuffer,
+                                                  UBaseType_t uxHeaderLength )
 {
-eFrameProcessingResult_t eReturn = eProcessBuffer;
+    eFrameProcessingResult_t eReturn = eProcessBuffer;
 
-#if( ( ipconfigETHERNET_DRIVER_FILTERS_PACKETS == 0 ) || ( ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM == 0 ) )
-	const IPHeader_t * pxIPHeader = &( pxIPPacket->xIPHeader );
-#else
-	/* or else, the parameter won't be used and the function will be optimised
-	away */
-	( void ) pxIPPacket;
-#endif
+    #if ( ( ipconfigETHERNET_DRIVER_FILTERS_PACKETS == 0 ) || ( ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM == 0 ) )
+        const IPHeader_t * pxIPHeader = &( pxIPPacket->xIPHeader );
+    #else
+        /* or else, the parameter won't be used and the function will be optimised
+         * away */
+        ( void ) pxIPPacket;
+    #endif
 
-	#if( ipconfigETHERNET_DRIVER_FILTERS_PACKETS == 0 )
-	{
-		/* In systems with a very small amount of RAM, it might be advantageous
-		to have incoming messages checked earlier, by the network card driver.
-		This method may decrease the usage of sparse network buffers. */
-		uint32_t ulDestinationIPAddress = pxIPHeader->ulDestinationIPAddress;
+    #if ( ipconfigETHERNET_DRIVER_FILTERS_PACKETS == 0 )
+        {
+            /* In systems with a very small amount of RAM, it might be advantageous
+             * to have incoming messages checked earlier, by the network card driver.
+             * This method may decrease the usage of sparse network buffers. */
+            uint32_t ulDestinationIPAddress = pxIPHeader->ulDestinationIPAddress;
 
-			/* Ensure that the incoming packet is not fragmented (only outgoing
-			packets can be fragmented) as these are the only handled IP frames
-			currently. */
-			if( ( pxIPHeader->usFragmentOffset & ipFRAGMENT_OFFSET_BIT_MASK ) != 0U )
-			{
-				/* Can not handle, fragmented packet. */
-				eReturn = eReleaseBuffer;
-			}
-			/* 0x45 means: IPv4 with an IP header of 5 x 4 = 20 bytes
-			 * 0x47 means: IPv4 with an IP header of 7 x 4 = 28 bytes */
-			else if( ( pxIPHeader->ucVersionHeaderLength < 0x45U ) || ( pxIPHeader->ucVersionHeaderLength > 0x4FU ) )
-			{
-				/* Can not handle, unknown or invalid header version. */
-				eReturn = eReleaseBuffer;
-			}
-				/* Is the packet for this IP address? */
-			else if( ( ulDestinationIPAddress != *ipLOCAL_IP_ADDRESS_POINTER ) &&
-				/* Is it the global broadcast address 255.255.255.255 ? */
-				( ulDestinationIPAddress != ipBROADCAST_IP_ADDRESS ) &&
-				/* Is it a specific broadcast address 192.168.1.255 ? */
-				( ulDestinationIPAddress != xNetworkAddressing.ulBroadcastAddress ) &&
-			#if( ipconfigUSE_LLMNR == 1 )
-				/* Is it the LLMNR multicast address? */
-				( ulDestinationIPAddress != ipLLMNR_IP_ADDR ) &&
-			#endif
-				/* Or (during DHCP negotiation) we have no IP-address yet? */
-				( *ipLOCAL_IP_ADDRESS_POINTER != 0UL ) )
-			{
-				/* Packet is not for this node, release it */
-				eReturn = eReleaseBuffer;
-			}
-			else
-			{
-				/* Packet is not fragemented, destination is this device. */
-			}
-	}
-	#endif /* ipconfigETHERNET_DRIVER_FILTERS_PACKETS */
+            /* Ensure that the incoming packet is not fragmented (only outgoing
+             * packets can be fragmented) as these are the only handled IP frames
+             * currently. */
+            if( ( pxIPHeader->usFragmentOffset & ipFRAGMENT_OFFSET_BIT_MASK ) != 0U )
+            {
+                /* Can not handle, fragmented packet. */
+                eReturn = eReleaseBuffer;
+            }
 
-	#if( ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM == 0 )
-	{
-		/* Some drivers of NIC's with checksum-offloading will enable the above
-		define, so that the checksum won't be checked again here */
-		if (eReturn == eProcessBuffer )
-		{
-			/* Is the IP header checksum correct? */
-			if( ( pxIPHeader->ucProtocol != ( uint8_t ) ipPROTOCOL_ICMP ) &&
-				( usGenerateChecksum( 0U, ( uint8_t * ) &( pxIPHeader->ucVersionHeaderLength ), ( size_t ) uxHeaderLength ) != ipCORRECT_CRC ) )
-			{
-				/* Check sum in IP-header not correct. */
-				eReturn = eReleaseBuffer;
-			}
-			/* Is the upper-layer checksum (TCP/UDP/ICMP) correct? */
-			else if( usGenerateProtocolChecksum( ( uint8_t * )( pxNetworkBuffer->pucEthernetBuffer ), pxNetworkBuffer->xDataLength, pdFALSE ) != ipCORRECT_CRC )
-			{
-				/* Protocol checksum not accepted. */
-				eReturn = eReleaseBuffer;
-			}
-			else
-			{
-				/* The checksum of the received packet is OK. */
-			}
-		}
-	}
-	#else
-	{
-		/* to avoid warning unused parameters */
-		( void ) pxNetworkBuffer;
-		( void ) uxHeaderLength;
-	}
-	#endif /* ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM == 0 */
+            /* 0x45 means: IPv4 with an IP header of 5 x 4 = 20 bytes
+             * 0x47 means: IPv4 with an IP header of 7 x 4 = 28 bytes */
+            else if( ( pxIPHeader->ucVersionHeaderLength < 0x45U ) || ( pxIPHeader->ucVersionHeaderLength > 0x4FU ) )
+            {
+                /* Can not handle, unknown or invalid header version. */
+                eReturn = eReleaseBuffer;
+            }
+            /* Is the packet for this IP address? */
+            else if( ( ulDestinationIPAddress != *ipLOCAL_IP_ADDRESS_POINTER ) &&
+                     /* Is it the global broadcast address 255.255.255.255 ? */
+                     ( ulDestinationIPAddress != ipBROADCAST_IP_ADDRESS ) &&
+                     /* Is it a specific broadcast address 192.168.1.255 ? */
+                     ( ulDestinationIPAddress != xNetworkAddressing.ulBroadcastAddress ) &&
+                     #if ( ipconfigUSE_LLMNR == 1 )
+                         /* Is it the LLMNR multicast address? */
+                         ( ulDestinationIPAddress != ipLLMNR_IP_ADDR ) &&
+                     #endif
+                     /* Or (during DHCP negotiation) we have no IP-address yet? */
+                     ( *ipLOCAL_IP_ADDRESS_POINTER != 0UL ) )
+            {
+                /* Packet is not for this node, release it */
+                eReturn = eReleaseBuffer;
+            }
+            else
+            {
+                /* Packet is not fragemented, destination is this device. */
+            }
+        }
+    #endif /* ipconfigETHERNET_DRIVER_FILTERS_PACKETS */
 
-	return eReturn;
+    #if ( ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM == 0 )
+        {
+            /* Some drivers of NIC's with checksum-offloading will enable the above
+             * define, so that the checksum won't be checked again here */
+            if( eReturn == eProcessBuffer )
+            {
+                /* Is the IP header checksum correct? */
+                if( ( pxIPHeader->ucProtocol != ( uint8_t ) ipPROTOCOL_ICMP ) &&
+                    ( usGenerateChecksum( 0U, ( uint8_t * ) &( pxIPHeader->ucVersionHeaderLength ), ( size_t ) uxHeaderLength ) != ipCORRECT_CRC ) )
+                {
+                    /* Check sum in IP-header not correct. */
+                    eReturn = eReleaseBuffer;
+                }
+                /* Is the upper-layer checksum (TCP/UDP/ICMP) correct? */
+                else if( usGenerateProtocolChecksum( ( uint8_t * ) ( pxNetworkBuffer->pucEthernetBuffer ), pxNetworkBuffer->xDataLength, pdFALSE ) != ipCORRECT_CRC )
+                {
+                    /* Protocol checksum not accepted. */
+                    eReturn = eReleaseBuffer;
+                }
+                else
+                {
+                    /* The checksum of the received packet is OK. */
+                }
+            }
+        }
+    #else /* if ( ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM == 0 ) */
+        {
+            /* to avoid warning unused parameters */
+            ( void ) pxNetworkBuffer;
+            ( void ) uxHeaderLength;
+        }
+    #endif /* ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM == 0 */
+
+    return eReturn;
 }
 /*-----------------------------------------------------------*/
 
-static eFrameProcessingResult_t prvProcessIPPacket( IPPacket_t * pxIPPacket, NetworkBufferDescriptor_t * const pxNetworkBuffer )
+static eFrameProcessingResult_t prvProcessIPPacket( IPPacket_t * pxIPPacket,
+                                                    NetworkBufferDescriptor_t * const pxNetworkBuffer )
 {
-eFrameProcessingResult_t eReturn;
-IPHeader_t * pxIPHeader = &( pxIPPacket->xIPHeader );
-size_t uxLength = ( size_t ) pxIPHeader->ucVersionHeaderLength;
-UBaseType_t uxHeaderLength = ( UBaseType_t ) ( ( uxLength & 0x0FU ) << 2 );
-uint8_t ucProtocol;
+    eFrameProcessingResult_t eReturn;
+    IPHeader_t * pxIPHeader = &( pxIPPacket->xIPHeader );
+    size_t uxLength = ( size_t ) pxIPHeader->ucVersionHeaderLength;
+    UBaseType_t uxHeaderLength = ( UBaseType_t ) ( ( uxLength & 0x0FU ) << 2 );
+    uint8_t ucProtocol;
 
-	/* Bound the calculated header length: take away the Ethernet header size,
-	then check if the IP header is claiming to be longer than the remaining
-	total packet size. Also check for minimal header field length. */
-	if( ( uxHeaderLength > ( pxNetworkBuffer->xDataLength - ipSIZE_OF_ETH_HEADER ) ) ||
-		( uxHeaderLength < ipSIZE_OF_IPv4_HEADER ) )
-	{
-		return eReleaseBuffer;
-	}
+    /* Bound the calculated header length: take away the Ethernet header size,
+     * then check if the IP header is claiming to be longer than the remaining
+     * total packet size. Also check for minimal header field length. */
+    if( ( uxHeaderLength > ( pxNetworkBuffer->xDataLength - ipSIZE_OF_ETH_HEADER ) ) ||
+        ( uxHeaderLength < ipSIZE_OF_IPv4_HEADER ) )
+    {
+        return eReleaseBuffer;
+    }
 
-	ucProtocol = pxIPPacket->xIPHeader.ucProtocol;
-	/* Check if the IP headers are acceptable and if it has our destination. */
-	eReturn = prvAllowIPPacket( pxIPPacket, pxNetworkBuffer, uxHeaderLength );
+    ucProtocol = pxIPPacket->xIPHeader.ucProtocol;
+    /* Check if the IP headers are acceptable and if it has our destination. */
+    eReturn = prvAllowIPPacket( pxIPPacket, pxNetworkBuffer, uxHeaderLength );
 
-	if( eReturn == eProcessBuffer )
-	{
-		if( uxHeaderLength > ipSIZE_OF_IPv4_HEADER )
-		{
-			/* All structs of headers expect a IP header size of 20 bytes
-			 * IP header options were included, we'll ignore them and cut them out
-			 * Note: IP options are mostly use in Multi-cast protocols */
-			const size_t optlen = ( ( size_t ) uxHeaderLength ) - ipSIZE_OF_IPv4_HEADER;
-			/* From: the previous start of UDP/ICMP/TCP data */
-			const uint8_t *pucSource = ( const uint8_t * ) &( pxNetworkBuffer->pucEthernetBuffer[ sizeof( EthernetHeader_t ) + uxHeaderLength ] );
-			/* To: the usual start of UDP/ICMP/TCP data at offset 20 from IP header */
-			uint8_t *pucTarget = ( uint8_t * ) &( pxNetworkBuffer->pucEthernetBuffer[ sizeof( EthernetHeader_t ) + ipSIZE_OF_IPv4_HEADER ] );
-			/* How many: total length minus the options and the lower headers */
-			const size_t  xMoveLen = pxNetworkBuffer->xDataLength - ( optlen + ipSIZE_OF_IPv4_HEADER + ipSIZE_OF_ETH_HEADER );
+    if( eReturn == eProcessBuffer )
+    {
+        if( uxHeaderLength > ipSIZE_OF_IPv4_HEADER )
+        {
+            /* All structs of headers expect a IP header size of 20 bytes
+             * IP header options were included, we'll ignore them and cut them out
+             * Note: IP options are mostly use in Multi-cast protocols */
+            const size_t optlen = ( ( size_t ) uxHeaderLength ) - ipSIZE_OF_IPv4_HEADER;
+            /* From: the previous start of UDP/ICMP/TCP data */
+            const uint8_t * pucSource = ( const uint8_t * ) &( pxNetworkBuffer->pucEthernetBuffer[ sizeof( EthernetHeader_t ) + uxHeaderLength ] );
+            /* To: the usual start of UDP/ICMP/TCP data at offset 20 from IP header */
+            uint8_t * pucTarget = ( uint8_t * ) &( pxNetworkBuffer->pucEthernetBuffer[ sizeof( EthernetHeader_t ) + ipSIZE_OF_IPv4_HEADER ] );
+            /* How many: total length minus the options and the lower headers */
+            const size_t xMoveLen = pxNetworkBuffer->xDataLength - ( optlen + ipSIZE_OF_IPv4_HEADER + ipSIZE_OF_ETH_HEADER );
 
-			( void ) memmove( pucTarget, pucSource, xMoveLen );
-			pxNetworkBuffer->xDataLength -= optlen;
+            ( void ) memmove( pucTarget, pucSource, xMoveLen );
+            pxNetworkBuffer->xDataLength -= optlen;
 
-			/* Fix-up new version/header length field in IP packet. */
-			pxIPHeader->ucVersionHeaderLength = ( pxIPHeader->ucVersionHeaderLength & 0xF0U ) | /* High nibble is the version. */
-												( ( ipSIZE_OF_IPv4_HEADER >> 2 ) & 0x0FU );
-		}
+            /* Fix-up new version/header length field in IP packet. */
+            pxIPHeader->ucVersionHeaderLength = ( pxIPHeader->ucVersionHeaderLength & 0xF0U ) | /* High nibble is the version. */
+                                                ( ( ipSIZE_OF_IPv4_HEADER >> 2 ) & 0x0FU );
+        }
 
-		/* Add the IP and MAC addresses to the ARP table if they are not
-		already there - otherwise refresh the age of the existing
-		entry. */
-		if( ucProtocol != ( uint8_t ) ipPROTOCOL_UDP )
-		{
-			/* Refresh the ARP cache with the IP/MAC-address of the received
-			packet. For UDP packets, this will be done later in
-			xProcessReceivedUDPPacket(), as soon as it's know that the message
-			will be handled.  This will prevent the ARP cache getting
-			overwritten with the IP address of useless broadcast packets. */
-			vARPRefreshCacheEntry( &( pxIPPacket->xEthernetHeader.xSourceAddress ), pxIPHeader->ulSourceIPAddress );
-		}
-		switch( ucProtocol )
-		{
-			case ipPROTOCOL_ICMP :
-				/* The IP packet contained an ICMP frame.  Don't bother checking
-				the ICMP checksum, as if it is wrong then the wrong data will
-				also be returned, and the source of the ping will know something
-				went wrong because it will not be able to validate what it
-				receives. */
-				#if ( ipconfigREPLY_TO_INCOMING_PINGS == 1 ) || ( ipconfigSUPPORT_OUTGOING_PINGS == 1 )
-				{
-					if( pxNetworkBuffer->xDataLength >= sizeof( ICMPPacket_t ) )
-					{
-						ICMPPacket_t *pxICMPPacket = ipPOINTER_CAST( ICMPPacket_t *, pxNetworkBuffer->pucEthernetBuffer );
-						if( pxIPHeader->ulDestinationIPAddress == *ipLOCAL_IP_ADDRESS_POINTER )
-						{
-							eReturn = prvProcessICMPPacket( pxICMPPacket );
-						}
-					}
-					else
-					{
-						eReturn = eReleaseBuffer;
-					}
-				}
-				#endif /* ( ipconfigREPLY_TO_INCOMING_PINGS == 1 ) || ( ipconfigSUPPORT_OUTGOING_PINGS == 1 ) */
-				break;
+        /* Add the IP and MAC addresses to the ARP table if they are not
+         * already there - otherwise refresh the age of the existing
+         * entry. */
+        if( ucProtocol != ( uint8_t ) ipPROTOCOL_UDP )
+        {
+            /* Refresh the ARP cache with the IP/MAC-address of the received
+             *  packet. For UDP packets, this will be done later in
+             *  xProcessReceivedUDPPacket(), as soon as it's know that the message
+             *  will be handled.  This will prevent the ARP cache getting
+             *  overwritten with the IP address of useless broadcast packets. */
+            vARPRefreshCacheEntry( &( pxIPPacket->xEthernetHeader.xSourceAddress ), pxIPHeader->ulSourceIPAddress );
+        }
 
-			case ipPROTOCOL_UDP :
-				{
-				/* The IP packet contained a UDP frame. */
-				const UDPPacket_t *pxUDPPacket = ipPOINTER_CAST( const UDPPacket_t *, pxNetworkBuffer->pucEthernetBuffer );
-				uint16_t usLength;
+        switch( ucProtocol )
+        {
+            case ipPROTOCOL_ICMP:
+                /* The IP packet contained an ICMP frame.  Don't bother checking
+                 * the ICMP checksum, as if it is wrong then the wrong data will
+                 * also be returned, and the source of the ping will know something
+                 * went wrong because it will not be able to validate what it
+                 * receives. */
+                #if ( ipconfigREPLY_TO_INCOMING_PINGS == 1 ) || ( ipconfigSUPPORT_OUTGOING_PINGS == 1 )
+                    if( pxNetworkBuffer->xDataLength >= sizeof( ICMPPacket_t ) )
+                    {
+                        ICMPPacket_t * pxICMPPacket = ipPOINTER_CAST( ICMPPacket_t *, pxNetworkBuffer->pucEthernetBuffer );
 
-					/* Note the header values required prior to the checksum
-					generation as the checksum pseudo header may clobber some of
-					these values. */
-					usLength = FreeRTOS_ntohs( pxUDPPacket->xUDPHeader.usLength  );
-					if ( ( pxNetworkBuffer->xDataLength >= sizeof( UDPPacket_t ) ) &&
-						 ( ( ( size_t ) usLength ) >= sizeof( UDPHeader_t ) ) )
-					{
-					size_t uxPayloadSize_1, uxPayloadSize_2;
-						/* Ensure that downstream UDP packet handling has the lesser
-						of: the actual network buffer Ethernet frame length, or
-						the sender's UDP packet header payload length, minus the
-						size of the UDP header.
+                        if( pxIPHeader->ulDestinationIPAddress == *ipLOCAL_IP_ADDRESS_POINTER )
+                        {
+                            eReturn = prvProcessICMPPacket( pxICMPPacket );
+                        }
+                    }
+                    else
+                    {
+                        eReturn = eReleaseBuffer;
+                    }
+                #endif /* ( ipconfigREPLY_TO_INCOMING_PINGS == 1 ) || ( ipconfigSUPPORT_OUTGOING_PINGS == 1 ) */
+                break;
 
-						The size of the UDP packet structure in this implementation
-						includes the size of the Ethernet header, the size of
-						the IP header, and the size of the UDP header. */
-						uxPayloadSize_1 = pxNetworkBuffer->xDataLength - sizeof( UDPPacket_t );
-						uxPayloadSize_2 = ( ( size_t ) usLength ) - sizeof( UDPHeader_t );
-						if( uxPayloadSize_1 > uxPayloadSize_2 )
-						{
-							pxNetworkBuffer->xDataLength = uxPayloadSize_2 + sizeof( UDPPacket_t );
-						}
+            case ipPROTOCOL_UDP:
+               {
+                   /* The IP packet contained a UDP frame. */
+                   const UDPPacket_t * pxUDPPacket = ipPOINTER_CAST( const UDPPacket_t *, pxNetworkBuffer->pucEthernetBuffer );
+                   uint16_t usLength;
 
-						/* Fields in pxNetworkBuffer (usPort, ulIPAddress) are network order. */
-						pxNetworkBuffer->usPort = pxUDPPacket->xUDPHeader.usSourcePort;
-						pxNetworkBuffer->ulIPAddress = pxUDPPacket->xIPHeader.ulSourceIPAddress;
+                   /* Note the header values required prior to the checksum
+                    * generation as the checksum pseudo header may clobber some of
+                    * these values. */
+                   usLength = FreeRTOS_ntohs( pxUDPPacket->xUDPHeader.usLength );
 
-						/* ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM:
-						In some cases, the upper-layer checksum has been calculated
-						by the NIC driver. */
+                   if( ( pxNetworkBuffer->xDataLength >= sizeof( UDPPacket_t ) ) &&
+                       ( ( ( size_t ) usLength ) >= sizeof( UDPHeader_t ) ) )
+                   {
+                       size_t uxPayloadSize_1, uxPayloadSize_2;
 
-						/* Pass the packet payload to the UDP sockets
-						implementation. */
-						if( xProcessReceivedUDPPacket( pxNetworkBuffer,
-													   pxUDPPacket->xUDPHeader.usDestinationPort ) == pdPASS )
-						{
-							eReturn = eFrameConsumed;
-						}
-					}
-					else
-					{
-						eReturn = eReleaseBuffer;
-					}
-				}
-				break;
+                       /* Ensure that downstream UDP packet handling has the lesser
+                        * of: the actual network buffer Ethernet frame length, or
+                        * the sender's UDP packet header payload length, minus the
+                        * size of the UDP header.
+                        *
+                        * The size of the UDP packet structure in this implementation
+                        * includes the size of the Ethernet header, the size of
+                        * the IP header, and the size of the UDP header. */
+                       uxPayloadSize_1 = pxNetworkBuffer->xDataLength - sizeof( UDPPacket_t );
+                       uxPayloadSize_2 = ( ( size_t ) usLength ) - sizeof( UDPHeader_t );
 
-#if ipconfigUSE_TCP == 1
-			case ipPROTOCOL_TCP :
-				{
+                       if( uxPayloadSize_1 > uxPayloadSize_2 )
+                       {
+                           pxNetworkBuffer->xDataLength = uxPayloadSize_2 + sizeof( UDPPacket_t );
+                       }
 
-					if( xProcessReceivedTCPPacket( pxNetworkBuffer ) == pdPASS )
-					{
-						eReturn = eFrameConsumed;
-					}
+                       /* Fields in pxNetworkBuffer (usPort, ulIPAddress) are network order. */
+                       pxNetworkBuffer->usPort = pxUDPPacket->xUDPHeader.usSourcePort;
+                       pxNetworkBuffer->ulIPAddress = pxUDPPacket->xIPHeader.ulSourceIPAddress;
 
-					/* Setting this variable will cause xTCPTimerCheck()
-					to be called just before the IP-task blocks. */
-					xProcessedTCPMessage++;
-				}
-				break;
-#endif
-			default	:
-				/* Not a supported frame type. */
-				break;
-		}
-	}
+                       /* ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM:
+                        * In some cases, the upper-layer checksum has been calculated
+                        * by the NIC driver. */
 
-	return eReturn;
+                       /* Pass the packet payload to the UDP sockets
+                        * implementation. */
+                       if( xProcessReceivedUDPPacket( pxNetworkBuffer,
+                                                      pxUDPPacket->xUDPHeader.usDestinationPort ) == pdPASS )
+                       {
+                           eReturn = eFrameConsumed;
+                       }
+                   }
+                   else
+                   {
+                       eReturn = eReleaseBuffer;
+                   }
+               }
+               break;
+
+                #if ipconfigUSE_TCP == 1
+                    case ipPROTOCOL_TCP:
+
+                        if( xProcessReceivedTCPPacket( pxNetworkBuffer ) == pdPASS )
+                        {
+                            eReturn = eFrameConsumed;
+                        }
+
+                        /* Setting this variable will cause xTCPTimerCheck()
+                         * to be called just before the IP-task blocks. */
+                        xProcessedTCPMessage++;
+                        break;
+                #endif /* if ipconfigUSE_TCP == 1 */
+            default:
+                /* Not a supported frame type. */
+                break;
+        }
+    }
+
+    return eReturn;
 }
 /*-----------------------------------------------------------*/
 
 #if ( ipconfigSUPPORT_OUTGOING_PINGS == 1 )
 
-	static void prvProcessICMPEchoReply( ICMPPacket_t * const pxICMPPacket )
-	{
-	ePingReplyStatus_t eStatus = eSuccess;
-	uint16_t usDataLength, usCount;
-	uint8_t *pucByte;
+    static void prvProcessICMPEchoReply( ICMPPacket_t * const pxICMPPacket )
+    {
+        ePingReplyStatus_t eStatus = eSuccess;
+        uint16_t usDataLength, usCount;
+        uint8_t * pucByte;
 
-		/* Find the total length of the IP packet. */
-		usDataLength = pxICMPPacket->xIPHeader.usLength;
-		usDataLength = FreeRTOS_ntohs( usDataLength );
+        /* Find the total length of the IP packet. */
+        usDataLength = pxICMPPacket->xIPHeader.usLength;
+        usDataLength = FreeRTOS_ntohs( usDataLength );
 
-		/* Remove the length of the IP headers to obtain the length of the ICMP
-		message itself. */
-		usDataLength = ( uint16_t ) ( ( ( uint32_t ) usDataLength ) - ipSIZE_OF_IPv4_HEADER );
+        /* Remove the length of the IP headers to obtain the length of the ICMP
+         * message itself. */
+        usDataLength = ( uint16_t ) ( ( ( uint32_t ) usDataLength ) - ipSIZE_OF_IPv4_HEADER );
 
-		/* Remove the length of the ICMP header, to obtain the length of
-		data contained in the ping. */
-		usDataLength = ( uint16_t ) ( ( ( uint32_t ) usDataLength ) - ipSIZE_OF_ICMP_HEADER );
+        /* Remove the length of the ICMP header, to obtain the length of
+         * data contained in the ping. */
+        usDataLength = ( uint16_t ) ( ( ( uint32_t ) usDataLength ) - ipSIZE_OF_ICMP_HEADER );
 
-		/* Checksum has already been checked before in prvProcessIPPacket */
+        /* Checksum has already been checked before in prvProcessIPPacket */
 
-		/* Find the first byte of the data within the ICMP packet. */
-		pucByte = ( uint8_t * ) pxICMPPacket;
-		pucByte = &( pucByte[ sizeof( ICMPPacket_t ) ] );
+        /* Find the first byte of the data within the ICMP packet. */
+        pucByte = ( uint8_t * ) pxICMPPacket;
+        pucByte = &( pucByte[ sizeof( ICMPPacket_t ) ] );
 
-		/* Check each byte. */
-		for( usCount = 0; usCount < usDataLength; usCount++ )
-		{
-			if( *pucByte != ( uint8_t ) ipECHO_DATA_FILL_BYTE )
-			{
-				eStatus = eInvalidData;
-				break;
-			}
+        /* Check each byte. */
+        for( usCount = 0; usCount < usDataLength; usCount++ )
+        {
+            if( *pucByte != ( uint8_t ) ipECHO_DATA_FILL_BYTE )
+            {
+                eStatus = eInvalidData;
+                break;
+            }
 
-			pucByte++;
-		}
+            pucByte++;
+        }
 
-		/* Call back into the application to pass it the result. */
-		vApplicationPingReplyHook( eStatus, pxICMPPacket->xICMPHeader.usIdentifier );
-	}
+        /* Call back into the application to pass it the result. */
+        vApplicationPingReplyHook( eStatus, pxICMPPacket->xICMPHeader.usIdentifier );
+    }
 
-#endif
+#endif /* if ( ipconfigSUPPORT_OUTGOING_PINGS == 1 ) */
 /*-----------------------------------------------------------*/
 
 #if ( ipconfigREPLY_TO_INCOMING_PINGS == 1 )
 
-	static eFrameProcessingResult_t prvProcessICMPEchoRequest( ICMPPacket_t * const pxICMPPacket )
-	{
-	ICMPHeader_t *pxICMPHeader;
-	IPHeader_t *pxIPHeader;
-	uint16_t usRequest;
+    static eFrameProcessingResult_t prvProcessICMPEchoRequest( ICMPPacket_t * const pxICMPPacket )
+    {
+        ICMPHeader_t * pxICMPHeader;
+        IPHeader_t * pxIPHeader;
+        uint16_t usRequest;
 
-		pxICMPHeader = &( pxICMPPacket->xICMPHeader );
-		pxIPHeader = &( pxICMPPacket->xIPHeader );
+        pxICMPHeader = &( pxICMPPacket->xICMPHeader );
+        pxIPHeader = &( pxICMPPacket->xIPHeader );
 
-		/* HT:endian: changed back */
-		iptraceSENDING_PING_REPLY( pxIPHeader->ulSourceIPAddress );
+        /* HT:endian: changed back */
+        iptraceSENDING_PING_REPLY( pxIPHeader->ulSourceIPAddress );
 
-		/* The checksum can be checked here - but a ping reply should be
-		returned even if the checksum is incorrect so the other end can
-		tell that the ping was received - even if the ping reply contains
-		invalid data. */
-		pxICMPHeader->ucTypeOfMessage = ( uint8_t ) ipICMP_ECHO_REPLY;
-		pxIPHeader->ulDestinationIPAddress = pxIPHeader->ulSourceIPAddress;
-		pxIPHeader->ulSourceIPAddress = *ipLOCAL_IP_ADDRESS_POINTER;
+        /* The checksum can be checked here - but a ping reply should be
+         * returned even if the checksum is incorrect so the other end can
+         * tell that the ping was received - even if the ping reply contains
+         * invalid data. */
+        pxICMPHeader->ucTypeOfMessage = ( uint8_t ) ipICMP_ECHO_REPLY;
+        pxIPHeader->ulDestinationIPAddress = pxIPHeader->ulSourceIPAddress;
+        pxIPHeader->ulSourceIPAddress = *ipLOCAL_IP_ADDRESS_POINTER;
 
-		/* Update the checksum because the ucTypeOfMessage member in the header
-		has been changed to ipICMP_ECHO_REPLY.  This is faster than calling
-		usGenerateChecksum(). */
+        /* Update the checksum because the ucTypeOfMessage member in the header
+         * has been changed to ipICMP_ECHO_REPLY.  This is faster than calling
+         * usGenerateChecksum(). */
 
-		/* due to compiler warning "integer operation result is out of range" */
+        /* due to compiler warning "integer operation result is out of range" */
 
-		usRequest = ( uint16_t ) ( ( uint16_t )ipICMP_ECHO_REQUEST << 8 );
+        usRequest = ( uint16_t ) ( ( uint16_t ) ipICMP_ECHO_REQUEST << 8 );
 
-		if( pxICMPHeader->usChecksum >= FreeRTOS_htons( 0xFFFFU - usRequest ) )
-		{
-			pxICMPHeader->usChecksum = pxICMPHeader->usChecksum + FreeRTOS_htons( usRequest + 1U );
-		}
-		else
-		{
-			pxICMPHeader->usChecksum = pxICMPHeader->usChecksum + FreeRTOS_htons( usRequest );
-		}
-		return eReturnEthernetFrame;
-	}
+        if( pxICMPHeader->usChecksum >= FreeRTOS_htons( 0xFFFFU - usRequest ) )
+        {
+            pxICMPHeader->usChecksum = pxICMPHeader->usChecksum + FreeRTOS_htons( usRequest + 1U );
+        }
+        else
+        {
+            pxICMPHeader->usChecksum = pxICMPHeader->usChecksum + FreeRTOS_htons( usRequest );
+        }
+
+        return eReturnEthernetFrame;
+    }
 
 #endif /* ipconfigREPLY_TO_INCOMING_PINGS == 1 */
 /*-----------------------------------------------------------*/
 
 #if ( ipconfigREPLY_TO_INCOMING_PINGS == 1 ) || ( ipconfigSUPPORT_OUTGOING_PINGS == 1 )
 
-	static eFrameProcessingResult_t prvProcessICMPPacket( ICMPPacket_t * const pxICMPPacket )
-	{
-	eFrameProcessingResult_t eReturn = eReleaseBuffer;
+    static eFrameProcessingResult_t prvProcessICMPPacket( ICMPPacket_t * const pxICMPPacket )
+    {
+        eFrameProcessingResult_t eReturn = eReleaseBuffer;
 
-		iptraceICMP_PACKET_RECEIVED();
-		switch( pxICMPPacket->xICMPHeader.ucTypeOfMessage )
-		{
-			case ipICMP_ECHO_REQUEST	:
-				#if ( ipconfigREPLY_TO_INCOMING_PINGS == 1 )
-				{
-					eReturn = prvProcessICMPEchoRequest( pxICMPPacket );
-				}
-				#endif /* ( ipconfigREPLY_TO_INCOMING_PINGS == 1 ) */
-				break;
+        iptraceICMP_PACKET_RECEIVED();
 
-			case ipICMP_ECHO_REPLY		:
-				#if ( ipconfigSUPPORT_OUTGOING_PINGS == 1 )
-				{
-					prvProcessICMPEchoReply( pxICMPPacket );
-				}
-				#endif /* ipconfigSUPPORT_OUTGOING_PINGS */
-				break;
+        switch( pxICMPPacket->xICMPHeader.ucTypeOfMessage )
+        {
+            case ipICMP_ECHO_REQUEST:
+                #if ( ipconfigREPLY_TO_INCOMING_PINGS == 1 )
+                    eReturn = prvProcessICMPEchoRequest( pxICMPPacket );
+                #endif /* ( ipconfigREPLY_TO_INCOMING_PINGS == 1 ) */
+                break;
 
-			default	:
-				/* Only ICMP echo packets are handled. */
-				break;
-		}
+            case ipICMP_ECHO_REPLY:
+                #if ( ipconfigSUPPORT_OUTGOING_PINGS == 1 )
+                    prvProcessICMPEchoReply( pxICMPPacket );
+                #endif /* ipconfigSUPPORT_OUTGOING_PINGS */
+                break;
 
-		return eReturn;
-	}
+            default:
+                /* Only ICMP echo packets are handled. */
+                break;
+        }
+
+        return eReturn;
+    }
 
 #endif /* ( ipconfigREPLY_TO_INCOMING_PINGS == 1 ) || ( ipconfigSUPPORT_OUTGOING_PINGS == 1 ) */
 /*-----------------------------------------------------------*/
 
-uint16_t usGenerateProtocolChecksum( const uint8_t * const pucEthernetBuffer, size_t uxBufferLength, BaseType_t xOutgoingPacket )
+uint16_t usGenerateProtocolChecksum( const uint8_t * const pucEthernetBuffer,
+                                     size_t uxBufferLength,
+                                     BaseType_t xOutgoingPacket )
 {
-uint32_t ulLength;
-uint16_t usChecksum, *pusChecksum;
-const IPPacket_t * pxIPPacket;
-UBaseType_t uxIPHeaderLength;
-ProtocolPacket_t *pxProtPack;
-uint8_t ucProtocol;
-#if( ipconfigHAS_DEBUG_PRINTF != 0 )
-	const char *pcType;
-#endif
-uint16_t usLength;
-uint16_t ucVersionHeaderLength;
+    uint32_t ulLength;
+    uint16_t usChecksum, * pusChecksum;
+    const IPPacket_t * pxIPPacket;
+    UBaseType_t uxIPHeaderLength;
+    ProtocolPacket_t * pxProtPack;
+    uint8_t ucProtocol;
+
+    #if ( ipconfigHAS_DEBUG_PRINTF != 0 )
+        const char * pcType;
+    #endif
+    uint16_t usLength;
+    uint16_t ucVersionHeaderLength;
 
 
-BaseType_t location = 0;
+    BaseType_t location = 0;
 
-	/* Check for minimum packet size. */
-	if( uxBufferLength < sizeof( IPPacket_t ) )
-	{
-	 	usChecksum = ipINVALID_LENGTH;
-		location = 1;
-	 	goto error_exit;
-	}
+    /* Check for minimum packet size. */
+    if( uxBufferLength < sizeof( IPPacket_t ) )
+    {
+        usChecksum = ipINVALID_LENGTH;
+        location = 1;
+        goto error_exit;
+    }
 
-	/* Parse the packet length. */
-	pxIPPacket = ipPOINTER_CAST( const IPPacket_t *, pucEthernetBuffer );
+    /* Parse the packet length. */
+    pxIPPacket = ipPOINTER_CAST( const IPPacket_t *, pucEthernetBuffer );
 
-	/* Per https://tools.ietf.org/html/rfc791, the four-bit Internet Header
-	Length field contains the length of the internet header in 32-bit words. */
-	ucVersionHeaderLength = pxIPPacket->xIPHeader.ucVersionHeaderLength;
-	ucVersionHeaderLength = ( ucVersionHeaderLength & ( uint8_t ) 0x0FU ) << 2;
-	uxIPHeaderLength = ( UBaseType_t ) ucVersionHeaderLength;
+    /* Per https://tools.ietf.org/html/rfc791, the four-bit Internet Header
+     * Length field contains the length of the internet header in 32-bit words. */
+    ucVersionHeaderLength = pxIPPacket->xIPHeader.ucVersionHeaderLength;
+    ucVersionHeaderLength = ( ucVersionHeaderLength & ( uint8_t ) 0x0FU ) << 2;
+    uxIPHeaderLength = ( UBaseType_t ) ucVersionHeaderLength;
 
-	/* Check for minimum packet size. */
-	if( uxBufferLength < ( sizeof( IPPacket_t ) + ( uxIPHeaderLength - ipSIZE_OF_IPv4_HEADER ) ) )
-	{
-	 	usChecksum = ipINVALID_LENGTH;
-		location = 2;
-	 	goto error_exit;
-	}
-	usLength = pxIPPacket->xIPHeader.usLength;
-	usLength = FreeRTOS_ntohs( usLength );
-	if( uxBufferLength < ( size_t ) ( ipSIZE_OF_ETH_HEADER + ( size_t ) usLength ) )
-	{
-	 	usChecksum = ipINVALID_LENGTH;
-		location = 3;
-	 	goto error_exit;
-	}
+    /* Check for minimum packet size. */
+    if( uxBufferLength < ( sizeof( IPPacket_t ) + ( uxIPHeaderLength - ipSIZE_OF_IPv4_HEADER ) ) )
+    {
+        usChecksum = ipINVALID_LENGTH;
+        location = 2;
+        goto error_exit;
+    }
 
-	/* Identify the next protocol. */
-	ucProtocol = pxIPPacket->xIPHeader.ucProtocol;
+    usLength = pxIPPacket->xIPHeader.usLength;
+    usLength = FreeRTOS_ntohs( usLength );
 
-	/* N.B., if this IP packet header includes Options, then the following
-	assignment results in a pointer into the protocol packet with the Ethernet
-	and IP headers incorrectly aligned. However, either way, the "third"
-	protocol (Layer 3 or 4) header will be aligned, which is the convenience
-	of this calculation. */
-	pxProtPack = ipPOINTER_CAST( ProtocolPacket_t *, &( pucEthernetBuffer[ uxIPHeaderLength - ipSIZE_OF_IPv4_HEADER ] ) );
+    if( uxBufferLength < ( size_t ) ( ipSIZE_OF_ETH_HEADER + ( size_t ) usLength ) )
+    {
+        usChecksum = ipINVALID_LENGTH;
+        location = 3;
+        goto error_exit;
+    }
 
-	/* Switch on the Layer 3/4 protocol. */
-	if( ucProtocol == ( uint8_t ) ipPROTOCOL_UDP )
-	{
-		if( uxBufferLength < ( uxIPHeaderLength + ipSIZE_OF_ETH_HEADER + ipSIZE_OF_UDP_HEADER ) )
-		{
-			usChecksum = ipINVALID_LENGTH;
-			location = 4;
-			goto error_exit;
-		}
+    /* Identify the next protocol. */
+    ucProtocol = pxIPPacket->xIPHeader.ucProtocol;
 
-		pusChecksum = ( uint16_t * ) ( &( pxProtPack->xUDPPacket.xUDPHeader.usChecksum ) );
-		#if( ipconfigHAS_DEBUG_PRINTF != 0 )
-		{
-			pcType = "UDP";
-		}
-		#endif	/* ipconfigHAS_DEBUG_PRINTF != 0 */
-	}
-	else if( ucProtocol == ( uint8_t ) ipPROTOCOL_TCP )
-	{
-		if( uxBufferLength < ( uxIPHeaderLength + ipSIZE_OF_ETH_HEADER + ipSIZE_OF_TCP_HEADER ) )
-		{
-			usChecksum = ipINVALID_LENGTH;
-			location = 5;
-			goto error_exit;
-		}
+    /* N.B., if this IP packet header includes Options, then the following
+     * assignment results in a pointer into the protocol packet with the Ethernet
+     * and IP headers incorrectly aligned. However, either way, the "third"
+     * protocol (Layer 3 or 4) header will be aligned, which is the convenience
+     * of this calculation. */
+    pxProtPack = ipPOINTER_CAST( ProtocolPacket_t *, &( pucEthernetBuffer[ uxIPHeaderLength - ipSIZE_OF_IPv4_HEADER ] ) );
 
-		pusChecksum = ( uint16_t * ) ( &( pxProtPack->xTCPPacket.xTCPHeader.usChecksum ) );
-		#if( ipconfigHAS_DEBUG_PRINTF != 0 )
-		{
-			pcType = "TCP";
-		}
-		#endif	/* ipconfigHAS_DEBUG_PRINTF != 0 */
-	}
-	else if( ( ucProtocol == ( uint8_t ) ipPROTOCOL_ICMP ) ||
-			( ucProtocol == ( uint8_t ) ipPROTOCOL_IGMP ) )
-	{
-		if( uxBufferLength < ( uxIPHeaderLength + ipSIZE_OF_ETH_HEADER + ipSIZE_OF_ICMP_HEADER ) )
-		{
-			usChecksum = ipINVALID_LENGTH;
-			location = 6;
-			goto error_exit;
-		}
+    /* Switch on the Layer 3/4 protocol. */
+    if( ucProtocol == ( uint8_t ) ipPROTOCOL_UDP )
+    {
+        if( uxBufferLength < ( uxIPHeaderLength + ipSIZE_OF_ETH_HEADER + ipSIZE_OF_UDP_HEADER ) )
+        {
+            usChecksum = ipINVALID_LENGTH;
+            location = 4;
+            goto error_exit;
+        }
 
-		pusChecksum = ( uint16_t * ) ( &( pxProtPack->xICMPPacket.xICMPHeader.usChecksum ) );
-		#if( ipconfigHAS_DEBUG_PRINTF != 0 )
-		{
-			if( ucProtocol == ( uint8_t ) ipPROTOCOL_ICMP )
-			{
-				pcType = "ICMP";
-			}
-			else
-			{
-				pcType = "IGMP";
-			}
-		}
-		#endif	/* ipconfigHAS_DEBUG_PRINTF != 0 */
-	}
-	else
-	{
-		/* Unhandled protocol, other than ICMP, IGMP, UDP, or TCP. */
-		usChecksum = ipUNHANDLED_PROTOCOL;
-		location = 7;
-		goto error_exit;
-	}
+        pusChecksum = ( uint16_t * ) ( &( pxProtPack->xUDPPacket.xUDPHeader.usChecksum ) );
+        #if ( ipconfigHAS_DEBUG_PRINTF != 0 )
+            {
+                pcType = "UDP";
+            }
+        #endif /* ipconfigHAS_DEBUG_PRINTF != 0 */
+    }
+    else if( ucProtocol == ( uint8_t ) ipPROTOCOL_TCP )
+    {
+        if( uxBufferLength < ( uxIPHeaderLength + ipSIZE_OF_ETH_HEADER + ipSIZE_OF_TCP_HEADER ) )
+        {
+            usChecksum = ipINVALID_LENGTH;
+            location = 5;
+            goto error_exit;
+        }
 
-	/* The protocol and checksum field have been identified. Check the direction
-	of the packet. */
-	if( xOutgoingPacket != pdFALSE )
-	{
-		/* This is an outgoing packet. Before calculating the checksum, set it
-		to zero. */
-		*( pusChecksum ) = 0U;
-	}
-	else if( ( *pusChecksum == 0U ) && ( ucProtocol == ( uint8_t ) ipPROTOCOL_UDP ) )
-	{
-		/* Sender hasn't set the checksum, no use to calculate it. */
-		usChecksum = ipCORRECT_CRC;
-		location = 8;
-		goto error_exit;
-	}
-	else
-	{
-		/* Other incoming packet than UDP. */
-	}
+        pusChecksum = ( uint16_t * ) ( &( pxProtPack->xTCPPacket.xTCPHeader.usChecksum ) );
+        #if ( ipconfigHAS_DEBUG_PRINTF != 0 )
+            {
+                pcType = "TCP";
+            }
+        #endif /* ipconfigHAS_DEBUG_PRINTF != 0 */
+    }
+    else if( ( ucProtocol == ( uint8_t ) ipPROTOCOL_ICMP ) ||
+             ( ucProtocol == ( uint8_t ) ipPROTOCOL_IGMP ) )
+    {
+        if( uxBufferLength < ( uxIPHeaderLength + ipSIZE_OF_ETH_HEADER + ipSIZE_OF_ICMP_HEADER ) )
+        {
+            usChecksum = ipINVALID_LENGTH;
+            location = 6;
+            goto error_exit;
+        }
 
-	usLength = pxIPPacket->xIPHeader.usLength;
-	usLength = FreeRTOS_ntohs( usLength );
-	ulLength = ( uint32_t ) usLength;
-	ulLength -= ( ( uint16_t ) uxIPHeaderLength ); /* normally minus 20 */
+        pusChecksum = ( uint16_t * ) ( &( pxProtPack->xICMPPacket.xICMPHeader.usChecksum ) );
+        #if ( ipconfigHAS_DEBUG_PRINTF != 0 )
+            {
+                if( ucProtocol == ( uint8_t ) ipPROTOCOL_ICMP )
+                {
+                    pcType = "ICMP";
+                }
+                else
+                {
+                    pcType = "IGMP";
+                }
+            }
+        #endif /* ipconfigHAS_DEBUG_PRINTF != 0 */
+    }
+    else
+    {
+        /* Unhandled protocol, other than ICMP, IGMP, UDP, or TCP. */
+        usChecksum = ipUNHANDLED_PROTOCOL;
+        location = 7;
+        goto error_exit;
+    }
 
-	if( ( ulLength < ( ( uint32_t ) sizeof( pxProtPack->xUDPPacket.xUDPHeader ) ) ) ||
-		( ulLength > ( ( uint32_t ) ipconfigNETWORK_MTU - ( uint32_t ) uxIPHeaderLength ) ) )
-	{
-		#if( ipconfigHAS_DEBUG_PRINTF != 0 )
-		{
-			FreeRTOS_debug_printf( ( "usGenerateProtocolChecksum[%s]: len invalid: %lu\n", pcType, ulLength ) );
-		}
-		#endif	/* ipconfigHAS_DEBUG_PRINTF != 0 */
+    /* The protocol and checksum field have been identified. Check the direction
+     * of the packet. */
+    if( xOutgoingPacket != pdFALSE )
+    {
+        /* This is an outgoing packet. Before calculating the checksum, set it
+         * to zero. */
+        *( pusChecksum ) = 0U;
+    }
+    else if( ( *pusChecksum == 0U ) && ( ucProtocol == ( uint8_t ) ipPROTOCOL_UDP ) )
+    {
+        /* Sender hasn't set the checksum, no use to calculate it. */
+        usChecksum = ipCORRECT_CRC;
+        location = 8;
+        goto error_exit;
+    }
+    else
+    {
+        /* Other incoming packet than UDP. */
+    }
 
-		/* Again, in a 16-bit return value there is no space to indicate an
-		error.  For incoming packets, 0x1234 will cause dropping of the packet.
-		For outgoing packets, there is a serious problem with the
-		format/length */
-		usChecksum = ipINVALID_LENGTH;
-		location = 9;
-		goto error_exit;
-	}
-	if( ucProtocol <= ( uint8_t ) ipPROTOCOL_IGMP )
-	{
-		/* ICMP/IGMP do not have a pseudo header for CRC-calculation. */
-		usChecksum = ( uint16_t )
-			( ~usGenerateChecksum( 0U,
-				( uint8_t * ) &( pxProtPack->xTCPPacket.xTCPHeader ), ( size_t ) ulLength ) );
-	}
-	else
-	{
-		/* For UDP and TCP, sum the pseudo header, i.e. IP protocol + length
-		fields */
-		usChecksum = ( uint16_t ) ( ulLength + ( ( uint16_t ) ucProtocol ) );
+    usLength = pxIPPacket->xIPHeader.usLength;
+    usLength = FreeRTOS_ntohs( usLength );
+    ulLength = ( uint32_t ) usLength;
+    ulLength -= ( ( uint16_t ) uxIPHeaderLength ); /* normally minus 20 */
 
-		/* And then continue at the IPv4 source and destination addresses. */
-		usChecksum = ( uint16_t )
-				( ~usGenerateChecksum( usChecksum,
-									   ipPOINTER_CAST( const uint8_t *, &( pxIPPacket->xIPHeader.ulSourceIPAddress ) ),
-									   ( size_t )( ( 2U * ipSIZE_OF_IPv4_ADDRESS ) + ulLength ) ) );
-		/* Sum TCP header and data. */
-	}
+    if( ( ulLength < ( ( uint32_t ) sizeof( pxProtPack->xUDPPacket.xUDPHeader ) ) ) ||
+        ( ulLength > ( ( uint32_t ) ipconfigNETWORK_MTU - ( uint32_t ) uxIPHeaderLength ) ) )
+    {
+        #if ( ipconfigHAS_DEBUG_PRINTF != 0 )
+            {
+                FreeRTOS_debug_printf( ( "usGenerateProtocolChecksum[%s]: len invalid: %lu\n", pcType, ulLength ) );
+            }
+        #endif /* ipconfigHAS_DEBUG_PRINTF != 0 */
 
-	if( xOutgoingPacket == pdFALSE )
-	{
-		/* This is in incoming packet. If the CRC is correct, it should be zero. */
-		if( usChecksum == 0U )
-		{
-			usChecksum = ( uint16_t )ipCORRECT_CRC;
-		}
-	}
-	else
-	{
-		if( ( usChecksum == 0U ) && ( ucProtocol == ( uint8_t ) ipPROTOCOL_UDP ) )
-		{
-			/* In case of UDP, a calculated checksum of 0x0000 is transmitted
-			as 0xffff. A value of zero would mean that the checksum is not used. */
-			#if( ipconfigHAS_DEBUG_PRINTF != 0 )
-			{
-				if( xOutgoingPacket != pdFALSE )
-				{
-					FreeRTOS_debug_printf( ( "usGenerateProtocolChecksum[%s]: crc swap: %04X\n", pcType, usChecksum ) );
-				}
-			}
-			#endif	/* ipconfigHAS_DEBUG_PRINTF != 0 */
+        /* Again, in a 16-bit return value there is no space to indicate an
+         * error.  For incoming packets, 0x1234 will cause dropping of the packet.
+         * For outgoing packets, there is a serious problem with the
+         * format/length */
+        usChecksum = ipINVALID_LENGTH;
+        location = 9;
+        goto error_exit;
+    }
 
-			usChecksum = ( uint16_t )0xffffu;
-		}
-	}
-	usChecksum = FreeRTOS_htons( usChecksum );
+    if( ucProtocol <= ( uint8_t ) ipPROTOCOL_IGMP )
+    {
+        /* ICMP/IGMP do not have a pseudo header for CRC-calculation. */
+        usChecksum = ( uint16_t )
+                     ( ~usGenerateChecksum( 0U,
+                                            ( uint8_t * ) &( pxProtPack->xTCPPacket.xTCPHeader ), ( size_t ) ulLength ) );
+    }
+    else
+    {
+        /* For UDP and TCP, sum the pseudo header, i.e. IP protocol + length
+         * fields */
+        usChecksum = ( uint16_t ) ( ulLength + ( ( uint16_t ) ucProtocol ) );
 
-	if( xOutgoingPacket != pdFALSE )
-	{
-		*( pusChecksum ) = usChecksum;
-	}
-	#if( ipconfigHAS_DEBUG_PRINTF != 0 )
-	else if( ( xOutgoingPacket == pdFALSE ) && ( usChecksum != ipCORRECT_CRC ) )
-	{
-		FreeRTOS_debug_printf( ( "usGenerateProtocolChecksum[%s]: ID %04X: from %lxip to %lxip bad crc: %04X\n",
-			pcType,
-			FreeRTOS_ntohs( pxIPPacket->xIPHeader.usIdentification ),
-			FreeRTOS_ntohl( pxIPPacket->xIPHeader.ulSourceIPAddress ),
-			FreeRTOS_ntohl( pxIPPacket->xIPHeader.ulDestinationIPAddress ),
-			FreeRTOS_ntohs( *pusChecksum ) ) );
-	}
-	else
-	{
-		/* Nothing. */
-	}
-	#endif	/* ipconfigHAS_DEBUG_PRINTF != 0 */
+        /* And then continue at the IPv4 source and destination addresses. */
+        usChecksum = ( uint16_t )
+                     ( ~usGenerateChecksum( usChecksum,
+                                            ipPOINTER_CAST( const uint8_t *, &( pxIPPacket->xIPHeader.ulSourceIPAddress ) ),
+                                            ( size_t ) ( ( 2U * ipSIZE_OF_IPv4_ADDRESS ) + ulLength ) ) );
+        /* Sum TCP header and data. */
+    }
 
- error_exit:
+    if( xOutgoingPacket == pdFALSE )
+    {
+        /* This is in incoming packet. If the CRC is correct, it should be zero. */
+        if( usChecksum == 0U )
+        {
+            usChecksum = ( uint16_t ) ipCORRECT_CRC;
+        }
+    }
+    else
+    {
+        if( ( usChecksum == 0U ) && ( ucProtocol == ( uint8_t ) ipPROTOCOL_UDP ) )
+        {
+            /* In case of UDP, a calculated checksum of 0x0000 is transmitted
+             * as 0xffff. A value of zero would mean that the checksum is not used. */
+            #if ( ipconfigHAS_DEBUG_PRINTF != 0 )
+                {
+                    if( xOutgoingPacket != pdFALSE )
+                    {
+                        FreeRTOS_debug_printf( ( "usGenerateProtocolChecksum[%s]: crc swap: %04X\n", pcType, usChecksum ) );
+                    }
+                }
+            #endif /* ipconfigHAS_DEBUG_PRINTF != 0 */
 
-	if( ( usChecksum == ipUNHANDLED_PROTOCOL ) || 
-		( usChecksum == ipINVALID_LENGTH ) )
-	{
-		FreeRTOS_printf( ( "CRC error: %04x location %ld\n", usChecksum, location ) );
-	}
+            usChecksum = ( uint16_t ) 0xffffu;
+        }
+    }
 
-	return usChecksum;
+    usChecksum = FreeRTOS_htons( usChecksum );
+
+    if( xOutgoingPacket != pdFALSE )
+    {
+        *( pusChecksum ) = usChecksum;
+    }
+
+    #if ( ipconfigHAS_DEBUG_PRINTF != 0 )
+        else if( ( xOutgoingPacket == pdFALSE ) && ( usChecksum != ipCORRECT_CRC ) )
+        {
+            FreeRTOS_debug_printf( ( "usGenerateProtocolChecksum[%s]: ID %04X: from %lxip to %lxip bad crc: %04X\n",
+                                     pcType,
+                                     FreeRTOS_ntohs( pxIPPacket->xIPHeader.usIdentification ),
+                                     FreeRTOS_ntohl( pxIPPacket->xIPHeader.ulSourceIPAddress ),
+                                     FreeRTOS_ntohl( pxIPPacket->xIPHeader.ulDestinationIPAddress ),
+                                     FreeRTOS_ntohs( *pusChecksum ) ) );
+        }
+        else
+        {
+            /* Nothing. */
+        }
+    #endif /* ipconfigHAS_DEBUG_PRINTF != 0 */
+
+error_exit:
+
+    if( ( usChecksum == ipUNHANDLED_PROTOCOL ) ||
+        ( usChecksum == ipINVALID_LENGTH ) )
+    {
+        FreeRTOS_printf( ( "CRC error: %04x location %ld\n", usChecksum, location ) );
+    }
+
+    return usChecksum;
 }
 /*-----------------------------------------------------------*/
 
@@ -2175,348 +2201,405 @@ BaseType_t location = 0;
  *   uxDataLengthBytes: This argument contains the number of bytes that this method
  *	 should process.
  */
-uint16_t usGenerateChecksum( uint16_t usSum, const uint8_t * pucNextData, size_t uxByteCount )
+uint16_t usGenerateChecksum( uint16_t usSum,
+                             const uint8_t * pucNextData,
+                             size_t uxByteCount )
 {
 /* MISRA/PC-lint doesn't like the use of unions. Here, they are a great
-aid though to optimise the calculations. */
-xUnion32 xSum2, xSum, xTerm;
-xUnionPtr xSource;
-xUnionPtr xLastSource;
-uint32_t ulAlignBits, ulCarry = 0UL;
-uint16_t usTemp;
-size_t uxDataLengthBytes = uxByteCount;
+ * aid though to optimise the calculations. */
+    xUnion32 xSum2, xSum, xTerm;
+    xUnionPtr xSource;
+    xUnionPtr xLastSource;
+    uint32_t ulAlignBits, ulCarry = 0UL;
+    uint16_t usTemp;
+    size_t uxDataLengthBytes = uxByteCount;
 
-	/* Small MCUs often spend up to 30% of the time doing checksum calculations
-	This function is optimised for 32-bit CPUs; Each time it will try to fetch
-	32-bits, sums it with an accumulator and counts the number of carries. */
+    /* Small MCUs often spend up to 30% of the time doing checksum calculations
+    * This function is optimised for 32-bit CPUs; Each time it will try to fetch
+    * 32-bits, sums it with an accumulator and counts the number of carries. */
 
-	/* Swap the input (little endian platform only). */
-	usTemp = FreeRTOS_ntohs( usSum );
-	xSum.u32 = ( uint32_t ) usTemp;
-	xTerm.u32 = 0UL;
+    /* Swap the input (little endian platform only). */
+    usTemp = FreeRTOS_ntohs( usSum );
+    xSum.u32 = ( uint32_t ) usTemp;
+    xTerm.u32 = 0UL;
 
-	xSource.u8ptr = ipPOINTER_CAST( uint8_t *, pucNextData );
-	/* coverity[misra_c_2012_rule_11_4_violation] */
-	/* The object pointer expression "pucNextData" of type "uint8_t const *" is cast to an integer type "unsigned int". */
-	ulAlignBits = ( ( ( uint32_t ) pucNextData ) & 0x03U ); /*lint !e9078 !e923*/	/* gives 0, 1, 2, or 3 */
+    xSource.u8ptr = ipPOINTER_CAST( uint8_t *, pucNextData );
+    /* coverity[misra_c_2012_rule_11_4_violation] */
+    /* The object pointer expression "pucNextData" of type "uint8_t const *" is cast to an integer type "unsigned int". */
+    ulAlignBits = ( ( ( uint32_t ) pucNextData ) & 0x03U ); /*lint !e9078 !e923*/	/* gives 0, 1, 2, or 3 */
 
-	/* If byte (8-bit) aligned... */
-	if( ( ( ulAlignBits & 1UL ) != 0UL ) && ( uxDataLengthBytes >= ( size_t ) 1 ) )
-	{
-		xTerm.u8[ 1 ] = *( xSource.u8ptr );
-		xSource.u8ptr++;
-		uxDataLengthBytes--;
-		/* Now xSource is word (16-bit) aligned. */
-	}
+    /* If byte (8-bit) aligned... */
+    if( ( ( ulAlignBits & 1UL ) != 0UL ) && ( uxDataLengthBytes >= ( size_t ) 1 ) )
+    {
+        xTerm.u8[ 1 ] = *( xSource.u8ptr );
+        xSource.u8ptr++;
+        uxDataLengthBytes--;
+        /* Now xSource is word (16-bit) aligned. */
+    }
 
-	/* If half-word (16-bit) aligned... */
-	if( ( ( ulAlignBits == 1U ) || ( ulAlignBits == 2U ) ) && ( uxDataLengthBytes >= 2U ) )
-	{
-		xSum.u32 += *(xSource.u16ptr);
-		xSource.u16ptr++;
-		uxDataLengthBytes -= 2U;
-		/* Now xSource is word (32-bit) aligned. */
-	}
+    /* If half-word (16-bit) aligned... */
+    if( ( ( ulAlignBits == 1U ) || ( ulAlignBits == 2U ) ) && ( uxDataLengthBytes >= 2U ) )
+    {
+        xSum.u32 += *( xSource.u16ptr );
+        xSource.u16ptr++;
+        uxDataLengthBytes -= 2U;
+        /* Now xSource is word (32-bit) aligned. */
+    }
 
-	/* Word (32-bit) aligned, do the most part. */
-	xLastSource.u32ptr = ( xSource.u32ptr + ( uxDataLengthBytes / 4U ) ) - 3U;
+    /* Word (32-bit) aligned, do the most part. */
+    xLastSource.u32ptr = ( xSource.u32ptr + ( uxDataLengthBytes / 4U ) ) - 3U;
 
-	/* In this loop, four 32-bit additions will be done, in total 16 bytes.
-	Indexing with constants (0,1,2,3) gives faster code than using
-	post-increments. */
-	while( xSource.u32ptr < xLastSource.u32ptr )
-	{
-		/* Use a secondary Sum2, just to see if the addition produced an
-		overflow. */
-		xSum2.u32 = xSum.u32 + xSource.u32ptr[ 0 ];
-		if( xSum2.u32 < xSum.u32 )
-		{
-			ulCarry++;
-		}
+    /* In this loop, four 32-bit additions will be done, in total 16 bytes.
+     * Indexing with constants (0,1,2,3) gives faster code than using
+     * post-increments. */
+    while( xSource.u32ptr < xLastSource.u32ptr )
+    {
+        /* Use a secondary Sum2, just to see if the addition produced an
+         * overflow. */
+        xSum2.u32 = xSum.u32 + xSource.u32ptr[ 0 ];
 
-		/* Now add the secondary sum to the major sum, and remember if there was
-		a carry. */
-		xSum.u32 = xSum2.u32 + xSource.u32ptr[ 1 ];
-		if( xSum2.u32 > xSum.u32 )
-		{
-			ulCarry++;
-		}
+        if( xSum2.u32 < xSum.u32 )
+        {
+            ulCarry++;
+        }
 
-		/* And do the same trick once again for indexes 2 and 3 */
-		xSum2.u32 = xSum.u32 + xSource.u32ptr[ 2 ];
-		if( xSum2.u32 < xSum.u32 )
-		{
-			ulCarry++;
-		}
+        /* Now add the secondary sum to the major sum, and remember if there was
+         * a carry. */
+        xSum.u32 = xSum2.u32 + xSource.u32ptr[ 1 ];
 
-		xSum.u32 = xSum2.u32 + xSource.u32ptr[ 3 ];
+        if( xSum2.u32 > xSum.u32 )
+        {
+            ulCarry++;
+        }
 
-		if( xSum2.u32 > xSum.u32 )
-		{
-			ulCarry++;
-		}
+        /* And do the same trick once again for indexes 2 and 3 */
+        xSum2.u32 = xSum.u32 + xSource.u32ptr[ 2 ];
 
-		/* And finally advance the pointer 4 * 4 = 16 bytes. */
-		xSource.u32ptr = &( xSource.u32ptr[ 4 ] );
-	}
+        if( xSum2.u32 < xSum.u32 )
+        {
+            ulCarry++;
+        }
 
-	/* Now add all carries. */
-	xSum.u32 = ( uint32_t )xSum.u16[ 0 ] + xSum.u16[ 1 ] + ulCarry;
+        xSum.u32 = xSum2.u32 + xSource.u32ptr[ 3 ];
 
-	uxDataLengthBytes %= 16U;
-	xLastSource.u8ptr = ( uint8_t * ) ( xSource.u8ptr + ( uxDataLengthBytes & ~( ( size_t ) 1 ) ) );
+        if( xSum2.u32 > xSum.u32 )
+        {
+            ulCarry++;
+        }
 
-	/* Half-word aligned. */
-	/* The operator "<" is being applied to the pointers "xSource.u16ptr" and "xLastSource.u16ptr", which do not point into the same object. */
-	while( xSource.u16ptr < xLastSource.u16ptr )
-	{
-		/* At least one more short. */
-		xSum.u32 += xSource.u16ptr[ 0 ];
-		xSource.u16ptr++;
-	}
+        /* And finally advance the pointer 4 * 4 = 16 bytes. */
+        xSource.u32ptr = &( xSource.u32ptr[ 4 ] );
+    }
 
-	if( ( uxDataLengthBytes & ( size_t ) 1 ) != 0U )	/* Maybe one more ? */
-	{
-		xTerm.u8[ 0 ] = xSource.u8ptr[ 0 ];
-	}
-	xSum.u32 += xTerm.u32;
+    /* Now add all carries. */
+    xSum.u32 = ( uint32_t ) xSum.u16[ 0 ] + xSum.u16[ 1 ] + ulCarry;
 
-	/* Now add all carries again. */
-	/* Assigning value from "xTerm.u32" to "xSum.u32" here, but that stored value is overwritten before it can be used.
-	Coverity doesn't understand about union variables. */
-	xSum.u32 = ( uint32_t ) xSum.u16[ 0 ] + xSum.u16[ 1 ];
+    uxDataLengthBytes %= 16U;
+    xLastSource.u8ptr = ( uint8_t * ) ( xSource.u8ptr + ( uxDataLengthBytes & ~( ( size_t ) 1 ) ) );
 
-	/* coverity[value_overwrite] */
-	xSum.u32 = ( uint32_t ) xSum.u16[ 0 ] + xSum.u16[ 1 ];
+    /* Half-word aligned. */
+    /* The operator "<" is being applied to the pointers "xSource.u16ptr" and "xLastSource.u16ptr", which do not point into the same object. */
+    while( xSource.u16ptr < xLastSource.u16ptr )
+    {
+        /* At least one more short. */
+        xSum.u32 += xSource.u16ptr[ 0 ];
+        xSource.u16ptr++;
+    }
 
-	if( ( ulAlignBits & 1U ) != 0U )
-	{
-		/* Quite unlikely, but pucNextData might be non-aligned, which would
-		 mean that a checksum is calculated starting at an odd position. */
-		xSum.u32 = ( ( xSum.u32 & 0xffU ) << 8 ) | ( ( xSum.u32 & 0xff00U ) >> 8 );
-	}
+    if( ( uxDataLengthBytes & ( size_t ) 1 ) != 0U ) /* Maybe one more ? */
+    {
+        xTerm.u8[ 0 ] = xSource.u8ptr[ 0 ];
+    }
 
-	/* swap the output (little endian platform only). */
-	return FreeRTOS_htons( ( (uint16_t) xSum.u32 ) );
+    xSum.u32 += xTerm.u32;
+
+    /* Now add all carries again. */
+
+    /* Assigning value from "xTerm.u32" to "xSum.u32" here, but that stored value is overwritten before it can be used.
+     * Coverity doesn't understand about union variables. */
+    xSum.u32 = ( uint32_t ) xSum.u16[ 0 ] + xSum.u16[ 1 ];
+
+    /* coverity[value_overwrite] */
+    xSum.u32 = ( uint32_t ) xSum.u16[ 0 ] + xSum.u16[ 1 ];
+
+    if( ( ulAlignBits & 1U ) != 0U )
+    {
+        /* Quite unlikely, but pucNextData might be non-aligned, which would
+        * mean that a checksum is calculated starting at an odd position. */
+        xSum.u32 = ( ( xSum.u32 & 0xffU ) << 8 ) | ( ( xSum.u32 & 0xff00U ) >> 8 );
+    }
+
+    /* swap the output (little endian platform only). */
+    return FreeRTOS_htons( ( ( uint16_t ) xSum.u32 ) );
 }
 /*-----------------------------------------------------------*/
 
-void vReturnEthernetFrame( NetworkBufferDescriptor_t * pxNetworkBuffer, BaseType_t xReleaseAfterSend )
+void vReturnEthernetFrame( NetworkBufferDescriptor_t * pxNetworkBuffer,
+                           BaseType_t xReleaseAfterSend )
 {
-EthernetHeader_t *pxEthernetHeader;
+    EthernetHeader_t * pxEthernetHeader;
 
-#if( ipconfigZERO_COPY_TX_DRIVER != 0 )
-	NetworkBufferDescriptor_t *pxNewBuffer;
-#endif
+    #if ( ipconfigZERO_COPY_TX_DRIVER != 0 )
+        NetworkBufferDescriptor_t * pxNewBuffer;
+    #endif
 
-	#if defined( ipconfigETHERNET_MINIMUM_PACKET_BYTES )
-	{
-		if( pxNetworkBuffer->xDataLength < ( size_t ) ipconfigETHERNET_MINIMUM_PACKET_BYTES )
-		{
-		BaseType_t xIndex;
+    #if defined( ipconfigETHERNET_MINIMUM_PACKET_BYTES )
+        {
+            if( pxNetworkBuffer->xDataLength < ( size_t ) ipconfigETHERNET_MINIMUM_PACKET_BYTES )
+            {
+                BaseType_t xIndex;
 
-			FreeRTOS_printf( ( "vReturnEthernetFrame: length %u\n", ( unsigned ) pxNetworkBuffer->xDataLength ) );
-			for( xIndex = ( BaseType_t ) pxNetworkBuffer->xDataLength; xIndex < ( BaseType_t ) ipconfigETHERNET_MINIMUM_PACKET_BYTES; xIndex++ )
-			{
-				pxNetworkBuffer->pucEthernetBuffer[ xIndex ] = 0U;
-			}
-			pxNetworkBuffer->xDataLength = ( size_t ) ipconfigETHERNET_MINIMUM_PACKET_BYTES;
-		}
-	}
-	#endif
+                FreeRTOS_printf( ( "vReturnEthernetFrame: length %u\n", ( unsigned ) pxNetworkBuffer->xDataLength ) );
 
-#if( ipconfigZERO_COPY_TX_DRIVER != 0 )
+                for( xIndex = ( BaseType_t ) pxNetworkBuffer->xDataLength; xIndex < ( BaseType_t ) ipconfigETHERNET_MINIMUM_PACKET_BYTES; xIndex++ )
+                {
+                    pxNetworkBuffer->pucEthernetBuffer[ xIndex ] = 0U;
+                }
 
-	if( xReleaseAfterSend == pdFALSE )
-	{
-		pxNewBuffer = pxDuplicateNetworkBufferWithDescriptor( pxNetworkBuffer, pxNetworkBuffer->xDataLength );
-		xReleaseAfterSend = pdTRUE;
-		/* Want no rounding up. */
-		pxNewBuffer->xDataLength = pxNetworkBuffer->xDataLength;
-		pxNetworkBuffer = pxNewBuffer;
-	}
+                pxNetworkBuffer->xDataLength = ( size_t ) ipconfigETHERNET_MINIMUM_PACKET_BYTES;
+            }
+        }
+    #endif /* if defined( ipconfigETHERNET_MINIMUM_PACKET_BYTES ) */
 
-	if( pxNetworkBuffer != NULL )
-#endif
-	{
-		pxEthernetHeader = ipPOINTER_CAST( EthernetHeader_t *, pxNetworkBuffer->pucEthernetBuffer );
+    #if ( ipconfigZERO_COPY_TX_DRIVER != 0 )
+        if( xReleaseAfterSend == pdFALSE )
+        {
+            pxNewBuffer = pxDuplicateNetworkBufferWithDescriptor( pxNetworkBuffer, pxNetworkBuffer->xDataLength );
+            xReleaseAfterSend = pdTRUE;
+            /* Want no rounding up. */
+            pxNewBuffer->xDataLength = pxNetworkBuffer->xDataLength;
+            pxNetworkBuffer = pxNewBuffer;
+        }
 
-		/* Swap source and destination MAC addresses. */
-		( void ) memcpy( &( pxEthernetHeader->xDestinationAddress ), &( pxEthernetHeader->xSourceAddress ), sizeof( pxEthernetHeader->xDestinationAddress ) );
-		( void ) memcpy( &( pxEthernetHeader->xSourceAddress) , ipLOCAL_MAC_ADDRESS, ( size_t ) ipMAC_ADDRESS_LENGTH_BYTES );
+        if( pxNetworkBuffer != NULL )
+    #endif /* if ( ipconfigZERO_COPY_TX_DRIVER != 0 ) */
+    {
+        pxEthernetHeader = ipPOINTER_CAST( EthernetHeader_t *, pxNetworkBuffer->pucEthernetBuffer );
 
-		/* Send! */
-		( void ) xNetworkInterfaceOutput( pxNetworkBuffer, xReleaseAfterSend );
-	}
+        /* Swap source and destination MAC addresses. */
+        ( void ) memcpy( &( pxEthernetHeader->xDestinationAddress ), &( pxEthernetHeader->xSourceAddress ), sizeof( pxEthernetHeader->xDestinationAddress ) );
+        ( void ) memcpy( &( pxEthernetHeader->xSourceAddress ), ipLOCAL_MAC_ADDRESS, ( size_t ) ipMAC_ADDRESS_LENGTH_BYTES );
+
+        /* Send! */
+        ( void ) xNetworkInterfaceOutput( pxNetworkBuffer, xReleaseAfterSend );
+    }
 }
 /*-----------------------------------------------------------*/
 
 uint32_t FreeRTOS_GetIPAddress( void )
 {
-	/* Returns the IP address of the NIC. */
-	return *ipLOCAL_IP_ADDRESS_POINTER;
+    /* Returns the IP address of the NIC. */
+    return *ipLOCAL_IP_ADDRESS_POINTER;
 }
 /*-----------------------------------------------------------*/
 
 void FreeRTOS_SetIPAddress( uint32_t ulIPAddress )
 {
-	/* Sets the IP address of the NIC. */
-	*ipLOCAL_IP_ADDRESS_POINTER = ulIPAddress;
+    /* Sets the IP address of the NIC. */
+    *ipLOCAL_IP_ADDRESS_POINTER = ulIPAddress;
 }
 /*-----------------------------------------------------------*/
 
 uint32_t FreeRTOS_GetGatewayAddress( void )
 {
-	return xNetworkAddressing.ulGatewayAddress;
+    return xNetworkAddressing.ulGatewayAddress;
 }
 /*-----------------------------------------------------------*/
 
 uint32_t FreeRTOS_GetDNSServerAddress( void )
 {
-	return xNetworkAddressing.ulDNSServerAddress;
+    return xNetworkAddressing.ulDNSServerAddress;
 }
 /*-----------------------------------------------------------*/
 
 uint32_t FreeRTOS_GetNetmask( void )
 {
-	return xNetworkAddressing.ulNetMask;
+    return xNetworkAddressing.ulNetMask;
 }
 /*-----------------------------------------------------------*/
 
-void FreeRTOS_UpdateMACAddress( const uint8_t ucMACAddress[ipMAC_ADDRESS_LENGTH_BYTES] )
+void FreeRTOS_UpdateMACAddress( const uint8_t ucMACAddress[ ipMAC_ADDRESS_LENGTH_BYTES ] )
 {
-	/* Copy the MAC address at the start of the default packet header fragment. */
-	( void ) memcpy( ipLOCAL_MAC_ADDRESS, ucMACAddress, ( size_t ) ipMAC_ADDRESS_LENGTH_BYTES );
+    /* Copy the MAC address at the start of the default packet header fragment. */
+    ( void ) memcpy( ipLOCAL_MAC_ADDRESS, ucMACAddress, ( size_t ) ipMAC_ADDRESS_LENGTH_BYTES );
 }
 /*-----------------------------------------------------------*/
 
 const uint8_t * FreeRTOS_GetMACAddress( void )
 {
-	return ipLOCAL_MAC_ADDRESS;
+    return ipLOCAL_MAC_ADDRESS;
 }
 /*-----------------------------------------------------------*/
 
-void FreeRTOS_SetNetmask ( uint32_t ulNetmask )
+void FreeRTOS_SetNetmask( uint32_t ulNetmask )
 {
-	xNetworkAddressing.ulNetMask = ulNetmask;
+    xNetworkAddressing.ulNetMask = ulNetmask;
 }
 /*-----------------------------------------------------------*/
 
-void FreeRTOS_SetGatewayAddress ( uint32_t ulGatewayAddress )
+void FreeRTOS_SetGatewayAddress( uint32_t ulGatewayAddress )
 {
-	xNetworkAddressing.ulGatewayAddress = ulGatewayAddress;
+    xNetworkAddressing.ulGatewayAddress = ulGatewayAddress;
 }
 /*-----------------------------------------------------------*/
 
-#if( ipconfigUSE_DHCP == 1 )
-	void vIPSetDHCPTimerEnableState( BaseType_t xEnableState )
-	{
-		if( xEnableState != pdFALSE )
-		{
-			xDHCPTimer.bActive = pdTRUE_UNSIGNED;
-		}
-		else
-		{
-			xDHCPTimer.bActive = pdFALSE_UNSIGNED;
-		}
-	}
+#if ( ipconfigUSE_DHCP == 1 )
+    void vIPSetDHCPTimerEnableState( BaseType_t xEnableState )
+    {
+        if( xEnableState != pdFALSE )
+        {
+            xDHCPTimer.bActive = pdTRUE_UNSIGNED;
+        }
+        else
+        {
+            xDHCPTimer.bActive = pdFALSE_UNSIGNED;
+        }
+    }
 #endif /* ipconfigUSE_DHCP */
 /*-----------------------------------------------------------*/
 
-#if( ipconfigUSE_DHCP == 1 )
-	void vIPReloadDHCPTimer( uint32_t ulLeaseTime )
-	{
-		prvIPTimerReload( &xDHCPTimer, ulLeaseTime );
-	}
+#if ( ipconfigUSE_DHCP == 1 )
+    void vIPReloadDHCPTimer( uint32_t ulLeaseTime )
+    {
+        prvIPTimerReload( &xDHCPTimer, ulLeaseTime );
+    }
 #endif /* ipconfigUSE_DHCP */
 /*-----------------------------------------------------------*/
 
-#if( ipconfigDNS_USE_CALLBACKS == 1 )
-	void vIPSetDnsTimerEnableState( BaseType_t xEnableState )
-	{
-		if( xEnableState != 0 )
-		{
-			xDNSTimer.bActive = pdTRUE;
-		}
-		else
-		{
-			xDNSTimer.bActive = pdFALSE;
-		}
-	}
+#if ( ipconfigDNS_USE_CALLBACKS == 1 )
+    void vIPSetDnsTimerEnableState( BaseType_t xEnableState )
+    {
+        if( xEnableState != 0 )
+        {
+            xDNSTimer.bActive = pdTRUE;
+        }
+        else
+        {
+            xDNSTimer.bActive = pdFALSE;
+        }
+    }
 #endif /* ipconfigUSE_DHCP */
 /*-----------------------------------------------------------*/
 
-#if( ipconfigDNS_USE_CALLBACKS != 0 )
-	void vIPReloadDNSTimer( uint32_t ulCheckTime )
-	{
-		prvIPTimerReload( &xDNSTimer, ulCheckTime );
-	}
+#if ( ipconfigDNS_USE_CALLBACKS != 0 )
+    void vIPReloadDNSTimer( uint32_t ulCheckTime )
+    {
+        prvIPTimerReload( &xDNSTimer, ulCheckTime );
+    }
 #endif /* ipconfigDNS_USE_CALLBACKS != 0 */
 /*-----------------------------------------------------------*/
 
 BaseType_t xIPIsNetworkTaskReady( void )
 {
-	return xIPTaskInitialised;
+    return xIPTaskInitialised;
 }
 /*-----------------------------------------------------------*/
 
 BaseType_t FreeRTOS_IsNetworkUp( void )
 {
-	return xNetworkUp;
+    return xNetworkUp;
 }
 /*-----------------------------------------------------------*/
 
-#if( ipconfigCHECK_IP_QUEUE_SPACE != 0 )
-	UBaseType_t uxGetMinimumIPQueueSpace( void )
-	{
-		return uxQueueMinimumSpace;
-	}
+#if ( ipconfigCHECK_IP_QUEUE_SPACE != 0 )
+    UBaseType_t uxGetMinimumIPQueueSpace( void )
+    {
+        return uxQueueMinimumSpace;
+    }
 #endif
 /*-----------------------------------------------------------*/
 
-const char *FreeRTOS_strerror_r( BaseType_t xErrnum, char *pcBuffer, size_t uxLength )
+const char * FreeRTOS_strerror_r( BaseType_t xErrnum,
+                                  char * pcBuffer,
+                                  size_t uxLength )
 {
-const char *pcName;
+    const char * pcName;
 
-	switch( xErrnum )
-	{
-		case pdFREERTOS_ERRNO_EADDRINUSE:     pcName = "EADDRINUSE"; break;
-		case pdFREERTOS_ERRNO_ENOMEM:         pcName = "ENOMEM"; break;
-		case pdFREERTOS_ERRNO_EADDRNOTAVAIL:  pcName = "EADDRNOTAVAIL"; break;
-		case pdFREERTOS_ERRNO_ENOPROTOOPT:    pcName = "ENOPROTOOPT"; break;
-		case pdFREERTOS_ERRNO_EBADF:          pcName = "EBADF"; break;
-		case pdFREERTOS_ERRNO_ENOSPC:         pcName = "ENOSPC"; break;
-		case pdFREERTOS_ERRNO_ECANCELED:      pcName = "ECANCELED"; break;
-		case pdFREERTOS_ERRNO_ENOTCONN:       pcName = "ENOTCONN"; break;
-		case pdFREERTOS_ERRNO_EINPROGRESS:    pcName = "EINPROGRESS"; break;
-		case pdFREERTOS_ERRNO_EOPNOTSUPP:     pcName = "EOPNOTSUPP"; break;
-		case pdFREERTOS_ERRNO_EINTR:          pcName = "EINTR"; break;
-		case pdFREERTOS_ERRNO_ETIMEDOUT:      pcName = "ETIMEDOUT"; break;
-		case pdFREERTOS_ERRNO_EINVAL:         pcName = "EINVAL"; break;
-		case pdFREERTOS_ERRNO_EWOULDBLOCK:    pcName = "EWOULDBLOCK"; break; /* same as EAGAIN */
-		case pdFREERTOS_ERRNO_EISCONN:        pcName = "EISCONN"; break;
-		default:
-			/* Using function "snprintf". */
-			( void ) snprintf( pcBuffer, uxLength, "Errno %d", ( int32_t ) xErrnum );
-			pcName = NULL;
-			break;
-	}
-	if( pcName != NULL )
-	{
-		/* Using function "snprintf". */
-		( void ) snprintf( pcBuffer, uxLength, "%s", pcName );
-	}
-	if( uxLength > 0U )
-	{
-		pcBuffer[ uxLength - 1U ] = '\0';
-	}
+    switch( xErrnum )
+    {
+        case pdFREERTOS_ERRNO_EADDRINUSE:
+            pcName = "EADDRINUSE";
+            break;
 
-	return pcBuffer;
+        case pdFREERTOS_ERRNO_ENOMEM:
+            pcName = "ENOMEM";
+            break;
+
+        case pdFREERTOS_ERRNO_EADDRNOTAVAIL:
+            pcName = "EADDRNOTAVAIL";
+            break;
+
+        case pdFREERTOS_ERRNO_ENOPROTOOPT:
+            pcName = "ENOPROTOOPT";
+            break;
+
+        case pdFREERTOS_ERRNO_EBADF:
+            pcName = "EBADF";
+            break;
+
+        case pdFREERTOS_ERRNO_ENOSPC:
+            pcName = "ENOSPC";
+            break;
+
+        case pdFREERTOS_ERRNO_ECANCELED:
+            pcName = "ECANCELED";
+            break;
+
+        case pdFREERTOS_ERRNO_ENOTCONN:
+            pcName = "ENOTCONN";
+            break;
+
+        case pdFREERTOS_ERRNO_EINPROGRESS:
+            pcName = "EINPROGRESS";
+            break;
+
+        case pdFREERTOS_ERRNO_EOPNOTSUPP:
+            pcName = "EOPNOTSUPP";
+            break;
+
+        case pdFREERTOS_ERRNO_EINTR:
+            pcName = "EINTR";
+            break;
+
+        case pdFREERTOS_ERRNO_ETIMEDOUT:
+            pcName = "ETIMEDOUT";
+            break;
+
+        case pdFREERTOS_ERRNO_EINVAL:
+            pcName = "EINVAL";
+            break;
+
+        case pdFREERTOS_ERRNO_EWOULDBLOCK:
+            pcName = "EWOULDBLOCK";
+            break; /* same as EAGAIN */
+
+        case pdFREERTOS_ERRNO_EISCONN:
+            pcName = "EISCONN";
+            break;
+
+        default:
+            /* Using function "snprintf". */
+            ( void ) snprintf( pcBuffer, uxLength, "Errno %d", ( int32_t ) xErrnum );
+            pcName = NULL;
+            break;
+    }
+
+    if( pcName != NULL )
+    {
+        /* Using function "snprintf". */
+        ( void ) snprintf( pcBuffer, uxLength, "%s", pcName );
+    }
+
+    if( uxLength > 0U )
+    {
+        pcBuffer[ uxLength - 1U ] = '\0';
+    }
+
+    return pcBuffer;
 }
 /*-----------------------------------------------------------*/
 
 /* Provide access to private members for verification. */
 #ifdef FREERTOS_TCP_ENABLE_VERIFICATION
-	#include "aws_freertos_ip_verification_access_ip_define.h"
+    #include "aws_freertos_ip_verification_access_ip_define.h"
 #endif
-

--- a/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/FreeRTOS_Sockets.c
+++ b/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/FreeRTOS_Sockets.c
@@ -42,50 +42,50 @@
 #include "NetworkBufferManagement.h"
 
 /* A tool to measure RAM usage. By default, it is disabled
-and it won't add any code.
-See also tools/tcp_mem_stats.md */
+ * and it won't add any code.
+ * See also tools/tcp_mem_stats.md */
 
 /*lint -e766 Header files is sometimes not used, depending on the configuration. */
 #include "tcp_mem_stats.h"
 
 /* The ItemValue of the sockets xBoundSocketListItem member holds the socket's
-port number. */
-#define socketSET_SOCKET_PORT( pxSocket, usPort ) listSET_LIST_ITEM_VALUE( ( &( ( pxSocket )->xBoundSocketListItem ) ), ( usPort ) )
-#define socketGET_SOCKET_PORT( pxSocket ) listGET_LIST_ITEM_VALUE( ( &( ( pxSocket )->xBoundSocketListItem ) ) )
+ * port number. */
+#define socketSET_SOCKET_PORT( pxSocket, usPort )    listSET_LIST_ITEM_VALUE( ( &( ( pxSocket )->xBoundSocketListItem ) ), ( usPort ) )
+#define socketGET_SOCKET_PORT( pxSocket )            listGET_LIST_ITEM_VALUE( ( &( ( pxSocket )->xBoundSocketListItem ) ) )
 
 /* Test if a socket it bound which means it is either included in
-xBoundUDPSocketsList or xBoundTCPSocketsList */
-#define socketSOCKET_IS_BOUND( pxSocket )	  ( listLIST_ITEM_CONTAINER( & ( pxSocket )->xBoundSocketListItem ) != NULL )
+ * xBoundUDPSocketsList or xBoundTCPSocketsList */
+#define socketSOCKET_IS_BOUND( pxSocket )            ( listLIST_ITEM_CONTAINER( &( pxSocket )->xBoundSocketListItem ) != NULL )
 
 /* If FreeRTOS_sendto() is called on a socket that is not bound to a port
-number then, depending on the FreeRTOSIPConfig.h settings, it might be that a
-port number is automatically generated for the socket.  Automatically generated
-port numbers will be between socketAUTO_PORT_ALLOCATION_START_NUMBER and
-0xffff.
-
-Per https://tools.ietf.org/html/rfc6056, "the dynamic ports consist of the range
-49152-65535. However, ephemeral port selection algorithms should use the whole
-range 1024-65535" excluding those already in use (inbound or outbound). */
+ * number then, depending on the FreeRTOSIPConfig.h settings, it might be that a
+ * port number is automatically generated for the socket.  Automatically generated
+ * port numbers will be between socketAUTO_PORT_ALLOCATION_START_NUMBER and
+ * 0xffff.
+ *
+ * Per https://tools.ietf.org/html/rfc6056, "the dynamic ports consist of the range
+ * 49152-65535. However, ephemeral port selection algorithms should use the whole
+ * range 1024-65535" excluding those already in use (inbound or outbound). */
 #if !defined( socketAUTO_PORT_ALLOCATION_START_NUMBER )
-	#define socketAUTO_PORT_ALLOCATION_START_NUMBER ( ( uint16_t ) 0x0400 )
+    #define socketAUTO_PORT_ALLOCATION_START_NUMBER    ( ( uint16_t ) 0x0400 )
 #endif
 
-#define socketAUTO_PORT_ALLOCATION_MAX_NUMBER   ( ( uint16_t ) 0xffff )
+#define socketAUTO_PORT_ALLOCATION_MAX_NUMBER          ( ( uint16_t ) 0xffff )
 
 /* The number of octets that make up an IP address. */
-#define socketMAX_IP_ADDRESS_OCTETS		4U
+#define socketMAX_IP_ADDRESS_OCTETS                    4U
 
 /* A block time of 0 simply means "don't block". */
-#define socketDONT_BLOCK				( ( TickType_t ) 0 )
+#define socketDONT_BLOCK                               ( ( TickType_t ) 0 )
 
-#if( ( ipconfigUSE_TCP == 1 ) && !defined( ipTCP_TIMER_PERIOD_MS ) )
-	#define ipTCP_TIMER_PERIOD_MS	( 1000U )
+#if ( ( ipconfigUSE_TCP == 1 ) && !defined( ipTCP_TIMER_PERIOD_MS ) )
+    #define ipTCP_TIMER_PERIOD_MS                      ( 1000U )
 #endif
 
 /* Some helper macro's for defining the 20/80 % limits of uxLittleSpace / uxEnoughSpace. */
-#define sock20_PERCENT						20U
-#define sock80_PERCENT						80U
-#define sock100_PERCENT						100U
+#define sock20_PERCENT     20U
+#define sock80_PERCENT     80U
+#define sock100_PERCENT    100U
 
 
 /*-----------------------------------------------------------*/
@@ -101,531 +101,568 @@ static uint16_t prvGetPrivatePortNumber( BaseType_t xProtocol );
  * Return the list item from within pxList that has an item value of
  * xWantedItemValue.  If there is no such list item return NULL.
  */
-static const ListItem_t * pxListFindListItemWithValue( const List_t *pxList, TickType_t xWantedItemValue );
+static const ListItem_t * pxListFindListItemWithValue( const List_t * pxList,
+                                                       TickType_t xWantedItemValue );
 
 /*
  * Return pdTRUE only if pxSocket is valid and bound, as far as can be
  * determined.
  */
-static BaseType_t prvValidSocket( const FreeRTOS_Socket_t *pxSocket, BaseType_t xProtocol, BaseType_t xIsBound );
+static BaseType_t prvValidSocket( const FreeRTOS_Socket_t * pxSocket,
+                                  BaseType_t xProtocol,
+                                  BaseType_t xIsBound );
 
 /*
  * Internal function prvSockopt_so_buffer(): sets FREERTOS_SO_SNDBUF or
  * FREERTOS_SO_RCVBUF properties of a socket.
  */
-static BaseType_t prvSockopt_so_buffer( FreeRTOS_Socket_t *pxSocket, int32_t lOptionName, const void *pvOptionValue );
+static BaseType_t prvSockopt_so_buffer( FreeRTOS_Socket_t * pxSocket,
+                                        int32_t lOptionName,
+                                        const void * pvOptionValue );
 
 /*
  * Before creating a socket, check the validity of the parameters used
  * and find the size of the socket space, which is different for UDP and TCP
  */
-static BaseType_t prvDetermineSocketSize( BaseType_t xDomain, BaseType_t xType, BaseType_t xProtocol, size_t *pxSocketSize );
+static BaseType_t prvDetermineSocketSize( BaseType_t xDomain,
+                                          BaseType_t xType,
+                                          BaseType_t xProtocol,
+                                          size_t * pxSocketSize );
 
-#if( ipconfigUSE_TCP == 1 )
-	/*
-	 * Create a txStream or a rxStream, depending on the parameter 'xIsInputStream'
-	 */
-	static StreamBuffer_t *prvTCPCreateStream (FreeRTOS_Socket_t *pxSocket, BaseType_t xIsInputStream );
+#if ( ipconfigUSE_TCP == 1 )
+
+    /*
+     * Create a txStream or a rxStream, depending on the parameter 'xIsInputStream'
+     */
+    static StreamBuffer_t * prvTCPCreateStream( FreeRTOS_Socket_t * pxSocket,
+                                                BaseType_t xIsInputStream );
 #endif /* ipconfigUSE_TCP == 1 */
 
-#if( ipconfigUSE_TCP == 1 )
-	/*
-	 * Called from FreeRTOS_send(): some checks which will be done before
-	 * sending a TCP packed.
-	 */
-	static int32_t prvTCPSendCheck( FreeRTOS_Socket_t *pxSocket, size_t uxDataLength );
+#if ( ipconfigUSE_TCP == 1 )
+
+    /*
+     * Called from FreeRTOS_send(): some checks which will be done before
+     * sending a TCP packed.
+     */
+    static int32_t prvTCPSendCheck( FreeRTOS_Socket_t * pxSocket,
+                                    size_t uxDataLength );
 #endif /* ipconfigUSE_TCP */
 
-#if( ipconfigUSE_TCP == 1 )
-	/*
-	 * When a child socket gets closed, make sure to update the child-count of the parent
-	 */
-	static void prvTCPSetSocketCount( FreeRTOS_Socket_t const * pxSocketToDelete );
-#endif  /* ipconfigUSE_TCP == 1 */
+#if ( ipconfigUSE_TCP == 1 )
 
-#if( ipconfigUSE_TCP == 1 )
-	/*
-	 * Called from FreeRTOS_connect(): make some checks and if allowed, send a
-	 * message to the IP-task to start connecting to a remote socket
-	 */
-	static BaseType_t prvTCPConnectStart( FreeRTOS_Socket_t * pxSocket, struct freertos_sockaddr const * pxAddress );
+    /*
+     * When a child socket gets closed, make sure to update the child-count of the parent
+     */
+    static void prvTCPSetSocketCount( FreeRTOS_Socket_t const * pxSocketToDelete );
+#endif /* ipconfigUSE_TCP == 1 */
+
+#if ( ipconfigUSE_TCP == 1 )
+
+    /*
+     * Called from FreeRTOS_connect(): make some checks and if allowed, send a
+     * message to the IP-task to start connecting to a remote socket
+     */
+    static BaseType_t prvTCPConnectStart( FreeRTOS_Socket_t * pxSocket,
+                                          struct freertos_sockaddr const * pxAddress );
 #endif /* ipconfigUSE_TCP */
 
-#if( ipconfigUSE_TCP == 1 )
-	/*
-	 * Check if it makes any sense to wait for a connect event.
-	 * It may return: -EINPROGRESS, -EAGAIN, or 0 for OK.
-	 */
-	static BaseType_t bMayConnect( FreeRTOS_Socket_t const * pxSocket );
+#if ( ipconfigUSE_TCP == 1 )
+
+    /*
+     * Check if it makes any sense to wait for a connect event.
+     * It may return: -EINPROGRESS, -EAGAIN, or 0 for OK.
+     */
+    static BaseType_t bMayConnect( FreeRTOS_Socket_t const * pxSocket );
 #endif /* ipconfigUSE_TCP */
 
-#if( ipconfigSUPPORT_SELECT_FUNCTION == 1 )
+#if ( ipconfigSUPPORT_SELECT_FUNCTION == 1 )
 
-	/* Executed by the IP-task, it will check all sockets belonging to a set */
-	static void prvFindSelectedSocket( SocketSelect_t *pxSocketSet );
+    /* Executed by the IP-task, it will check all sockets belonging to a set */
+    static void prvFindSelectedSocket( SocketSelect_t * pxSocketSet );
 
 #endif /* ipconfigSUPPORT_SELECT_FUNCTION == 1 */
 /*-----------------------------------------------------------*/
 
 /* The list that contains mappings between sockets and port numbers.  Accesses
-to this list must be protected by critical sections of one kind or another. */
+ *  to this list must be protected by critical sections of one kind or another. */
 static List_t xBoundUDPSocketsList;
 
 #if ipconfigUSE_TCP == 1
-	List_t xBoundTCPSocketsList;
+    List_t xBoundTCPSocketsList;
 #endif /* ipconfigUSE_TCP == 1 */
 
 /*-----------------------------------------------------------*/
 
-static BaseType_t prvValidSocket( const FreeRTOS_Socket_t *pxSocket, BaseType_t xProtocol, BaseType_t xIsBound )
+static BaseType_t prvValidSocket( const FreeRTOS_Socket_t * pxSocket,
+                                  BaseType_t xProtocol,
+                                  BaseType_t xIsBound )
 {
-BaseType_t xReturn;
+    BaseType_t xReturn;
 
-	if( ( pxSocket == NULL ) || ( pxSocket == FREERTOS_INVALID_SOCKET ) )
-	{
-		xReturn = pdFALSE;
-	}
-	else if( ( xIsBound != pdFALSE ) && !socketSOCKET_IS_BOUND( pxSocket ) )
-	{
-		/* The caller expects the socket to be bound, but it isn't. */
-		xReturn = pdFALSE;
-	}
-	else if( pxSocket->ucProtocol != ( uint8_t ) xProtocol )
-	{
-		/* Socket has a wrong type (UDP != TCP). */
-		xReturn = pdFALSE;
-	}
-	else
-	{
-		xReturn = pdTRUE;
-	}
+    if( ( pxSocket == NULL ) || ( pxSocket == FREERTOS_INVALID_SOCKET ) )
+    {
+        xReturn = pdFALSE;
+    }
+    else if( ( xIsBound != pdFALSE ) && !socketSOCKET_IS_BOUND( pxSocket ) )
+    {
+        /* The caller expects the socket to be bound, but it isn't. */
+        xReturn = pdFALSE;
+    }
+    else if( pxSocket->ucProtocol != ( uint8_t ) xProtocol )
+    {
+        /* Socket has a wrong type (UDP != TCP). */
+        xReturn = pdFALSE;
+    }
+    else
+    {
+        xReturn = pdTRUE;
+    }
 
-	return xReturn;
+    return xReturn;
 }
 /*-----------------------------------------------------------*/
 
 void vNetworkSocketsInit( void )
 {
-	vListInitialise( &xBoundUDPSocketsList );
+    vListInitialise( &xBoundUDPSocketsList );
 
-	#if( ipconfigUSE_TCP == 1 )
-	{
-		vListInitialise( &xBoundTCPSocketsList );
-	}
-	#endif  /* ipconfigUSE_TCP == 1 */
+    #if ( ipconfigUSE_TCP == 1 )
+        {
+            vListInitialise( &xBoundTCPSocketsList );
+        }
+    #endif /* ipconfigUSE_TCP == 1 */
 }
 /*-----------------------------------------------------------*/
 
-static BaseType_t prvDetermineSocketSize( BaseType_t xDomain, BaseType_t xType, BaseType_t xProtocol, size_t *pxSocketSize )
+static BaseType_t prvDetermineSocketSize( BaseType_t xDomain,
+                                          BaseType_t xType,
+                                          BaseType_t xProtocol,
+                                          size_t * pxSocketSize )
 {
-BaseType_t xReturn = pdPASS;
-FreeRTOS_Socket_t const *pxSocket = NULL;
+    BaseType_t xReturn = pdPASS;
+    FreeRTOS_Socket_t const * pxSocket = NULL;
 
-	/* Asserts must not appear before it has been determined that the network
-	task is ready - otherwise the asserts will fail. */
-	if( xIPIsNetworkTaskReady() == pdFALSE )
-	{
-		xReturn = pdFAIL;
-	}
-	else
-	{
-		/* Only Ethernet is currently supported. */
-		configASSERT( xDomain == FREERTOS_AF_INET );
+    /* Asserts must not appear before it has been determined that the network
+     * task is ready - otherwise the asserts will fail. */
+    if( xIPIsNetworkTaskReady() == pdFALSE )
+    {
+        xReturn = pdFAIL;
+    }
+    else
+    {
+        /* Only Ethernet is currently supported. */
+        configASSERT( xDomain == FREERTOS_AF_INET );
 
-		/* Check if the UDP socket-list has been initialised. */
-		configASSERT( listLIST_IS_INITIALISED( &xBoundUDPSocketsList ) );
-		#if( ipconfigUSE_TCP == 1 )
-		{
-			/* Check if the TCP socket-list has been initialised. */
-			configASSERT( listLIST_IS_INITIALISED( &xBoundTCPSocketsList ) );
-		}
-		#endif  /* ipconfigUSE_TCP == 1 */
+        /* Check if the UDP socket-list has been initialised. */
+        configASSERT( listLIST_IS_INITIALISED( &xBoundUDPSocketsList ) );
+        #if ( ipconfigUSE_TCP == 1 )
+            {
+                /* Check if the TCP socket-list has been initialised. */
+                configASSERT( listLIST_IS_INITIALISED( &xBoundTCPSocketsList ) );
+            }
+        #endif /* ipconfigUSE_TCP == 1 */
 
-		if( xProtocol == FREERTOS_IPPROTO_UDP )
-		{
-			if( xType != FREERTOS_SOCK_DGRAM )
-			{
-				xReturn = pdFAIL;
-				configASSERT( xReturn == pdPASS );
-			}
-			/* In case a UDP socket is created, do not allocate space for TCP data. */
-			*pxSocketSize = ( sizeof( *pxSocket ) - sizeof( pxSocket->u ) ) + sizeof( pxSocket->u.xUDP );
-		}
-#if( ipconfigUSE_TCP == 1 )
-		else if( xProtocol == FREERTOS_IPPROTO_TCP )
-		{
-			if( xType != FREERTOS_SOCK_STREAM )
-			{
-				xReturn = pdFAIL;
-				configASSERT( xReturn == pdPASS );
-			}
+        if( xProtocol == FREERTOS_IPPROTO_UDP )
+        {
+            if( xType != FREERTOS_SOCK_DGRAM )
+            {
+                xReturn = pdFAIL;
+                configASSERT( xReturn == pdPASS );
+            }
 
-			*pxSocketSize = ( sizeof( *pxSocket ) - sizeof( pxSocket->u ) ) + sizeof( pxSocket->u.xTCP );
-		}
-#endif  /* ipconfigUSE_TCP == 1 */
-		else
-		{
-			xReturn = pdFAIL;
-			configASSERT( xReturn == pdPASS );
-		}
-	}
-	/* In case configASSERT() is not used */
-	( void )xDomain;
-	( void )pxSocket;	/* Was only use fot sizeof. */
-	return xReturn;
+            /* In case a UDP socket is created, do not allocate space for TCP data. */
+            *pxSocketSize = ( sizeof( *pxSocket ) - sizeof( pxSocket->u ) ) + sizeof( pxSocket->u.xUDP );
+        }
+
+        #if ( ipconfigUSE_TCP == 1 )
+            else if( xProtocol == FREERTOS_IPPROTO_TCP )
+            {
+                if( xType != FREERTOS_SOCK_STREAM )
+                {
+                    xReturn = pdFAIL;
+                    configASSERT( xReturn == pdPASS );
+                }
+
+                *pxSocketSize = ( sizeof( *pxSocket ) - sizeof( pxSocket->u ) ) + sizeof( pxSocket->u.xTCP );
+            }
+        #endif /* ipconfigUSE_TCP == 1 */
+        else
+        {
+            xReturn = pdFAIL;
+            configASSERT( xReturn == pdPASS );
+        }
+    }
+
+    /* In case configASSERT() is not used */
+    ( void ) xDomain;
+    ( void ) pxSocket; /* Was only use fot sizeof. */
+    return xReturn;
 }
 /*-----------------------------------------------------------*/
 
 /* FreeRTOS_socket() allocates and initiates a socket */
-Socket_t FreeRTOS_socket( BaseType_t xDomain, BaseType_t xType, BaseType_t xProtocol )
+Socket_t FreeRTOS_socket( BaseType_t xDomain,
+                          BaseType_t xType,
+                          BaseType_t xProtocol )
 {
-FreeRTOS_Socket_t *pxSocket;
-size_t uxSocketSize;
-EventGroupHandle_t xEventGroup;
-Socket_t xReturn;
+    FreeRTOS_Socket_t * pxSocket;
+    size_t uxSocketSize;
+    EventGroupHandle_t xEventGroup;
+    Socket_t xReturn;
 
-	if( prvDetermineSocketSize( xDomain, xType, xProtocol, &uxSocketSize ) == pdFAIL )
-	{
-		xReturn = FREERTOS_INVALID_SOCKET;
-	}
-	else
-	{
-		/* Allocate the structure that will hold the socket information.  The
-		size depends on the type of socket: UDP sockets need less space.  A
-		define 'pvPortMallocSocket' will used to allocate the necessary space.
-		By default it points to the FreeRTOS function 'pvPortMalloc()'. */
-		pxSocket = ipPOINTER_CAST( FreeRTOS_Socket_t *, pvPortMallocSocket( uxSocketSize ) );
+    if( prvDetermineSocketSize( xDomain, xType, xProtocol, &uxSocketSize ) == pdFAIL )
+    {
+        xReturn = FREERTOS_INVALID_SOCKET;
+    }
+    else
+    {
+        /* Allocate the structure that will hold the socket information.  The
+         * size depends on the type of socket: UDP sockets need less space.  A
+         * define 'pvPortMallocSocket' will used to allocate the necessary space.
+         * By default it points to the FreeRTOS function 'pvPortMalloc()'. */
+        pxSocket = ipPOINTER_CAST( FreeRTOS_Socket_t *, pvPortMallocSocket( uxSocketSize ) );
 
-		if( pxSocket == NULL )
-		{
-			xReturn = FREERTOS_INVALID_SOCKET;
-			iptraceFAILED_TO_CREATE_SOCKET();
-		}
-		else
-		{
-			xEventGroup = xEventGroupCreate();
-			if( xEventGroup == NULL )
-			{
-				vPortFreeSocket( pxSocket );
-				xReturn = FREERTOS_INVALID_SOCKET;
-				iptraceFAILED_TO_CREATE_EVENT_GROUP();
-			}
-			else
-			{
-				if( xProtocol == FREERTOS_IPPROTO_UDP )
-				{
-					iptraceMEM_STATS_CREATE( tcpSOCKET_UDP, pxSocket, uxSocketSize + sizeof( StaticEventGroup_t ) );
-				}	
-				else
-				{
-					/* Lint wants at least a comment, in case the macro is empty. */
-					iptraceMEM_STATS_CREATE( tcpSOCKET_TCP, pxSocket, uxSocketSize + sizeof( StaticEventGroup_t ) );
-				}
+        if( pxSocket == NULL )
+        {
+            xReturn = FREERTOS_INVALID_SOCKET;
+            iptraceFAILED_TO_CREATE_SOCKET();
+        }
+        else
+        {
+            xEventGroup = xEventGroupCreate();
 
-				/* Clear the entire space to avoid nulling individual entries. */
-				( void ) memset( pxSocket, 0, uxSocketSize );
+            if( xEventGroup == NULL )
+            {
+                vPortFreeSocket( pxSocket );
+                xReturn = FREERTOS_INVALID_SOCKET;
+                iptraceFAILED_TO_CREATE_EVENT_GROUP();
+            }
+            else
+            {
+                if( xProtocol == FREERTOS_IPPROTO_UDP )
+                {
+                    iptraceMEM_STATS_CREATE( tcpSOCKET_UDP, pxSocket, uxSocketSize + sizeof( StaticEventGroup_t ) );
+                }
+                else
+                {
+                    /* Lint wants at least a comment, in case the macro is empty. */
+                    iptraceMEM_STATS_CREATE( tcpSOCKET_TCP, pxSocket, uxSocketSize + sizeof( StaticEventGroup_t ) );
+                }
 
-				pxSocket->xEventGroup = xEventGroup;
+                /* Clear the entire space to avoid nulling individual entries. */
+                ( void ) memset( pxSocket, 0, uxSocketSize );
 
-				/* Initialise the socket's members.  The semaphore will be created
-				if the socket is bound to an address, for now the pointer to the
-				semaphore is just set to NULL to show it has not been created. */
-				if( xProtocol == FREERTOS_IPPROTO_UDP )
-				{
-					vListInitialise( &( pxSocket->u.xUDP.xWaitingPacketsList ) );
+                pxSocket->xEventGroup = xEventGroup;
 
-					#if( ipconfigUDP_MAX_RX_PACKETS > 0U )
-					{
-						pxSocket->u.xUDP.uxMaxPackets = ( UBaseType_t ) ipconfigUDP_MAX_RX_PACKETS;
-					}
-					#endif /* ipconfigUDP_MAX_RX_PACKETS > 0 */
-				}
+                /* Initialise the socket's members.  The semaphore will be created
+                 * if the socket is bound to an address, for now the pointer to the
+                 * semaphore is just set to NULL to show it has not been created. */
+                if( xProtocol == FREERTOS_IPPROTO_UDP )
+                {
+                    vListInitialise( &( pxSocket->u.xUDP.xWaitingPacketsList ) );
 
-				vListInitialiseItem( &( pxSocket->xBoundSocketListItem ) );
-				listSET_LIST_ITEM_OWNER( &( pxSocket->xBoundSocketListItem ), ipPOINTER_CAST( void *, pxSocket ) );
+                    #if ( ipconfigUDP_MAX_RX_PACKETS > 0U )
+                        {
+                            pxSocket->u.xUDP.uxMaxPackets = ( UBaseType_t ) ipconfigUDP_MAX_RX_PACKETS;
+                        }
+                    #endif /* ipconfigUDP_MAX_RX_PACKETS > 0 */
+                }
 
-				pxSocket->xReceiveBlockTime = ipconfigSOCK_DEFAULT_RECEIVE_BLOCK_TIME;
-				pxSocket->xSendBlockTime	= ipconfigSOCK_DEFAULT_SEND_BLOCK_TIME;
-				pxSocket->ucSocketOptions   = ( uint8_t ) FREERTOS_SO_UDPCKSUM_OUT;
-				pxSocket->ucProtocol		= ( uint8_t ) xProtocol; /* protocol: UDP or TCP */
+                vListInitialiseItem( &( pxSocket->xBoundSocketListItem ) );
+                listSET_LIST_ITEM_OWNER( &( pxSocket->xBoundSocketListItem ), ipPOINTER_CAST( void *, pxSocket ) );
 
-				#if( ipconfigUSE_TCP == 1 )
-				{
-					if( xProtocol == FREERTOS_IPPROTO_TCP )
-					{
-						/* StreamSize is expressed in number of bytes */
-						/* Round up buffer sizes to nearest multiple of MSS */
-						pxSocket->u.xTCP.usCurMSS     = ( uint16_t ) ipconfigTCP_MSS;
-						pxSocket->u.xTCP.usInitMSS    = ( uint16_t ) ipconfigTCP_MSS;
-						pxSocket->u.xTCP.uxRxStreamSize = ( size_t ) ipconfigTCP_RX_BUFFER_LENGTH;
-						pxSocket->u.xTCP.uxTxStreamSize = ( size_t ) FreeRTOS_round_up( ipconfigTCP_TX_BUFFER_LENGTH, ipconfigTCP_MSS );
-						/* Use half of the buffer size of the TCP windows */
-						#if ( ipconfigUSE_TCP_WIN == 1 )
-						{
-							pxSocket->u.xTCP.uxRxWinSize  = FreeRTOS_max_uint32( 1UL, ( uint32_t ) ( pxSocket->u.xTCP.uxRxStreamSize / 2U ) / ipconfigTCP_MSS );
-							pxSocket->u.xTCP.uxTxWinSize  = FreeRTOS_max_uint32( 1UL, ( uint32_t ) ( pxSocket->u.xTCP.uxTxStreamSize / 2U ) / ipconfigTCP_MSS );
-						}
-						#else
-						{
-							pxSocket->u.xTCP.uxRxWinSize  = 1U;
-							pxSocket->u.xTCP.uxTxWinSize  = 1U;
-						}
-						#endif
-						/* The above values are just defaults, and can be overridden by
-						calling FreeRTOS_setsockopt().  No buffers will be allocated until a
-						socket is connected and data is exchanged. */
-					}
-				}
-				#endif  /* ipconfigUSE_TCP == 1 */
-				xReturn = pxSocket;
-			}
-		}
-	}
-	/* Remove compiler warnings in the case the configASSERT() is not defined. */
-	( void ) xDomain;
+                pxSocket->xReceiveBlockTime = ipconfigSOCK_DEFAULT_RECEIVE_BLOCK_TIME;
+                pxSocket->xSendBlockTime = ipconfigSOCK_DEFAULT_SEND_BLOCK_TIME;
+                pxSocket->ucSocketOptions = ( uint8_t ) FREERTOS_SO_UDPCKSUM_OUT;
+                pxSocket->ucProtocol = ( uint8_t ) xProtocol; /* protocol: UDP or TCP */
 
-	return xReturn;
+                #if ( ipconfigUSE_TCP == 1 )
+                    {
+                        if( xProtocol == FREERTOS_IPPROTO_TCP )
+                        {
+                            /* StreamSize is expressed in number of bytes */
+                            /* Round up buffer sizes to nearest multiple of MSS */
+                            pxSocket->u.xTCP.usCurMSS = ( uint16_t ) ipconfigTCP_MSS;
+                            pxSocket->u.xTCP.usInitMSS = ( uint16_t ) ipconfigTCP_MSS;
+                            pxSocket->u.xTCP.uxRxStreamSize = ( size_t ) ipconfigTCP_RX_BUFFER_LENGTH;
+                            pxSocket->u.xTCP.uxTxStreamSize = ( size_t ) FreeRTOS_round_up( ipconfigTCP_TX_BUFFER_LENGTH, ipconfigTCP_MSS );
+                            /* Use half of the buffer size of the TCP windows */
+                            #if ( ipconfigUSE_TCP_WIN == 1 )
+                                {
+                                    pxSocket->u.xTCP.uxRxWinSize = FreeRTOS_max_uint32( 1UL, ( uint32_t ) ( pxSocket->u.xTCP.uxRxStreamSize / 2U ) / ipconfigTCP_MSS );
+                                    pxSocket->u.xTCP.uxTxWinSize = FreeRTOS_max_uint32( 1UL, ( uint32_t ) ( pxSocket->u.xTCP.uxTxStreamSize / 2U ) / ipconfigTCP_MSS );
+                                }
+                            #else
+                                {
+                                    pxSocket->u.xTCP.uxRxWinSize = 1U;
+                                    pxSocket->u.xTCP.uxTxWinSize = 1U;
+                                }
+                            #endif
+
+                            /* The above values are just defaults, and can be overridden by
+                             * calling FreeRTOS_setsockopt().  No buffers will be allocated until a
+                             * socket is connected and data is exchanged. */
+                        }
+                    }
+                #endif /* ipconfigUSE_TCP == 1 */
+                xReturn = pxSocket;
+            }
+        }
+    }
+
+    /* Remove compiler warnings in the case the configASSERT() is not defined. */
+    ( void ) xDomain;
+
+    return xReturn;
 }
 /*-----------------------------------------------------------*/
 
-#if( ipconfigSUPPORT_SELECT_FUNCTION == 1 )
+#if ( ipconfigSUPPORT_SELECT_FUNCTION == 1 )
 
-	SocketSet_t FreeRTOS_CreateSocketSet( void )
-	{
-	SocketSelect_t *pxSocketSet;
+    SocketSet_t FreeRTOS_CreateSocketSet( void )
+    {
+        SocketSelect_t * pxSocketSet;
 
-		pxSocketSet = ipPOINTER_CAST( SocketSelect_t *, pvPortMalloc( sizeof( *pxSocketSet ) ) );
+        pxSocketSet = ipPOINTER_CAST( SocketSelect_t *, pvPortMalloc( sizeof( *pxSocketSet ) ) );
 
-		if( pxSocketSet != NULL )
-		{
-			( void ) memset( pxSocketSet, 0, sizeof( *pxSocketSet ) );
-			pxSocketSet->xSelectGroup = xEventGroupCreate();
+        if( pxSocketSet != NULL )
+        {
+            ( void ) memset( pxSocketSet, 0, sizeof( *pxSocketSet ) );
+            pxSocketSet->xSelectGroup = xEventGroupCreate();
 
-			if( pxSocketSet->xSelectGroup == NULL )
-			{
-				vPortFree( pxSocketSet );
-				pxSocketSet = NULL;
-			}
-			else
-			{
-				/* Lint wants at least a comment, in case the macro is empty. */
-				iptraceMEM_STATS_CREATE( tcpSOCKET_SET, pxSocketSet, sizeof( *pxSocketSet ) + sizeof( StaticEventGroup_t ) );
-			}
-		}
+            if( pxSocketSet->xSelectGroup == NULL )
+            {
+                vPortFree( pxSocketSet );
+                pxSocketSet = NULL;
+            }
+            else
+            {
+                /* Lint wants at least a comment, in case the macro is empty. */
+                iptraceMEM_STATS_CREATE( tcpSOCKET_SET, pxSocketSet, sizeof( *pxSocketSet ) + sizeof( StaticEventGroup_t ) );
+            }
+        }
 
-		return ( SocketSet_t ) pxSocketSet;
-	}
-
-#endif /* ipconfigSUPPORT_SELECT_FUNCTION == 1 */
-/*-----------------------------------------------------------*/
-
-#if( ipconfigSUPPORT_SELECT_FUNCTION == 1 )
-
-	void FreeRTOS_DeleteSocketSet( SocketSet_t xSocketSet )
-	{
-		SocketSelect_t *pxSocketSet = ( SocketSelect_t*) xSocketSet;
-
-		iptraceMEM_STATS_DELETE( pxSocketSet );
-
-		vEventGroupDelete( pxSocketSet->xSelectGroup );
-		vPortFree( pxSocketSet );
-	}
+        return ( SocketSet_t ) pxSocketSet;
+    }
 
 #endif /* ipconfigSUPPORT_SELECT_FUNCTION == 1 */
 /*-----------------------------------------------------------*/
 
-#if( ipconfigSUPPORT_SELECT_FUNCTION == 1 )
+#if ( ipconfigSUPPORT_SELECT_FUNCTION == 1 )
 
-	/* Add a socket to a set */
-	void FreeRTOS_FD_SET( Socket_t xSocket, SocketSet_t xSocketSet, EventBits_t xBitsToSet )
-	{
-	FreeRTOS_Socket_t *pxSocket = ( FreeRTOS_Socket_t * ) xSocket;
-	SocketSelect_t *pxSocketSet = ( SocketSelect_t * ) xSocketSet;
+    void FreeRTOS_DeleteSocketSet( SocketSet_t xSocketSet )
+    {
+        SocketSelect_t * pxSocketSet = ( SocketSelect_t * ) xSocketSet;
 
-		configASSERT( pxSocket != NULL );
-		configASSERT( xSocketSet != NULL );
+        iptraceMEM_STATS_DELETE( pxSocketSet );
 
-		/* Make sure we're not adding bits which are reserved for internal use,
-		such as eSELECT_CALL_IP */
-		pxSocket->xSelectBits |= xBitsToSet & ( ( EventBits_t ) eSELECT_ALL );
-
-		if( ( pxSocket->xSelectBits & ( ( EventBits_t ) eSELECT_ALL ) ) != ( EventBits_t ) 0U )
-		{
-			/* Adding a socket to a socket set. */
-			pxSocket->pxSocketSet = ( SocketSelect_t * ) xSocketSet;
-
-			/* Now have the IP-task call vSocketSelect() to see if the set contains
-			any sockets which are 'ready' and set the proper bits. */
-			prvFindSelectedSocket( pxSocketSet );
-		}
-	}
+        vEventGroupDelete( pxSocketSet->xSelectGroup );
+        vPortFree( pxSocketSet );
+    }
 
 #endif /* ipconfigSUPPORT_SELECT_FUNCTION == 1 */
 /*-----------------------------------------------------------*/
 
-#if( ipconfigSUPPORT_SELECT_FUNCTION == 1 )
-	/* Clear select bits for a socket
-	If the mask becomes 0, remove the socket from the set */
-	void FreeRTOS_FD_CLR( Socket_t xSocket, SocketSet_t xSocketSet, EventBits_t xBitsToClear )
-	{
-	FreeRTOS_Socket_t *pxSocket = ( FreeRTOS_Socket_t * ) xSocket;
+#if ( ipconfigSUPPORT_SELECT_FUNCTION == 1 )
 
-		configASSERT( pxSocket != NULL );
-		configASSERT( xSocketSet != NULL );
+    /* Add a socket to a set */
+    void FreeRTOS_FD_SET( Socket_t xSocket,
+                          SocketSet_t xSocketSet,
+                          EventBits_t xBitsToSet )
+    {
+        FreeRTOS_Socket_t * pxSocket = ( FreeRTOS_Socket_t * ) xSocket;
+        SocketSelect_t * pxSocketSet = ( SocketSelect_t * ) xSocketSet;
 
-		pxSocket->xSelectBits &= ~( xBitsToClear & ( ( EventBits_t ) eSELECT_ALL ) );
-		if( ( pxSocket->xSelectBits & ( ( EventBits_t ) eSELECT_ALL ) ) != ( EventBits_t ) 0U )
-		{
-			pxSocket->pxSocketSet = ( SocketSelect_t *)xSocketSet;
-		}
-		else
-		{
-			/* disconnect it from the socket set */
-			pxSocket->pxSocketSet = NULL;
-		}
-	}
+        configASSERT( pxSocket != NULL );
+        configASSERT( xSocketSet != NULL );
+
+        /* Make sure we're not adding bits which are reserved for internal use,
+         * such as eSELECT_CALL_IP */
+        pxSocket->xSelectBits |= xBitsToSet & ( ( EventBits_t ) eSELECT_ALL );
+
+        if( ( pxSocket->xSelectBits & ( ( EventBits_t ) eSELECT_ALL ) ) != ( EventBits_t ) 0U )
+        {
+            /* Adding a socket to a socket set. */
+            pxSocket->pxSocketSet = ( SocketSelect_t * ) xSocketSet;
+
+            /* Now have the IP-task call vSocketSelect() to see if the set contains
+             * any sockets which are 'ready' and set the proper bits. */
+            prvFindSelectedSocket( pxSocketSet );
+        }
+    }
+
+#endif /* ipconfigSUPPORT_SELECT_FUNCTION == 1 */
+/*-----------------------------------------------------------*/
+
+#if ( ipconfigSUPPORT_SELECT_FUNCTION == 1 )
+
+    /* Clear select bits for a socket
+     * If the mask becomes 0, remove the socket from the set */
+    void FreeRTOS_FD_CLR( Socket_t xSocket,
+                          SocketSet_t xSocketSet,
+                          EventBits_t xBitsToClear )
+    {
+        FreeRTOS_Socket_t * pxSocket = ( FreeRTOS_Socket_t * ) xSocket;
+
+        configASSERT( pxSocket != NULL );
+        configASSERT( xSocketSet != NULL );
+
+        pxSocket->xSelectBits &= ~( xBitsToClear & ( ( EventBits_t ) eSELECT_ALL ) );
+
+        if( ( pxSocket->xSelectBits & ( ( EventBits_t ) eSELECT_ALL ) ) != ( EventBits_t ) 0U )
+        {
+            pxSocket->pxSocketSet = ( SocketSelect_t * ) xSocketSet;
+        }
+        else
+        {
+            /* disconnect it from the socket set */
+            pxSocket->pxSocketSet = NULL;
+        }
+    }
 
 #endif /* ipconfigSUPPORT_SELECT_FUNCTION == 1 */
 /*-----------------------------------------------------------*/
 
 
-#if( ipconfigSUPPORT_SELECT_FUNCTION == 1 )
+#if ( ipconfigSUPPORT_SELECT_FUNCTION == 1 )
 
-	/* Test if a socket belongs to a socket-set */
-	EventBits_t FreeRTOS_FD_ISSET( Socket_t xSocket, SocketSet_t xSocketSet )
-	{
-	EventBits_t xReturn;
-	const FreeRTOS_Socket_t *pxSocket = ( const FreeRTOS_Socket_t * ) xSocket;
+    /* Test if a socket belongs to a socket-set */
+    EventBits_t FreeRTOS_FD_ISSET( Socket_t xSocket,
+                                   SocketSet_t xSocketSet )
+    {
+        EventBits_t xReturn;
+        const FreeRTOS_Socket_t * pxSocket = ( const FreeRTOS_Socket_t * ) xSocket;
 
-		configASSERT( pxSocket != NULL );
-		configASSERT( xSocketSet != NULL );
+        configASSERT( pxSocket != NULL );
+        configASSERT( xSocketSet != NULL );
 
-		if( xSocketSet == ( SocketSet_t ) pxSocket->pxSocketSet )
-		{
-			/* Make sure we're not adding bits which are reserved for internal
-			use. */
-			xReturn = pxSocket->xSocketBits & ( ( EventBits_t ) eSELECT_ALL );
-		}
-		else
-		{
-			xReturn = 0;
-		}
+        if( xSocketSet == ( SocketSet_t ) pxSocket->pxSocketSet )
+        {
+            /* Make sure we're not adding bits which are reserved for internal
+             * use. */
+            xReturn = pxSocket->xSocketBits & ( ( EventBits_t ) eSELECT_ALL );
+        }
+        else
+        {
+            xReturn = 0;
+        }
 
-		return xReturn;
-	}
+        return xReturn;
+    }
 
 #endif /* ipconfigSUPPORT_SELECT_FUNCTION == 1 */
 /*-----------------------------------------------------------*/
 
-#if( ipconfigSUPPORT_SELECT_FUNCTION == 1 )
+#if ( ipconfigSUPPORT_SELECT_FUNCTION == 1 )
 
-	/* The select() statement: wait for an event to occur on any of the sockets
-	included in a socket set */
-	BaseType_t FreeRTOS_select( SocketSet_t xSocketSet, TickType_t xBlockTimeTicks )
-	{
-	TimeOut_t xTimeOut;
-	TickType_t xRemainingTime;
-	SocketSelect_t *pxSocketSet = ( SocketSelect_t*) xSocketSet;
-	EventBits_t uxResult;
+    /* The select() statement: wait for an event to occur on any of the sockets
+     * included in a socket set */
+    BaseType_t FreeRTOS_select( SocketSet_t xSocketSet,
+                                TickType_t xBlockTimeTicks )
+    {
+        TimeOut_t xTimeOut;
+        TickType_t xRemainingTime;
+        SocketSelect_t * pxSocketSet = ( SocketSelect_t * ) xSocketSet;
+        EventBits_t uxResult;
 
-		configASSERT( xSocketSet != NULL );
+        configASSERT( xSocketSet != NULL );
 
-		/* Only in the first round, check for non-blocking */
-		xRemainingTime = xBlockTimeTicks;
+        /* Only in the first round, check for non-blocking */
+        xRemainingTime = xBlockTimeTicks;
 
-		/* Fetch the current time */
-		vTaskSetTimeOutState( &xTimeOut );
+        /* Fetch the current time */
+        vTaskSetTimeOutState( &xTimeOut );
 
-		for( ;; )
-		{
-			/* Find a socket which might have triggered the bit
-			This function might return immediately or block for a limited time */
-			uxResult = xEventGroupWaitBits( pxSocketSet->xSelectGroup, ( ( EventBits_t ) eSELECT_ALL ), pdFALSE, pdFALSE, xRemainingTime );
+        for( ; ; )
+        {
+            /* Find a socket which might have triggered the bit
+             * This function might return immediately or block for a limited time */
+            uxResult = xEventGroupWaitBits( pxSocketSet->xSelectGroup, ( ( EventBits_t ) eSELECT_ALL ), pdFALSE, pdFALSE, xRemainingTime );
 
-			#if( ipconfigSUPPORT_SIGNALS != 0 )
-			{
-				if( ( uxResult & ( ( EventBits_t ) eSELECT_INTR ) ) != 0U )
-				{
-					( void ) xEventGroupClearBits( pxSocketSet->xSelectGroup, ( EventBits_t  ) eSELECT_INTR );
-					FreeRTOS_debug_printf( ( "FreeRTOS_select: interrupted\n" ) );
-					break;
-				}
-			}
-			#endif /* ipconfigSUPPORT_SIGNALS */
+            #if ( ipconfigSUPPORT_SIGNALS != 0 )
+                {
+                    if( ( uxResult & ( ( EventBits_t ) eSELECT_INTR ) ) != 0U )
+                    {
+                        ( void ) xEventGroupClearBits( pxSocketSet->xSelectGroup, ( EventBits_t ) eSELECT_INTR );
+                        FreeRTOS_debug_printf( ( "FreeRTOS_select: interrupted\n" ) );
+                        break;
+                    }
+                }
+            #endif /* ipconfigSUPPORT_SIGNALS */
 
-			/* Have the IP-task find the socket which had an event */
-			prvFindSelectedSocket( pxSocketSet );
+            /* Have the IP-task find the socket which had an event */
+            prvFindSelectedSocket( pxSocketSet );
 
-			uxResult = xEventGroupGetBits( pxSocketSet->xSelectGroup );
+            uxResult = xEventGroupGetBits( pxSocketSet->xSelectGroup );
 
-			if( uxResult != 0U )
-			{
-				break;
-			}
+            if( uxResult != 0U )
+            {
+                break;
+            }
 
-			/* Has the timeout been reached? */
-			if( xTaskCheckForTimeOut( &xTimeOut, &xRemainingTime ) != pdFALSE )
-			{
-				break;
-			}
-		}
+            /* Has the timeout been reached? */
+            if( xTaskCheckForTimeOut( &xTimeOut, &xRemainingTime ) != pdFALSE )
+            {
+                break;
+            }
+        }
 
-		return ( BaseType_t ) uxResult;
-	}
+        return ( BaseType_t ) uxResult;
+    }
 
 #endif /* ipconfigSUPPORT_SELECT_FUNCTION */
 /*-----------------------------------------------------------*/
 
-#if( ipconfigSUPPORT_SELECT_FUNCTION == 1 )
+#if ( ipconfigSUPPORT_SELECT_FUNCTION == 1 )
 
-	/* Send a message to the IP-task to have it check all sockets belonging to
-	'pxSocketSet' */
-	static void prvFindSelectedSocket( SocketSelect_t *pxSocketSet )
-	{
-	IPStackEvent_t xSelectEvent;
-	#if( ipconfigSELECT_USES_NOTIFY != 0 )
-	SocketSelectMessage_t xSelectMessage;
-	#endif
+    /* Send a message to the IP-task to have it check all sockets belonging to
+     * 'pxSocketSet' */
+    static void prvFindSelectedSocket( SocketSelect_t * pxSocketSet )
+    {
+        IPStackEvent_t xSelectEvent;
 
-		xSelectEvent.eEventType = eSocketSelectEvent;
-		#if( ipconfigSELECT_USES_NOTIFY != 0 )
-		{
-			xSelectMessage.pxSocketSet = pxSocketSet;
-			xSelectMessage.xTaskhandle = xTaskGetCurrentTaskHandle();
-			xSelectEvent.pvData = &( xSelectMessage );
-		}
-		#else
-		{
-			xSelectEvent.pvData = pxSocketSet;
+        #if ( ipconfigSELECT_USES_NOTIFY != 0 )
+            SocketSelectMessage_t xSelectMessage;
+        #endif
 
-			/* while the IP-task works on the request, the API will block on
-			'eSELECT_CALL_IP'.  So clear it first. */
-			( void ) xEventGroupClearBits( pxSocketSet->xSelectGroup, ( BaseType_t ) eSELECT_CALL_IP );
-		}
-		#endif
+        xSelectEvent.eEventType = eSocketSelectEvent;
+        #if ( ipconfigSELECT_USES_NOTIFY != 0 )
+            {
+                xSelectMessage.pxSocketSet = pxSocketSet;
+                xSelectMessage.xTaskhandle = xTaskGetCurrentTaskHandle();
+                xSelectEvent.pvData = &( xSelectMessage );
+            }
+        #else
+            {
+                xSelectEvent.pvData = pxSocketSet;
 
+                /* while the IP-task works on the request, the API will block on
+                 * 'eSELECT_CALL_IP'.  So clear it first. */
+                ( void ) xEventGroupClearBits( pxSocketSet->xSelectGroup, ( BaseType_t ) eSELECT_CALL_IP );
+            }
+        #endif /* if ( ipconfigSELECT_USES_NOTIFY != 0 ) */
 
-		/* Now send the socket select event */
-		if( xSendEventStructToIPTask( &xSelectEvent, ( TickType_t ) portMAX_DELAY ) == pdFAIL )
-		{
-			/* Oops, we failed to wake-up the IP task. No use to wait for it. */
-			FreeRTOS_debug_printf( ( "prvFindSelectedSocket: failed\n" ) );
-		}
-		else
-		{
-			/* As soon as the IP-task is ready, it will set 'eSELECT_CALL_IP' to
-			wakeup the calling API */
-			#if( ipconfigSELECT_USES_NOTIFY != 0 )
-			{
-				( void ) ulTaskNotifyTake( pdFALSE, portMAX_DELAY );
-			}
-			#else
-			{
-				( void ) xEventGroupWaitBits( pxSocketSet->xSelectGroup, ( BaseType_t ) eSELECT_CALL_IP, pdTRUE, pdFALSE, portMAX_DELAY );
-			}
-			#endif
-		}
-	}
+        /* Now send the socket select event */
+        if( xSendEventStructToIPTask( &xSelectEvent, ( TickType_t ) portMAX_DELAY ) == pdFAIL )
+        {
+            /* Oops, we failed to wake-up the IP task. No use to wait for it. */
+            FreeRTOS_debug_printf( ( "prvFindSelectedSocket: failed\n" ) );
+        }
+        else
+        {
+            /* As soon as the IP-task is ready, it will set 'eSELECT_CALL_IP' to
+             * wakeup the calling API */
+            #if ( ipconfigSELECT_USES_NOTIFY != 0 )
+                {
+                    ( void ) ulTaskNotifyTake( pdFALSE, portMAX_DELAY );
+                }
+            #else
+                {
+                    ( void ) xEventGroupWaitBits( pxSocketSet->xSelectGroup, ( BaseType_t ) eSELECT_CALL_IP, pdTRUE, pdFALSE, portMAX_DELAY );
+                }
+            #endif
+        }
+    }
 
 #endif /* ipconfigSUPPORT_SELECT_FUNCTION == 1 */
 /*-----------------------------------------------------------*/
@@ -635,312 +672,324 @@ Socket_t xReturn;
  * In this library, the function can only be used with connectionsless sockets
  * (UDP)
  */
-int32_t FreeRTOS_recvfrom( Socket_t xSocket, void *pvBuffer, size_t uxBufferLength, BaseType_t xFlags, struct freertos_sockaddr *pxSourceAddress, socklen_t *pxSourceAddressLength )
+int32_t FreeRTOS_recvfrom( Socket_t xSocket,
+                           void * pvBuffer,
+                           size_t uxBufferLength,
+                           BaseType_t xFlags,
+                           struct freertos_sockaddr * pxSourceAddress,
+                           socklen_t * pxSourceAddressLength )
 {
-BaseType_t lPacketCount;
-NetworkBufferDescriptor_t *pxNetworkBuffer;
-FreeRTOS_Socket_t const * pxSocket = xSocket;
-TickType_t xRemainingTime = ( TickType_t ) 0; /* Obsolete assignment, but some compilers output a warning if its not done. */
-BaseType_t xTimed = pdFALSE;
-TimeOut_t xTimeOut;
-int32_t lReturn;
-EventBits_t xEventBits = ( EventBits_t ) 0;
+    BaseType_t lPacketCount;
+    NetworkBufferDescriptor_t * pxNetworkBuffer;
+    FreeRTOS_Socket_t const * pxSocket = xSocket;
+    TickType_t xRemainingTime = ( TickType_t ) 0; /* Obsolete assignment, but some compilers output a warning if its not done. */
+    BaseType_t xTimed = pdFALSE;
+    TimeOut_t xTimeOut;
+    int32_t lReturn;
+    EventBits_t xEventBits = ( EventBits_t ) 0;
 
-	if( prvValidSocket( pxSocket, FREERTOS_IPPROTO_UDP, pdTRUE ) == pdFALSE )
-	{
-		return -pdFREERTOS_ERRNO_EINVAL;
-	}
+    if( prvValidSocket( pxSocket, FREERTOS_IPPROTO_UDP, pdTRUE ) == pdFALSE )
+    {
+        return -pdFREERTOS_ERRNO_EINVAL;
+    }
 
-	lPacketCount = ( BaseType_t ) listCURRENT_LIST_LENGTH( &( pxSocket->u.xUDP.xWaitingPacketsList ) );
+    lPacketCount = ( BaseType_t ) listCURRENT_LIST_LENGTH( &( pxSocket->u.xUDP.xWaitingPacketsList ) );
 
-	/* The function prototype is designed to maintain the expected Berkeley
-	sockets standard, but this implementation does not use all the parameters. */
-	( void ) pxSourceAddressLength;
+    /* The function prototype is designed to maintain the expected Berkeley
+     * sockets standard, but this implementation does not use all the parameters. */
+    ( void ) pxSourceAddressLength;
 
-	while( lPacketCount == 0 )
-	{
-		if( xTimed == pdFALSE )
-		{
-			/* Check to see if the socket is non blocking on the first
-			iteration.  */
-			xRemainingTime = pxSocket->xReceiveBlockTime;
+    while( lPacketCount == 0 )
+    {
+        if( xTimed == pdFALSE )
+        {
+            /* Check to see if the socket is non blocking on the first
+             * iteration.  */
+            xRemainingTime = pxSocket->xReceiveBlockTime;
 
-			if( xRemainingTime == ( TickType_t ) 0 )
-			{
-				#if( ipconfigSUPPORT_SIGNALS != 0 )
-				{
-					/* Just check for the interrupt flag. */
-					xEventBits = xEventGroupWaitBits( pxSocket->xEventGroup, ( EventBits_t ) eSOCKET_INTR,
-						pdTRUE /*xClearOnExit*/, pdFALSE /*xWaitAllBits*/, socketDONT_BLOCK );
-				}
-				#endif /* ipconfigSUPPORT_SIGNALS */
-				break;
-			}
+            if( xRemainingTime == ( TickType_t ) 0 )
+            {
+                #if ( ipconfigSUPPORT_SIGNALS != 0 )
+                    {
+                        /* Just check for the interrupt flag. */
+                        xEventBits = xEventGroupWaitBits( pxSocket->xEventGroup, ( EventBits_t ) eSOCKET_INTR,
+                                                          pdTRUE /*xClearOnExit*/, pdFALSE /*xWaitAllBits*/, socketDONT_BLOCK );
+                    }
+                #endif /* ipconfigSUPPORT_SIGNALS */
+                break;
+            }
 
-			if( ( ( ( UBaseType_t ) xFlags ) & ( ( UBaseType_t ) FREERTOS_MSG_DONTWAIT ) ) != 0U )
-			{
-				break;
-			}
+            if( ( ( ( UBaseType_t ) xFlags ) & ( ( UBaseType_t ) FREERTOS_MSG_DONTWAIT ) ) != 0U )
+            {
+                break;
+            }
 
-			/* To ensure this part only executes once. */
-			xTimed = pdTRUE;
+            /* To ensure this part only executes once. */
+            xTimed = pdTRUE;
 
-			/* Fetch the current time. */
-			vTaskSetTimeOutState( &xTimeOut );
-		}
+            /* Fetch the current time. */
+            vTaskSetTimeOutState( &xTimeOut );
+        }
 
-		/* Wait for arrival of data.  While waiting, the IP-task may set the
-		'eSOCKET_RECEIVE' bit in 'xEventGroup', if it receives data for this
-		socket, thus unblocking this API call. */
-		xEventBits = xEventGroupWaitBits( pxSocket->xEventGroup, ( ( EventBits_t ) eSOCKET_RECEIVE ) | ( ( EventBits_t ) eSOCKET_INTR ),
-			pdTRUE /*xClearOnExit*/, pdFALSE /*xWaitAllBits*/, xRemainingTime );
+        /* Wait for arrival of data.  While waiting, the IP-task may set the
+         * 'eSOCKET_RECEIVE' bit in 'xEventGroup', if it receives data for this
+         * socket, thus unblocking this API call. */
+        xEventBits = xEventGroupWaitBits( pxSocket->xEventGroup, ( ( EventBits_t ) eSOCKET_RECEIVE ) | ( ( EventBits_t ) eSOCKET_INTR ),
+                                          pdTRUE /*xClearOnExit*/, pdFALSE /*xWaitAllBits*/, xRemainingTime );
 
-		#if( ipconfigSUPPORT_SIGNALS != 0 )
-		{
-			if( ( xEventBits & ( EventBits_t ) eSOCKET_INTR ) != 0U )
-			{
-				if( ( xEventBits & ( EventBits_t ) eSOCKET_RECEIVE ) != 0U )
-				{
-					/* Shouldn't have cleared the eSOCKET_RECEIVE flag. */
-					( void ) xEventGroupSetBits( pxSocket->xEventGroup, ( EventBits_t ) eSOCKET_RECEIVE );
-				}
-				break;
-			}
-		}
-		#else
-		{
-			( void ) xEventBits;
-		}
-		#endif /* ipconfigSUPPORT_SIGNALS */
+        #if ( ipconfigSUPPORT_SIGNALS != 0 )
+            {
+                if( ( xEventBits & ( EventBits_t ) eSOCKET_INTR ) != 0U )
+                {
+                    if( ( xEventBits & ( EventBits_t ) eSOCKET_RECEIVE ) != 0U )
+                    {
+                        /* Shouldn't have cleared the eSOCKET_RECEIVE flag. */
+                        ( void ) xEventGroupSetBits( pxSocket->xEventGroup, ( EventBits_t ) eSOCKET_RECEIVE );
+                    }
 
-		lPacketCount = ( BaseType_t ) listCURRENT_LIST_LENGTH( &( pxSocket->u.xUDP.xWaitingPacketsList ) );
+                    break;
+                }
+            }
+        #else /* if ( ipconfigSUPPORT_SIGNALS != 0 ) */
+            {
+                ( void ) xEventBits;
+            }
+        #endif /* ipconfigSUPPORT_SIGNALS */
 
-		if( lPacketCount != 0 )
-		{
-			break;
-		}
+        lPacketCount = ( BaseType_t ) listCURRENT_LIST_LENGTH( &( pxSocket->u.xUDP.xWaitingPacketsList ) );
 
-		/* Has the timeout been reached ? */
-		if( xTaskCheckForTimeOut( &xTimeOut, &xRemainingTime ) != pdFALSE )
-		{
-			break;
-		}
-	} /* while( lPacketCount == 0 ) */
+        if( lPacketCount != 0 )
+        {
+            break;
+        }
 
-	if( lPacketCount != 0 )
-	{
-		taskENTER_CRITICAL();
-		{
-			/* The owner of the list item is the network buffer. */
-			pxNetworkBuffer = ipPOINTER_CAST( NetworkBufferDescriptor_t *, listGET_OWNER_OF_HEAD_ENTRY( &( pxSocket->u.xUDP.xWaitingPacketsList ) ) );
+        /* Has the timeout been reached ? */
+        if( xTaskCheckForTimeOut( &xTimeOut, &xRemainingTime ) != pdFALSE )
+        {
+            break;
+        }
+    } /* while( lPacketCount == 0 ) */
 
-			if( ( ( UBaseType_t ) xFlags & ( UBaseType_t ) FREERTOS_MSG_PEEK ) == 0U )
-			{
-				/* Remove the network buffer from the list of buffers waiting to
-				be processed by the socket. */
-				( void ) uxListRemove( &( pxNetworkBuffer->xBufferListItem ) );
-			}
-		}
-		taskEXIT_CRITICAL();
+    if( lPacketCount != 0 )
+    {
+        taskENTER_CRITICAL();
+        {
+            /* The owner of the list item is the network buffer. */
+            pxNetworkBuffer = ipPOINTER_CAST( NetworkBufferDescriptor_t *, listGET_OWNER_OF_HEAD_ENTRY( &( pxSocket->u.xUDP.xWaitingPacketsList ) ) );
 
-		/* The returned value is the length of the payload data, which is
-		calculated at the total packet size minus the headers.
-		The validity of `xDataLength` prvProcessIPPacket has been confirmed
-		in 'prvProcessIPPacket()'. */
-		lReturn = ( int32_t ) ( pxNetworkBuffer->xDataLength - sizeof( UDPPacket_t ) );
+            if( ( ( UBaseType_t ) xFlags & ( UBaseType_t ) FREERTOS_MSG_PEEK ) == 0U )
+            {
+                /* Remove the network buffer from the list of buffers waiting to
+                 * be processed by the socket. */
+                ( void ) uxListRemove( &( pxNetworkBuffer->xBufferListItem ) );
+            }
+        }
+        taskEXIT_CRITICAL();
 
-		if( pxSourceAddress != NULL )
-		{
-			pxSourceAddress->sin_port = pxNetworkBuffer->usPort;
-			pxSourceAddress->sin_addr = pxNetworkBuffer->ulIPAddress;
-		}
+        /* The returned value is the length of the payload data, which is
+         * calculated at the total packet size minus the headers.
+         * The validity of `xDataLength` prvProcessIPPacket has been confirmed
+         * in 'prvProcessIPPacket()'. */
+        lReturn = ( int32_t ) ( pxNetworkBuffer->xDataLength - sizeof( UDPPacket_t ) );
 
-		if( ( ( UBaseType_t ) xFlags & ( UBaseType_t ) FREERTOS_ZERO_COPY ) == 0U )
-		{
-			/* The zero copy flag is not set.  Truncate the length if it won't
-			fit in the provided buffer. */
-			if( lReturn > ( int32_t ) uxBufferLength )
-			{
-				iptraceRECVFROM_DISCARDING_BYTES( ( uxBufferLength - lReturn ) );
-				lReturn = ( int32_t ) uxBufferLength;
-			}
+        if( pxSourceAddress != NULL )
+        {
+            pxSourceAddress->sin_port = pxNetworkBuffer->usPort;
+            pxSourceAddress->sin_addr = pxNetworkBuffer->ulIPAddress;
+        }
 
-			/* Copy the received data into the provided buffer, then release the
-			network buffer. */
-			( void ) memcpy( pvBuffer, &( pxNetworkBuffer->pucEthernetBuffer[ ipUDP_PAYLOAD_OFFSET_IPv4 ] ), ( size_t )lReturn );
+        if( ( ( UBaseType_t ) xFlags & ( UBaseType_t ) FREERTOS_ZERO_COPY ) == 0U )
+        {
+            /* The zero copy flag is not set.  Truncate the length if it won't
+             * fit in the provided buffer. */
+            if( lReturn > ( int32_t ) uxBufferLength )
+            {
+                iptraceRECVFROM_DISCARDING_BYTES( ( uxBufferLength - lReturn ) );
+                lReturn = ( int32_t ) uxBufferLength;
+            }
 
-			if( ( ( UBaseType_t ) xFlags & ( UBaseType_t ) FREERTOS_MSG_PEEK ) == 0U )
-			{
-				vReleaseNetworkBufferAndDescriptor( pxNetworkBuffer );
-			}
-		}
-		else
-		{
-			/* The zero copy flag was set.  pvBuffer is not a buffer into which
-			the received data can be copied, but a pointer that must be set to
-			point to the buffer in which the received data has already been
-			placed. */
-			/* 9079: (Note -- conversion from pointer to void to pointer to other type [MISRA 2012 Rule 11.5, advisory]) */
-			/* 9087: (Note -- cast performed between a pointer to object type and a pointer to a different object type [MISRA 2012 Rule 11.3, required]) */
-			*( ( void** ) pvBuffer ) = ipPOINTER_CAST( void *, &( pxNetworkBuffer->pucEthernetBuffer[ ipUDP_PAYLOAD_OFFSET_IPv4 ] ) );
-		}
+            /* Copy the received data into the provided buffer, then release the
+             * network buffer. */
+            ( void ) memcpy( pvBuffer, &( pxNetworkBuffer->pucEthernetBuffer[ ipUDP_PAYLOAD_OFFSET_IPv4 ] ), ( size_t ) lReturn );
 
-	}
-#if( ipconfigSUPPORT_SIGNALS != 0 )
-	else if( ( xEventBits & ( EventBits_t ) eSOCKET_INTR ) != 0U )
-	{
-		lReturn = -pdFREERTOS_ERRNO_EINTR;
-		iptraceRECVFROM_INTERRUPTED();
-	}
-#endif /* ipconfigSUPPORT_SIGNALS */
-	else
-	{
-		lReturn = -pdFREERTOS_ERRNO_EWOULDBLOCK;
-		iptraceRECVFROM_TIMEOUT();
-	}
+            if( ( ( UBaseType_t ) xFlags & ( UBaseType_t ) FREERTOS_MSG_PEEK ) == 0U )
+            {
+                vReleaseNetworkBufferAndDescriptor( pxNetworkBuffer );
+            }
+        }
+        else
+        {
+            /* The zero copy flag was set.  pvBuffer is not a buffer into which
+             * the received data can be copied, but a pointer that must be set to
+             * point to the buffer in which the received data has already been
+             * placed. */
+            /* 9079: (Note -- conversion from pointer to void to pointer to other type [MISRA 2012 Rule 11.5, advisory]) */
+            /* 9087: (Note -- cast performed between a pointer to object type and a pointer to a different object type [MISRA 2012 Rule 11.3, required]) */
+            *( ( void ** ) pvBuffer ) = ipPOINTER_CAST( void *, &( pxNetworkBuffer->pucEthernetBuffer[ ipUDP_PAYLOAD_OFFSET_IPv4 ] ) );
+        }
+    }
 
-	return lReturn;
+    #if ( ipconfigSUPPORT_SIGNALS != 0 )
+        else if( ( xEventBits & ( EventBits_t ) eSOCKET_INTR ) != 0U )
+        {
+            lReturn = -pdFREERTOS_ERRNO_EINTR;
+            iptraceRECVFROM_INTERRUPTED();
+        }
+    #endif /* ipconfigSUPPORT_SIGNALS */
+    else
+    {
+        lReturn = -pdFREERTOS_ERRNO_EWOULDBLOCK;
+        iptraceRECVFROM_TIMEOUT();
+    }
+
+    return lReturn;
 }
 /*-----------------------------------------------------------*/
 
-int32_t FreeRTOS_sendto( Socket_t xSocket, const void *pvBuffer, size_t uxTotalDataLength, BaseType_t xFlags, const struct freertos_sockaddr *pxDestinationAddress, socklen_t xDestinationAddressLength )
+int32_t FreeRTOS_sendto( Socket_t xSocket,
+                         const void * pvBuffer,
+                         size_t uxTotalDataLength,
+                         BaseType_t xFlags,
+                         const struct freertos_sockaddr * pxDestinationAddress,
+                         socklen_t xDestinationAddressLength )
 {
-NetworkBufferDescriptor_t *pxNetworkBuffer;
-IPStackEvent_t xStackTxEvent = { eStackTxEvent, NULL };
-TimeOut_t xTimeOut;
-TickType_t xTicksToWait;
-int32_t lReturn = 0;
-FreeRTOS_Socket_t const * pxSocket;
-const size_t uxMaxPayloadLength = ( size_t ) ipMAX_UDP_PAYLOAD_LENGTH;
-const size_t uxPayloadOffset = ( size_t ) ipUDP_PAYLOAD_OFFSET_IPv4;
+    NetworkBufferDescriptor_t * pxNetworkBuffer;
+    IPStackEvent_t xStackTxEvent = { eStackTxEvent, NULL };
+    TimeOut_t xTimeOut;
+    TickType_t xTicksToWait;
+    int32_t lReturn = 0;
+    FreeRTOS_Socket_t const * pxSocket;
+    const size_t uxMaxPayloadLength = ( size_t ) ipMAX_UDP_PAYLOAD_LENGTH;
+    const size_t uxPayloadOffset = ( size_t ) ipUDP_PAYLOAD_OFFSET_IPv4;
 
 
-	pxSocket = ( FreeRTOS_Socket_t * ) xSocket;
+    pxSocket = ( FreeRTOS_Socket_t * ) xSocket;
 
-	/* The function prototype is designed to maintain the expected Berkeley
-	sockets standard, but this implementation does not use all the
-	parameters. */
-	( void ) xDestinationAddressLength;
-	configASSERT( pvBuffer != NULL );
+    /* The function prototype is designed to maintain the expected Berkeley
+     * sockets standard, but this implementation does not use all the
+     * parameters. */
+    ( void ) xDestinationAddressLength;
+    configASSERT( pvBuffer != NULL );
 
-	if( uxTotalDataLength <= ( size_t ) uxMaxPayloadLength )
-	{
-		/* If the socket is not already bound to an address, bind it now.
-		Passing NULL as the address parameter tells FreeRTOS_bind() to select
-		the address to bind to. */
-		if( socketSOCKET_IS_BOUND( pxSocket ) ||
-			( FreeRTOS_bind( xSocket, NULL, 0U ) == 0 ) )
-		{
-			xTicksToWait = pxSocket->xSendBlockTime;
+    if( uxTotalDataLength <= ( size_t ) uxMaxPayloadLength )
+    {
+        /* If the socket is not already bound to an address, bind it now.
+         * Passing NULL as the address parameter tells FreeRTOS_bind() to select
+         * the address to bind to. */
+        if( socketSOCKET_IS_BOUND( pxSocket ) ||
+            ( FreeRTOS_bind( xSocket, NULL, 0U ) == 0 ) )
+        {
+            xTicksToWait = pxSocket->xSendBlockTime;
 
-			#if( ipconfigUSE_CALLBACKS != 0 )
-			{
-				if( xIsCallingFromIPTask() != pdFALSE )
-				{
-					/* If this send function is called from within a call-back
-					handler it may not block, otherwise chances would be big to
-					get a deadlock: the IP-task waiting for itself. */
-					xTicksToWait = ( TickType_t )0;
-				}
-			}
-			#endif /* ipconfigUSE_CALLBACKS */
+            #if ( ipconfigUSE_CALLBACKS != 0 )
+                {
+                    if( xIsCallingFromIPTask() != pdFALSE )
+                    {
+                        /* If this send function is called from within a call-back
+                         * handler it may not block, otherwise chances would be big to
+                         * get a deadlock: the IP-task waiting for itself. */
+                        xTicksToWait = ( TickType_t ) 0;
+                    }
+                }
+            #endif /* ipconfigUSE_CALLBACKS */
 
-			if( ( ( UBaseType_t ) xFlags & ( UBaseType_t ) FREERTOS_MSG_DONTWAIT ) != 0U )
-			{
-				xTicksToWait = ( TickType_t ) 0;
-			}
+            if( ( ( UBaseType_t ) xFlags & ( UBaseType_t ) FREERTOS_MSG_DONTWAIT ) != 0U )
+            {
+                xTicksToWait = ( TickType_t ) 0;
+            }
 
-			if( ( ( UBaseType_t ) xFlags & ( UBaseType_t ) FREERTOS_ZERO_COPY ) == 0U )
-			{
-				/* Zero copy is not set, so obtain a network buffer into
-				which the payload will be copied. */
-				vTaskSetTimeOutState( &xTimeOut );
+            if( ( ( UBaseType_t ) xFlags & ( UBaseType_t ) FREERTOS_ZERO_COPY ) == 0U )
+            {
+                /* Zero copy is not set, so obtain a network buffer into
+                 * which the payload will be copied. */
+                vTaskSetTimeOutState( &xTimeOut );
 
-				/* Block until a buffer becomes available, or until a
-				timeout has been reached */
-				pxNetworkBuffer = pxGetNetworkBufferWithDescriptor( uxPayloadOffset + uxTotalDataLength, xTicksToWait );
+                /* Block until a buffer becomes available, or until a
+                 * timeout has been reached */
+                pxNetworkBuffer = pxGetNetworkBufferWithDescriptor( uxPayloadOffset + uxTotalDataLength, xTicksToWait );
 
-				if( pxNetworkBuffer != NULL )
-				{
-					( void ) memcpy( &( pxNetworkBuffer->pucEthernetBuffer[ uxPayloadOffset ] ), pvBuffer, uxTotalDataLength );
+                if( pxNetworkBuffer != NULL )
+                {
+                    ( void ) memcpy( &( pxNetworkBuffer->pucEthernetBuffer[ uxPayloadOffset ] ), pvBuffer, uxTotalDataLength );
 
-					if( xTaskCheckForTimeOut( &xTimeOut, &xTicksToWait ) == pdTRUE )
-					{
-						/* The entire block time has been used up. */
-						xTicksToWait = ( TickType_t ) 0;
-					}
-				}
-			}
-			else
-			{
-				/* When zero copy is used, pvBuffer is a pointer to the
-				payload of a buffer that has already been obtained from the
-				stack.  Obtain the network buffer pointer from the buffer. */
-				pxNetworkBuffer = pxUDPPayloadBuffer_to_NetworkBuffer( ( void * ) pvBuffer );
-			}
+                    if( xTaskCheckForTimeOut( &xTimeOut, &xTicksToWait ) == pdTRUE )
+                    {
+                        /* The entire block time has been used up. */
+                        xTicksToWait = ( TickType_t ) 0;
+                    }
+                }
+            }
+            else
+            {
+                /* When zero copy is used, pvBuffer is a pointer to the
+                 * payload of a buffer that has already been obtained from the
+                 * stack.  Obtain the network buffer pointer from the buffer. */
+                pxNetworkBuffer = pxUDPPayloadBuffer_to_NetworkBuffer( ( void * ) pvBuffer );
+            }
 
-			if( pxNetworkBuffer != NULL )
-			{
-				/* xDataLength is the size of the total packet, including the Ethernet header. */
-				pxNetworkBuffer->xDataLength = uxTotalDataLength + sizeof( UDPPacket_t );
-				pxNetworkBuffer->usPort = pxDestinationAddress->sin_port;
-				pxNetworkBuffer->usBoundPort = ( uint16_t ) socketGET_SOCKET_PORT( pxSocket );
-				pxNetworkBuffer->ulIPAddress = pxDestinationAddress->sin_addr;
+            if( pxNetworkBuffer != NULL )
+            {
+                /* xDataLength is the size of the total packet, including the Ethernet header. */
+                pxNetworkBuffer->xDataLength = uxTotalDataLength + sizeof( UDPPacket_t );
+                pxNetworkBuffer->usPort = pxDestinationAddress->sin_port;
+                pxNetworkBuffer->usBoundPort = ( uint16_t ) socketGET_SOCKET_PORT( pxSocket );
+                pxNetworkBuffer->ulIPAddress = pxDestinationAddress->sin_addr;
 
-				/* The socket options are passed to the IP layer in the
-				space that will eventually get used by the Ethernet header. */
-				pxNetworkBuffer->pucEthernetBuffer[ ipSOCKET_OPTIONS_OFFSET ] = pxSocket->ucSocketOptions;
+                /* The socket options are passed to the IP layer in the
+                 * space that will eventually get used by the Ethernet header. */
+                pxNetworkBuffer->pucEthernetBuffer[ ipSOCKET_OPTIONS_OFFSET ] = pxSocket->ucSocketOptions;
 
-				/* Tell the networking task that the packet needs sending. */
-				xStackTxEvent.pvData = pxNetworkBuffer;
+                /* Tell the networking task that the packet needs sending. */
+                xStackTxEvent.pvData = pxNetworkBuffer;
 
-				/* Ask the IP-task to send this packet */
-				if( xSendEventStructToIPTask( &xStackTxEvent, xTicksToWait ) == pdPASS )
-				{
-					/* The packet was successfully sent to the IP task. */
-					lReturn = ( int32_t ) uxTotalDataLength;
-					#if( ipconfigUSE_CALLBACKS == 1 )
-					{
-						if( ipconfigIS_VALID_PROG_ADDRESS( pxSocket->u.xUDP.pxHandleSent ) )
-						{
-							pxSocket->u.xUDP.pxHandleSent( xSocket, uxTotalDataLength );
-						}
-					}
-					#endif /* ipconfigUSE_CALLBACKS */
-				}
-				else
-				{
-					/* If the buffer was allocated in this function, release
-					it. */
-					if( ( ( UBaseType_t ) xFlags & ( UBaseType_t ) FREERTOS_ZERO_COPY ) == 0U )
-					{
-						vReleaseNetworkBufferAndDescriptor( pxNetworkBuffer );
-					}
-					iptraceSTACK_TX_EVENT_LOST( ipSTACK_TX_EVENT );
-				}
-			}
-			else
-			{
-				/* If errno was available, errno would be set to
-				FREERTOS_ENOPKTS.  As it is, the function must return the
-				number of transmitted bytes, so the calling function knows
-				how	much data was actually sent. */
-				iptraceNO_BUFFER_FOR_SENDTO();
-			}
-		}
-		else
-		{
-			/* No comment. */
-			iptraceSENDTO_SOCKET_NOT_BOUND();
-		}
-	}
-	else
-	{
-		/* The data is longer than the available buffer space. */
-		iptraceSENDTO_DATA_TOO_LONG();
-	}
+                /* Ask the IP-task to send this packet */
+                if( xSendEventStructToIPTask( &xStackTxEvent, xTicksToWait ) == pdPASS )
+                {
+                    /* The packet was successfully sent to the IP task. */
+                    lReturn = ( int32_t ) uxTotalDataLength;
+                    #if ( ipconfigUSE_CALLBACKS == 1 )
+                        {
+                            if( ipconfigIS_VALID_PROG_ADDRESS( pxSocket->u.xUDP.pxHandleSent ) )
+                            {
+                                pxSocket->u.xUDP.pxHandleSent( xSocket, uxTotalDataLength );
+                            }
+                        }
+                    #endif /* ipconfigUSE_CALLBACKS */
+                }
+                else
+                {
+                    /* If the buffer was allocated in this function, release
+                     * it. */
+                    if( ( ( UBaseType_t ) xFlags & ( UBaseType_t ) FREERTOS_ZERO_COPY ) == 0U )
+                    {
+                        vReleaseNetworkBufferAndDescriptor( pxNetworkBuffer );
+                    }
 
-	return lReturn;
+                    iptraceSTACK_TX_EVENT_LOST( ipSTACK_TX_EVENT );
+                }
+            }
+            else
+            {
+                /* If errno was available, errno would be set to
+                 * FREERTOS_ENOPKTS.  As it is, the function must return the
+                 * number of transmitted bytes, so the calling function knows
+                 * how	much data was actually sent. */
+                iptraceNO_BUFFER_FOR_SENDTO();
+            }
+        }
+        else
+        {
+            /* No comment. */
+            iptraceSENDTO_SOCKET_NOT_BOUND();
+        }
+    }
+    else
+    {
+        /* The data is longer than the available buffer space. */
+        iptraceSENDTO_DATA_TOO_LONG();
+    }
+
+    return lReturn;
 } /* Tested */
 /*-----------------------------------------------------------*/
 
@@ -951,66 +1000,71 @@ const size_t uxPayloadOffset = ( size_t ) ipUDP_PAYLOAD_OFFSET_IPv4;
  * by the IP-task to avoid mutual access to the bound-socket-lists
  * (xBoundUDPSocketsList or xBoundTCPSocketsList).
  */
-BaseType_t FreeRTOS_bind( Socket_t xSocket, struct freertos_sockaddr const * pxAddress, socklen_t xAddressLength )
+BaseType_t FreeRTOS_bind( Socket_t xSocket,
+                          struct freertos_sockaddr const * pxAddress,
+                          socklen_t xAddressLength )
 {
-IPStackEvent_t xBindEvent;
-FreeRTOS_Socket_t *pxSocket = ( FreeRTOS_Socket_t * ) xSocket;
-BaseType_t xReturn = 0;
+    IPStackEvent_t xBindEvent;
+    FreeRTOS_Socket_t * pxSocket = ( FreeRTOS_Socket_t * ) xSocket;
+    BaseType_t xReturn = 0;
 
-	( void ) xAddressLength;
+    ( void ) xAddressLength;
 
-	configASSERT( xIsCallingFromIPTask() == pdFALSE );
+    configASSERT( xIsCallingFromIPTask() == pdFALSE );
 
-	if( ( pxSocket == NULL ) || ( pxSocket == FREERTOS_INVALID_SOCKET ) )
-	{
-		xReturn = -pdFREERTOS_ERRNO_EINVAL;
-	}
-	/* Once a socket is bound to a port, it can not be bound to a different
-	port number */
-	else if( socketSOCKET_IS_BOUND( pxSocket) )
-	{
-		/* The socket is already bound. */
-		FreeRTOS_debug_printf( ( "vSocketBind: Socket already bound to %d\n", pxSocket->usLocalPort ) );
-		xReturn = -pdFREERTOS_ERRNO_EINVAL;
-	}
-	else
-	{
-		/* Prepare a messages to the IP-task in order to perform the binding.
-		The desired port number will be passed in usLocalPort. */
-		xBindEvent.eEventType = eSocketBindEvent;
-		xBindEvent.pvData = xSocket;
-		if( pxAddress != NULL )
-		{
-			pxSocket->usLocalPort = FreeRTOS_ntohs( pxAddress->sin_port );
-		}
-		else
-		{
-			/* Caller wants to bind to a random port number. */
-			pxSocket->usLocalPort = 0U;
-		}
+    if( ( pxSocket == NULL ) || ( pxSocket == FREERTOS_INVALID_SOCKET ) )
+    {
+        xReturn = -pdFREERTOS_ERRNO_EINVAL;
+    }
 
-		/* portMAX_DELAY is used as a the time-out parameter, as binding *must*
-		succeed before the socket can be used.  _RB_ The use of an infinite
-		block time needs be changed as it could result in the task hanging. */
-		if( xSendEventStructToIPTask( &xBindEvent, ( TickType_t ) portMAX_DELAY ) == pdFAIL )
-		{
-			/* Failed to wake-up the IP-task, no use to wait for it */
-			FreeRTOS_debug_printf( ( "FreeRTOS_bind: send event failed\n" ) );
-			xReturn = -pdFREERTOS_ERRNO_ECANCELED;
-		}
-		else
-		{
-			/* The IP-task will set the 'eSOCKET_BOUND' bit when it has done its
-			job. */
-			( void ) xEventGroupWaitBits( pxSocket->xEventGroup, ( EventBits_t ) eSOCKET_BOUND, pdTRUE /*xClearOnExit*/, pdFALSE /*xWaitAllBits*/, portMAX_DELAY );
-			if( !socketSOCKET_IS_BOUND( pxSocket ) )
-			{
-				xReturn = -pdFREERTOS_ERRNO_EINVAL;
-			}
-		}
-	}
+    /* Once a socket is bound to a port, it can not be bound to a different
+     * port number */
+    else if( socketSOCKET_IS_BOUND( pxSocket ) )
+    {
+        /* The socket is already bound. */
+        FreeRTOS_debug_printf( ( "vSocketBind: Socket already bound to %d\n", pxSocket->usLocalPort ) );
+        xReturn = -pdFREERTOS_ERRNO_EINVAL;
+    }
+    else
+    {
+        /* Prepare a messages to the IP-task in order to perform the binding.
+         * The desired port number will be passed in usLocalPort. */
+        xBindEvent.eEventType = eSocketBindEvent;
+        xBindEvent.pvData = xSocket;
 
-	return xReturn;
+        if( pxAddress != NULL )
+        {
+            pxSocket->usLocalPort = FreeRTOS_ntohs( pxAddress->sin_port );
+        }
+        else
+        {
+            /* Caller wants to bind to a random port number. */
+            pxSocket->usLocalPort = 0U;
+        }
+
+        /* portMAX_DELAY is used as a the time-out parameter, as binding *must*
+         * succeed before the socket can be used.  _RB_ The use of an infinite
+         * block time needs be changed as it could result in the task hanging. */
+        if( xSendEventStructToIPTask( &xBindEvent, ( TickType_t ) portMAX_DELAY ) == pdFAIL )
+        {
+            /* Failed to wake-up the IP-task, no use to wait for it */
+            FreeRTOS_debug_printf( ( "FreeRTOS_bind: send event failed\n" ) );
+            xReturn = -pdFREERTOS_ERRNO_ECANCELED;
+        }
+        else
+        {
+            /* The IP-task will set the 'eSOCKET_BOUND' bit when it has done its
+             * job. */
+            ( void ) xEventGroupWaitBits( pxSocket->xEventGroup, ( EventBits_t ) eSOCKET_BOUND, pdTRUE /*xClearOnExit*/, pdFALSE /*xWaitAllBits*/, portMAX_DELAY );
+
+            if( !socketSOCKET_IS_BOUND( pxSocket ) )
+            {
+                xReturn = -pdFREERTOS_ERRNO_EINVAL;
+            }
+        }
+    }
+
+    return xReturn;
 }
 
 /*
@@ -1018,128 +1072,134 @@ BaseType_t xReturn = 0;
  * 'xInternal' is used for TCP sockets only: it allows to have several
  * (connected) child sockets bound to the same server port.
  */
-BaseType_t vSocketBind( FreeRTOS_Socket_t *pxSocket, struct freertos_sockaddr * pxBindAddress, size_t uxAddressLength, BaseType_t xInternal )
+BaseType_t vSocketBind( FreeRTOS_Socket_t * pxSocket,
+                        struct freertos_sockaddr * pxBindAddress,
+                        size_t uxAddressLength,
+                        BaseType_t xInternal )
 {
-BaseType_t xReturn = 0; /* In Berkeley sockets, 0 means pass for bind(). */
-List_t *pxSocketList;
-struct freertos_sockaddr * pxAddress = pxBindAddress;
-#if( ipconfigALLOW_SOCKET_SEND_WITHOUT_BIND == 1 )
-	struct freertos_sockaddr xAddress;
-#endif /* ipconfigALLOW_SOCKET_SEND_WITHOUT_BIND */
+    BaseType_t xReturn = 0; /* In Berkeley sockets, 0 means pass for bind(). */
+    List_t * pxSocketList;
+    struct freertos_sockaddr * pxAddress = pxBindAddress;
 
-#if( ipconfigUSE_TCP == 1 )
-	if( pxSocket->ucProtocol == ( uint8_t ) FREERTOS_IPPROTO_TCP )
-	{
-		pxSocketList = &xBoundTCPSocketsList;
-	}
-	else
-#endif  /* ipconfigUSE_TCP == 1 */
-	{
-		pxSocketList = &xBoundUDPSocketsList;
-	}
+    #if ( ipconfigALLOW_SOCKET_SEND_WITHOUT_BIND == 1 )
+        struct freertos_sockaddr xAddress;
+    #endif /* ipconfigALLOW_SOCKET_SEND_WITHOUT_BIND */
 
-	/* The function prototype is designed to maintain the expected Berkeley
-	sockets standard, but this implementation does not use all the parameters. */
-	( void ) uxAddressLength;
+    #if ( ipconfigUSE_TCP == 1 )
+        if( pxSocket->ucProtocol == ( uint8_t ) FREERTOS_IPPROTO_TCP )
+        {
+            pxSocketList = &xBoundTCPSocketsList;
+        }
+        else
+    #endif /* ipconfigUSE_TCP == 1 */
+    {
+        pxSocketList = &xBoundUDPSocketsList;
+    }
 
-	configASSERT( pxSocket != NULL );
-	configASSERT( pxSocket != FREERTOS_INVALID_SOCKET );
+    /* The function prototype is designed to maintain the expected Berkeley
+     * sockets standard, but this implementation does not use all the parameters. */
+    ( void ) uxAddressLength;
 
-	#if( ipconfigALLOW_SOCKET_SEND_WITHOUT_BIND == 1 )
-	{
-		/* pxAddress will be NULL if sendto() was called on a socket without the
-		socket being bound to an address. In this case, automatically allocate
-		an address to the socket.  There is a small chance that the allocated
-		port will already be in use - if that is the case, then the check below
-		[pxListFindListItemWithValue()] will result in an error being returned. */
-		if( pxAddress == NULL )
-		{
-			pxAddress = &xAddress;
-			/* Put the port to zero to be assigned later. */
-			pxAddress->sin_port = 0U;
-		}
-	}
-	#endif /* ipconfigALLOW_SOCKET_SEND_WITHOUT_BIND == 1 */
+    configASSERT( pxSocket != NULL );
+    configASSERT( pxSocket != FREERTOS_INVALID_SOCKET );
 
-	/* Sockets must be bound before calling FreeRTOS_sendto() if
-	ipconfigALLOW_SOCKET_SEND_WITHOUT_BIND is not set to 1. */
-	configASSERT( pxAddress != NULL );
+    #if ( ipconfigALLOW_SOCKET_SEND_WITHOUT_BIND == 1 )
+        {
+            /* pxAddress will be NULL if sendto() was called on a socket without the
+             * socket being bound to an address. In this case, automatically allocate
+             * an address to the socket.  There is a small chance that the allocated
+             * port will already be in use - if that is the case, then the check below
+             * [pxListFindListItemWithValue()] will result in an error being returned. */
+            if( pxAddress == NULL )
+            {
+                pxAddress = &xAddress;
+                /* Put the port to zero to be assigned later. */
+                pxAddress->sin_port = 0U;
+            }
+        }
+    #endif /* ipconfigALLOW_SOCKET_SEND_WITHOUT_BIND == 1 */
 
-	#if( ipconfigALLOW_SOCKET_SEND_WITHOUT_BIND == 1 )
-	/* pxAddress is not NULL, no testing needed. */
-	#else
-	if( pxAddress != NULL )
-	#endif
-	{
-		if( pxAddress->sin_port == 0U )
-		{
-			pxAddress->sin_port = prvGetPrivatePortNumber( ( BaseType_t ) pxSocket->ucProtocol );
-			if( pxAddress->sin_port == ( uint16_t ) 0U )
-			{
-				return -pdFREERTOS_ERRNO_EADDRNOTAVAIL;
-			}
-		}
+    /* Sockets must be bound before calling FreeRTOS_sendto() if
+    * ipconfigALLOW_SOCKET_SEND_WITHOUT_BIND is not set to 1. */
+    configASSERT( pxAddress != NULL );
 
-		/* If vSocketBind() is called from the API FreeRTOS_bind() it has been
-		confirmed that the socket was not yet bound to a port.  If it is called
-		from the IP-task, no such check is necessary. */
+    #if ( ipconfigALLOW_SOCKET_SEND_WITHOUT_BIND == 1 )
+        /* pxAddress is not NULL, no testing needed. */
+    #else
+        if( pxAddress != NULL )
+    #endif
+    {
+        if( pxAddress->sin_port == 0U )
+        {
+            pxAddress->sin_port = prvGetPrivatePortNumber( ( BaseType_t ) pxSocket->ucProtocol );
 
-		/* Check to ensure the port is not already in use.  If the bind is
-		called internally, a port MAY be used by more than one socket. */
-		if( ( ( xInternal == pdFALSE ) || ( pxSocket->ucProtocol != ( uint8_t ) FREERTOS_IPPROTO_TCP ) ) &&
-			( pxListFindListItemWithValue( pxSocketList, ( TickType_t ) pxAddress->sin_port ) != NULL ) )
-		{
-			FreeRTOS_debug_printf( ( "vSocketBind: %sP port %d in use\n",
-				( pxSocket->ucProtocol == ( uint8_t ) FREERTOS_IPPROTO_TCP ) ? "TC" : "UD",
-				FreeRTOS_ntohs( pxAddress->sin_port ) ) );
-			xReturn = -pdFREERTOS_ERRNO_EADDRINUSE;
-		}
-		else
-		{
-			/* Allocate the port number to the socket.
-			This macro will set 'xBoundSocketListItem->xItemValue' */
-			socketSET_SOCKET_PORT( pxSocket, pxAddress->sin_port );
+            if( pxAddress->sin_port == ( uint16_t ) 0U )
+            {
+                return -pdFREERTOS_ERRNO_EADDRNOTAVAIL;
+            }
+        }
 
-			/* And also store it in a socket field 'usLocalPort' in host-byte-order,
-			mostly used for logging and debugging purposes */
-			pxSocket->usLocalPort = FreeRTOS_ntohs( pxAddress->sin_port );
+        /* If vSocketBind() is called from the API FreeRTOS_bind() it has been
+         * confirmed that the socket was not yet bound to a port.  If it is called
+         * from the IP-task, no such check is necessary. */
 
-			/* Add the socket to the list of bound ports. */
-			{
-				/* If the network driver can iterate through 'xBoundUDPSocketsList',
-				by calling xPortHasUDPSocket() then the IP-task must temporarily
-				suspend the scheduler to keep the list in a consistent state. */
-				#if( ipconfigETHERNET_DRIVER_FILTERS_PACKETS == 1 )
-				{
-					vTaskSuspendAll();
-				}
-				#endif /* ipconfigETHERNET_DRIVER_FILTERS_PACKETS */
+        /* Check to ensure the port is not already in use.  If the bind is
+         * called internally, a port MAY be used by more than one socket. */
+        if( ( ( xInternal == pdFALSE ) || ( pxSocket->ucProtocol != ( uint8_t ) FREERTOS_IPPROTO_TCP ) ) &&
+            ( pxListFindListItemWithValue( pxSocketList, ( TickType_t ) pxAddress->sin_port ) != NULL ) )
+        {
+            FreeRTOS_debug_printf( ( "vSocketBind: %sP port %d in use\n",
+                                     ( pxSocket->ucProtocol == ( uint8_t ) FREERTOS_IPPROTO_TCP ) ? "TC" : "UD",
+                                     FreeRTOS_ntohs( pxAddress->sin_port ) ) );
+            xReturn = -pdFREERTOS_ERRNO_EADDRINUSE;
+        }
+        else
+        {
+            /* Allocate the port number to the socket.
+             * This macro will set 'xBoundSocketListItem->xItemValue' */
+            socketSET_SOCKET_PORT( pxSocket, pxAddress->sin_port );
 
-				/* Add the socket to 'xBoundUDPSocketsList' or 'xBoundTCPSocketsList' */
-				vListInsertEnd( pxSocketList, &( pxSocket->xBoundSocketListItem ) );
+            /* And also store it in a socket field 'usLocalPort' in host-byte-order,
+             * mostly used for logging and debugging purposes */
+            pxSocket->usLocalPort = FreeRTOS_ntohs( pxAddress->sin_port );
 
-				#if( ipconfigETHERNET_DRIVER_FILTERS_PACKETS == 1 )
-				{
-					( void ) xTaskResumeAll();
-				}
-				#endif /* ipconfigETHERNET_DRIVER_FILTERS_PACKETS */
-			}
-		}
-	}
-	#if( ipconfigALLOW_SOCKET_SEND_WITHOUT_BIND == 0 )
-	else
-	{
-		xReturn = -pdFREERTOS_ERRNO_EADDRNOTAVAIL;
-		FreeRTOS_debug_printf( ( "vSocketBind: Socket no addr\n" ) );
-	}
-	#endif
+            /* Add the socket to the list of bound ports. */
+            {
+                /* If the network driver can iterate through 'xBoundUDPSocketsList',
+                 * by calling xPortHasUDPSocket() then the IP-task must temporarily
+                 * suspend the scheduler to keep the list in a consistent state. */
+                #if ( ipconfigETHERNET_DRIVER_FILTERS_PACKETS == 1 )
+                    {
+                        vTaskSuspendAll();
+                    }
+                #endif /* ipconfigETHERNET_DRIVER_FILTERS_PACKETS */
 
-	if( xReturn != 0 )
-	{
-		iptraceBIND_FAILED( xSocket, ( FreeRTOS_ntohs( pxAddress->sin_port ) ) );
-	}
+                /* Add the socket to 'xBoundUDPSocketsList' or 'xBoundTCPSocketsList' */
+                vListInsertEnd( pxSocketList, &( pxSocket->xBoundSocketListItem ) );
 
-	return xReturn;
+                #if ( ipconfigETHERNET_DRIVER_FILTERS_PACKETS == 1 )
+                    {
+                        ( void ) xTaskResumeAll();
+                    }
+                #endif /* ipconfigETHERNET_DRIVER_FILTERS_PACKETS */
+            }
+        }
+    }
+
+    #if ( ipconfigALLOW_SOCKET_SEND_WITHOUT_BIND == 0 )
+        else
+        {
+            xReturn = -pdFREERTOS_ERRNO_EADDRNOTAVAIL;
+            FreeRTOS_debug_printf( ( "vSocketBind: Socket no addr\n" ) );
+        }
+    #endif
+
+    if( xReturn != 0 )
+    {
+        iptraceBIND_FAILED( xSocket, ( FreeRTOS_ntohs( pxAddress->sin_port ) ) );
+    }
+
+    return xReturn;
 } /* Tested */
 /*-----------------------------------------------------------*/
 
@@ -1151,582 +1211,604 @@ struct freertos_sockaddr * pxAddress = pxBindAddress;
  */
 BaseType_t FreeRTOS_closesocket( Socket_t xSocket )
 {
-BaseType_t xResult;
-#if( ipconfigUSE_TCP == 1 ) && ( ipconfigUSE_CALLBACKS == 1 )
-	FreeRTOS_Socket_t *pxSocket = ( FreeRTOS_Socket_t * )xSocket;
-#endif
-IPStackEvent_t xCloseEvent;
-xCloseEvent.eEventType = eSocketCloseEvent;
-xCloseEvent.pvData = xSocket;
+    BaseType_t xResult;
 
-	if( ( xSocket == NULL ) || ( xSocket == FREERTOS_INVALID_SOCKET ) )
-	{
-		xResult = 0;
-	}
-	else
-	{
-		#if( ( ipconfigUSE_TCP == 1 ) && ( ipconfigUSE_CALLBACKS == 1 ) )
-		{
-			if( pxSocket->ucProtocol == ( uint8_t ) FREERTOS_IPPROTO_TCP )
-			{
-				/* Make sure that IP-task won't call the user callback's anymore */
-				pxSocket->u.xTCP.pxHandleConnected = NULL;
-				pxSocket->u.xTCP.pxHandleReceive = NULL;
-				pxSocket->u.xTCP.pxHandleSent = NULL;
-			}
-		}
-		#endif  /* ( ( ipconfigUSE_TCP == 1 ) && ( ipconfigUSE_CALLBACKS == 1 ) ) */
+    #if ( ipconfigUSE_TCP == 1 ) && ( ipconfigUSE_CALLBACKS == 1 )
+        FreeRTOS_Socket_t * pxSocket = ( FreeRTOS_Socket_t * ) xSocket;
+    #endif
+    IPStackEvent_t xCloseEvent;
+    xCloseEvent.eEventType = eSocketCloseEvent;
+    xCloseEvent.pvData = xSocket;
 
-		/* Let the IP task close the socket to keep it synchronised	with the
-		packet handling. */
+    if( ( xSocket == NULL ) || ( xSocket == FREERTOS_INVALID_SOCKET ) )
+    {
+        xResult = 0;
+    }
+    else
+    {
+        #if ( ( ipconfigUSE_TCP == 1 ) && ( ipconfigUSE_CALLBACKS == 1 ) )
+            {
+                if( pxSocket->ucProtocol == ( uint8_t ) FREERTOS_IPPROTO_TCP )
+                {
+                    /* Make sure that IP-task won't call the user callback's anymore */
+                    pxSocket->u.xTCP.pxHandleConnected = NULL;
+                    pxSocket->u.xTCP.pxHandleReceive = NULL;
+                    pxSocket->u.xTCP.pxHandleSent = NULL;
+                }
+            }
+        #endif /* ( ( ipconfigUSE_TCP == 1 ) && ( ipconfigUSE_CALLBACKS == 1 ) ) */
 
-		/* Note when changing the time-out value below, it must be checked who is calling
-		this function. If it is called by the IP-task, a deadlock could occur.
-		The IP-task would only call it in case of a user call-back */
-		if( xSendEventStructToIPTask( &xCloseEvent, ( TickType_t ) 0 ) == pdFAIL )
-		{
-			FreeRTOS_debug_printf( ( "FreeRTOS_closesocket: failed\n" ) );
-			xResult = -1;
-		}
-		else
-		{
-			xResult = 1;
-		}
-	}
+        /* Let the IP task close the socket to keep it synchronised	with the
+         * packet handling. */
 
-	return xResult;
+        /* Note when changing the time-out value below, it must be checked who is calling
+         * this function. If it is called by the IP-task, a deadlock could occur.
+         * The IP-task would only call it in case of a user call-back */
+        if( xSendEventStructToIPTask( &xCloseEvent, ( TickType_t ) 0 ) == pdFAIL )
+        {
+            FreeRTOS_debug_printf( ( "FreeRTOS_closesocket: failed\n" ) );
+            xResult = -1;
+        }
+        else
+        {
+            xResult = 1;
+        }
+    }
+
+    return xResult;
 }
 
 /* This is the internal version of FreeRTOS_closesocket()
  * It will be called by the IPtask only to avoid problems with synchronicity
  */
-void *vSocketClose( FreeRTOS_Socket_t *pxSocket )
+void * vSocketClose( FreeRTOS_Socket_t * pxSocket )
 {
-NetworkBufferDescriptor_t *pxNetworkBuffer;
+    NetworkBufferDescriptor_t * pxNetworkBuffer;
 
-	#if( ipconfigUSE_TCP == 1 )
-	{
-		/* For TCP: clean up a little more. */
-		if( pxSocket->ucProtocol == ( uint8_t ) FREERTOS_IPPROTO_TCP )
-		{
-			#if( ipconfigUSE_TCP_WIN == 1 )
-			{
-				if( pxSocket->u.xTCP.pxAckMessage != NULL )
-				{
-					vReleaseNetworkBufferAndDescriptor( pxSocket->u.xTCP.pxAckMessage );
-				}
-				/* Free the resources which were claimed by the tcpWin member */
-				vTCPWindowDestroy( &pxSocket->u.xTCP.xTCPWindow );
-			}
-			#endif /* ipconfigUSE_TCP_WIN */
+    #if ( ipconfigUSE_TCP == 1 )
+        {
+            /* For TCP: clean up a little more. */
+            if( pxSocket->ucProtocol == ( uint8_t ) FREERTOS_IPPROTO_TCP )
+            {
+                #if ( ipconfigUSE_TCP_WIN == 1 )
+                    {
+                        if( pxSocket->u.xTCP.pxAckMessage != NULL )
+                        {
+                            vReleaseNetworkBufferAndDescriptor( pxSocket->u.xTCP.pxAckMessage );
+                        }
 
-			/* Free the input and output streams */
-			if( pxSocket->u.xTCP.rxStream != NULL )
-			{
-				iptraceMEM_STATS_DELETE( pxSocket->u.xTCP.rxStream );
-				vPortFreeLarge( pxSocket->u.xTCP.rxStream );
-			}
+                        /* Free the resources which were claimed by the tcpWin member */
+                        vTCPWindowDestroy( &pxSocket->u.xTCP.xTCPWindow );
+                    }
+                #endif /* ipconfigUSE_TCP_WIN */
 
-			if( pxSocket->u.xTCP.txStream != NULL )
-			{
-				iptraceMEM_STATS_DELETE( pxSocket->u.xTCP.txStream );
-				vPortFreeLarge( pxSocket->u.xTCP.txStream );
-			}
+                /* Free the input and output streams */
+                if( pxSocket->u.xTCP.rxStream != NULL )
+                {
+                    iptraceMEM_STATS_DELETE( pxSocket->u.xTCP.rxStream );
+                    vPortFreeLarge( pxSocket->u.xTCP.rxStream );
+                }
 
-			/* In case this is a child socket, make sure the child-count of the
-			parent socket is decreased. */
-			prvTCPSetSocketCount( pxSocket );
-		}
-	}
-	#endif  /* ipconfigUSE_TCP == 1 */
+                if( pxSocket->u.xTCP.txStream != NULL )
+                {
+                    iptraceMEM_STATS_DELETE( pxSocket->u.xTCP.txStream );
+                    vPortFreeLarge( pxSocket->u.xTCP.txStream );
+                }
 
-	/* Socket must be unbound first, to ensure no more packets are queued on
-	it. */
-	if( socketSOCKET_IS_BOUND( pxSocket ) )
-	{
-		/* If the network driver can iterate through 'xBoundUDPSocketsList',
-		by calling xPortHasUDPSocket(), then the IP-task must temporarily
-		suspend the scheduler to keep the list in a consistent state. */
-		#if( ipconfigETHERNET_DRIVER_FILTERS_PACKETS == 1 )
-		{
-			vTaskSuspendAll();
-		}
-		#endif /* ipconfigETHERNET_DRIVER_FILTERS_PACKETS */
+                /* In case this is a child socket, make sure the child-count of the
+                 * parent socket is decreased. */
+                prvTCPSetSocketCount( pxSocket );
+            }
+        }
+    #endif /* ipconfigUSE_TCP == 1 */
 
-		( void ) uxListRemove( &( pxSocket->xBoundSocketListItem ) );
+    /* Socket must be unbound first, to ensure no more packets are queued on
+     * it. */
+    if( socketSOCKET_IS_BOUND( pxSocket ) )
+    {
+        /* If the network driver can iterate through 'xBoundUDPSocketsList',
+         * by calling xPortHasUDPSocket(), then the IP-task must temporarily
+         * suspend the scheduler to keep the list in a consistent state. */
+        #if ( ipconfigETHERNET_DRIVER_FILTERS_PACKETS == 1 )
+            {
+                vTaskSuspendAll();
+            }
+        #endif /* ipconfigETHERNET_DRIVER_FILTERS_PACKETS */
 
-		#if( ipconfigETHERNET_DRIVER_FILTERS_PACKETS == 1 )
-		{
-			( void ) xTaskResumeAll();
-		}
-		#endif /* ipconfigETHERNET_DRIVER_FILTERS_PACKETS */
-	}
+        ( void ) uxListRemove( &( pxSocket->xBoundSocketListItem ) );
 
-	/* Now the socket is not bound the list of waiting packets can be
-	drained. */
-	if( pxSocket->ucProtocol == ( uint8_t ) FREERTOS_IPPROTO_UDP )
-	{
-		while( listCURRENT_LIST_LENGTH( &( pxSocket->u.xUDP.xWaitingPacketsList ) ) > 0U )
-		{
-			pxNetworkBuffer = ipPOINTER_CAST( NetworkBufferDescriptor_t *, listGET_OWNER_OF_HEAD_ENTRY( &( pxSocket->u.xUDP.xWaitingPacketsList ) ) );
-			( void ) uxListRemove( &( pxNetworkBuffer->xBufferListItem ) );
-			vReleaseNetworkBufferAndDescriptor( pxNetworkBuffer );
-		}
-	}
+        #if ( ipconfigETHERNET_DRIVER_FILTERS_PACKETS == 1 )
+            {
+                ( void ) xTaskResumeAll();
+            }
+        #endif /* ipconfigETHERNET_DRIVER_FILTERS_PACKETS */
+    }
 
-	if( pxSocket->xEventGroup != NULL )
-	{
-		vEventGroupDelete( pxSocket->xEventGroup );
-	}
+    /* Now the socket is not bound the list of waiting packets can be
+     * drained. */
+    if( pxSocket->ucProtocol == ( uint8_t ) FREERTOS_IPPROTO_UDP )
+    {
+        while( listCURRENT_LIST_LENGTH( &( pxSocket->u.xUDP.xWaitingPacketsList ) ) > 0U )
+        {
+            pxNetworkBuffer = ipPOINTER_CAST( NetworkBufferDescriptor_t *, listGET_OWNER_OF_HEAD_ENTRY( &( pxSocket->u.xUDP.xWaitingPacketsList ) ) );
+            ( void ) uxListRemove( &( pxNetworkBuffer->xBufferListItem ) );
+            vReleaseNetworkBufferAndDescriptor( pxNetworkBuffer );
+        }
+    }
 
-	#if( ipconfigUSE_TCP == 1 ) && ( ipconfigHAS_DEBUG_PRINTF != 0 )
-	{
-		if( pxSocket->ucProtocol == ( uint8_t ) FREERTOS_IPPROTO_TCP )
-		{
-			FreeRTOS_debug_printf( ( "FreeRTOS_closesocket[%u to %lxip:%u]: buffers %lu socks %lu\n",
-				pxSocket->usLocalPort,
-				pxSocket->u.xTCP.ulRemoteIP,
-				pxSocket->u.xTCP.usRemotePort,
-				uxGetNumberOfFreeNetworkBuffers(),
-				listCURRENT_LIST_LENGTH( &xBoundTCPSocketsList ) ) );
-		}
-	}
-	#endif /* ( ipconfigUSE_TCP == 1 ) && ( ipconfigHAS_DEBUG_PRINTF != 0 ) */
+    if( pxSocket->xEventGroup != NULL )
+    {
+        vEventGroupDelete( pxSocket->xEventGroup );
+    }
 
-	/* Anf finally, after all resources have been freed, free the socket space */
-	iptraceMEM_STATS_DELETE( pxSocket );
-	vPortFreeSocket( pxSocket );
+    #if ( ipconfigUSE_TCP == 1 ) && ( ipconfigHAS_DEBUG_PRINTF != 0 )
+        {
+            if( pxSocket->ucProtocol == ( uint8_t ) FREERTOS_IPPROTO_TCP )
+            {
+                FreeRTOS_debug_printf( ( "FreeRTOS_closesocket[%u to %lxip:%u]: buffers %lu socks %lu\n",
+                                         pxSocket->usLocalPort,
+                                         pxSocket->u.xTCP.ulRemoteIP,
+                                         pxSocket->u.xTCP.usRemotePort,
+                                         uxGetNumberOfFreeNetworkBuffers(),
+                                         listCURRENT_LIST_LENGTH( &xBoundTCPSocketsList ) ) );
+            }
+        }
+    #endif /* ( ipconfigUSE_TCP == 1 ) && ( ipconfigHAS_DEBUG_PRINTF != 0 ) */
 
-	return NULL;
+    /* Anf finally, after all resources have been freed, free the socket space */
+    iptraceMEM_STATS_DELETE( pxSocket );
+    vPortFreeSocket( pxSocket );
+
+    return NULL;
 } /* Tested */
 
 /*-----------------------------------------------------------*/
 
 #if ipconfigUSE_TCP == 1
 
-	/*
-	 * When a child socket gets closed, make sure to update the child-count of the
-	 * parent.  When a listening parent socket is closed, make sure no child-sockets
-	 * keep a pointer to it.
-	 */
-	static void prvTCPSetSocketCount( FreeRTOS_Socket_t const * pxSocketToDelete )
-	{
-	const ListItem_t *pxIterator;
-	const ListItem_t *pxEnd = ipPOINTER_CAST( const ListItem_t *, listGET_END_MARKER( &xBoundTCPSocketsList ) );
-	FreeRTOS_Socket_t *pxOtherSocket;
-	uint16_t usLocalPort = pxSocketToDelete->usLocalPort;
+    /*
+     * When a child socket gets closed, make sure to update the child-count of the
+     * parent.  When a listening parent socket is closed, make sure no child-sockets
+     * keep a pointer to it.
+     */
+    static void prvTCPSetSocketCount( FreeRTOS_Socket_t const * pxSocketToDelete )
+    {
+        const ListItem_t * pxIterator;
+        const ListItem_t * pxEnd = ipPOINTER_CAST( const ListItem_t *, listGET_END_MARKER( &xBoundTCPSocketsList ) );
+        FreeRTOS_Socket_t * pxOtherSocket;
+        uint16_t usLocalPort = pxSocketToDelete->usLocalPort;
 
-		for( pxIterator  = listGET_NEXT( pxEnd );
-			 pxIterator != pxEnd;
-			 pxIterator  = listGET_NEXT( pxIterator ) )
-		{
-			pxOtherSocket = ipPOINTER_CAST( FreeRTOS_Socket_t *, listGET_LIST_ITEM_OWNER( pxIterator ) );
-			if( ( pxOtherSocket->u.xTCP.ucTCPState == ( uint8_t ) eTCP_LISTEN ) &&
-				( pxOtherSocket->usLocalPort == usLocalPort ) &&
-				( pxOtherSocket->u.xTCP.usChildCount != 0U ) )
-			{
-				pxOtherSocket->u.xTCP.usChildCount--;
-				FreeRTOS_debug_printf( ( "Lost: Socket %u now has %u / %u child%s\n",
-					pxOtherSocket->usLocalPort,
-					pxOtherSocket->u.xTCP.usChildCount,
-					pxOtherSocket->u.xTCP.usBacklog,
-					( pxOtherSocket->u.xTCP.usChildCount == 1U ) ? "" : "ren" ) );
-				break;
-			}
-		}
-	}
+        for( pxIterator = listGET_NEXT( pxEnd );
+             pxIterator != pxEnd;
+             pxIterator = listGET_NEXT( pxIterator ) )
+        {
+            pxOtherSocket = ipPOINTER_CAST( FreeRTOS_Socket_t *, listGET_LIST_ITEM_OWNER( pxIterator ) );
+
+            if( ( pxOtherSocket->u.xTCP.ucTCPState == ( uint8_t ) eTCP_LISTEN ) &&
+                ( pxOtherSocket->usLocalPort == usLocalPort ) &&
+                ( pxOtherSocket->u.xTCP.usChildCount != 0U ) )
+            {
+                pxOtherSocket->u.xTCP.usChildCount--;
+                FreeRTOS_debug_printf( ( "Lost: Socket %u now has %u / %u child%s\n",
+                                         pxOtherSocket->usLocalPort,
+                                         pxOtherSocket->u.xTCP.usChildCount,
+                                         pxOtherSocket->u.xTCP.usBacklog,
+                                         ( pxOtherSocket->u.xTCP.usChildCount == 1U ) ? "" : "ren" ) );
+                break;
+            }
+        }
+    }
 
 #endif /* ipconfigUSE_TCP == 1 */
 
 /*-----------------------------------------------------------*/
 
-static BaseType_t prvSockopt_so_buffer( FreeRTOS_Socket_t *pxSocket, int32_t lOptionName, const void *pvOptionValue )
+static BaseType_t prvSockopt_so_buffer( FreeRTOS_Socket_t * pxSocket,
+                                        int32_t lOptionName,
+                                        const void * pvOptionValue )
 {
-uint32_t ulNewValue;
-BaseType_t xReturn;
+    uint32_t ulNewValue;
+    BaseType_t xReturn;
 
-	if( pxSocket->ucProtocol != ( uint8_t ) FREERTOS_IPPROTO_TCP )
-	{
-		FreeRTOS_debug_printf( ( "Set SO_%sBUF: wrong socket type\n",
-			( lOptionName == FREERTOS_SO_SNDBUF ) ? "SND" : "RCV" ) );
-		xReturn = -pdFREERTOS_ERRNO_EINVAL;
-	}
-	else
-	if( ( ( lOptionName == FREERTOS_SO_SNDBUF ) && ( pxSocket->u.xTCP.txStream != NULL ) ) ||
-		( ( lOptionName == FREERTOS_SO_RCVBUF ) && ( pxSocket->u.xTCP.rxStream != NULL ) ) )
-	{
-		FreeRTOS_debug_printf( ( "Set SO_%sBUF: buffer already created\n",
-			( lOptionName == FREERTOS_SO_SNDBUF ) ? "SND" : "RCV" ) );
-		xReturn = -pdFREERTOS_ERRNO_EINVAL;
-	}
-	else
-	{
-		ulNewValue = *( ipPOINTER_CAST( uint32_t *, pvOptionValue ) );
+    if( pxSocket->ucProtocol != ( uint8_t ) FREERTOS_IPPROTO_TCP )
+    {
+        FreeRTOS_debug_printf( ( "Set SO_%sBUF: wrong socket type\n",
+                                 ( lOptionName == FREERTOS_SO_SNDBUF ) ? "SND" : "RCV" ) );
+        xReturn = -pdFREERTOS_ERRNO_EINVAL;
+    }
+    else
+    if( ( ( lOptionName == FREERTOS_SO_SNDBUF ) && ( pxSocket->u.xTCP.txStream != NULL ) ) ||
+        ( ( lOptionName == FREERTOS_SO_RCVBUF ) && ( pxSocket->u.xTCP.rxStream != NULL ) ) )
+    {
+        FreeRTOS_debug_printf( ( "Set SO_%sBUF: buffer already created\n",
+                                 ( lOptionName == FREERTOS_SO_SNDBUF ) ? "SND" : "RCV" ) );
+        xReturn = -pdFREERTOS_ERRNO_EINVAL;
+    }
+    else
+    {
+        ulNewValue = *( ipPOINTER_CAST( uint32_t *, pvOptionValue ) );
 
-		if( lOptionName == FREERTOS_SO_SNDBUF )
-		{
-			/* Round up to nearest MSS size */
-			ulNewValue = FreeRTOS_round_up( ulNewValue, ( uint32_t ) pxSocket->u.xTCP.usInitMSS );
-			pxSocket->u.xTCP.uxTxStreamSize = ulNewValue;
-		}
-		else
-		{
-			pxSocket->u.xTCP.uxRxStreamSize = ulNewValue;
-		}
-		xReturn = 0;
-	}
+        if( lOptionName == FREERTOS_SO_SNDBUF )
+        {
+            /* Round up to nearest MSS size */
+            ulNewValue = FreeRTOS_round_up( ulNewValue, ( uint32_t ) pxSocket->u.xTCP.usInitMSS );
+            pxSocket->u.xTCP.uxTxStreamSize = ulNewValue;
+        }
+        else
+        {
+            pxSocket->u.xTCP.uxRxStreamSize = ulNewValue;
+        }
 
-	return xReturn;
+        xReturn = 0;
+    }
+
+    return xReturn;
 }
 /*-----------------------------------------------------------*/
 
 /* FreeRTOS_setsockopt calls itself, but in a very limited way,
-only when FREERTOS_SO_WIN_PROPERTIES is being set. */
-BaseType_t FreeRTOS_setsockopt( Socket_t xSocket, int32_t lLevel, int32_t lOptionName, const void *pvOptionValue, size_t uxOptionLength )
+ * only when FREERTOS_SO_WIN_PROPERTIES is being set. */
+BaseType_t FreeRTOS_setsockopt( Socket_t xSocket,
+                                int32_t lLevel,
+                                int32_t lOptionName,
+                                const void * pvOptionValue,
+                                size_t uxOptionLength )
 {
 /* The standard Berkeley function returns 0 for success. */
-BaseType_t xReturn = -pdFREERTOS_ERRNO_EINVAL;
-BaseType_t lOptionValue;
-FreeRTOS_Socket_t *pxSocket;
+    BaseType_t xReturn = -pdFREERTOS_ERRNO_EINVAL;
+    BaseType_t lOptionValue;
+    FreeRTOS_Socket_t * pxSocket;
 
-	pxSocket = ( FreeRTOS_Socket_t * ) xSocket;
+    pxSocket = ( FreeRTOS_Socket_t * ) xSocket;
 
-	/* The function prototype is designed to maintain the expected Berkeley
-	sockets standard, but this implementation does not use all the parameters. */
-	( void ) lLevel;
-	( void ) uxOptionLength;
-	
-	if( ( pxSocket == NULL ) || ( pxSocket == FREERTOS_INVALID_SOCKET ) )
-	{
-		xReturn = -pdFREERTOS_ERRNO_EINVAL;
-		return xReturn;
-	}
+    /* The function prototype is designed to maintain the expected Berkeley
+     * sockets standard, but this implementation does not use all the parameters. */
+    ( void ) lLevel;
+    ( void ) uxOptionLength;
 
-	switch( lOptionName )
-	{
-		case FREERTOS_SO_RCVTIMEO	:
-			/* Receive time out. */
-			pxSocket->xReceiveBlockTime = *( ipPOINTER_CAST( const TickType_t *, pvOptionValue ) );
-			xReturn = 0;
-			break;
+    if( ( pxSocket == NULL ) || ( pxSocket == FREERTOS_INVALID_SOCKET ) )
+    {
+        xReturn = -pdFREERTOS_ERRNO_EINVAL;
+        return xReturn;
+    }
 
-		case FREERTOS_SO_SNDTIMEO	:
-			pxSocket->xSendBlockTime = *( ipPOINTER_CAST( const TickType_t *, pvOptionValue ) );
-			if( pxSocket->ucProtocol == ( uint8_t ) FREERTOS_IPPROTO_UDP )
-			{
-				/* The send time out is capped for the reason stated in the
-				comments where ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS is defined
-				in FreeRTOSIPConfig.h (assuming an official configuration file
-				is being used. */
-				if( pxSocket->xSendBlockTime > ( ( TickType_t ) ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS ) )
-				{
-					pxSocket->xSendBlockTime = ( ( TickType_t ) ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS );
-				}
-			}
-			else
-			{
-				/* For TCP socket, it isn't necessary to limit the blocking time
-				because	the FreeRTOS_send() function does not wait for a network
-				buffer to become available. */
-			}
-			xReturn = 0;
-			break;
-		#if( ipconfigUDP_MAX_RX_PACKETS > 0U )
-			case FREERTOS_SO_UDP_MAX_RX_PACKETS:
-				if( pxSocket->ucProtocol != ( uint8_t ) FREERTOS_IPPROTO_UDP )
-				{
-					break;	/* will return -pdFREERTOS_ERRNO_EINVAL */
-				}
-				pxSocket->u.xUDP.uxMaxPackets = *( ( const UBaseType_t * ) pvOptionValue );
-				xReturn = 0;
-				break;
-		#endif /* ipconfigUDP_MAX_RX_PACKETS */
+    switch( lOptionName )
+    {
+        case FREERTOS_SO_RCVTIMEO:
+            /* Receive time out. */
+            pxSocket->xReceiveBlockTime = *( ipPOINTER_CAST( const TickType_t *, pvOptionValue ) );
+            xReturn = 0;
+            break;
 
-		case FREERTOS_SO_UDPCKSUM_OUT :
-			/* Turn calculating of the UDP checksum on/off for this socket. */
-			/* The expression "pvOptionValue" of type "void const *" is cast to type "BaseType_t". */
-			lOptionValue = ipNUMERIC_CAST( BaseType_t, pvOptionValue );
+        case FREERTOS_SO_SNDTIMEO:
+            pxSocket->xSendBlockTime = *( ipPOINTER_CAST( const TickType_t *, pvOptionValue ) );
 
-			if( lOptionValue == 0 )
-			{
-				pxSocket->ucSocketOptions &= ~( ( uint8_t ) FREERTOS_SO_UDPCKSUM_OUT );
-			}
-			else
-			{
-				pxSocket->ucSocketOptions |= ( uint8_t ) FREERTOS_SO_UDPCKSUM_OUT;
-			}
-			xReturn = 0;
-			break;
+            if( pxSocket->ucProtocol == ( uint8_t ) FREERTOS_IPPROTO_UDP )
+            {
+                /* The send time out is capped for the reason stated in the
+                 * comments where ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS is defined
+                 * in FreeRTOSIPConfig.h (assuming an official configuration file
+                 * is being used. */
+                if( pxSocket->xSendBlockTime > ( ( TickType_t ) ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS ) )
+                {
+                    pxSocket->xSendBlockTime = ( ( TickType_t ) ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS );
+                }
+            }
+            else
+            {
+                /* For TCP socket, it isn't necessary to limit the blocking time
+                 * because	the FreeRTOS_send() function does not wait for a network
+                 * buffer to become available. */
+            }
 
-		#if( ipconfigUSE_CALLBACKS == 1 )
-			#if( ipconfigUSE_TCP == 1 )
-				case FREERTOS_SO_TCP_CONN_HANDLER:	/* Set a callback for (dis)connection events */
-				case FREERTOS_SO_TCP_RECV_HANDLER:	/* Install a callback for receiving TCP data. Supply pointer to 'F_TCP_UDP_Handler_t' (see below) */
-				case FREERTOS_SO_TCP_SENT_HANDLER:	/* Install a callback for sending TCP data. Supply pointer to 'F_TCP_UDP_Handler_t' (see below) */
-			#endif /* ipconfigUSE_TCP */
-				case FREERTOS_SO_UDP_RECV_HANDLER:	/* Install a callback for receiving UDP data. Supply pointer to 'F_TCP_UDP_Handler_t' (see below) */
-				case FREERTOS_SO_UDP_SENT_HANDLER:	/* Install a callback for sending UDP data. Supply pointer to 'F_TCP_UDP_Handler_t' (see below) */
-					{
-						#if( ipconfigUSE_TCP == 1 )
-						{
-							UBaseType_t uxProtocol;
-							if( ( lOptionName == FREERTOS_SO_UDP_RECV_HANDLER ) ||
-								( lOptionName == FREERTOS_SO_UDP_SENT_HANDLER ) )
-							{
-								uxProtocol = ( UBaseType_t ) FREERTOS_IPPROTO_UDP;
-							}
-							else
-							{
-								uxProtocol = ( UBaseType_t ) FREERTOS_IPPROTO_TCP;
-							}
+            xReturn = 0;
+            break;
 
-							if( pxSocket->ucProtocol != ( uint8_t ) uxProtocol )
-							{
-								break;	/* will return -pdFREERTOS_ERRNO_EINVAL */
-							}
-						}
-						#else
-						{
-							/* No need to check if the socket has the right
-							protocol, because only UDP socket can be created. */
-						}
-						#endif /* ipconfigUSE_TCP */
+            #if ( ipconfigUDP_MAX_RX_PACKETS > 0U )
+                case FREERTOS_SO_UDP_MAX_RX_PACKETS:
 
-						switch( lOptionName )
-						{
-						#if ipconfigUSE_TCP == 1
-							case FREERTOS_SO_TCP_CONN_HANDLER:
-								pxSocket->u.xTCP.pxHandleConnected = ipPOINTER_CAST( const F_TCP_UDP_Handler_t *, pvOptionValue )->pxOnTCPConnected;
-								break;
-							case FREERTOS_SO_TCP_RECV_HANDLER:
-								pxSocket->u.xTCP.pxHandleReceive = ipPOINTER_CAST( const F_TCP_UDP_Handler_t *, pvOptionValue )->pxOnTCPReceive;
-								break;
-							case FREERTOS_SO_TCP_SENT_HANDLER:
-								pxSocket->u.xTCP.pxHandleSent = ipPOINTER_CAST( const F_TCP_UDP_Handler_t *, pvOptionValue )->pxOnTCPSent;
-								break;
-						#endif /* ipconfigUSE_TCP */
-						case FREERTOS_SO_UDP_RECV_HANDLER:
-							pxSocket->u.xUDP.pxHandleReceive = ipPOINTER_CAST( const F_TCP_UDP_Handler_t *, pvOptionValue )->pxOnUDPReceive;
-							break;
-						case FREERTOS_SO_UDP_SENT_HANDLER:
-							pxSocket->u.xUDP.pxHandleSent = ipPOINTER_CAST( const F_TCP_UDP_Handler_t *, pvOptionValue )->pxOnUDPSent;
-							break;
-						default:
-							/* Should it throw an error here? */
-							break;
-						}
-					}
+                    if( pxSocket->ucProtocol != ( uint8_t ) FREERTOS_IPPROTO_UDP )
+                    {
+                        break; /* will return -pdFREERTOS_ERRNO_EINVAL */
+                    }
 
-					xReturn = 0;
-					break;
-		#endif /* ipconfigUSE_CALLBACKS */
+                    pxSocket->u.xUDP.uxMaxPackets = *( ( const UBaseType_t * ) pvOptionValue );
+                    xReturn = 0;
+                    break;
+            #endif /* ipconfigUDP_MAX_RX_PACKETS */
 
-		#if( ipconfigUSE_TCP != 0 )
-			#if( ipconfigSOCKET_HAS_USER_SEMAPHORE != 0 )
-				/* Each socket has a semaphore on which the using task normally
-				sleeps. */
-				case FREERTOS_SO_SET_SEMAPHORE:
-					{
-						pxSocket->pxUserSemaphore = *( ipPOINTER_CAST( SemaphoreHandle_t *, pvOptionValue ) );
-					}
-					xReturn = 0;
-					break;
-			#endif /* ipconfigSOCKET_HAS_USER_SEMAPHORE */
+        case FREERTOS_SO_UDPCKSUM_OUT:
+            /* Turn calculating of the UDP checksum on/off for this socket. */
+            /* The expression "pvOptionValue" of type "void const *" is cast to type "BaseType_t". */
+            lOptionValue = ipNUMERIC_CAST( BaseType_t, pvOptionValue );
 
-			#if( ipconfigSOCKET_HAS_USER_WAKE_CALLBACK != 0 )
-				case FREERTOS_SO_WAKEUP_CALLBACK:
-				{
-					/* Each socket can have a callback function that is executed
-					when there is an event the socket's owner might want to
-					process. */
-					/* The type cast of the pointer expression "A" to type "B" removes const qualifier from the pointed to type. */
-					pxSocket->pxUserWakeCallback = ( SocketWakeupCallback_t ) pvOptionValue;
-					xReturn = 0;
-				}
-				break;
-			#endif /* ipconfigSOCKET_HAS_USER_WAKE_CALLBACK */
+            if( lOptionValue == 0 )
+            {
+                pxSocket->ucSocketOptions &= ~( ( uint8_t ) FREERTOS_SO_UDPCKSUM_OUT );
+            }
+            else
+            {
+                pxSocket->ucSocketOptions |= ( uint8_t ) FREERTOS_SO_UDPCKSUM_OUT;
+            }
 
-			case FREERTOS_SO_SET_LOW_HIGH_WATER:
-				{
-				const LowHighWater_t *pxLowHighWater = ipPOINTER_CAST( LowHighWater_t *, pvOptionValue );
+            xReturn = 0;
+            break;
 
-					if( pxSocket->ucProtocol != ( uint8_t ) FREERTOS_IPPROTO_TCP )
-					{
-						/* It is not allowed to access 'pxSocket->u.xTCP'. */
-						FreeRTOS_debug_printf( ( "FREERTOS_SO_SET_LOW_HIGH_WATER: wrong socket type\n" ) );
-						break;	/* will return -pdFREERTOS_ERRNO_EINVAL */
-					}
-					if( ( pxLowHighWater->uxLittleSpace >= pxLowHighWater->uxEnoughSpace ) ||
-						( pxLowHighWater->uxEnoughSpace > pxSocket->u.xTCP.uxRxStreamSize ) )
-					{
-						/* Impossible values. */
-						FreeRTOS_debug_printf( ( "FREERTOS_SO_SET_LOW_HIGH_WATER: bad values\n" ) );
-						break;	/* will return -pdFREERTOS_ERRNO_EINVAL */
-					}
-					/* Send a STOP when buffer space drops below 'uxLittleSpace' bytes. */
-					pxSocket->u.xTCP.uxLittleSpace = pxLowHighWater->uxLittleSpace;
-					/* Send a GO when buffer space grows above 'uxEnoughSpace' bytes. */
-					pxSocket->u.xTCP.uxEnoughSpace = pxLowHighWater->uxEnoughSpace;
-					xReturn = 0;
-				}
-				break;
+            #if ( ipconfigUSE_CALLBACKS == 1 )
+                #if ( ipconfigUSE_TCP == 1 )
+                    case FREERTOS_SO_TCP_CONN_HANDLER: /* Set a callback for (dis)connection events */
+                    case FREERTOS_SO_TCP_RECV_HANDLER: /* Install a callback for receiving TCP data. Supply pointer to 'F_TCP_UDP_Handler_t' (see below) */
+                    case FREERTOS_SO_TCP_SENT_HANDLER: /* Install a callback for sending TCP data. Supply pointer to 'F_TCP_UDP_Handler_t' (see below) */
+                #endif /* ipconfigUSE_TCP */
+                case FREERTOS_SO_UDP_RECV_HANDLER:     /* Install a callback for receiving UDP data. Supply pointer to 'F_TCP_UDP_Handler_t' (see below) */
+                case FREERTOS_SO_UDP_SENT_HANDLER:     /* Install a callback for sending UDP data. Supply pointer to 'F_TCP_UDP_Handler_t' (see below) */
+                   {
+                       #if ( ipconfigUSE_TCP == 1 )
+                           {
+                               UBaseType_t uxProtocol;
 
-			case FREERTOS_SO_SNDBUF:	/* Set the size of the send buffer, in units of MSS (TCP only) */
-			case FREERTOS_SO_RCVBUF:	/* Set the size of the receive buffer, in units of MSS (TCP only) */
-				{
-					xReturn = prvSockopt_so_buffer( pxSocket, lOptionName, pvOptionValue );
-				}
-				break;
+                               if( ( lOptionName == FREERTOS_SO_UDP_RECV_HANDLER ) ||
+                                   ( lOptionName == FREERTOS_SO_UDP_SENT_HANDLER ) )
+                               {
+                                   uxProtocol = ( UBaseType_t ) FREERTOS_IPPROTO_UDP;
+                               }
+                               else
+                               {
+                                   uxProtocol = ( UBaseType_t ) FREERTOS_IPPROTO_TCP;
+                               }
 
-			case FREERTOS_SO_WIN_PROPERTIES:	/* Set all buffer and window properties in one call, parameter is pointer to WinProperties_t */
-				{
-					const WinProperties_t* pxProps;
+                               if( pxSocket->ucProtocol != ( uint8_t ) uxProtocol )
+                               {
+                                   break; /* will return -pdFREERTOS_ERRNO_EINVAL */
+                               }
+                           }
+                       #else /* if ( ipconfigUSE_TCP == 1 ) */
+                           {
+                               /* No need to check if the socket has the right
+                                * protocol, because only UDP socket can be created. */
+                           }
+                       #endif /* ipconfigUSE_TCP */
 
-					if( pxSocket->ucProtocol != ( uint8_t ) FREERTOS_IPPROTO_TCP )
-					{
-						FreeRTOS_debug_printf( ( "Set SO_WIN_PROP: wrong socket type\n" ) );
-						break;	/* will return -pdFREERTOS_ERRNO_EINVAL */
-					}
+                       switch( lOptionName )
+                       {
+                           #if ipconfigUSE_TCP == 1
+                               case FREERTOS_SO_TCP_CONN_HANDLER:
+                                   pxSocket->u.xTCP.pxHandleConnected = ipPOINTER_CAST( const F_TCP_UDP_Handler_t *, pvOptionValue )->pxOnTCPConnected;
+                                   break;
 
-					if( ( pxSocket->u.xTCP.txStream != NULL ) || ( pxSocket->u.xTCP.rxStream != NULL ) )
-					{
-						FreeRTOS_debug_printf( ( "Set SO_WIN_PROP: buffer already created\n" ) );
-						break;	/* will return -pdFREERTOS_ERRNO_EINVAL */
-					}
+                               case FREERTOS_SO_TCP_RECV_HANDLER:
+                                   pxSocket->u.xTCP.pxHandleReceive = ipPOINTER_CAST( const F_TCP_UDP_Handler_t *, pvOptionValue )->pxOnTCPReceive;
+                                   break;
 
-					pxProps = ipPOINTER_CAST( WinProperties_t *, pvOptionValue );
+                               case FREERTOS_SO_TCP_SENT_HANDLER:
+                                   pxSocket->u.xTCP.pxHandleSent = ipPOINTER_CAST( const F_TCP_UDP_Handler_t *, pvOptionValue )->pxOnTCPSent;
+                                   break;
+                           #endif /* ipconfigUSE_TCP */
+                           case FREERTOS_SO_UDP_RECV_HANDLER:
+                               pxSocket->u.xUDP.pxHandleReceive = ipPOINTER_CAST( const F_TCP_UDP_Handler_t *, pvOptionValue )->pxOnUDPReceive;
+                               break;
 
-					xReturn = prvSockopt_so_buffer( pxSocket, FREERTOS_SO_SNDBUF, &( pxProps->lTxBufSize ) );
-					if ( xReturn != 0 )
-					{
-						break;	/* will return an error. */
-					}
+                           case FREERTOS_SO_UDP_SENT_HANDLER:
+                               pxSocket->u.xUDP.pxHandleSent = ipPOINTER_CAST( const F_TCP_UDP_Handler_t *, pvOptionValue )->pxOnUDPSent;
+                               break;
 
-					xReturn = prvSockopt_so_buffer( pxSocket, FREERTOS_SO_RCVBUF, &( pxProps->lRxBufSize ) );
-					if ( xReturn != 0 )
-					{
-						break;	/* will return an error. */
-					}
+                           default:
+                               /* Should it throw an error here? */
+                               break;
+                       }
+                   }
 
-					#if( ipconfigUSE_TCP_WIN == 1 )
-					{
-						pxSocket->u.xTCP.uxRxWinSize = ( uint32_t )pxProps->lRxWinSize;	/* Fixed value: size of the TCP reception window */
-						pxSocket->u.xTCP.uxTxWinSize = ( uint32_t )pxProps->lTxWinSize;	/* Fixed value: size of the TCP transmit window */
-					}
-					#else
-					{
-						pxSocket->u.xTCP.uxRxWinSize = 1U;
-						pxSocket->u.xTCP.uxTxWinSize = 1U;
-					}
-					#endif
+                    xReturn = 0;
+                    break;
+            #endif /* ipconfigUSE_CALLBACKS */
 
-					/* In case the socket has already initialised its tcpWin,
-					adapt the window size parameters */
-					if( pxSocket->u.xTCP.xTCPWindow.u.bits.bHasInit != pdFALSE_UNSIGNED )
-					{
-						pxSocket->u.xTCP.xTCPWindow.xSize.ulRxWindowLength = pxSocket->u.xTCP.uxRxWinSize * pxSocket->u.xTCP.usInitMSS;
-						pxSocket->u.xTCP.xTCPWindow.xSize.ulTxWindowLength = pxSocket->u.xTCP.uxTxWinSize * pxSocket->u.xTCP.usInitMSS;
-					}
-				}
+            #if ( ipconfigUSE_TCP != 0 )
+                #if ( ipconfigSOCKET_HAS_USER_SEMAPHORE != 0 )
+                    /* Each socket has a semaphore on which the using task normally
+                     * sleeps. */
+                    case FREERTOS_SO_SET_SEMAPHORE:
+                       {
+                           pxSocket->pxUserSemaphore = *( ipPOINTER_CAST( SemaphoreHandle_t *, pvOptionValue ) );
+                       }
+                        xReturn = 0;
+                        break;
+                #endif /* ipconfigSOCKET_HAS_USER_SEMAPHORE */
 
-				xReturn = 0;
-				break;
+                #if ( ipconfigSOCKET_HAS_USER_WAKE_CALLBACK != 0 )
+                    case FREERTOS_SO_WAKEUP_CALLBACK:
+                        /* Each socket can have a callback function that is executed
+                         * when there is an event the socket's owner might want to
+                         * process. */
+                        /* The type cast of the pointer expression "A" to type "B" removes const qualifier from the pointed to type. */
+                        pxSocket->pxUserWakeCallback = ( SocketWakeupCallback_t ) pvOptionValue;
+                        xReturn = 0;
+                        break;
+                #endif /* ipconfigSOCKET_HAS_USER_WAKE_CALLBACK */
 
-			case FREERTOS_SO_REUSE_LISTEN_SOCKET:	/* If true, the server-socket will turn into a connected socket */
-				{
-					if( pxSocket->ucProtocol != ( uint8_t ) FREERTOS_IPPROTO_TCP )
-					{
-						break;	/* will return -pdFREERTOS_ERRNO_EINVAL */
-					}
-					if( *( ipPOINTER_CAST( BaseType_t *, pvOptionValue ) ) != 0 )
-					{
-						pxSocket->u.xTCP.bits.bReuseSocket = pdTRUE;
-					}
-					else
-					{
-						pxSocket->u.xTCP.bits.bReuseSocket = pdFALSE;
-					}
-				}
-				xReturn = 0;
-				break;
+                case FREERTOS_SO_SET_LOW_HIGH_WATER:
+                   {
+                       const LowHighWater_t * pxLowHighWater = ipPOINTER_CAST( LowHighWater_t *, pvOptionValue );
 
-			case FREERTOS_SO_CLOSE_AFTER_SEND:		/* As soon as the last byte has been transmitted, finalise the connection */
-				{
-					if( pxSocket->ucProtocol != ( uint8_t ) FREERTOS_IPPROTO_TCP )
-					{
-						break;	/* will return -pdFREERTOS_ERRNO_EINVAL */
-					}
+                       if( pxSocket->ucProtocol != ( uint8_t ) FREERTOS_IPPROTO_TCP )
+                       {
+                           /* It is not allowed to access 'pxSocket->u.xTCP'. */
+                           FreeRTOS_debug_printf( ( "FREERTOS_SO_SET_LOW_HIGH_WATER: wrong socket type\n" ) );
+                           break; /* will return -pdFREERTOS_ERRNO_EINVAL */
+                       }
 
-					if( *( ipPOINTER_CAST( BaseType_t *, pvOptionValue ) ) != 0 )
-					{
-						pxSocket->u.xTCP.bits.bCloseAfterSend = pdTRUE;
-					}
-					else
-					{
-						pxSocket->u.xTCP.bits.bCloseAfterSend = pdFALSE;
-					}
-				}
-				xReturn = 0;
-				break;
+                       if( ( pxLowHighWater->uxLittleSpace >= pxLowHighWater->uxEnoughSpace ) ||
+                           ( pxLowHighWater->uxEnoughSpace > pxSocket->u.xTCP.uxRxStreamSize ) )
+                       {
+                           /* Impossible values. */
+                           FreeRTOS_debug_printf( ( "FREERTOS_SO_SET_LOW_HIGH_WATER: bad values\n" ) );
+                           break; /* will return -pdFREERTOS_ERRNO_EINVAL */
+                       }
 
-			case FREERTOS_SO_SET_FULL_SIZE:		/* Refuse to send packets smaller than MSS  */
-				{
-					if( pxSocket->ucProtocol != ( uint8_t ) FREERTOS_IPPROTO_TCP )
-					{
-						break;	/* will return -pdFREERTOS_ERRNO_EINVAL */
-					}
+                       /* Send a STOP when buffer space drops below 'uxLittleSpace' bytes. */
+                       pxSocket->u.xTCP.uxLittleSpace = pxLowHighWater->uxLittleSpace;
+                       /* Send a GO when buffer space grows above 'uxEnoughSpace' bytes. */
+                       pxSocket->u.xTCP.uxEnoughSpace = pxLowHighWater->uxEnoughSpace;
+                       xReturn = 0;
+                   }
+                   break;
 
-					if( *( ipPOINTER_CAST( BaseType_t *, pvOptionValue ) ) != 0 )
-					{
-						pxSocket->u.xTCP.xTCPWindow.u.bits.bSendFullSize = pdTRUE;
-					}
-					else
-					{
-						pxSocket->u.xTCP.xTCPWindow.u.bits.bSendFullSize = pdFALSE;
-					}
+                case FREERTOS_SO_SNDBUF: /* Set the size of the send buffer, in units of MSS (TCP only) */
+                case FREERTOS_SO_RCVBUF: /* Set the size of the receive buffer, in units of MSS (TCP only) */
+                    xReturn = prvSockopt_so_buffer( pxSocket, lOptionName, pvOptionValue );
+                    break;
 
-					if( ( pxSocket->u.xTCP.xTCPWindow.u.bits.bSendFullSize == pdFALSE_UNSIGNED ) &&
-						( pxSocket->u.xTCP.ucTCPState >= ( uint8_t ) eESTABLISHED ) &&
-						( FreeRTOS_outstanding( pxSocket ) != 0 ) )
-					{
-						pxSocket->u.xTCP.usTimeout = 1U; /* to set/clear bSendFullSize */
-						( void ) xSendEventToIPTask( eTCPTimerEvent );
-					}
-				}
-				xReturn = 0;
-				break;
+                case FREERTOS_SO_WIN_PROPERTIES: /* Set all buffer and window properties in one call, parameter is pointer to WinProperties_t */
+                   {
+                       const WinProperties_t * pxProps;
 
-			case FREERTOS_SO_STOP_RX:		/* Refuse to receive more packts */
-				{
-					if( pxSocket->ucProtocol != ( uint8_t ) FREERTOS_IPPROTO_TCP )
-					{
-						break;	/* will return -pdFREERTOS_ERRNO_EINVAL */
-					}
-					if( *( ipPOINTER_CAST( BaseType_t *, pvOptionValue ) ) != 0 )
-					{
-						pxSocket->u.xTCP.bits.bRxStopped = pdTRUE;
-					}
-					else
-					{
-						pxSocket->u.xTCP.bits.bRxStopped = pdFALSE;
-					}
+                       if( pxSocket->ucProtocol != ( uint8_t ) FREERTOS_IPPROTO_TCP )
+                       {
+                           FreeRTOS_debug_printf( ( "Set SO_WIN_PROP: wrong socket type\n" ) );
+                           break; /* will return -pdFREERTOS_ERRNO_EINVAL */
+                       }
 
-					pxSocket->u.xTCP.bits.bWinChange = pdTRUE;
-					pxSocket->u.xTCP.usTimeout = 1U; /* to set/clear bRxStopped */
-					( void ) xSendEventToIPTask( eTCPTimerEvent );
-				}
-				xReturn = 0;
-				break;
+                       if( ( pxSocket->u.xTCP.txStream != NULL ) || ( pxSocket->u.xTCP.rxStream != NULL ) )
+                       {
+                           FreeRTOS_debug_printf( ( "Set SO_WIN_PROP: buffer already created\n" ) );
+                           break; /* will return -pdFREERTOS_ERRNO_EINVAL */
+                       }
 
-		#endif  /* ipconfigUSE_TCP == 1 */
+                       pxProps = ipPOINTER_CAST( WinProperties_t *, pvOptionValue );
 
-		default :
-			/* No other options are handled. */
-			xReturn = -pdFREERTOS_ERRNO_ENOPROTOOPT;
-			break;
-	}
+                       xReturn = prvSockopt_so_buffer( pxSocket, FREERTOS_SO_SNDBUF, &( pxProps->lTxBufSize ) );
 
-	return xReturn;
+                       if( xReturn != 0 )
+                       {
+                           break; /* will return an error. */
+                       }
+
+                       xReturn = prvSockopt_so_buffer( pxSocket, FREERTOS_SO_RCVBUF, &( pxProps->lRxBufSize ) );
+
+                       if( xReturn != 0 )
+                       {
+                           break; /* will return an error. */
+                       }
+
+                       #if ( ipconfigUSE_TCP_WIN == 1 )
+                           {
+                               pxSocket->u.xTCP.uxRxWinSize = ( uint32_t ) pxProps->lRxWinSize; /* Fixed value: size of the TCP reception window */
+                               pxSocket->u.xTCP.uxTxWinSize = ( uint32_t ) pxProps->lTxWinSize; /* Fixed value: size of the TCP transmit window */
+                           }
+                       #else
+                           {
+                               pxSocket->u.xTCP.uxRxWinSize = 1U;
+                               pxSocket->u.xTCP.uxTxWinSize = 1U;
+                           }
+                       #endif
+
+                       /* In case the socket has already initialised its tcpWin,
+                        * adapt the window size parameters */
+                       if( pxSocket->u.xTCP.xTCPWindow.u.bits.bHasInit != pdFALSE_UNSIGNED )
+                       {
+                           pxSocket->u.xTCP.xTCPWindow.xSize.ulRxWindowLength = pxSocket->u.xTCP.uxRxWinSize * pxSocket->u.xTCP.usInitMSS;
+                           pxSocket->u.xTCP.xTCPWindow.xSize.ulTxWindowLength = pxSocket->u.xTCP.uxTxWinSize * pxSocket->u.xTCP.usInitMSS;
+                       }
+                   }
+
+                    xReturn = 0;
+                    break;
+
+                case FREERTOS_SO_REUSE_LISTEN_SOCKET: /* If true, the server-socket will turn into a connected socket */
+                   {
+                       if( pxSocket->ucProtocol != ( uint8_t ) FREERTOS_IPPROTO_TCP )
+                       {
+                           break; /* will return -pdFREERTOS_ERRNO_EINVAL */
+                       }
+
+                       if( *( ipPOINTER_CAST( BaseType_t *, pvOptionValue ) ) != 0 )
+                       {
+                           pxSocket->u.xTCP.bits.bReuseSocket = pdTRUE;
+                       }
+                       else
+                       {
+                           pxSocket->u.xTCP.bits.bReuseSocket = pdFALSE;
+                       }
+                   }
+                    xReturn = 0;
+                    break;
+
+                case FREERTOS_SO_CLOSE_AFTER_SEND: /* As soon as the last byte has been transmitted, finalise the connection */
+                   {
+                       if( pxSocket->ucProtocol != ( uint8_t ) FREERTOS_IPPROTO_TCP )
+                       {
+                           break; /* will return -pdFREERTOS_ERRNO_EINVAL */
+                       }
+
+                       if( *( ipPOINTER_CAST( BaseType_t *, pvOptionValue ) ) != 0 )
+                       {
+                           pxSocket->u.xTCP.bits.bCloseAfterSend = pdTRUE;
+                       }
+                       else
+                       {
+                           pxSocket->u.xTCP.bits.bCloseAfterSend = pdFALSE;
+                       }
+                   }
+                    xReturn = 0;
+                    break;
+
+                case FREERTOS_SO_SET_FULL_SIZE: /* Refuse to send packets smaller than MSS  */
+                   {
+                       if( pxSocket->ucProtocol != ( uint8_t ) FREERTOS_IPPROTO_TCP )
+                       {
+                           break; /* will return -pdFREERTOS_ERRNO_EINVAL */
+                       }
+
+                       if( *( ipPOINTER_CAST( BaseType_t *, pvOptionValue ) ) != 0 )
+                       {
+                           pxSocket->u.xTCP.xTCPWindow.u.bits.bSendFullSize = pdTRUE;
+                       }
+                       else
+                       {
+                           pxSocket->u.xTCP.xTCPWindow.u.bits.bSendFullSize = pdFALSE;
+                       }
+
+                       if( ( pxSocket->u.xTCP.xTCPWindow.u.bits.bSendFullSize == pdFALSE_UNSIGNED ) &&
+                           ( pxSocket->u.xTCP.ucTCPState >= ( uint8_t ) eESTABLISHED ) &&
+                           ( FreeRTOS_outstanding( pxSocket ) != 0 ) )
+                       {
+                           pxSocket->u.xTCP.usTimeout = 1U; /* to set/clear bSendFullSize */
+                           ( void ) xSendEventToIPTask( eTCPTimerEvent );
+                       }
+                   }
+                    xReturn = 0;
+                    break;
+
+                case FREERTOS_SO_STOP_RX: /* Refuse to receive more packts */
+                   {
+                       if( pxSocket->ucProtocol != ( uint8_t ) FREERTOS_IPPROTO_TCP )
+                       {
+                           break; /* will return -pdFREERTOS_ERRNO_EINVAL */
+                       }
+
+                       if( *( ipPOINTER_CAST( BaseType_t *, pvOptionValue ) ) != 0 )
+                       {
+                           pxSocket->u.xTCP.bits.bRxStopped = pdTRUE;
+                       }
+                       else
+                       {
+                           pxSocket->u.xTCP.bits.bRxStopped = pdFALSE;
+                       }
+
+                       pxSocket->u.xTCP.bits.bWinChange = pdTRUE;
+                       pxSocket->u.xTCP.usTimeout = 1U; /* to set/clear bRxStopped */
+                       ( void ) xSendEventToIPTask( eTCPTimerEvent );
+                   }
+                    xReturn = 0;
+                    break;
+            #endif /* ipconfigUSE_TCP == 1 */
+
+        default:
+            /* No other options are handled. */
+            xReturn = -pdFREERTOS_ERRNO_ENOPROTOOPT;
+            break;
+    }
+
+    return xReturn;
 } /* Tested */
 
 /*-----------------------------------------------------------*/
@@ -1734,2346 +1816,2442 @@ FreeRTOS_Socket_t *pxSocket;
 /* Find an available port number per https://tools.ietf.org/html/rfc6056. */
 static uint16_t prvGetPrivatePortNumber( BaseType_t xProtocol )
 {
-const uint16_t usEphemeralPortCount =
-	socketAUTO_PORT_ALLOCATION_MAX_NUMBER - ( socketAUTO_PORT_ALLOCATION_START_NUMBER - 1U );
-uint16_t usIterations = usEphemeralPortCount;
-uint32_t ulRandomSeed = 0;
-uint16_t usResult = 0;
-const List_t *pxList;
+    const uint16_t usEphemeralPortCount =
+        socketAUTO_PORT_ALLOCATION_MAX_NUMBER - ( socketAUTO_PORT_ALLOCATION_START_NUMBER - 1U );
+    uint16_t usIterations = usEphemeralPortCount;
+    uint32_t ulRandomSeed = 0;
+    uint16_t usResult = 0;
+    const List_t * pxList;
 
-#if ipconfigUSE_TCP == 1
-	if( xProtocol == ( BaseType_t ) FREERTOS_IPPROTO_TCP )
-	{
-		pxList = &xBoundTCPSocketsList;
-	}
-	else
-#endif
-	{
-		pxList = &xBoundUDPSocketsList;
-	}
+    #if ipconfigUSE_TCP == 1
+        if( xProtocol == ( BaseType_t ) FREERTOS_IPPROTO_TCP )
+        {
+            pxList = &xBoundTCPSocketsList;
+        }
+        else
+    #endif
+    {
+        pxList = &xBoundUDPSocketsList;
+    }
 
-	/* Avoid compiler warnings if ipconfigUSE_TCP is not defined. */
-	( void ) xProtocol;
+    /* Avoid compiler warnings if ipconfigUSE_TCP is not defined. */
+    ( void ) xProtocol;
 
-	/* Find the next available port using the random seed as a starting
-	point. */
-	do
-	{
-		/* Only proceed if the random number generator succeeded. */
-		if( xApplicationGetRandomNumber( &( ulRandomSeed ) ) == pdFALSE )
-		{
-			break;
-		}
+    /* Find the next available port using the random seed as a starting
+     * point. */
+    do
+    {
+        /* Only proceed if the random number generator succeeded. */
+        if( xApplicationGetRandomNumber( &( ulRandomSeed ) ) == pdFALSE )
+        {
+            break;
+        }
 
-		/* Map the random to a candidate port. */
-		usResult =
-			socketAUTO_PORT_ALLOCATION_START_NUMBER +
-			( ( ( uint16_t )ulRandomSeed ) % usEphemeralPortCount );
+        /* Map the random to a candidate port. */
+        usResult =
+            socketAUTO_PORT_ALLOCATION_START_NUMBER +
+            ( ( ( uint16_t ) ulRandomSeed ) % usEphemeralPortCount );
 
-		/* Check if there's already an open socket with the same protocol
-		and port. */
-		if( NULL == pxListFindListItemWithValue(
-			pxList,
-			( TickType_t )FreeRTOS_htons( usResult ) ) )
-		{
-			usResult = FreeRTOS_htons( usResult );
-			break;
-		}
-		else
-		{
-			usResult = 0;
-		}
+        /* Check if there's already an open socket with the same protocol
+         * and port. */
+        if( NULL == pxListFindListItemWithValue(
+                pxList,
+                ( TickType_t ) FreeRTOS_htons( usResult ) ) )
+        {
+            usResult = FreeRTOS_htons( usResult );
+            break;
+        }
+        else
+        {
+            usResult = 0;
+        }
 
-		usIterations--;
-	}
-	while( usIterations > 0U );
+        usIterations--;
+    }
+    while( usIterations > 0U );
 
-	return usResult;
+    return usResult;
 }
 /*-----------------------------------------------------------*/
 
 /* pxListFindListItemWithValue: find a list item in a bound socket list
-'xWantedItemValue' refers to a port number */
-static const ListItem_t * pxListFindListItemWithValue( const List_t *pxList, TickType_t xWantedItemValue )
+ * 'xWantedItemValue' refers to a port number */
+static const ListItem_t * pxListFindListItemWithValue( const List_t * pxList,
+                                                       TickType_t xWantedItemValue )
 {
-const ListItem_t * pxResult = NULL;
+    const ListItem_t * pxResult = NULL;
 
-	if( ( xIPIsNetworkTaskReady() != pdFALSE ) && ( pxList != NULL ) )
-	{
-		const ListItem_t *pxIterator;
-		const ListItem_t *pxEnd = ipPOINTER_CAST( const ListItem_t*, listGET_END_MARKER( pxList ) );
-		for( pxIterator  = listGET_NEXT( pxEnd );
-			 pxIterator != pxEnd;
-			 pxIterator  = listGET_NEXT( pxIterator ) )
-		{
-			if( listGET_LIST_ITEM_VALUE( pxIterator ) == xWantedItemValue )
-			{
-				pxResult = pxIterator;
-				break;
-			}
-		}
-	}
+    if( ( xIPIsNetworkTaskReady() != pdFALSE ) && ( pxList != NULL ) )
+    {
+        const ListItem_t * pxIterator;
+        const ListItem_t * pxEnd = ipPOINTER_CAST( const ListItem_t *, listGET_END_MARKER( pxList ) );
 
-	return pxResult;
+        for( pxIterator = listGET_NEXT( pxEnd );
+             pxIterator != pxEnd;
+             pxIterator = listGET_NEXT( pxIterator ) )
+        {
+            if( listGET_LIST_ITEM_VALUE( pxIterator ) == xWantedItemValue )
+            {
+                pxResult = pxIterator;
+                break;
+            }
+        }
+    }
+
+    return pxResult;
 } /* Tested */
 
 /*-----------------------------------------------------------*/
 
-FreeRTOS_Socket_t *pxUDPSocketLookup( UBaseType_t uxLocalPort )
+FreeRTOS_Socket_t * pxUDPSocketLookup( UBaseType_t uxLocalPort )
 {
-const ListItem_t *pxListItem;
-FreeRTOS_Socket_t *pxSocket = NULL;
+    const ListItem_t * pxListItem;
+    FreeRTOS_Socket_t * pxSocket = NULL;
 
-	/* Looking up a socket is quite simple, find a match with the local port.
+    /* Looking up a socket is quite simple, find a match with the local port.
+     *
+     * See if there is a list item associated with the port number on the
+     * list of bound sockets. */
+    pxListItem = pxListFindListItemWithValue( &xBoundUDPSocketsList, ( TickType_t ) uxLocalPort );
 
-	See if there is a list item associated with the port number on the
-	list of bound sockets. */
-	pxListItem = pxListFindListItemWithValue( &xBoundUDPSocketsList, ( TickType_t ) uxLocalPort );
+    if( pxListItem != NULL )
+    {
+        /* The owner of the list item is the socket itself. */
+        pxSocket = ipPOINTER_CAST( FreeRTOS_Socket_t *, listGET_LIST_ITEM_OWNER( pxListItem ) );
+        configASSERT( pxSocket != NULL );
+    }
 
-	if( pxListItem != NULL )
-	{
-		/* The owner of the list item is the socket itself. */
-		pxSocket = ipPOINTER_CAST( FreeRTOS_Socket_t *, listGET_LIST_ITEM_OWNER( pxListItem ) );
-		configASSERT( pxSocket != NULL );
-	}
-	return pxSocket;
+    return pxSocket;
 }
 
 /*-----------------------------------------------------------*/
 
-const char *FreeRTOS_inet_ntoa( uint32_t ulIPAddress, char *pcBuffer )
+const char * FreeRTOS_inet_ntoa( uint32_t ulIPAddress,
+                                 char * pcBuffer )
 {
-socklen_t uxNibble;
-socklen_t uxIndex = 0;
-const uint8_t *pucAddress = ( const uint8_t * ) &( ulIPAddress );
-const char *pcResult = pcBuffer;
-const socklen_t uxSize = 16;
+    socklen_t uxNibble;
+    socklen_t uxIndex = 0;
+    const uint8_t * pucAddress = ( const uint8_t * ) &( ulIPAddress );
+    const char * pcResult = pcBuffer;
+    const socklen_t uxSize = 16;
 
 /* Each nibble is expressed in at most 3 digits, like e.g. "192". */
-#define sockDIGIT_COUNT		3
+#define sockDIGIT_COUNT    3
 
-	for( uxNibble = 0; uxNibble < ipSIZE_OF_IPv4_ADDRESS; uxNibble++ )
-	{
-	uint8_t pucDigits[ sockDIGIT_COUNT ];
-	uint8_t ucValue = pucAddress[ uxNibble ];
-	socklen_t uxSource = sockDIGIT_COUNT - 1;
-	socklen_t uxNeeded;
+    for( uxNibble = 0; uxNibble < ipSIZE_OF_IPv4_ADDRESS; uxNibble++ )
+    {
+        uint8_t pucDigits[ sockDIGIT_COUNT ];
+        uint8_t ucValue = pucAddress[ uxNibble ];
+        socklen_t uxSource = sockDIGIT_COUNT - 1;
+        socklen_t uxNeeded;
 
-		for( ;; )
-		{
-			pucDigits[ uxSource ] = ucValue % ( uint8_t ) 10U;
-			ucValue /= ( uint8_t ) 10U;
-			if( uxSource == 1U )
-			{
-				break;
-			}
-			uxSource--;
-		}
-		pucDigits[ 0 ] = ucValue;
+        for( ; ; )
+        {
+            pucDigits[ uxSource ] = ucValue % ( uint8_t ) 10U;
+            ucValue /= ( uint8_t ) 10U;
 
-		/* Skip leading zeros. */
-		for( uxSource = 0; uxSource < ( socklen_t ) ( sockDIGIT_COUNT - 1 ); uxSource++ )
-		{
-			if( pucDigits[ uxSource ] != 0U )
-			{
-				break;
-			}
-		}
-		/* Write e.g. "192.", which is 3 digits and a dot. */
-		uxNeeded = ( ( socklen_t ) sockDIGIT_COUNT - uxSource ) + 1U;
-		if( ( uxIndex + uxNeeded ) > uxSize )
-		{
-			/* The result won't fit. */
-			pcResult = NULL;
-			break;
-		}
-	
-		for( ; uxSource < ( socklen_t ) sockDIGIT_COUNT; uxSource++ )
-		{
-			pcBuffer[ uxIndex ] = ( char ) ( pucDigits[ uxSource ] + ( char ) '0' );
-			uxIndex++;
-		}
-		if( uxNibble < ( ipSIZE_OF_IPv4_ADDRESS - 1U ) )
-		{
-			pcBuffer[ uxIndex ] = '.';
-		}
-		else
-		{
-			pcBuffer[ uxIndex ] = '\0';
-		}
-		uxIndex++;
-	}
+            if( uxSource == 1U )
+            {
+                break;
+            }
 
-	return pcResult;
+            uxSource--;
+        }
+
+        pucDigits[ 0 ] = ucValue;
+
+        /* Skip leading zeros. */
+        for( uxSource = 0; uxSource < ( socklen_t ) ( sockDIGIT_COUNT - 1 ); uxSource++ )
+        {
+            if( pucDigits[ uxSource ] != 0U )
+            {
+                break;
+            }
+        }
+
+        /* Write e.g. "192.", which is 3 digits and a dot. */
+        uxNeeded = ( ( socklen_t ) sockDIGIT_COUNT - uxSource ) + 1U;
+
+        if( ( uxIndex + uxNeeded ) > uxSize )
+        {
+            /* The result won't fit. */
+            pcResult = NULL;
+            break;
+        }
+
+        for( ; uxSource < ( socklen_t ) sockDIGIT_COUNT; uxSource++ )
+        {
+            pcBuffer[ uxIndex ] = ( char ) ( pucDigits[ uxSource ] + ( char ) '0' );
+            uxIndex++;
+        }
+
+        if( uxNibble < ( ipSIZE_OF_IPv4_ADDRESS - 1U ) )
+        {
+            pcBuffer[ uxIndex ] = '.';
+        }
+        else
+        {
+            pcBuffer[ uxIndex ] = '\0';
+        }
+
+        uxIndex++;
+    }
+
+    return pcResult;
 }
 /*-----------------------------------------------------------*/
 
-BaseType_t FreeRTOS_inet_pton( BaseType_t xAddressFamily, const char *pcSource, void *pvDestination )
+BaseType_t FreeRTOS_inet_pton( BaseType_t xAddressFamily,
+                               const char * pcSource,
+                               void * pvDestination )
 {
-BaseType_t xResult;
+    BaseType_t xResult;
 
-	/* Printable string to struct sockaddr. */
-	switch( xAddressFamily )
-	{
-		case FREERTOS_AF_INET:
-			xResult = FreeRTOS_inet_pton4( pcSource, pvDestination );
-			break;
-		default:
-			xResult = -pdFREERTOS_ERRNO_EAFNOSUPPORT;
-			break;
-	}
-	return xResult;
+    /* Printable string to struct sockaddr. */
+    switch( xAddressFamily )
+    {
+        case FREERTOS_AF_INET:
+            xResult = FreeRTOS_inet_pton4( pcSource, pvDestination );
+            break;
+
+        default:
+            xResult = -pdFREERTOS_ERRNO_EAFNOSUPPORT;
+            break;
+    }
+
+    return xResult;
 }
 /*-----------------------------------------------------------*/
 
-const char *FreeRTOS_inet_ntop( BaseType_t xAddressFamily, const void *pvSource, char *pcDestination, socklen_t uxSize )
+const char * FreeRTOS_inet_ntop( BaseType_t xAddressFamily,
+                                 const void * pvSource,
+                                 char * pcDestination,
+                                 socklen_t uxSize )
 {
-const char *pcResult;
+    const char * pcResult;
 
-	/* Printable struct sockaddr to string. */
-	switch( xAddressFamily )
-	{
-		case FREERTOS_AF_INET:
-			pcResult = FreeRTOS_inet_ntop4( pvSource, pcDestination, uxSize );
-			break;
-		default:
-			/* errno should be set to pdFREERTOS_ERRNO_EAFNOSUPPORT. */
-			pcResult = NULL;
-			break;
-	}
-	return pcResult;
+    /* Printable struct sockaddr to string. */
+    switch( xAddressFamily )
+    {
+        case FREERTOS_AF_INET:
+            pcResult = FreeRTOS_inet_ntop4( pvSource, pcDestination, uxSize );
+            break;
+
+        default:
+            /* errno should be set to pdFREERTOS_ERRNO_EAFNOSUPPORT. */
+            pcResult = NULL;
+            break;
+    }
+
+    return pcResult;
 }
 /*-----------------------------------------------------------*/
 
-const char *FreeRTOS_inet_ntop4( const void *pvSource, char *pcDestination, socklen_t uxSize )
+const char * FreeRTOS_inet_ntop4( const void * pvSource,
+                                  char * pcDestination,
+                                  socklen_t uxSize )
 {
-uint32_t ulIPAddress;
-const char *pcReturn;
+    uint32_t ulIPAddress;
+    const char * pcReturn;
 
-	if( uxSize < 16U )
-	{
-		/* There must be space for "255.255.255.255". */
-		pcReturn = NULL;
-	}
-	else
-	{
-		( void ) memcpy( &( ulIPAddress ), pvSource, sizeof( ulIPAddress ) );
-		( void ) FreeRTOS_inet_ntoa( ulIPAddress, pcDestination );
-		pcReturn = pcDestination;
-	}
-	return pcReturn;
+    if( uxSize < 16U )
+    {
+        /* There must be space for "255.255.255.255". */
+        pcReturn = NULL;
+    }
+    else
+    {
+        ( void ) memcpy( &( ulIPAddress ), pvSource, sizeof( ulIPAddress ) );
+        ( void ) FreeRTOS_inet_ntoa( ulIPAddress, pcDestination );
+        pcReturn = pcDestination;
+    }
+
+    return pcReturn;
 }
 /*-----------------------------------------------------------*/
 
-BaseType_t FreeRTOS_inet_pton4( const char *pcSource, void *pvDestination )
+BaseType_t FreeRTOS_inet_pton4( const char * pcSource,
+                                void * pvDestination )
 {
-const uint32_t ulDecimalBase = 10U;
-uint8_t ucOctet[ socketMAX_IP_ADDRESS_OCTETS ];
-uint32_t ulReturn = 0UL, ulValue;
-UBaseType_t uxOctetNumber;
-BaseType_t xResult = pdPASS;
-const char *pcIPAddress = pcSource;
+    const uint32_t ulDecimalBase = 10U;
+    uint8_t ucOctet[ socketMAX_IP_ADDRESS_OCTETS ];
+    uint32_t ulReturn = 0UL, ulValue;
+    UBaseType_t uxOctetNumber;
+    BaseType_t xResult = pdPASS;
+    const char * pcIPAddress = pcSource;
 
-	/* Translate "192.168.2.100" to a 32-bit number, network-endian. */
-	for( uxOctetNumber = 0U; uxOctetNumber < socketMAX_IP_ADDRESS_OCTETS; uxOctetNumber++ )
-	{
-		ulValue = 0UL;
+    /* Translate "192.168.2.100" to a 32-bit number, network-endian. */
+    for( uxOctetNumber = 0U; uxOctetNumber < socketMAX_IP_ADDRESS_OCTETS; uxOctetNumber++ )
+    {
+        ulValue = 0UL;
 
-		while( ( *pcIPAddress >= '0' ) && ( *pcIPAddress <= '9' ) )
-		{
-		BaseType_t xChar;
-			/* Move previous read characters into the next decimal
-			position. */
-			ulValue *= ulDecimalBase;
+        while( ( *pcIPAddress >= '0' ) && ( *pcIPAddress <= '9' ) )
+        {
+            BaseType_t xChar;
 
-			/* Add the binary value of the ascii character. */
-			xChar = ( BaseType_t ) pcIPAddress[ 0 ];
-			xChar = xChar - ( BaseType_t ) '0';
-			ulValue += ( uint32_t ) xChar;
+            /* Move previous read characters into the next decimal
+             * position. */
+            ulValue *= ulDecimalBase;
 
-			/* Move to next character in the string. */
-			pcIPAddress++;
-		}
+            /* Add the binary value of the ascii character. */
+            xChar = ( BaseType_t ) pcIPAddress[ 0 ];
+            xChar = xChar - ( BaseType_t ) '0';
+            ulValue += ( uint32_t ) xChar;
 
-		/* Check characters were read. */
-		if( pcIPAddress == pcSource )
-		{
-			xResult = pdFAIL;
-		}
+            /* Move to next character in the string. */
+            pcIPAddress++;
+        }
 
-		/* Check the value fits in an 8-bit number. */
-		if( ulValue > 0xffUL )
-		{
-			xResult = pdFAIL;
-		}
-		else
-		{
-			ucOctet[ uxOctetNumber ] = ( uint8_t ) ulValue;
+        /* Check characters were read. */
+        if( pcIPAddress == pcSource )
+        {
+            xResult = pdFAIL;
+        }
 
-			/* Check the next character is as expected. */
-			if( uxOctetNumber < ( socketMAX_IP_ADDRESS_OCTETS - 1U ) )
-			{
-				if( *pcIPAddress != '.' )
-				{
-					xResult = pdFAIL;
-				}
-				else
-				{
-					/* Move past the dot. */
-					pcIPAddress++;
-				}
-			}
-		}
+        /* Check the value fits in an 8-bit number. */
+        if( ulValue > 0xffUL )
+        {
+            xResult = pdFAIL;
+        }
+        else
+        {
+            ucOctet[ uxOctetNumber ] = ( uint8_t ) ulValue;
 
-		if( xResult == pdFAIL )
-		{
-			/* No point going on. */
-			break;
-		}
-	}
+            /* Check the next character is as expected. */
+            if( uxOctetNumber < ( socketMAX_IP_ADDRESS_OCTETS - 1U ) )
+            {
+                if( *pcIPAddress != '.' )
+                {
+                    xResult = pdFAIL;
+                }
+                else
+                {
+                    /* Move past the dot. */
+                    pcIPAddress++;
+                }
+            }
+        }
 
-	if( *pcIPAddress != ( char ) 0 )
-	{
-		/* Expected the end of the string. */
-		xResult = pdFAIL;
-	}
+        if( xResult == pdFAIL )
+        {
+            /* No point going on. */
+            break;
+        }
+    }
 
-	if( uxOctetNumber != socketMAX_IP_ADDRESS_OCTETS )
-	{
-		/* Didn't read enough octets. */
-		xResult = pdFAIL;
-	}
+    if( *pcIPAddress != ( char ) 0 )
+    {
+        /* Expected the end of the string. */
+        xResult = pdFAIL;
+    }
 
-	if( xResult == pdPASS )
-	{
-		/* lint: ucOctet has been set because xResult == pdPASS. */
-		ulReturn = FreeRTOS_inet_addr_quick( ucOctet[ 0 ], ucOctet[ 1 ], ucOctet[ 2 ], ucOctet[ 3 ] );
-	}
-	else
-	{
-		ulReturn = 0UL;
-	}
-	( void ) memcpy( pvDestination, &( ulReturn ), sizeof( ulReturn ) );
+    if( uxOctetNumber != socketMAX_IP_ADDRESS_OCTETS )
+    {
+        /* Didn't read enough octets. */
+        xResult = pdFAIL;
+    }
 
-	return xResult;
+    if( xResult == pdPASS )
+    {
+        /* lint: ucOctet has been set because xResult == pdPASS. */
+        ulReturn = FreeRTOS_inet_addr_quick( ucOctet[ 0 ], ucOctet[ 1 ], ucOctet[ 2 ], ucOctet[ 3 ] );
+    }
+    else
+    {
+        ulReturn = 0UL;
+    }
+
+    ( void ) memcpy( pvDestination, &( ulReturn ), sizeof( ulReturn ) );
+
+    return xResult;
 }
 /*-----------------------------------------------------------*/
 
 uint32_t FreeRTOS_inet_addr( const char * pcIPAddress )
 {
-uint32_t ulReturn = 0UL;
+    uint32_t ulReturn = 0UL;
 
-	/* inet_pton AF_INET target is a 4-byte 'struct in_addr'. */
-	( void ) FreeRTOS_inet_pton4( pcIPAddress, &( ulReturn ) );
+    /* inet_pton AF_INET target is a 4-byte 'struct in_addr'. */
+    ( void ) FreeRTOS_inet_pton4( pcIPAddress, &( ulReturn ) );
 
-	return ulReturn;
+    return ulReturn;
 }
 /*-----------------------------------------------------------*/
 
 
 /* Function to get the local address and IP port */
-size_t FreeRTOS_GetLocalAddress( Socket_t xSocket, struct freertos_sockaddr *pxAddress )
+size_t FreeRTOS_GetLocalAddress( Socket_t xSocket,
+                                 struct freertos_sockaddr * pxAddress )
 {
-const FreeRTOS_Socket_t *pxSocket = ( const FreeRTOS_Socket_t * ) xSocket;
+    const FreeRTOS_Socket_t * pxSocket = ( const FreeRTOS_Socket_t * ) xSocket;
 
-	/* IP address of local machine. */
-	pxAddress->sin_addr = *ipLOCAL_IP_ADDRESS_POINTER;
+    /* IP address of local machine. */
+    pxAddress->sin_addr = *ipLOCAL_IP_ADDRESS_POINTER;
 
-	/* Local port on this machine. */
-	pxAddress->sin_port = FreeRTOS_htons( pxSocket->usLocalPort );
+    /* Local port on this machine. */
+    pxAddress->sin_port = FreeRTOS_htons( pxSocket->usLocalPort );
 
-	return sizeof( *pxAddress );
+    return sizeof( *pxAddress );
 }
 
 /*-----------------------------------------------------------*/
 
-void vSocketWakeUpUser( FreeRTOS_Socket_t *pxSocket )
+void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
 {
 /* _HT_ must work this out, now vSocketWakeUpUser will be called for any important
  * event or transition */
-	#if( ipconfigSOCKET_HAS_USER_SEMAPHORE == 1 )
-	{
-		if( pxSocket->pxUserSemaphore != NULL )
-		{
-			( void ) xSemaphoreGive( pxSocket->pxUserSemaphore );
-		}
-	}
-	#endif /* ipconfigSOCKET_HAS_USER_SEMAPHORE */
+    #if ( ipconfigSOCKET_HAS_USER_SEMAPHORE == 1 )
+        {
+            if( pxSocket->pxUserSemaphore != NULL )
+            {
+                ( void ) xSemaphoreGive( pxSocket->pxUserSemaphore );
+            }
+        }
+    #endif /* ipconfigSOCKET_HAS_USER_SEMAPHORE */
 
-	#if( ipconfigSOCKET_HAS_USER_WAKE_CALLBACK == 1 )
-	{
-		if( pxSocket->pxUserWakeCallback != NULL )
-		{
-			pxSocket->pxUserWakeCallback( pxSocket );
-		}
-	}
-	#endif /* ipconfigSOCKET_HAS_USER_WAKE_CALLBACK */
+    #if ( ipconfigSOCKET_HAS_USER_WAKE_CALLBACK == 1 )
+        {
+            if( pxSocket->pxUserWakeCallback != NULL )
+            {
+                pxSocket->pxUserWakeCallback( pxSocket );
+            }
+        }
+    #endif /* ipconfigSOCKET_HAS_USER_WAKE_CALLBACK */
 
-	#if( ipconfigSUPPORT_SELECT_FUNCTION == 1 )
-	{
-		if( pxSocket->pxSocketSet != NULL )
-		{
-			EventBits_t xSelectBits = ( pxSocket->xEventBits >> SOCKET_EVENT_BIT_COUNT ) & ( ( EventBits_t ) eSELECT_ALL );
-			if( xSelectBits != 0UL )
-			{
-				pxSocket->xSocketBits |= xSelectBits;
-				( void ) xEventGroupSetBits( pxSocket->pxSocketSet->xSelectGroup, xSelectBits );
-			}
-		}
+    #if ( ipconfigSUPPORT_SELECT_FUNCTION == 1 )
+        {
+            if( pxSocket->pxSocketSet != NULL )
+            {
+                EventBits_t xSelectBits = ( pxSocket->xEventBits >> SOCKET_EVENT_BIT_COUNT ) & ( ( EventBits_t ) eSELECT_ALL );
 
-		pxSocket->xEventBits &= ( EventBits_t ) eSOCKET_ALL;
-	}
-	#endif /* ipconfigSUPPORT_SELECT_FUNCTION */
+                if( xSelectBits != 0UL )
+                {
+                    pxSocket->xSocketBits |= xSelectBits;
+                    ( void ) xEventGroupSetBits( pxSocket->pxSocketSet->xSelectGroup, xSelectBits );
+                }
+            }
 
-	if( ( pxSocket->xEventGroup != NULL ) && ( pxSocket->xEventBits != 0U ) )
-	{
-		( void ) xEventGroupSetBits( pxSocket->xEventGroup, pxSocket->xEventBits );
-	}
+            pxSocket->xEventBits &= ( EventBits_t ) eSOCKET_ALL;
+        }
+    #endif /* ipconfigSUPPORT_SELECT_FUNCTION */
 
-	pxSocket->xEventBits = 0UL;
+    if( ( pxSocket->xEventGroup != NULL ) && ( pxSocket->xEventBits != 0U ) )
+    {
+        ( void ) xEventGroupSetBits( pxSocket->xEventGroup, pxSocket->xEventBits );
+    }
+
+    pxSocket->xEventBits = 0UL;
 }
 
 /*-----------------------------------------------------------*/
 
-#if( ipconfigETHERNET_DRIVER_FILTERS_PACKETS == 1 )
+#if ( ipconfigETHERNET_DRIVER_FILTERS_PACKETS == 1 )
 
-	/* This define makes it possible for network-card drivers to inspect
-	 * UDP message and see if there is any UDP socket bound to a given port
-	 * number.
-	 * This is probably only useful in systems with a minimum of RAM and
-	 * when lots of anonymous broadcast messages come in
-	 */
-	BaseType_t xPortHasUDPSocket( uint16_t usPortNr )
-	{
-	BaseType_t xFound = pdFALSE;
+    /* This define makes it possible for network-card drivers to inspect
+     * UDP message and see if there is any UDP socket bound to a given port
+     * number.
+     * This is probably only useful in systems with a minimum of RAM and
+     * when lots of anonymous broadcast messages come in
+     */
+    BaseType_t xPortHasUDPSocket( uint16_t usPortNr )
+    {
+        BaseType_t xFound = pdFALSE;
 
-		vTaskSuspendAll();
-		{
-			if( ( pxListFindListItemWithValue( &xBoundUDPSocketsList, ( TickType_t ) usPortNr ) != NULL ) )
-			{
-				xFound = pdTRUE;
-			}
-		}
-		( void ) xTaskResumeAll();
+        vTaskSuspendAll();
+        {
+            if( ( pxListFindListItemWithValue( &xBoundUDPSocketsList, ( TickType_t ) usPortNr ) != NULL ) )
+            {
+                xFound = pdTRUE;
+            }
+        }
+        ( void ) xTaskResumeAll();
 
-		return xFound;
-	}
+        return xFound;
+    }
 
 #endif /* ipconfigETHERNET_DRIVER_FILTERS_PACKETS */
 
 /*-----------------------------------------------------------*/
 
-#if( ipconfigUSE_TCP == 1 )
+#if ( ipconfigUSE_TCP == 1 )
 
-	static BaseType_t bMayConnect( FreeRTOS_Socket_t const * pxSocket )
-	{
-	BaseType_t xResult;
-	eIPTCPState_t eState = ipNUMERIC_CAST( eIPTCPState_t, pxSocket->u.xTCP.ucTCPState );
+    static BaseType_t bMayConnect( FreeRTOS_Socket_t const * pxSocket )
+    {
+        BaseType_t xResult;
+        eIPTCPState_t eState = ipNUMERIC_CAST( eIPTCPState_t, pxSocket->u.xTCP.ucTCPState );
 
-		switch( eState )
-		{
-			case eCLOSED:
-			case eCLOSE_WAIT:
-				xResult = 0;
-				break;
-			case eCONNECT_SYN:
-				xResult = -pdFREERTOS_ERRNO_EINPROGRESS;
-				break;
-			case eTCP_LISTEN:
-			case eSYN_FIRST:
-			case eSYN_RECEIVED:
-			case eESTABLISHED:
-			case eFIN_WAIT_1:
-			case eFIN_WAIT_2:
-			case eCLOSING:
-			case eLAST_ACK:
-			case eTIME_WAIT:
-			default:
-				xResult = -pdFREERTOS_ERRNO_EAGAIN;
-				break;
-		}
-		return xResult;
-	}
+        switch( eState )
+        {
+            case eCLOSED:
+            case eCLOSE_WAIT:
+                xResult = 0;
+                break;
 
-#endif /* ipconfigUSE_TCP */
-/*-----------------------------------------------------------*/
+            case eCONNECT_SYN:
+                xResult = -pdFREERTOS_ERRNO_EINPROGRESS;
+                break;
 
-#if( ipconfigUSE_TCP == 1 )
+            case eTCP_LISTEN:
+            case eSYN_FIRST:
+            case eSYN_RECEIVED:
+            case eESTABLISHED:
+            case eFIN_WAIT_1:
+            case eFIN_WAIT_2:
+            case eCLOSING:
+            case eLAST_ACK:
+            case eTIME_WAIT:
+            default:
+                xResult = -pdFREERTOS_ERRNO_EAGAIN;
+                break;
+        }
 
-	static BaseType_t prvTCPConnectStart( FreeRTOS_Socket_t * pxSocket, struct freertos_sockaddr const * pxAddress )
-	{
-	BaseType_t xResult = 0;
-
-		if( pxAddress == NULL )
-		{
-			/* NULL address passed to the function. Invalid value. */
-			xResult = -pdFREERTOS_ERRNO_EINVAL;
-		}
-		else if( prvValidSocket( pxSocket, FREERTOS_IPPROTO_TCP, pdFALSE ) == pdFALSE )
-		{
-			/* Not a valid socket or wrong type */
-			xResult = -pdFREERTOS_ERRNO_EBADF;
-		}
-		else if( FreeRTOS_issocketconnected( pxSocket ) > 0 )
-		{
-			/* The socket is already connected. */
-			xResult = -pdFREERTOS_ERRNO_EISCONN;
-		}
-		else if( !socketSOCKET_IS_BOUND( pxSocket ) )
-		{
-			/* Bind the socket to the port that the client task will send from.
-			Non-standard, so the error returned is that returned by bind(). */
-			xResult = FreeRTOS_bind( pxSocket, NULL, 0U );
-		}
-		else
-		{
-			/* The socket is valid, not yet connected, and already bound to a port number. */
-		}
-
-		if( xResult == 0 )
-		{
-			/* Check if it makes any sense to wait for a connect event, this condition
-			might change while sleeping, so it must be checked within each loop */
-			xResult = bMayConnect( pxSocket ); /* -EINPROGRESS, -EAGAIN, or 0 for OK */
-
-			/* Start the connect procedure, kernel will start working on it */
-			if( xResult == 0 )
-			{
-				pxSocket->u.xTCP.bits.bConnPrepared = pdFALSE;
-				pxSocket->u.xTCP.ucRepCount = 0U;
-
-				FreeRTOS_debug_printf( ( "FreeRTOS_connect: %u to %lxip:%u\n",
-					pxSocket->usLocalPort, FreeRTOS_ntohl( pxAddress->sin_addr ), FreeRTOS_ntohs( pxAddress->sin_port ) ) );
-
-				/* Port on remote machine. */
-				pxSocket->u.xTCP.usRemotePort = FreeRTOS_ntohs( pxAddress->sin_port );
-
-				/* IP address of remote machine. */
-				pxSocket->u.xTCP.ulRemoteIP = FreeRTOS_ntohl( pxAddress->sin_addr );
-
-				/* (client) internal state: socket wants to send a connect. */
-				vTCPStateChange( pxSocket, eCONNECT_SYN );
-
-				/* To start an active connect. */
-				pxSocket->u.xTCP.usTimeout = 1U;
-
-				if( xSendEventToIPTask( eTCPTimerEvent ) != pdPASS )
-				{
-					xResult = -pdFREERTOS_ERRNO_ECANCELED;
-				}
-			}
-		}
-
-		return xResult;
-	}
+        return xResult;
+    }
 
 #endif /* ipconfigUSE_TCP */
 /*-----------------------------------------------------------*/
 
-#if( ipconfigUSE_TCP == 1 )
+#if ( ipconfigUSE_TCP == 1 )
 
-	/*
-	 * FreeRTOS_connect: socket wants to connect to a remote port
-	 */
-	BaseType_t FreeRTOS_connect( Socket_t xClientSocket, struct freertos_sockaddr *pxAddress, socklen_t xAddressLength )
-	{
-	FreeRTOS_Socket_t *pxSocket = ( FreeRTOS_Socket_t* ) xClientSocket;
-	TickType_t xRemainingTime;
-	BaseType_t xTimed = pdFALSE;
-	BaseType_t xResult = -pdFREERTOS_ERRNO_EINVAL;
-	TimeOut_t xTimeOut;
+    static BaseType_t prvTCPConnectStart( FreeRTOS_Socket_t * pxSocket,
+                                          struct freertos_sockaddr const * pxAddress )
+    {
+        BaseType_t xResult = 0;
 
-		( void ) xAddressLength;
+        if( pxAddress == NULL )
+        {
+            /* NULL address passed to the function. Invalid value. */
+            xResult = -pdFREERTOS_ERRNO_EINVAL;
+        }
+        else if( prvValidSocket( pxSocket, FREERTOS_IPPROTO_TCP, pdFALSE ) == pdFALSE )
+        {
+            /* Not a valid socket or wrong type */
+            xResult = -pdFREERTOS_ERRNO_EBADF;
+        }
+        else if( FreeRTOS_issocketconnected( pxSocket ) > 0 )
+        {
+            /* The socket is already connected. */
+            xResult = -pdFREERTOS_ERRNO_EISCONN;
+        }
+        else if( !socketSOCKET_IS_BOUND( pxSocket ) )
+        {
+            /* Bind the socket to the port that the client task will send from.
+             * Non-standard, so the error returned is that returned by bind(). */
+            xResult = FreeRTOS_bind( pxSocket, NULL, 0U );
+        }
+        else
+        {
+            /* The socket is valid, not yet connected, and already bound to a port number. */
+        }
 
-		xResult = prvTCPConnectStart( pxSocket, pxAddress );
+        if( xResult == 0 )
+        {
+            /* Check if it makes any sense to wait for a connect event, this condition
+             * might change while sleeping, so it must be checked within each loop */
+            xResult = bMayConnect( pxSocket ); /* -EINPROGRESS, -EAGAIN, or 0 for OK */
 
-		if( xResult == 0 )
-		{
-			/* And wait for the result */
-			for( ;; )
-			{
-				if( xTimed == pdFALSE )
-				{
-					/* Only in the first round, check for non-blocking */
-					xRemainingTime = pxSocket->xReceiveBlockTime;
-					if( xRemainingTime == ( TickType_t )0 )
-					{
-						/* Not yet connected, correct state, non-blocking. */
-						xResult = -pdFREERTOS_ERRNO_EWOULDBLOCK;
-						break;
-					}
+            /* Start the connect procedure, kernel will start working on it */
+            if( xResult == 0 )
+            {
+                pxSocket->u.xTCP.bits.bConnPrepared = pdFALSE;
+                pxSocket->u.xTCP.ucRepCount = 0U;
 
-					/* Don't get here a second time. */
-					xTimed = pdTRUE;
+                FreeRTOS_debug_printf( ( "FreeRTOS_connect: %u to %lxip:%u\n",
+                                         pxSocket->usLocalPort, FreeRTOS_ntohl( pxAddress->sin_addr ), FreeRTOS_ntohs( pxAddress->sin_port ) ) );
 
-					/* Fetch the current time */
-					vTaskSetTimeOutState( &xTimeOut );
-				}
+                /* Port on remote machine. */
+                pxSocket->u.xTCP.usRemotePort = FreeRTOS_ntohs( pxAddress->sin_port );
 
-				/* Did it get connected while sleeping ? */
-				xResult = FreeRTOS_issocketconnected( pxSocket );
+                /* IP address of remote machine. */
+                pxSocket->u.xTCP.ulRemoteIP = FreeRTOS_ntohl( pxAddress->sin_addr );
 
-				/* Returns positive when connected, negative means an error */
-				if( xResult < 0 )
-				{
-					/* Return the error */
-					break;
-				}
+                /* (client) internal state: socket wants to send a connect. */
+                vTCPStateChange( pxSocket, eCONNECT_SYN );
 
-				if( xResult > 0 )
-				{
-					/* Socket now connected, return a zero */
-					xResult = 0;
-					break;
-				}
+                /* To start an active connect. */
+                pxSocket->u.xTCP.usTimeout = 1U;
 
-				/* Is it allowed to sleep more? */
-				if( xTaskCheckForTimeOut( &xTimeOut, &xRemainingTime ) != pdFALSE )
-				{
-					xResult = -pdFREERTOS_ERRNO_ETIMEDOUT;
-					break;
-				}
+                if( xSendEventToIPTask( eTCPTimerEvent ) != pdPASS )
+                {
+                    xResult = -pdFREERTOS_ERRNO_ECANCELED;
+                }
+            }
+        }
 
-				/* Go sleeping until we get any down-stream event */
-				( void ) xEventGroupWaitBits( pxSocket->xEventGroup, ( EventBits_t ) eSOCKET_CONNECT, pdTRUE /*xClearOnExit*/, pdFALSE /*xWaitAllBits*/, xRemainingTime );
-			}
-		}
-
-		return xResult;
-	}
-#endif /* ipconfigUSE_TCP */
-/*-----------------------------------------------------------*/
-
-#if( ipconfigUSE_TCP == 1 )
-
-	/*
-	 * FreeRTOS_accept: can return a new connected socket
-	 * if the server socket is in listen mode and receives a connection request
-	 * The new socket will be bound already to the same port number as the listing
-	 * socket.
-	 */
-	Socket_t FreeRTOS_accept( Socket_t xServerSocket, struct freertos_sockaddr *pxAddress, socklen_t *pxAddressLength )
-	{
-	FreeRTOS_Socket_t *pxSocket = ( FreeRTOS_Socket_t * ) xServerSocket;
-	FreeRTOS_Socket_t *pxClientSocket = NULL;
-	TickType_t xRemainingTime;
-	BaseType_t xTimed = pdFALSE, xAsk = pdFALSE;
-	TimeOut_t xTimeOut;
-	IPStackEvent_t xAskEvent;
-
-		if( prvValidSocket( pxSocket, FREERTOS_IPPROTO_TCP, pdTRUE ) == pdFALSE )
-		{
-			/* Not a valid socket or wrong type */
-			pxClientSocket = FREERTOS_INVALID_SOCKET;
-		}
-		else if( ( pxSocket->u.xTCP.bits.bReuseSocket == pdFALSE_UNSIGNED ) &&
-				 ( pxSocket->u.xTCP.ucTCPState != ( uint8_t ) eTCP_LISTEN ) )
-		{
-			/* Parent socket is not in listening mode */
-			pxClientSocket = FREERTOS_INVALID_SOCKET;
-		}
-		else
-		{
-			/* Loop will stop with breaks. */
-			for( ; ; )
-			{
-				/* Is there a new client? */
-				vTaskSuspendAll();
-				{
-					if( pxSocket->u.xTCP.bits.bReuseSocket == pdFALSE_UNSIGNED )
-					{
-						pxClientSocket = pxSocket->u.xTCP.pxPeerSocket;
-					}
-					else
-					{
-						pxClientSocket = pxSocket;
-					}
-					if( pxClientSocket != NULL )
-					{
-						pxSocket->u.xTCP.pxPeerSocket = NULL;
-
-						/* Is it still not taken ? */
-						if( pxClientSocket->u.xTCP.bits.bPassAccept != pdFALSE_UNSIGNED )
-						{
-							pxClientSocket->u.xTCP.bits.bPassAccept = pdFALSE;
-						}
-						else
-						{
-							pxClientSocket = NULL;
-						}
-					}
-				}
-				( void ) xTaskResumeAll();
-
-				if( pxClientSocket != NULL )
-				{
-					if( pxAddress != NULL )
-					{
-						/* IP address of remote machine. */
-						pxAddress->sin_addr = FreeRTOS_ntohl( pxClientSocket->u.xTCP.ulRemoteIP );
-
-						/* Port on remote machine. */
-						pxAddress->sin_port = FreeRTOS_ntohs( pxClientSocket->u.xTCP.usRemotePort );
-					}
-					if( pxAddressLength != NULL )
-					{
-						*pxAddressLength = sizeof( *pxAddress );
-					}
-
-					if( pxSocket->u.xTCP.bits.bReuseSocket == pdFALSE_UNSIGNED )
-					{
-						xAsk = pdTRUE;
-					}
-				}
-
-				if( xAsk != pdFALSE )
-				{
-					/* Ask to set an event in 'xEventGroup' as soon as a new
-					client gets connected for this listening socket. */
-					xAskEvent.eEventType = eTCPAcceptEvent;
-					xAskEvent.pvData = pxSocket;
-					( void ) xSendEventStructToIPTask( &xAskEvent, portMAX_DELAY );
-				}
-
-				if( pxClientSocket != NULL )
-				{
-					break;
-				}
-
-				if( xTimed == pdFALSE )
-				{
-					/* Only in the first round, check for non-blocking */
-					xRemainingTime = pxSocket->xReceiveBlockTime;
-					if( xRemainingTime == ( TickType_t ) 0 )
-					{
-						break;
-					}
-
-					/* Don't get here a second time */
-					xTimed = pdTRUE;
-
-					/* Fetch the current time */
-					vTaskSetTimeOutState( &xTimeOut );
-				}
-
-				/* Has the timeout been reached? */
-				if( xTaskCheckForTimeOut( &xTimeOut, &xRemainingTime ) != pdFALSE )
-				{
-					break;
-				}
-
-				/* Go sleeping until we get any down-stream event */
-				( void ) xEventGroupWaitBits( pxSocket->xEventGroup, ( EventBits_t ) eSOCKET_ACCEPT, pdTRUE /*xClearOnExit*/, pdFALSE /*xWaitAllBits*/, xRemainingTime );
-			}
-		}
-
-		return pxClientSocket;
-	}
-#endif /* ipconfigUSE_TCP */
-/*-----------------------------------------------------------*/
-
-#if( ipconfigUSE_TCP == 1 )
-
-	/*
-	 * Read incoming data from a TCP socket
-	 * Only after the last byte has been read, a close error might be returned
-	 */
-	BaseType_t FreeRTOS_recv( Socket_t xSocket, void *pvBuffer, size_t uxBufferLength, BaseType_t xFlags )
-	{
-	BaseType_t xByteCount;
-	FreeRTOS_Socket_t *pxSocket = ( FreeRTOS_Socket_t * ) xSocket;
-	TickType_t xRemainingTime;
-	BaseType_t xTimed = pdFALSE;
-	TimeOut_t xTimeOut;
-	EventBits_t xEventBits = ( EventBits_t ) 0;
-
-		/* Check if the socket is valid, has type TCP and if it is bound to a
-		port. */
-		if( prvValidSocket( pxSocket, FREERTOS_IPPROTO_TCP, pdTRUE ) == pdFALSE )
-		{
-			xByteCount = -pdFREERTOS_ERRNO_EINVAL;
-		}
-		else if( ( ( ( uint32_t ) xFlags & ( uint32_t ) FREERTOS_ZERO_COPY ) != 0U ) &&
-			 ( pvBuffer == NULL ) )
-		{
-			/* In zero-copy mode, pvBuffer is a pointer to a pointer ( not NULL ). */
-			xByteCount = -pdFREERTOS_ERRNO_EINVAL;
-		}
-		else
-		{
-			if( pxSocket->u.xTCP.rxStream != NULL )
-			{
-				xByteCount = ( BaseType_t )uxStreamBufferGetSize ( pxSocket->u.xTCP.rxStream );
-			}
-			else
-			{
-				xByteCount = 0;
-			}
-
-			while( xByteCount == 0 )
-			{
-				switch( ipNUMERIC_CAST( eIPTCPState_t, pxSocket->u.xTCP.ucTCPState ) )
-				{
-				case eCLOSED:
-				case eCLOSE_WAIT:	/* (server + client) waiting for a connection termination request from the local user. */
-				case eCLOSING:		/* (server + client) waiting for a connection termination request acknowledgement from the remote TCP. */
-					if( pxSocket->u.xTCP.bits.bMallocError != pdFALSE_UNSIGNED )
-					{
-						/* The no-memory error has priority above the non-connected error.
-						Both are fatal and will elad to closing the socket. */
-						xByteCount = -pdFREERTOS_ERRNO_ENOMEM;
-					}
-					else
-					{
-						xByteCount = -pdFREERTOS_ERRNO_ENOTCONN;
-					}
-					break;
-
-				case eTCP_LISTEN:
-				case eCONNECT_SYN:
-				case eSYN_FIRST:
-				case eSYN_RECEIVED:
-				case eESTABLISHED:
-				case eFIN_WAIT_1:
-				case eFIN_WAIT_2:
-				case eLAST_ACK:
-				case eTIME_WAIT:
-				default:
-					/* Nothing. */
-					break;
-				}
-				if( xByteCount < 0 )
-				{
-					break;
-				}
-
-				if( xTimed == pdFALSE )
-				{
-					/* Only in the first round, check for non-blocking. */
-					xRemainingTime = pxSocket->xReceiveBlockTime;
-
-					if( xRemainingTime == ( TickType_t ) 0 )
-					{
-						#if( ipconfigSUPPORT_SIGNALS != 0 )
-						{
-							/* Just check for the interrupt flag. */
-							xEventBits = xEventGroupWaitBits( pxSocket->xEventGroup, ( EventBits_t ) eSOCKET_INTR,
-								pdTRUE /*xClearOnExit*/, pdFALSE /*xWaitAllBits*/, socketDONT_BLOCK );
-						}
-						#endif /* ipconfigSUPPORT_SIGNALS */
-						break;
-					}
-
-					if( ( ( uint32_t ) xFlags & ( uint32_t ) FREERTOS_MSG_DONTWAIT ) != 0U )
-					{
-						break;
-					}
-
-					/* Don't get here a second time. */
-					xTimed = pdTRUE;
-
-					/* Fetch the current time. */
-					vTaskSetTimeOutState( &xTimeOut );
-				}
-
-				/* Has the timeout been reached? */
-				if( xTaskCheckForTimeOut( &xTimeOut, &xRemainingTime ) != pdFALSE )
-				{
-					break;
-				}
-
-				/* Block until there is a down-stream event. */
-				xEventBits = xEventGroupWaitBits( pxSocket->xEventGroup,
-					( EventBits_t ) eSOCKET_RECEIVE | ( EventBits_t ) eSOCKET_CLOSED | ( EventBits_t ) eSOCKET_INTR,
-					pdTRUE /*xClearOnExit*/, pdFALSE /*xWaitAllBits*/, xRemainingTime );
-				#if( ipconfigSUPPORT_SIGNALS != 0 )
-				{
-					if( ( xEventBits & ( EventBits_t ) eSOCKET_INTR ) != 0U )
-					{
-						break;
-					}
-				}
-				#else
-				{
-					( void ) xEventBits;
-				}
-				#endif /* ipconfigSUPPORT_SIGNALS */
-
-				if( pxSocket->u.xTCP.rxStream != NULL )
-				{
-					xByteCount = ( BaseType_t ) uxStreamBufferGetSize ( pxSocket->u.xTCP.rxStream );
-				}
-				else
-				{
-					xByteCount = 0;
-				}
-			}
-
-		#if( ipconfigSUPPORT_SIGNALS != 0 )
-			if( ( xEventBits & ( EventBits_t ) eSOCKET_INTR ) != 0U )
-			{
-				if( ( xEventBits & ( ( EventBits_t ) eSOCKET_RECEIVE | ( EventBits_t ) eSOCKET_CLOSED ) ) != 0U )
-				{
-					/* Shouldn't have cleared other flags. */
-					xEventBits &= ~( ( EventBits_t ) eSOCKET_INTR );
-					( void ) xEventGroupSetBits( pxSocket->xEventGroup, xEventBits );
-				}
-				xByteCount = -pdFREERTOS_ERRNO_EINTR;
-			}
-			else
-		#endif /* ipconfigSUPPORT_SIGNALS */
-			if( xByteCount > 0 )
-			{
-				if( ( ( uint32_t ) xFlags & ( uint32_t ) FREERTOS_ZERO_COPY ) == 0U )
-				{
-				BaseType_t xIsPeek = ( ( ( uint32_t ) xFlags & ( uint32_t ) FREERTOS_MSG_PEEK ) != 0U ) ? 1L : 0L;
-
-					xByteCount = ( BaseType_t )
-						uxStreamBufferGet( pxSocket->u.xTCP.rxStream,
-										   0UL,
-										   ipPOINTER_CAST( uint8_t *, pvBuffer ),
-										   ( size_t ) uxBufferLength,
-										   xIsPeek );
-					if( pxSocket->u.xTCP.bits.bLowWater != pdFALSE_UNSIGNED )
-					{
-						/* We had reached the low-water mark, now see if the flag
-						can be cleared */
-						size_t uxFrontSpace = uxStreamBufferFrontSpace( pxSocket->u.xTCP.rxStream );
-
-						if( uxFrontSpace >= pxSocket->u.xTCP.uxEnoughSpace )
-						{
-							pxSocket->u.xTCP.bits.bLowWater = pdFALSE;
-							pxSocket->u.xTCP.bits.bWinChange = pdTRUE;
-							pxSocket->u.xTCP.usTimeout = 1U; /* because bLowWater is cleared. */
-							( void ) xSendEventToIPTask( eTCPTimerEvent );
-						}
-					}
-				}
-				else
-				{
-					/* Zero-copy reception of data: pvBuffer is a pointer to a pointer. */
-					xByteCount = ( BaseType_t ) uxStreamBufferGetPtr( pxSocket->u.xTCP.rxStream, ipPOINTER_CAST( uint8_t **, pvBuffer ) );
-				}
-			}
-			else
-			{
-				/* Nothing. */
-			}
-		} /* prvValidSocket() */
-
-		return xByteCount;
-	}
+        return xResult;
+    }
 
 #endif /* ipconfigUSE_TCP */
 /*-----------------------------------------------------------*/
 
-#if( ipconfigUSE_TCP == 1 )
+#if ( ipconfigUSE_TCP == 1 )
 
-	static int32_t prvTCPSendCheck( FreeRTOS_Socket_t *pxSocket, size_t uxDataLength )
-	{
-	int32_t xResult = 1;
+    /*
+     * FreeRTOS_connect: socket wants to connect to a remote port
+     */
+    BaseType_t FreeRTOS_connect( Socket_t xClientSocket,
+                                 struct freertos_sockaddr * pxAddress,
+                                 socklen_t xAddressLength )
+    {
+        FreeRTOS_Socket_t * pxSocket = ( FreeRTOS_Socket_t * ) xClientSocket;
+        TickType_t xRemainingTime;
+        BaseType_t xTimed = pdFALSE;
+        BaseType_t xResult = -pdFREERTOS_ERRNO_EINVAL;
+        TimeOut_t xTimeOut;
 
-		/* Is this a socket of type TCP and is it already bound to a port number ? */
-		if( prvValidSocket( pxSocket, FREERTOS_IPPROTO_TCP, pdTRUE ) == pdFALSE )
-		{
-			xResult = -pdFREERTOS_ERRNO_EINVAL;
-		}
-		else if( pxSocket->u.xTCP.bits.bMallocError != pdFALSE_UNSIGNED )
-		{
-			xResult = -pdFREERTOS_ERRNO_ENOMEM;
-		}
-		else if( ( pxSocket->u.xTCP.ucTCPState == ( uint8_t ) eCLOSED ) ||
-				 ( pxSocket->u.xTCP.ucTCPState == ( uint8_t ) eCLOSE_WAIT ) ||
-				 ( pxSocket->u.xTCP.ucTCPState == ( uint8_t ) eCLOSING ) )
-		{
-			xResult = -pdFREERTOS_ERRNO_ENOTCONN;
-		}
-		else if( pxSocket->u.xTCP.bits.bFinSent != pdFALSE_UNSIGNED )
-		{
-			/* This TCP connection is closing already, the FIN flag has been sent.
-			Maybe it is still delivering or receiving data.
-			Return OK in order not to get closed/deleted too quickly */
-			xResult = 0;
-		}
-		else if( uxDataLength == 0UL )
-		{
-			/* send() is being called to send zero bytes */
-			xResult = 0;
-		}
-		else if( pxSocket->u.xTCP.txStream == NULL )
-		{
-			/* Create the outgoing stream only when it is needed */
-			( void ) prvTCPCreateStream( pxSocket, pdFALSE );
+        ( void ) xAddressLength;
 
-			if( pxSocket->u.xTCP.txStream == NULL )
-			{
-				xResult = -pdFREERTOS_ERRNO_ENOMEM;
-			}
-		}
-		else
-		{
-			/* Nothing. */
-		}
+        xResult = prvTCPConnectStart( pxSocket, pxAddress );
 
-		return xResult;
-	}
+        if( xResult == 0 )
+        {
+            /* And wait for the result */
+            for( ; ; )
+            {
+                if( xTimed == pdFALSE )
+                {
+                    /* Only in the first round, check for non-blocking */
+                    xRemainingTime = pxSocket->xReceiveBlockTime;
+
+                    if( xRemainingTime == ( TickType_t ) 0 )
+                    {
+                        /* Not yet connected, correct state, non-blocking. */
+                        xResult = -pdFREERTOS_ERRNO_EWOULDBLOCK;
+                        break;
+                    }
+
+                    /* Don't get here a second time. */
+                    xTimed = pdTRUE;
+
+                    /* Fetch the current time */
+                    vTaskSetTimeOutState( &xTimeOut );
+                }
+
+                /* Did it get connected while sleeping ? */
+                xResult = FreeRTOS_issocketconnected( pxSocket );
+
+                /* Returns positive when connected, negative means an error */
+                if( xResult < 0 )
+                {
+                    /* Return the error */
+                    break;
+                }
+
+                if( xResult > 0 )
+                {
+                    /* Socket now connected, return a zero */
+                    xResult = 0;
+                    break;
+                }
+
+                /* Is it allowed to sleep more? */
+                if( xTaskCheckForTimeOut( &xTimeOut, &xRemainingTime ) != pdFALSE )
+                {
+                    xResult = -pdFREERTOS_ERRNO_ETIMEDOUT;
+                    break;
+                }
+
+                /* Go sleeping until we get any down-stream event */
+                ( void ) xEventGroupWaitBits( pxSocket->xEventGroup, ( EventBits_t ) eSOCKET_CONNECT, pdTRUE /*xClearOnExit*/, pdFALSE /*xWaitAllBits*/, xRemainingTime );
+            }
+        }
+
+        return xResult;
+    }
+#endif /* ipconfigUSE_TCP */
+/*-----------------------------------------------------------*/
+
+#if ( ipconfigUSE_TCP == 1 )
+
+    /*
+     * FreeRTOS_accept: can return a new connected socket
+     * if the server socket is in listen mode and receives a connection request
+     * The new socket will be bound already to the same port number as the listing
+     * socket.
+     */
+    Socket_t FreeRTOS_accept( Socket_t xServerSocket,
+                              struct freertos_sockaddr * pxAddress,
+                              socklen_t * pxAddressLength )
+    {
+        FreeRTOS_Socket_t * pxSocket = ( FreeRTOS_Socket_t * ) xServerSocket;
+        FreeRTOS_Socket_t * pxClientSocket = NULL;
+        TickType_t xRemainingTime;
+        BaseType_t xTimed = pdFALSE, xAsk = pdFALSE;
+        TimeOut_t xTimeOut;
+        IPStackEvent_t xAskEvent;
+
+        if( prvValidSocket( pxSocket, FREERTOS_IPPROTO_TCP, pdTRUE ) == pdFALSE )
+        {
+            /* Not a valid socket or wrong type */
+            pxClientSocket = FREERTOS_INVALID_SOCKET;
+        }
+        else if( ( pxSocket->u.xTCP.bits.bReuseSocket == pdFALSE_UNSIGNED ) &&
+                 ( pxSocket->u.xTCP.ucTCPState != ( uint8_t ) eTCP_LISTEN ) )
+        {
+            /* Parent socket is not in listening mode */
+            pxClientSocket = FREERTOS_INVALID_SOCKET;
+        }
+        else
+        {
+            /* Loop will stop with breaks. */
+            for( ; ; )
+            {
+                /* Is there a new client? */
+                vTaskSuspendAll();
+                {
+                    if( pxSocket->u.xTCP.bits.bReuseSocket == pdFALSE_UNSIGNED )
+                    {
+                        pxClientSocket = pxSocket->u.xTCP.pxPeerSocket;
+                    }
+                    else
+                    {
+                        pxClientSocket = pxSocket;
+                    }
+
+                    if( pxClientSocket != NULL )
+                    {
+                        pxSocket->u.xTCP.pxPeerSocket = NULL;
+
+                        /* Is it still not taken ? */
+                        if( pxClientSocket->u.xTCP.bits.bPassAccept != pdFALSE_UNSIGNED )
+                        {
+                            pxClientSocket->u.xTCP.bits.bPassAccept = pdFALSE;
+                        }
+                        else
+                        {
+                            pxClientSocket = NULL;
+                        }
+                    }
+                }
+                ( void ) xTaskResumeAll();
+
+                if( pxClientSocket != NULL )
+                {
+                    if( pxAddress != NULL )
+                    {
+                        /* IP address of remote machine. */
+                        pxAddress->sin_addr = FreeRTOS_ntohl( pxClientSocket->u.xTCP.ulRemoteIP );
+
+                        /* Port on remote machine. */
+                        pxAddress->sin_port = FreeRTOS_ntohs( pxClientSocket->u.xTCP.usRemotePort );
+                    }
+
+                    if( pxAddressLength != NULL )
+                    {
+                        *pxAddressLength = sizeof( *pxAddress );
+                    }
+
+                    if( pxSocket->u.xTCP.bits.bReuseSocket == pdFALSE_UNSIGNED )
+                    {
+                        xAsk = pdTRUE;
+                    }
+                }
+
+                if( xAsk != pdFALSE )
+                {
+                    /* Ask to set an event in 'xEventGroup' as soon as a new
+                     * client gets connected for this listening socket. */
+                    xAskEvent.eEventType = eTCPAcceptEvent;
+                    xAskEvent.pvData = pxSocket;
+                    ( void ) xSendEventStructToIPTask( &xAskEvent, portMAX_DELAY );
+                }
+
+                if( pxClientSocket != NULL )
+                {
+                    break;
+                }
+
+                if( xTimed == pdFALSE )
+                {
+                    /* Only in the first round, check for non-blocking */
+                    xRemainingTime = pxSocket->xReceiveBlockTime;
+
+                    if( xRemainingTime == ( TickType_t ) 0 )
+                    {
+                        break;
+                    }
+
+                    /* Don't get here a second time */
+                    xTimed = pdTRUE;
+
+                    /* Fetch the current time */
+                    vTaskSetTimeOutState( &xTimeOut );
+                }
+
+                /* Has the timeout been reached? */
+                if( xTaskCheckForTimeOut( &xTimeOut, &xRemainingTime ) != pdFALSE )
+                {
+                    break;
+                }
+
+                /* Go sleeping until we get any down-stream event */
+                ( void ) xEventGroupWaitBits( pxSocket->xEventGroup, ( EventBits_t ) eSOCKET_ACCEPT, pdTRUE /*xClearOnExit*/, pdFALSE /*xWaitAllBits*/, xRemainingTime );
+            }
+        }
+
+        return pxClientSocket;
+    }
+#endif /* ipconfigUSE_TCP */
+/*-----------------------------------------------------------*/
+
+#if ( ipconfigUSE_TCP == 1 )
+
+    /*
+     * Read incoming data from a TCP socket
+     * Only after the last byte has been read, a close error might be returned
+     */
+    BaseType_t FreeRTOS_recv( Socket_t xSocket,
+                              void * pvBuffer,
+                              size_t uxBufferLength,
+                              BaseType_t xFlags )
+    {
+        BaseType_t xByteCount;
+        FreeRTOS_Socket_t * pxSocket = ( FreeRTOS_Socket_t * ) xSocket;
+        TickType_t xRemainingTime;
+        BaseType_t xTimed = pdFALSE;
+        TimeOut_t xTimeOut;
+        EventBits_t xEventBits = ( EventBits_t ) 0;
+
+        /* Check if the socket is valid, has type TCP and if it is bound to a
+         * port. */
+        if( prvValidSocket( pxSocket, FREERTOS_IPPROTO_TCP, pdTRUE ) == pdFALSE )
+        {
+            xByteCount = -pdFREERTOS_ERRNO_EINVAL;
+        }
+        else if( ( ( ( uint32_t ) xFlags & ( uint32_t ) FREERTOS_ZERO_COPY ) != 0U ) &&
+                 ( pvBuffer == NULL ) )
+        {
+            /* In zero-copy mode, pvBuffer is a pointer to a pointer ( not NULL ). */
+            xByteCount = -pdFREERTOS_ERRNO_EINVAL;
+        }
+        else
+        {
+            if( pxSocket->u.xTCP.rxStream != NULL )
+            {
+                xByteCount = ( BaseType_t ) uxStreamBufferGetSize( pxSocket->u.xTCP.rxStream );
+            }
+            else
+            {
+                xByteCount = 0;
+            }
+
+            while( xByteCount == 0 )
+            {
+                switch( ipNUMERIC_CAST( eIPTCPState_t, pxSocket->u.xTCP.ucTCPState ) )
+                {
+                    case eCLOSED:
+                    case eCLOSE_WAIT: /* (server + client) waiting for a connection termination request from the local user. */
+                    case eCLOSING:    /* (server + client) waiting for a connection termination request acknowledgement from the remote TCP. */
+
+                        if( pxSocket->u.xTCP.bits.bMallocError != pdFALSE_UNSIGNED )
+                        {
+                            /* The no-memory error has priority above the non-connected error.
+                             * Both are fatal and will elad to closing the socket. */
+                            xByteCount = -pdFREERTOS_ERRNO_ENOMEM;
+                        }
+                        else
+                        {
+                            xByteCount = -pdFREERTOS_ERRNO_ENOTCONN;
+                        }
+
+                        break;
+
+                    case eTCP_LISTEN:
+                    case eCONNECT_SYN:
+                    case eSYN_FIRST:
+                    case eSYN_RECEIVED:
+                    case eESTABLISHED:
+                    case eFIN_WAIT_1:
+                    case eFIN_WAIT_2:
+                    case eLAST_ACK:
+                    case eTIME_WAIT:
+                    default:
+                        /* Nothing. */
+                        break;
+                }
+
+                if( xByteCount < 0 )
+                {
+                    break;
+                }
+
+                if( xTimed == pdFALSE )
+                {
+                    /* Only in the first round, check for non-blocking. */
+                    xRemainingTime = pxSocket->xReceiveBlockTime;
+
+                    if( xRemainingTime == ( TickType_t ) 0 )
+                    {
+                        #if ( ipconfigSUPPORT_SIGNALS != 0 )
+                            {
+                                /* Just check for the interrupt flag. */
+                                xEventBits = xEventGroupWaitBits( pxSocket->xEventGroup, ( EventBits_t ) eSOCKET_INTR,
+                                                                  pdTRUE /*xClearOnExit*/, pdFALSE /*xWaitAllBits*/, socketDONT_BLOCK );
+                            }
+                        #endif /* ipconfigSUPPORT_SIGNALS */
+                        break;
+                    }
+
+                    if( ( ( uint32_t ) xFlags & ( uint32_t ) FREERTOS_MSG_DONTWAIT ) != 0U )
+                    {
+                        break;
+                    }
+
+                    /* Don't get here a second time. */
+                    xTimed = pdTRUE;
+
+                    /* Fetch the current time. */
+                    vTaskSetTimeOutState( &xTimeOut );
+                }
+
+                /* Has the timeout been reached? */
+                if( xTaskCheckForTimeOut( &xTimeOut, &xRemainingTime ) != pdFALSE )
+                {
+                    break;
+                }
+
+                /* Block until there is a down-stream event. */
+                xEventBits = xEventGroupWaitBits( pxSocket->xEventGroup,
+                                                  ( EventBits_t ) eSOCKET_RECEIVE | ( EventBits_t ) eSOCKET_CLOSED | ( EventBits_t ) eSOCKET_INTR,
+                                                  pdTRUE /*xClearOnExit*/, pdFALSE /*xWaitAllBits*/, xRemainingTime );
+                #if ( ipconfigSUPPORT_SIGNALS != 0 )
+                    {
+                        if( ( xEventBits & ( EventBits_t ) eSOCKET_INTR ) != 0U )
+                        {
+                            break;
+                        }
+                    }
+                #else
+                    {
+                        ( void ) xEventBits;
+                    }
+                #endif /* ipconfigSUPPORT_SIGNALS */
+
+                if( pxSocket->u.xTCP.rxStream != NULL )
+                {
+                    xByteCount = ( BaseType_t ) uxStreamBufferGetSize( pxSocket->u.xTCP.rxStream );
+                }
+                else
+                {
+                    xByteCount = 0;
+                }
+            }
+
+            #if ( ipconfigSUPPORT_SIGNALS != 0 )
+                if( ( xEventBits & ( EventBits_t ) eSOCKET_INTR ) != 0U )
+                {
+                    if( ( xEventBits & ( ( EventBits_t ) eSOCKET_RECEIVE | ( EventBits_t ) eSOCKET_CLOSED ) ) != 0U )
+                    {
+                        /* Shouldn't have cleared other flags. */
+                        xEventBits &= ~( ( EventBits_t ) eSOCKET_INTR );
+                        ( void ) xEventGroupSetBits( pxSocket->xEventGroup, xEventBits );
+                    }
+
+                    xByteCount = -pdFREERTOS_ERRNO_EINTR;
+                }
+                else
+            #endif /* ipconfigSUPPORT_SIGNALS */
+
+            if( xByteCount > 0 )
+            {
+                if( ( ( uint32_t ) xFlags & ( uint32_t ) FREERTOS_ZERO_COPY ) == 0U )
+                {
+                    BaseType_t xIsPeek = ( ( ( uint32_t ) xFlags & ( uint32_t ) FREERTOS_MSG_PEEK ) != 0U ) ? 1L : 0L;
+
+                    xByteCount = ( BaseType_t )
+                                 uxStreamBufferGet( pxSocket->u.xTCP.rxStream,
+                                                    0UL,
+                                                    ipPOINTER_CAST( uint8_t *, pvBuffer ),
+                                                    ( size_t ) uxBufferLength,
+                                                    xIsPeek );
+
+                    if( pxSocket->u.xTCP.bits.bLowWater != pdFALSE_UNSIGNED )
+                    {
+                        /* We had reached the low-water mark, now see if the flag
+                         * can be cleared */
+                        size_t uxFrontSpace = uxStreamBufferFrontSpace( pxSocket->u.xTCP.rxStream );
+
+                        if( uxFrontSpace >= pxSocket->u.xTCP.uxEnoughSpace )
+                        {
+                            pxSocket->u.xTCP.bits.bLowWater = pdFALSE;
+                            pxSocket->u.xTCP.bits.bWinChange = pdTRUE;
+                            pxSocket->u.xTCP.usTimeout = 1U; /* because bLowWater is cleared. */
+                            ( void ) xSendEventToIPTask( eTCPTimerEvent );
+                        }
+                    }
+                }
+                else
+                {
+                    /* Zero-copy reception of data: pvBuffer is a pointer to a pointer. */
+                    xByteCount = ( BaseType_t ) uxStreamBufferGetPtr( pxSocket->u.xTCP.rxStream, ipPOINTER_CAST( uint8_t * *, pvBuffer ) );
+                }
+            }
+            else
+            {
+                /* Nothing. */
+            }
+        } /* prvValidSocket() */
+
+        return xByteCount;
+    }
 
 #endif /* ipconfigUSE_TCP */
 /*-----------------------------------------------------------*/
 
-#if( ipconfigUSE_TCP == 1 )
+#if ( ipconfigUSE_TCP == 1 )
 
-	/* Get a direct pointer to the circular transmit buffer.
-	'*pxLength' will contain the number of bytes that may be written. */
-	uint8_t *FreeRTOS_get_tx_head( Socket_t xSocket, BaseType_t *pxLength )
-	{
-    uint8_t *pucReturn = NULL;
-	const FreeRTOS_Socket_t *pxSocket = ( const FreeRTOS_Socket_t * ) xSocket;
-	StreamBuffer_t *pxBuffer = NULL;
+    static int32_t prvTCPSendCheck( FreeRTOS_Socket_t * pxSocket,
+                                    size_t uxDataLength )
+    {
+        int32_t xResult = 1;
+
+        /* Is this a socket of type TCP and is it already bound to a port number ? */
+        if( prvValidSocket( pxSocket, FREERTOS_IPPROTO_TCP, pdTRUE ) == pdFALSE )
+        {
+            xResult = -pdFREERTOS_ERRNO_EINVAL;
+        }
+        else if( pxSocket->u.xTCP.bits.bMallocError != pdFALSE_UNSIGNED )
+        {
+            xResult = -pdFREERTOS_ERRNO_ENOMEM;
+        }
+        else if( ( pxSocket->u.xTCP.ucTCPState == ( uint8_t ) eCLOSED ) ||
+                 ( pxSocket->u.xTCP.ucTCPState == ( uint8_t ) eCLOSE_WAIT ) ||
+                 ( pxSocket->u.xTCP.ucTCPState == ( uint8_t ) eCLOSING ) )
+        {
+            xResult = -pdFREERTOS_ERRNO_ENOTCONN;
+        }
+        else if( pxSocket->u.xTCP.bits.bFinSent != pdFALSE_UNSIGNED )
+        {
+            /* This TCP connection is closing already, the FIN flag has been sent.
+             * Maybe it is still delivering or receiving data.
+             * Return OK in order not to get closed/deleted too quickly */
+            xResult = 0;
+        }
+        else if( uxDataLength == 0UL )
+        {
+            /* send() is being called to send zero bytes */
+            xResult = 0;
+        }
+        else if( pxSocket->u.xTCP.txStream == NULL )
+        {
+            /* Create the outgoing stream only when it is needed */
+            ( void ) prvTCPCreateStream( pxSocket, pdFALSE );
+
+            if( pxSocket->u.xTCP.txStream == NULL )
+            {
+                xResult = -pdFREERTOS_ERRNO_ENOMEM;
+            }
+        }
+        else
+        {
+            /* Nothing. */
+        }
+
+        return xResult;
+    }
+
+#endif /* ipconfigUSE_TCP */
+/*-----------------------------------------------------------*/
+
+#if ( ipconfigUSE_TCP == 1 )
+
+    /* Get a direct pointer to the circular transmit buffer.
+     * '*pxLength' will contain the number of bytes that may be written. */
+    uint8_t * FreeRTOS_get_tx_head( Socket_t xSocket,
+                                    BaseType_t * pxLength )
+    {
+        uint8_t * pucReturn = NULL;
+        const FreeRTOS_Socket_t * pxSocket = ( const FreeRTOS_Socket_t * ) xSocket;
+        StreamBuffer_t * pxBuffer = NULL;
 
         *pxLength = 0;
 
         /* Confirm that this is a TCP socket before dereferencing structure
-        member pointers. */
+         * member pointers. */
         if( prvValidSocket( pxSocket, FREERTOS_IPPROTO_TCP, pdFALSE ) == pdTRUE )
         {
             pxBuffer = pxSocket->u.xTCP.txStream;
-			if( pxBuffer != NULL )
-			{
-			BaseType_t xSpace = ( BaseType_t ) uxStreamBufferGetSpace( pxBuffer );
-			BaseType_t xRemain = ( BaseType_t ) pxBuffer->LENGTH - ( BaseType_t ) pxBuffer->uxHead;
 
-				*pxLength = FreeRTOS_min_BaseType( xSpace, xRemain );
-				pucReturn = &( pxBuffer->ucArray[ pxBuffer->uxHead ] );
-			}
-		}
+            if( pxBuffer != NULL )
+            {
+                BaseType_t xSpace = ( BaseType_t ) uxStreamBufferGetSpace( pxBuffer );
+                BaseType_t xRemain = ( BaseType_t ) pxBuffer->LENGTH - ( BaseType_t ) pxBuffer->uxHead;
 
-		return pucReturn;
-	}
+                *pxLength = FreeRTOS_min_BaseType( xSpace, xRemain );
+                pucReturn = &( pxBuffer->ucArray[ pxBuffer->uxHead ] );
+            }
+        }
+
+        return pucReturn;
+    }
 #endif /* ipconfigUSE_TCP */
 /*-----------------------------------------------------------*/
 
-#if( ipconfigUSE_TCP == 1 )
-	/*
-	 * Send data using a TCP socket.  It is not necessary to have the socket
-	 * connected already.  Outgoing data will be stored and delivered as soon as
-	 * the socket gets connected.
-	 */
-	BaseType_t FreeRTOS_send( Socket_t xSocket, const void *pvBuffer, size_t uxDataLength, BaseType_t xFlags )
-	{
-	BaseType_t xByteCount = -pdFREERTOS_ERRNO_EINVAL;
-	BaseType_t xBytesLeft;
-	FreeRTOS_Socket_t *pxSocket = ( FreeRTOS_Socket_t * ) xSocket;
-	TickType_t xRemainingTime;
-	BaseType_t xTimed = pdFALSE;
-	TimeOut_t xTimeOut;
-	BaseType_t xCloseAfterSend;
-	const uint8_t *pucSource = ipPOINTER_CAST( const uint8_t *, pvBuffer );
+#if ( ipconfigUSE_TCP == 1 )
 
-		/* Prevent compiler warnings about unused parameters.  The parameter
-		may be used in future versions. */
-		( void ) xFlags;
-		
-		if( pvBuffer != NULL )
-		{
-			xByteCount = ( BaseType_t ) prvTCPSendCheck( pxSocket, uxDataLength );
-		}
+    /*
+     * Send data using a TCP socket.  It is not necessary to have the socket
+     * connected already.  Outgoing data will be stored and delivered as soon as
+     * the socket gets connected.
+     */
+    BaseType_t FreeRTOS_send( Socket_t xSocket,
+                              const void * pvBuffer,
+                              size_t uxDataLength,
+                              BaseType_t xFlags )
+    {
+        BaseType_t xByteCount = -pdFREERTOS_ERRNO_EINVAL;
+        BaseType_t xBytesLeft;
+        FreeRTOS_Socket_t * pxSocket = ( FreeRTOS_Socket_t * ) xSocket;
+        TickType_t xRemainingTime;
+        BaseType_t xTimed = pdFALSE;
+        TimeOut_t xTimeOut;
+        BaseType_t xCloseAfterSend;
+        const uint8_t * pucSource = ipPOINTER_CAST( const uint8_t *, pvBuffer );
 
-		if( xByteCount > 0 )
-		{
-			/* xBytesLeft is number of bytes to send, will count to zero. */
-			xBytesLeft = ( BaseType_t ) uxDataLength;
+        /* Prevent compiler warnings about unused parameters.  The parameter
+         * may be used in future versions. */
+        ( void ) xFlags;
 
-			/* xByteCount is number of bytes that can be sent now. */
-			xByteCount = ( BaseType_t ) uxStreamBufferGetSpace( pxSocket->u.xTCP.txStream );
+        if( pvBuffer != NULL )
+        {
+            xByteCount = ( BaseType_t ) prvTCPSendCheck( pxSocket, uxDataLength );
+        }
 
-			/* While there are still bytes to be sent. */
-			while( xBytesLeft > 0 )
-			{
-				/* If txStream has space. */
-				if( xByteCount > 0 )
-				{
-					/* Don't send more than necessary. */
-					if( xByteCount > xBytesLeft )
-					{
-						xByteCount = xBytesLeft;
-					}
+        if( xByteCount > 0 )
+        {
+            /* xBytesLeft is number of bytes to send, will count to zero. */
+            xBytesLeft = ( BaseType_t ) uxDataLength;
 
-					/* Is the close-after-send flag set and is this really the
-					last transmission? */
-					if( ( pxSocket->u.xTCP.bits.bCloseAfterSend != pdFALSE_UNSIGNED ) && ( xByteCount == xBytesLeft ) )
-					{
-						xCloseAfterSend = pdTRUE;
-					}
-					else
-					{
-						xCloseAfterSend = pdFALSE;
-					}
+            /* xByteCount is number of bytes that can be sent now. */
+            xByteCount = ( BaseType_t ) uxStreamBufferGetSpace( pxSocket->u.xTCP.txStream );
 
-					/* The flag 'bCloseAfterSend' can be set before sending data
-					using setsockopt()
+            /* While there are still bytes to be sent. */
+            while( xBytesLeft > 0 )
+            {
+                /* If txStream has space. */
+                if( xByteCount > 0 )
+                {
+                    /* Don't send more than necessary. */
+                    if( xByteCount > xBytesLeft )
+                    {
+                        xByteCount = xBytesLeft;
+                    }
 
-					When the last data packet is being sent out, a FIN flag will
-					be included to let the peer know that no more data is to be
-					expected.  The use of 'bCloseAfterSend' is not mandatory, it
-					is just a faster way of transferring files (e.g. when using
-					FTP). */
-					if( xCloseAfterSend != pdFALSE )
-					{
-						/* Now suspend the scheduler: sending the last data	and
-						setting bCloseRequested must be done together */
-						vTaskSuspendAll();
-						pxSocket->u.xTCP.bits.bCloseRequested = pdTRUE;
-					}
+                    /* Is the close-after-send flag set and is this really the
+                     * last transmission? */
+                    if( ( pxSocket->u.xTCP.bits.bCloseAfterSend != pdFALSE_UNSIGNED ) && ( xByteCount == xBytesLeft ) )
+                    {
+                        xCloseAfterSend = pdTRUE;
+                    }
+                    else
+                    {
+                        xCloseAfterSend = pdFALSE;
+                    }
 
-					xByteCount = ( BaseType_t ) uxStreamBufferAdd( pxSocket->u.xTCP.txStream, 0UL, pucSource, ( size_t ) xByteCount );
+                    /* The flag 'bCloseAfterSend' can be set before sending data
+                     * using setsockopt()
+                     *
+                     * When the last data packet is being sent out, a FIN flag will
+                     * be included to let the peer know that no more data is to be
+                     * expected.  The use of 'bCloseAfterSend' is not mandatory, it
+                     * is just a faster way of transferring files (e.g. when using
+                     * FTP). */
+                    if( xCloseAfterSend != pdFALSE )
+                    {
+                        /* Now suspend the scheduler: sending the last data	and
+                         * setting bCloseRequested must be done together */
+                        vTaskSuspendAll();
+                        pxSocket->u.xTCP.bits.bCloseRequested = pdTRUE;
+                    }
 
-					if( xCloseAfterSend != pdFALSE )
-					{
-						/* Now when the IP-task transmits the data, it will also
-						see	that bCloseRequested is true and include the FIN
-						flag to start closure of the connection. */
-						( void ) xTaskResumeAll();
-					}
+                    xByteCount = ( BaseType_t ) uxStreamBufferAdd( pxSocket->u.xTCP.txStream, 0UL, pucSource, ( size_t ) xByteCount );
 
-					/* Send a message to the IP-task so it can work on this
-					socket.  Data is sent, let the IP-task work on it. */
-					pxSocket->u.xTCP.usTimeout = 1U;
+                    if( xCloseAfterSend != pdFALSE )
+                    {
+                        /* Now when the IP-task transmits the data, it will also
+                         * see	that bCloseRequested is true and include the FIN
+                         * flag to start closure of the connection. */
+                        ( void ) xTaskResumeAll();
+                    }
 
-					if( xIsCallingFromIPTask() == pdFALSE )
-					{
-						/* Only send a TCP timer event when not called from the
-						IP-task. */
-						( void ) xSendEventToIPTask( eTCPTimerEvent );
-					}
+                    /* Send a message to the IP-task so it can work on this
+                    * socket.  Data is sent, let the IP-task work on it. */
+                    pxSocket->u.xTCP.usTimeout = 1U;
 
-					xBytesLeft -= xByteCount;
+                    if( xIsCallingFromIPTask() == pdFALSE )
+                    {
+                        /* Only send a TCP timer event when not called from the
+                         * IP-task. */
+                        ( void ) xSendEventToIPTask( eTCPTimerEvent );
+                    }
 
-					if( xBytesLeft == 0 )
-					{
-						break;
-					}
+                    xBytesLeft -= xByteCount;
 
-					/* As there are still bytes left to be sent, increase the
-					data pointer. */
-					pucSource = &( pucSource [ xByteCount ] );
-				}
+                    if( xBytesLeft == 0 )
+                    {
+                        break;
+                    }
 
-				/* Not all bytes have been sent. In case the socket is marked as
-				blocking sleep for a while. */
-				if( xTimed == pdFALSE )
-				{
-					/* Only in the first round, check for non-blocking. */
-					xRemainingTime = pxSocket->xSendBlockTime;
+                    /* As there are still bytes left to be sent, increase the
+                     * data pointer. */
+                    pucSource = &( pucSource[ xByteCount ] );
+                }
 
-					#if( ipconfigUSE_CALLBACKS != 0 )
-					{
-						if( xIsCallingFromIPTask() != pdFALSE )
-						{
-							/* If this send function is called from within a
-							call-back handler it may not block, otherwise
-							chances would be big to get a deadlock: the IP-task
-							waiting for	itself. */
-							xRemainingTime = ( TickType_t ) 0;
-						}
-					}
-					#endif /* ipconfigUSE_CALLBACKS */
+                /* Not all bytes have been sent. In case the socket is marked as
+                 * blocking sleep for a while. */
+                if( xTimed == pdFALSE )
+                {
+                    /* Only in the first round, check for non-blocking. */
+                    xRemainingTime = pxSocket->xSendBlockTime;
 
-					if( xRemainingTime == ( TickType_t ) 0 )
-					{
-						break;
-					}
+                    #if ( ipconfigUSE_CALLBACKS != 0 )
+                        {
+                            if( xIsCallingFromIPTask() != pdFALSE )
+                            {
+                                /* If this send function is called from within a
+                                 * call-back handler it may not block, otherwise
+                                 * chances would be big to get a deadlock: the IP-task
+                                 * waiting for	itself. */
+                                xRemainingTime = ( TickType_t ) 0;
+                            }
+                        }
+                    #endif /* ipconfigUSE_CALLBACKS */
 
-					if( ( ( uint32_t ) xFlags & ( uint32_t ) FREERTOS_MSG_DONTWAIT ) != 0U )
-					{
-						break;
-					}
+                    if( xRemainingTime == ( TickType_t ) 0 )
+                    {
+                        break;
+                    }
 
-					/* Don't get here a second time. */
-					xTimed = pdTRUE;
+                    if( ( ( uint32_t ) xFlags & ( uint32_t ) FREERTOS_MSG_DONTWAIT ) != 0U )
+                    {
+                        break;
+                    }
 
-					/* Fetch the current time. */
-					vTaskSetTimeOutState( &xTimeOut );
-				}
-				else
-				{
-					/* Has the timeout been reached? */
-					if( xTaskCheckForTimeOut( &xTimeOut, &xRemainingTime ) != pdFALSE )
-					{
-						break;
-					}
-				}
+                    /* Don't get here a second time. */
+                    xTimed = pdTRUE;
 
-				/* Go sleeping until down-stream events are received. */
-				( void ) xEventGroupWaitBits( pxSocket->xEventGroup, ( EventBits_t ) eSOCKET_SEND | ( EventBits_t ) eSOCKET_CLOSED,
-					pdTRUE /*xClearOnExit*/, pdFALSE /*xWaitAllBits*/, xRemainingTime );
+                    /* Fetch the current time. */
+                    vTaskSetTimeOutState( &xTimeOut );
+                }
+                else
+                {
+                    /* Has the timeout been reached? */
+                    if( xTaskCheckForTimeOut( &xTimeOut, &xRemainingTime ) != pdFALSE )
+                    {
+                        break;
+                    }
+                }
 
-				xByteCount = ( BaseType_t ) uxStreamBufferGetSpace( pxSocket->u.xTCP.txStream );
-			}
+                /* Go sleeping until down-stream events are received. */
+                ( void ) xEventGroupWaitBits( pxSocket->xEventGroup, ( EventBits_t ) eSOCKET_SEND | ( EventBits_t ) eSOCKET_CLOSED,
+                                              pdTRUE /*xClearOnExit*/, pdFALSE /*xWaitAllBits*/, xRemainingTime );
 
-			/* How much was actually sent? */
-			xByteCount = ( ( BaseType_t ) uxDataLength ) - xBytesLeft;
+                xByteCount = ( BaseType_t ) uxStreamBufferGetSpace( pxSocket->u.xTCP.txStream );
+            }
 
-			if( xByteCount == 0 )
-			{
-				if( pxSocket->u.xTCP.ucTCPState > ( uint8_t ) eESTABLISHED )
-				{
-					xByteCount = ( BaseType_t ) -pdFREERTOS_ERRNO_ENOTCONN;
-				}
-				else
-				{
-					if( ipconfigTCP_MAY_LOG_PORT( pxSocket->usLocalPort ) )
-					{
-						FreeRTOS_debug_printf( ( "FreeRTOS_send: %u -> %lxip:%d: no space\n",
-							pxSocket->usLocalPort,
-							pxSocket->u.xTCP.ulRemoteIP,
-							pxSocket->u.xTCP.usRemotePort ) );
-					}
+            /* How much was actually sent? */
+            xByteCount = ( ( BaseType_t ) uxDataLength ) - xBytesLeft;
 
-					xByteCount = ( BaseType_t ) -pdFREERTOS_ERRNO_ENOSPC;
-				}
-			}
-		}
+            if( xByteCount == 0 )
+            {
+                if( pxSocket->u.xTCP.ucTCPState > ( uint8_t ) eESTABLISHED )
+                {
+                    xByteCount = ( BaseType_t ) -pdFREERTOS_ERRNO_ENOTCONN;
+                }
+                else
+                {
+                    if( ipconfigTCP_MAY_LOG_PORT( pxSocket->usLocalPort ) )
+                    {
+                        FreeRTOS_debug_printf( ( "FreeRTOS_send: %u -> %lxip:%d: no space\n",
+                                                 pxSocket->usLocalPort,
+                                                 pxSocket->u.xTCP.ulRemoteIP,
+                                                 pxSocket->u.xTCP.usRemotePort ) );
+                    }
 
-		return xByteCount;
-	}
+                    xByteCount = ( BaseType_t ) -pdFREERTOS_ERRNO_ENOSPC;
+                }
+            }
+        }
 
-#endif /* ipconfigUSE_TCP */
-/*-----------------------------------------------------------*/
-
-#if( ipconfigUSE_TCP == 1 )
-
-	/*
-	 * Request to put a socket in listen mode
-	 */
-	BaseType_t FreeRTOS_listen( Socket_t xSocket, BaseType_t xBacklog )
-	{
-	FreeRTOS_Socket_t *pxSocket;
-	BaseType_t xResult = 0;
-
-		pxSocket = ( FreeRTOS_Socket_t * ) xSocket;
-
-		/* listen() is allowed for a valid TCP socket in Closed state and already
-		bound. */
-		if( prvValidSocket( pxSocket, FREERTOS_IPPROTO_TCP, pdTRUE ) == pdFALSE )
-		{
-			xResult = -pdFREERTOS_ERRNO_EOPNOTSUPP;
-		}
-		else if( ( pxSocket->u.xTCP.ucTCPState != ( uint8_t ) eCLOSED ) && ( pxSocket->u.xTCP.ucTCPState != ( uint8_t ) eCLOSE_WAIT ) )
-		{
-			/* Socket is in a wrong state. */
-			xResult = -pdFREERTOS_ERRNO_EOPNOTSUPP;
-		}
-		else
-		{
-			/* Backlog is interpreted here as "the maximum number of child
-			sockets. */
-			pxSocket->u.xTCP.usBacklog = ( uint16_t )FreeRTOS_min_int32( ( int32_t ) 0xffff, ( int32_t ) xBacklog );
-
-			/* This cleaning is necessary only if a listening socket is being
-			reused as it might have had a previous connection. */
-			if( pxSocket->u.xTCP.bits.bReuseSocket != pdFALSE_UNSIGNED )
-			{
-				if( pxSocket->u.xTCP.rxStream != NULL )
-				{
-					vStreamBufferClear( pxSocket->u.xTCP.rxStream );
-				}
-
-				if( pxSocket->u.xTCP.txStream != NULL )
-				{
-					vStreamBufferClear( pxSocket->u.xTCP.txStream );
-				}
-
-				( void ) memset( pxSocket->u.xTCP.xPacket.u.ucLastPacket, 0, sizeof( pxSocket->u.xTCP.xPacket.u.ucLastPacket ) );
-				( void ) memset( &pxSocket->u.xTCP.xTCPWindow, 0, sizeof( pxSocket->u.xTCP.xTCPWindow ) );
-				( void ) memset( &pxSocket->u.xTCP.bits, 0, sizeof( pxSocket->u.xTCP.bits ) );
-
-				/* Now set the bReuseSocket flag again, because the bits have
-				just been cleared. */
-				pxSocket->u.xTCP.bits.bReuseSocket = pdTRUE;
-			}
-
-			vTCPStateChange( pxSocket, eTCP_LISTEN );
-		}
-
-		return xResult;
-	}
+        return xByteCount;
+    }
 
 #endif /* ipconfigUSE_TCP */
 /*-----------------------------------------------------------*/
 
-#if( ipconfigUSE_TCP == 1 )
+#if ( ipconfigUSE_TCP == 1 )
 
-	/* shutdown - shut down part of a full-duplex connection */
-	BaseType_t FreeRTOS_shutdown( Socket_t xSocket, BaseType_t xHow )
-	{
-	FreeRTOS_Socket_t *pxSocket = ( FreeRTOS_Socket_t * ) xSocket;
-	BaseType_t xResult;
+    /*
+     * Request to put a socket in listen mode
+     */
+    BaseType_t FreeRTOS_listen( Socket_t xSocket,
+                                BaseType_t xBacklog )
+    {
+        FreeRTOS_Socket_t * pxSocket;
+        BaseType_t xResult = 0;
 
-		if( prvValidSocket( pxSocket, FREERTOS_IPPROTO_TCP, pdTRUE ) == pdFALSE )
-		{
-			/*_RB_ Is this comment correct?  The socket is not of a type that
-			supports the listen() operation. */
-			xResult = -pdFREERTOS_ERRNO_EOPNOTSUPP;
-		}
-		else if ( pxSocket->u.xTCP.ucTCPState != ( uint8_t ) eESTABLISHED )
-		{
-			/*_RB_ Is this comment correct?  The socket is not of a type that
-			supports the listen() operation. */
-			xResult = -pdFREERTOS_ERRNO_EOPNOTSUPP;
-		}
-		else
-		{
-			pxSocket->u.xTCP.bits.bUserShutdown = pdTRUE_UNSIGNED;
+        pxSocket = ( FreeRTOS_Socket_t * ) xSocket;
 
-			/* Let the IP-task perform the shutdown of the connection. */
-			pxSocket->u.xTCP.usTimeout = 1U;
-			( void ) xSendEventToIPTask( eTCPTimerEvent );
-			xResult = 0;
-		}
-		(void) xHow;
+        /* listen() is allowed for a valid TCP socket in Closed state and already
+         * bound. */
+        if( prvValidSocket( pxSocket, FREERTOS_IPPROTO_TCP, pdTRUE ) == pdFALSE )
+        {
+            xResult = -pdFREERTOS_ERRNO_EOPNOTSUPP;
+        }
+        else if( ( pxSocket->u.xTCP.ucTCPState != ( uint8_t ) eCLOSED ) && ( pxSocket->u.xTCP.ucTCPState != ( uint8_t ) eCLOSE_WAIT ) )
+        {
+            /* Socket is in a wrong state. */
+            xResult = -pdFREERTOS_ERRNO_EOPNOTSUPP;
+        }
+        else
+        {
+            /* Backlog is interpreted here as "the maximum number of child
+             * sockets. */
+            pxSocket->u.xTCP.usBacklog = ( uint16_t ) FreeRTOS_min_int32( ( int32_t ) 0xffff, ( int32_t ) xBacklog );
 
-		return xResult;
-	}
+            /* This cleaning is necessary only if a listening socket is being
+             * reused as it might have had a previous connection. */
+            if( pxSocket->u.xTCP.bits.bReuseSocket != pdFALSE_UNSIGNED )
+            {
+                if( pxSocket->u.xTCP.rxStream != NULL )
+                {
+                    vStreamBufferClear( pxSocket->u.xTCP.rxStream );
+                }
 
-#endif /* ipconfigUSE_TCP */
-/*-----------------------------------------------------------*/
+                if( pxSocket->u.xTCP.txStream != NULL )
+                {
+                    vStreamBufferClear( pxSocket->u.xTCP.txStream );
+                }
 
-#if( ipconfigUSE_TCP == 1 )
+                ( void ) memset( pxSocket->u.xTCP.xPacket.u.ucLastPacket, 0, sizeof( pxSocket->u.xTCP.xPacket.u.ucLastPacket ) );
+                ( void ) memset( &pxSocket->u.xTCP.xTCPWindow, 0, sizeof( pxSocket->u.xTCP.xTCPWindow ) );
+                ( void ) memset( &pxSocket->u.xTCP.bits, 0, sizeof( pxSocket->u.xTCP.bits ) );
 
-	/*
-	 * A TCP timer has expired, now check all TCP sockets for:
-	 * - Active connect
-	 * - Send a delayed ACK
-	 * - Send new data
-	 * - Send a keep-alive packet
-	 * - Check for timeout (in non-connected states only)
-	 */
-	TickType_t xTCPTimerCheck( BaseType_t xWillSleep )
-	{
-	FreeRTOS_Socket_t *pxSocket;
-	TickType_t xShortest = pdMS_TO_TICKS( ( TickType_t ) ipTCP_TIMER_PERIOD_MS );
-	TickType_t xNow = xTaskGetTickCount();
-	static TickType_t xLastTime = 0U;
-	TickType_t xDelta = xNow - xLastTime;
-	const ListItem_t* pxEnd = ipPOINTER_CAST( const ListItem_t *, listGET_END_MARKER( &xBoundTCPSocketsList ) );
-	const ListItem_t *pxIterator = ( const ListItem_t * ) listGET_HEAD_ENTRY( &xBoundTCPSocketsList );
+                /* Now set the bReuseSocket flag again, because the bits have
+                 * just been cleared. */
+                pxSocket->u.xTCP.bits.bReuseSocket = pdTRUE;
+            }
 
-		xLastTime = xNow;
+            vTCPStateChange( pxSocket, eTCP_LISTEN );
+        }
 
-		if( xDelta == 0U )
-		{
-			xDelta = 1U;
-		}
-
-		while( pxIterator != pxEnd )
-		{
-			pxSocket = ipPOINTER_CAST( FreeRTOS_Socket_t *, listGET_LIST_ITEM_OWNER( pxIterator ) );
-			pxIterator = ( ListItem_t * ) listGET_NEXT( pxIterator );
-
-			/* Sockets with 'tmout == 0' do not need any regular attention. */
-			if( pxSocket->u.xTCP.usTimeout == 0U )
-			{
-				continue;
-			}
-
-			if( xDelta < ( TickType_t ) pxSocket->u.xTCP.usTimeout )
-			{
-				pxSocket->u.xTCP.usTimeout = ( uint16_t ) ( ( ( TickType_t ) pxSocket->u.xTCP.usTimeout ) - xDelta );
-			}
-			else
-			{
-			BaseType_t xRc;
-
-				pxSocket->u.xTCP.usTimeout = 0U;
-				xRc = xTCPSocketCheck( pxSocket );
-
-				/* Within this function, the socket might want to send a delayed
-				ack or send out data or whatever it needs to do. */
-				if( xRc < 0 )
-				{
-					/* Continue because the socket was deleted. */
-					continue;
-				}
-			}
-
-			/* In xEventBits the driver may indicate that the socket has
-			important events for the user.  These are only done just before the
-			IP-task goes to sleep. */
-			if( pxSocket->xEventBits != 0U )
-			{
-				if( xWillSleep != pdFALSE )
-				{
-					/* The IP-task is about to go to sleep, so messages can be
-					sent to the socket owners. */
-					vSocketWakeUpUser( pxSocket );
-				}
-				else
-				{
-					/* Or else make sure this will be called again to wake-up
-					the sockets' owner. */
-					xShortest = ( TickType_t ) 0;
-				}
-			}
-
-			if( ( pxSocket->u.xTCP.usTimeout != 0U ) && ( xShortest > ( TickType_t ) pxSocket->u.xTCP.usTimeout ) )
-			{
-				xShortest = ( TickType_t ) pxSocket->u.xTCP.usTimeout;
-			}
-		}
-
-		return xShortest;
-	}
+        return xResult;
+    }
 
 #endif /* ipconfigUSE_TCP */
 /*-----------------------------------------------------------*/
 
-#if( ipconfigUSE_TCP == 1 )
+#if ( ipconfigUSE_TCP == 1 )
 
-	/*
-	 * TCP: as multiple sockets may be bound to the same local port number
-	 * looking up a socket is a little more complex:
-	 * Both a local port, and a remote port and IP address are being used
-	 * For a socket in listening mode, the remote port and IP address are both 0
-	 */
-	FreeRTOS_Socket_t *pxTCPSocketLookup( uint32_t ulLocalIP, UBaseType_t uxLocalPort, uint32_t ulRemoteIP, UBaseType_t uxRemotePort )
-	{
-	const ListItem_t *pxIterator;
-	FreeRTOS_Socket_t *pxResult = NULL, *pxListenSocket = NULL;
-	const ListItem_t *pxEnd = ipPOINTER_CAST( const ListItem_t *, listGET_END_MARKER( &xBoundTCPSocketsList ) );
+    /* shutdown - shut down part of a full-duplex connection */
+    BaseType_t FreeRTOS_shutdown( Socket_t xSocket,
+                                  BaseType_t xHow )
+    {
+        FreeRTOS_Socket_t * pxSocket = ( FreeRTOS_Socket_t * ) xSocket;
+        BaseType_t xResult;
 
-		/* Parameter not yet supported. */
-		( void ) ulLocalIP;
+        if( prvValidSocket( pxSocket, FREERTOS_IPPROTO_TCP, pdTRUE ) == pdFALSE )
+        {
+            /*_RB_ Is this comment correct?  The socket is not of a type that
+             * supports the listen() operation. */
+            xResult = -pdFREERTOS_ERRNO_EOPNOTSUPP;
+        }
+        else if( pxSocket->u.xTCP.ucTCPState != ( uint8_t ) eESTABLISHED )
+        {
+            /*_RB_ Is this comment correct?  The socket is not of a type that
+             * supports the listen() operation. */
+            xResult = -pdFREERTOS_ERRNO_EOPNOTSUPP;
+        }
+        else
+        {
+            pxSocket->u.xTCP.bits.bUserShutdown = pdTRUE_UNSIGNED;
 
-		for( pxIterator  = listGET_NEXT( pxEnd );
-			 pxIterator != pxEnd;
-			 pxIterator  = listGET_NEXT( pxIterator ) )
-		{
-			FreeRTOS_Socket_t *pxSocket = ipPOINTER_CAST( FreeRTOS_Socket_t *, listGET_LIST_ITEM_OWNER( pxIterator ) );
+            /* Let the IP-task perform the shutdown of the connection. */
+            pxSocket->u.xTCP.usTimeout = 1U;
+            ( void ) xSendEventToIPTask( eTCPTimerEvent );
+            xResult = 0;
+        }
 
-			if( pxSocket->usLocalPort == ( uint16_t ) uxLocalPort )
-			{
-				if( pxSocket->u.xTCP.ucTCPState == ( uint8_t ) eTCP_LISTEN )
-				{
-					/* If this is a socket listening to uxLocalPort, remember it
-					in case there is no perfect match. */
-					pxListenSocket = pxSocket;
-				}
-				else if( ( pxSocket->u.xTCP.usRemotePort == ( uint16_t ) uxRemotePort ) && ( pxSocket->u.xTCP.ulRemoteIP == ulRemoteIP ) )
-				{
-					/* For sockets not in listening mode, find a match with
-					xLocalPort, ulRemoteIP AND xRemotePort. */
-					pxResult = pxSocket;
-					break;
-				}
-				else
-				{
-					/* This 'pxSocket' doesn't match. */
-				}
-			}
-		}
-		if( pxResult == NULL )
-		{
-			/* An exact match was not found, maybe a listening socket was
-			found. */
-			pxResult = pxListenSocket;
-		}
+        ( void ) xHow;
 
-		return pxResult;
-	}
+        return xResult;
+    }
 
 #endif /* ipconfigUSE_TCP */
 /*-----------------------------------------------------------*/
 
-#if( ipconfigUSE_TCP == 1 )
+#if ( ipconfigUSE_TCP == 1 )
 
-	const struct xSTREAM_BUFFER *FreeRTOS_get_rx_buf( Socket_t xSocket )
-	{
-	FreeRTOS_Socket_t const * pxSocket = ( FreeRTOS_Socket_t const * )xSocket;
-    const struct xSTREAM_BUFFER *pxReturn = NULL;
+    /*
+     * A TCP timer has expired, now check all TCP sockets for:
+     * - Active connect
+     * - Send a delayed ACK
+     * - Send new data
+     * - Send a keep-alive packet
+     * - Check for timeout (in non-connected states only)
+     */
+    TickType_t xTCPTimerCheck( BaseType_t xWillSleep )
+    {
+        FreeRTOS_Socket_t * pxSocket;
+        TickType_t xShortest = pdMS_TO_TICKS( ( TickType_t ) ipTCP_TIMER_PERIOD_MS );
+        TickType_t xNow = xTaskGetTickCount();
+        static TickType_t xLastTime = 0U;
+        TickType_t xDelta = xNow - xLastTime;
+        const ListItem_t * pxEnd = ipPOINTER_CAST( const ListItem_t *, listGET_END_MARKER( &xBoundTCPSocketsList ) );
+        const ListItem_t * pxIterator = ( const ListItem_t * ) listGET_HEAD_ENTRY( &xBoundTCPSocketsList );
+
+        xLastTime = xNow;
+
+        if( xDelta == 0U )
+        {
+            xDelta = 1U;
+        }
+
+        while( pxIterator != pxEnd )
+        {
+            pxSocket = ipPOINTER_CAST( FreeRTOS_Socket_t *, listGET_LIST_ITEM_OWNER( pxIterator ) );
+            pxIterator = ( ListItem_t * ) listGET_NEXT( pxIterator );
+
+            /* Sockets with 'tmout == 0' do not need any regular attention. */
+            if( pxSocket->u.xTCP.usTimeout == 0U )
+            {
+                continue;
+            }
+
+            if( xDelta < ( TickType_t ) pxSocket->u.xTCP.usTimeout )
+            {
+                pxSocket->u.xTCP.usTimeout = ( uint16_t ) ( ( ( TickType_t ) pxSocket->u.xTCP.usTimeout ) - xDelta );
+            }
+            else
+            {
+                BaseType_t xRc;
+
+                pxSocket->u.xTCP.usTimeout = 0U;
+                xRc = xTCPSocketCheck( pxSocket );
+
+                /* Within this function, the socket might want to send a delayed
+                 * ack or send out data or whatever it needs to do. */
+                if( xRc < 0 )
+                {
+                    /* Continue because the socket was deleted. */
+                    continue;
+                }
+            }
+
+            /* In xEventBits the driver may indicate that the socket has
+             * important events for the user.  These are only done just before the
+             * IP-task goes to sleep. */
+            if( pxSocket->xEventBits != 0U )
+            {
+                if( xWillSleep != pdFALSE )
+                {
+                    /* The IP-task is about to go to sleep, so messages can be
+                     * sent to the socket owners. */
+                    vSocketWakeUpUser( pxSocket );
+                }
+                else
+                {
+                    /* Or else make sure this will be called again to wake-up
+                     * the sockets' owner. */
+                    xShortest = ( TickType_t ) 0;
+                }
+            }
+
+            if( ( pxSocket->u.xTCP.usTimeout != 0U ) && ( xShortest > ( TickType_t ) pxSocket->u.xTCP.usTimeout ) )
+            {
+                xShortest = ( TickType_t ) pxSocket->u.xTCP.usTimeout;
+            }
+        }
+
+        return xShortest;
+    }
+
+#endif /* ipconfigUSE_TCP */
+/*-----------------------------------------------------------*/
+
+#if ( ipconfigUSE_TCP == 1 )
+
+    /*
+     * TCP: as multiple sockets may be bound to the same local port number
+     * looking up a socket is a little more complex:
+     * Both a local port, and a remote port and IP address are being used
+     * For a socket in listening mode, the remote port and IP address are both 0
+     */
+    FreeRTOS_Socket_t * pxTCPSocketLookup( uint32_t ulLocalIP,
+                                           UBaseType_t uxLocalPort,
+                                           uint32_t ulRemoteIP,
+                                           UBaseType_t uxRemotePort )
+    {
+        const ListItem_t * pxIterator;
+        FreeRTOS_Socket_t * pxResult = NULL, * pxListenSocket = NULL;
+        const ListItem_t * pxEnd = ipPOINTER_CAST( const ListItem_t *, listGET_END_MARKER( &xBoundTCPSocketsList ) );
+
+        /* Parameter not yet supported. */
+        ( void ) ulLocalIP;
+
+        for( pxIterator = listGET_NEXT( pxEnd );
+             pxIterator != pxEnd;
+             pxIterator = listGET_NEXT( pxIterator ) )
+        {
+            FreeRTOS_Socket_t * pxSocket = ipPOINTER_CAST( FreeRTOS_Socket_t *, listGET_LIST_ITEM_OWNER( pxIterator ) );
+
+            if( pxSocket->usLocalPort == ( uint16_t ) uxLocalPort )
+            {
+                if( pxSocket->u.xTCP.ucTCPState == ( uint8_t ) eTCP_LISTEN )
+                {
+                    /* If this is a socket listening to uxLocalPort, remember it
+                     * in case there is no perfect match. */
+                    pxListenSocket = pxSocket;
+                }
+                else if( ( pxSocket->u.xTCP.usRemotePort == ( uint16_t ) uxRemotePort ) && ( pxSocket->u.xTCP.ulRemoteIP == ulRemoteIP ) )
+                {
+                    /* For sockets not in listening mode, find a match with
+                     * xLocalPort, ulRemoteIP AND xRemotePort. */
+                    pxResult = pxSocket;
+                    break;
+                }
+                else
+                {
+                    /* This 'pxSocket' doesn't match. */
+                }
+            }
+        }
+
+        if( pxResult == NULL )
+        {
+            /* An exact match was not found, maybe a listening socket was
+             * found. */
+            pxResult = pxListenSocket;
+        }
+
+        return pxResult;
+    }
+
+#endif /* ipconfigUSE_TCP */
+/*-----------------------------------------------------------*/
+
+#if ( ipconfigUSE_TCP == 1 )
+
+    const struct xSTREAM_BUFFER * FreeRTOS_get_rx_buf( Socket_t xSocket )
+    {
+        FreeRTOS_Socket_t const * pxSocket = ( FreeRTOS_Socket_t const * ) xSocket;
+        const struct xSTREAM_BUFFER * pxReturn = NULL;
 
         /* Confirm that this is a TCP socket before dereferencing structure
-        member pointers. */
+         * member pointers. */
         if( prvValidSocket( pxSocket, FREERTOS_IPPROTO_TCP, pdFALSE ) == pdTRUE )
         {
             pxReturn = pxSocket->u.xTCP.rxStream;
         }
 
         return pxReturn;
-	}
+    }
 
 #endif /* ipconfigUSE_TCP */
 /*-----------------------------------------------------------*/
 
-#if( ipconfigUSE_TCP == 1 )
+#if ( ipconfigUSE_TCP == 1 )
 
-	static StreamBuffer_t *prvTCPCreateStream ( FreeRTOS_Socket_t *pxSocket, BaseType_t xIsInputStream )
-	{
-	StreamBuffer_t *pxBuffer;
-	size_t uxLength;
-	size_t uxSize;
+    static StreamBuffer_t * prvTCPCreateStream( FreeRTOS_Socket_t * pxSocket,
+                                                BaseType_t xIsInputStream )
+    {
+        StreamBuffer_t * pxBuffer;
+        size_t uxLength;
+        size_t uxSize;
 
-		/* Now that a stream is created, the maximum size is fixed before
-		creation, it could still be changed with setsockopt(). */
-		if( xIsInputStream != pdFALSE )
-		{
-			uxLength = pxSocket->u.xTCP.uxRxStreamSize;
+        /* Now that a stream is created, the maximum size is fixed before
+         * creation, it could still be changed with setsockopt(). */
+        if( xIsInputStream != pdFALSE )
+        {
+            uxLength = pxSocket->u.xTCP.uxRxStreamSize;
 
-			if( pxSocket->u.xTCP.uxLittleSpace == 0UL )
-			{
-				pxSocket->u.xTCP.uxLittleSpace  = ( sock20_PERCENT * pxSocket->u.xTCP.uxRxStreamSize ) / sock100_PERCENT;
-			}
+            if( pxSocket->u.xTCP.uxLittleSpace == 0UL )
+            {
+                pxSocket->u.xTCP.uxLittleSpace = ( sock20_PERCENT * pxSocket->u.xTCP.uxRxStreamSize ) / sock100_PERCENT;
+            }
 
-			if( pxSocket->u.xTCP.uxEnoughSpace == 0UL )
-			{
-				pxSocket->u.xTCP.uxEnoughSpace = ( sock80_PERCENT * pxSocket->u.xTCP.uxRxStreamSize ) / sock100_PERCENT;
-			}
-		}
-		else
-		{
-			uxLength = pxSocket->u.xTCP.uxTxStreamSize;
-		}
+            if( pxSocket->u.xTCP.uxEnoughSpace == 0UL )
+            {
+                pxSocket->u.xTCP.uxEnoughSpace = ( sock80_PERCENT * pxSocket->u.xTCP.uxRxStreamSize ) / sock100_PERCENT;
+            }
+        }
+        else
+        {
+            uxLength = pxSocket->u.xTCP.uxTxStreamSize;
+        }
 
-		/* Add an extra 4 (or 8) bytes. */
-		uxLength += sizeof( size_t );
+        /* Add an extra 4 (or 8) bytes. */
+        uxLength += sizeof( size_t );
 
-		/* And make the length a multiple of sizeof( size_t ). */
-		uxLength &= ~( sizeof( size_t ) - 1U );
+        /* And make the length a multiple of sizeof( size_t ). */
+        uxLength &= ~( sizeof( size_t ) - 1U );
 
-		uxSize = ( sizeof( *pxBuffer )  + uxLength ) - sizeof( pxBuffer->ucArray );
+        uxSize = ( sizeof( *pxBuffer ) + uxLength ) - sizeof( pxBuffer->ucArray );
 
-		pxBuffer = ipPOINTER_CAST( StreamBuffer_t *, pvPortMallocLarge( uxSize ) );
+        pxBuffer = ipPOINTER_CAST( StreamBuffer_t *, pvPortMallocLarge( uxSize ) );
 
-		if( pxBuffer == NULL )
-		{
-			FreeRTOS_debug_printf( ( "prvTCPCreateStream: malloc failed\n" ) );
-			pxSocket->u.xTCP.bits.bMallocError = pdTRUE;
-			vTCPStateChange( pxSocket, eCLOSE_WAIT );
-		}
-		else
-		{
-			/* Clear the markers of the stream */
-			( void ) memset( pxBuffer, 0, sizeof( *pxBuffer ) - sizeof( pxBuffer->ucArray ) );
-			pxBuffer->LENGTH = ( size_t ) uxLength ;
+        if( pxBuffer == NULL )
+        {
+            FreeRTOS_debug_printf( ( "prvTCPCreateStream: malloc failed\n" ) );
+            pxSocket->u.xTCP.bits.bMallocError = pdTRUE;
+            vTCPStateChange( pxSocket, eCLOSE_WAIT );
+        }
+        else
+        {
+            /* Clear the markers of the stream */
+            ( void ) memset( pxBuffer, 0, sizeof( *pxBuffer ) - sizeof( pxBuffer->ucArray ) );
+            pxBuffer->LENGTH = ( size_t ) uxLength;
 
-			if( xTCPWindowLoggingLevel != 0 )
-			{
-				FreeRTOS_debug_printf( ( "prvTCPCreateStream: %cxStream created %u bytes (total %u)\n", ( xIsInputStream != 0 ) ? 'R' : 'T', uxLength, uxSize ) );
-			}
+            if( xTCPWindowLoggingLevel != 0 )
+            {
+                FreeRTOS_debug_printf( ( "prvTCPCreateStream: %cxStream created %u bytes (total %u)\n", ( xIsInputStream != 0 ) ? 'R' : 'T', uxLength, uxSize ) );
+            }
 
-			if( xIsInputStream != 0 )
-			{
-				iptraceMEM_STATS_CREATE( tcpRX_STREAM_BUFFER, pxBuffer, uxSize );
-				pxSocket->u.xTCP.rxStream = pxBuffer;
-			}
-			else
-			{
-				iptraceMEM_STATS_CREATE( tcpTX_STREAM_BUFFER, pxBuffer, uxSize );
-				pxSocket->u.xTCP.txStream = pxBuffer;
-			}
-		}
+            if( xIsInputStream != 0 )
+            {
+                iptraceMEM_STATS_CREATE( tcpRX_STREAM_BUFFER, pxBuffer, uxSize );
+                pxSocket->u.xTCP.rxStream = pxBuffer;
+            }
+            else
+            {
+                iptraceMEM_STATS_CREATE( tcpTX_STREAM_BUFFER, pxBuffer, uxSize );
+                pxSocket->u.xTCP.txStream = pxBuffer;
+            }
+        }
 
-		return pxBuffer;
-	}
-
-#endif /* ipconfigUSE_TCP */
-/*-----------------------------------------------------------*/
-
-#if( ipconfigUSE_TCP == 1 )
-
-	/*
-	 * Add data to the RxStream.  When uxOffset > 0, data has come in out-of-order
-	 * and will be put in front of the head so it can not be popped by the user.
-	 */
-	int32_t lTCPAddRxdata( FreeRTOS_Socket_t *pxSocket, size_t uxOffset, const uint8_t *pcData, uint32_t ulByteCount )
-	{
-	StreamBuffer_t *pxStream = pxSocket->u.xTCP.rxStream;
-	int32_t xResult;
-	#if( ipconfigUSE_CALLBACKS == 1 )
-		BaseType_t bHasHandler = ipconfigIS_VALID_PROG_ADDRESS( pxSocket->u.xTCP.pxHandleReceive )  ? pdTRUE : pdFALSE;
-		const uint8_t *pucBuffer = NULL;
-	#endif /* ipconfigUSE_CALLBACKS */
-
-		/* int32_t uxStreamBufferAdd( pxBuffer, uxOffset, pucData, aCount )
-		if( pucData != NULL ) copy data the the buffer
-		if( pucData == NULL ) no copying, just advance rxHead
-		if( uxOffset != 0 ) Just store data which has come out-of-order
-		if( uxOffset == 0 ) Also advance rxHead */
-		if( pxStream == NULL )
-		{
-			pxStream = prvTCPCreateStream( pxSocket, pdTRUE );
-			if( pxStream == NULL )
-			{
-				return -1;
-			}
-		}
-
-		#if( ipconfigUSE_CALLBACKS == 1 )
-		{
-			if( ( bHasHandler != pdFALSE ) && ( uxStreamBufferGetSize( pxStream ) == 0U ) && ( uxOffset == 0UL ) && ( pcData != NULL ) )
-			{
-				/* Data can be passed directly to the user */
-				pucBuffer = pcData;
-
-				pcData = NULL;
-			}
-		}
-		#endif /* ipconfigUSE_CALLBACKS */
-
-		xResult = ( int32_t ) uxStreamBufferAdd( pxStream, uxOffset, pcData, ( size_t ) ulByteCount );
-
-		#if( ipconfigHAS_DEBUG_PRINTF != 0 )
-		{
-			if( xResult != ( int32_t ) ulByteCount )
-			{
-				FreeRTOS_debug_printf( ( "lTCPAddRxdata: at %u: %d/%u bytes (tail %u head %u space %u front %u)\n",
-					( UBaseType_t ) uxOffset,
-					( BaseType_t ) xResult,
-					( UBaseType_t ) ulByteCount,
-					( UBaseType_t ) pxStream->uxTail,
-					( UBaseType_t ) pxStream->uxHead,
-					( UBaseType_t ) uxStreamBufferFrontSpace( pxStream ),
-					( UBaseType_t ) pxStream->uxFront ) );
-			}
-		}
-		#endif /* ipconfigHAS_DEBUG_PRINTF */
-
-		if( uxOffset == 0U )
-		{
-			/* Data is being added to rxStream at the head (offs = 0) */
-			#if( ipconfigUSE_CALLBACKS == 1 )
-			if( bHasHandler != pdFALSE )
-			{
-				/* The socket owner has installed an OnReceive handler. Pass the
-				Rx data, without copying from the rxStream, to the user. */
-				for (;;)
-				{
-					uint8_t *ucReadPtr = NULL;
-					uint32_t ulCount;
-					if( pucBuffer != NULL )
-					{
-						ucReadPtr = ipPOINTER_CAST( uint8_t *, pucBuffer );
-						ulCount = ulByteCount;
-						pucBuffer = NULL;
-					}
-					else
-					{
-						ulCount = ( uint32_t ) uxStreamBufferGetPtr( pxStream, &( ucReadPtr ) );
-					}
-
-					if( ulCount == 0UL )
-					{
-						break;
-					}
-
-					( void ) pxSocket->u.xTCP.pxHandleReceive( pxSocket, ucReadPtr, ( size_t ) ulCount );
-					( void ) uxStreamBufferGet( pxStream, 0UL, NULL, ( size_t ) ulCount, pdFALSE );
-				}
-			} else
-			#endif /* ipconfigUSE_CALLBACKS */
-			{
-				/* See if running out of space. */
-				if( pxSocket->u.xTCP.bits.bLowWater == pdFALSE_UNSIGNED )
-				{
-					size_t uxFrontSpace = uxStreamBufferFrontSpace( pxSocket->u.xTCP.rxStream );
-					if( uxFrontSpace <= pxSocket->u.xTCP.uxLittleSpace  )
-					{
-						pxSocket->u.xTCP.bits.bLowWater = pdTRUE;
-						pxSocket->u.xTCP.bits.bWinChange = pdTRUE;
-
-						/* bLowWater was reached, send the changed window size. */
-						pxSocket->u.xTCP.usTimeout = 1U;
-						( void ) xSendEventToIPTask( eTCPTimerEvent );
-					}
-				}
-
-				/* New incoming data is available, wake up the user.   User's
-				semaphores will be set just before the IP-task goes asleep. */
-				pxSocket->xEventBits |= ( EventBits_t ) eSOCKET_RECEIVE;
-
-				#if ipconfigSUPPORT_SELECT_FUNCTION == 1
-				{
-					if( ( pxSocket->xSelectBits & ( EventBits_t ) eSELECT_READ ) != 0U )
-					{
-						pxSocket->xEventBits |= ( ( ( EventBits_t ) eSELECT_READ ) << SOCKET_EVENT_BIT_COUNT );
-					}
-				}
-				#endif
-			}
-		}
-
-		return xResult;
-	}
+        return pxBuffer;
+    }
 
 #endif /* ipconfigUSE_TCP */
 /*-----------------------------------------------------------*/
 
-#if( ipconfigUSE_TCP == 1 )
+#if ( ipconfigUSE_TCP == 1 )
 
-	/* Function to get the remote address and IP port */
-	BaseType_t FreeRTOS_GetRemoteAddress( Socket_t xSocket, struct freertos_sockaddr *pxAddress )
-	{
-	const FreeRTOS_Socket_t *pxSocket = ( const FreeRTOS_Socket_t * ) xSocket;
-	BaseType_t xResult;
+    /*
+     * Add data to the RxStream.  When uxOffset > 0, data has come in out-of-order
+     * and will be put in front of the head so it can not be popped by the user.
+     */
+    int32_t lTCPAddRxdata( FreeRTOS_Socket_t * pxSocket,
+                           size_t uxOffset,
+                           const uint8_t * pcData,
+                           uint32_t ulByteCount )
+    {
+        StreamBuffer_t * pxStream = pxSocket->u.xTCP.rxStream;
+        int32_t xResult;
 
-		if( pxSocket->ucProtocol != ( uint8_t ) FREERTOS_IPPROTO_TCP )
-		{
-			xResult = -pdFREERTOS_ERRNO_EINVAL;
-		}
-		else
-		{
-			/* BSD style sockets communicate IP and port addresses in network
-			byte order.
-			IP address of remote machine. */
-			pxAddress->sin_addr = FreeRTOS_htonl ( pxSocket->u.xTCP.ulRemoteIP );
+        #if ( ipconfigUSE_CALLBACKS == 1 )
+            BaseType_t bHasHandler = ipconfigIS_VALID_PROG_ADDRESS( pxSocket->u.xTCP.pxHandleReceive ) ? pdTRUE : pdFALSE;
+            const uint8_t * pucBuffer = NULL;
+        #endif /* ipconfigUSE_CALLBACKS */
 
-			/* Port on remote machine. */
-			pxAddress->sin_port = FreeRTOS_htons ( pxSocket->u.xTCP.usRemotePort );
+        /* int32_t uxStreamBufferAdd( pxBuffer, uxOffset, pucData, aCount )
+         * if( pucData != NULL ) copy data the the buffer
+         * if( pucData == NULL ) no copying, just advance rxHead
+         * if( uxOffset != 0 ) Just store data which has come out-of-order
+         * if( uxOffset == 0 ) Also advance rxHead */
+        if( pxStream == NULL )
+        {
+            pxStream = prvTCPCreateStream( pxSocket, pdTRUE );
 
-			xResult = ( BaseType_t ) sizeof( *pxAddress );
-		}
+            if( pxStream == NULL )
+            {
+                return -1;
+            }
+        }
 
-		return xResult;
-	}
+        #if ( ipconfigUSE_CALLBACKS == 1 )
+            {
+                if( ( bHasHandler != pdFALSE ) && ( uxStreamBufferGetSize( pxStream ) == 0U ) && ( uxOffset == 0UL ) && ( pcData != NULL ) )
+                {
+                    /* Data can be passed directly to the user */
+                    pucBuffer = pcData;
+
+                    pcData = NULL;
+                }
+            }
+        #endif /* ipconfigUSE_CALLBACKS */
+
+        xResult = ( int32_t ) uxStreamBufferAdd( pxStream, uxOffset, pcData, ( size_t ) ulByteCount );
+
+        #if ( ipconfigHAS_DEBUG_PRINTF != 0 )
+            {
+                if( xResult != ( int32_t ) ulByteCount )
+                {
+                    FreeRTOS_debug_printf( ( "lTCPAddRxdata: at %u: %d/%u bytes (tail %u head %u space %u front %u)\n",
+                                             ( UBaseType_t ) uxOffset,
+                                             ( BaseType_t ) xResult,
+                                             ( UBaseType_t ) ulByteCount,
+                                             ( UBaseType_t ) pxStream->uxTail,
+                                             ( UBaseType_t ) pxStream->uxHead,
+                                             ( UBaseType_t ) uxStreamBufferFrontSpace( pxStream ),
+                                             ( UBaseType_t ) pxStream->uxFront ) );
+                }
+            }
+        #endif /* ipconfigHAS_DEBUG_PRINTF */
+
+        if( uxOffset == 0U )
+        {
+            /* Data is being added to rxStream at the head (offs = 0) */
+            #if ( ipconfigUSE_CALLBACKS == 1 )
+                if( bHasHandler != pdFALSE )
+                {
+                    /* The socket owner has installed an OnReceive handler. Pass the
+                     * Rx data, without copying from the rxStream, to the user. */
+                    for( ; ; )
+                    {
+                        uint8_t * ucReadPtr = NULL;
+                        uint32_t ulCount;
+
+                        if( pucBuffer != NULL )
+                        {
+                            ucReadPtr = ipPOINTER_CAST( uint8_t *, pucBuffer );
+                            ulCount = ulByteCount;
+                            pucBuffer = NULL;
+                        }
+                        else
+                        {
+                            ulCount = ( uint32_t ) uxStreamBufferGetPtr( pxStream, &( ucReadPtr ) );
+                        }
+
+                        if( ulCount == 0UL )
+                        {
+                            break;
+                        }
+
+                        ( void ) pxSocket->u.xTCP.pxHandleReceive( pxSocket, ucReadPtr, ( size_t ) ulCount );
+                        ( void ) uxStreamBufferGet( pxStream, 0UL, NULL, ( size_t ) ulCount, pdFALSE );
+                    }
+                }
+                else
+            #endif /* ipconfigUSE_CALLBACKS */
+            {
+                /* See if running out of space. */
+                if( pxSocket->u.xTCP.bits.bLowWater == pdFALSE_UNSIGNED )
+                {
+                    size_t uxFrontSpace = uxStreamBufferFrontSpace( pxSocket->u.xTCP.rxStream );
+
+                    if( uxFrontSpace <= pxSocket->u.xTCP.uxLittleSpace )
+                    {
+                        pxSocket->u.xTCP.bits.bLowWater = pdTRUE;
+                        pxSocket->u.xTCP.bits.bWinChange = pdTRUE;
+
+                        /* bLowWater was reached, send the changed window size. */
+                        pxSocket->u.xTCP.usTimeout = 1U;
+                        ( void ) xSendEventToIPTask( eTCPTimerEvent );
+                    }
+                }
+
+                /* New incoming data is available, wake up the user.   User's
+                 * semaphores will be set just before the IP-task goes asleep. */
+                pxSocket->xEventBits |= ( EventBits_t ) eSOCKET_RECEIVE;
+
+                #if ipconfigSUPPORT_SELECT_FUNCTION == 1
+                    {
+                        if( ( pxSocket->xSelectBits & ( EventBits_t ) eSELECT_READ ) != 0U )
+                        {
+                            pxSocket->xEventBits |= ( ( ( EventBits_t ) eSELECT_READ ) << SOCKET_EVENT_BIT_COUNT );
+                        }
+                    }
+                #endif
+            }
+        }
+
+        return xResult;
+    }
+
+#endif /* ipconfigUSE_TCP */
+/*-----------------------------------------------------------*/
+
+#if ( ipconfigUSE_TCP == 1 )
+
+    /* Function to get the remote address and IP port */
+    BaseType_t FreeRTOS_GetRemoteAddress( Socket_t xSocket,
+                                          struct freertos_sockaddr * pxAddress )
+    {
+        const FreeRTOS_Socket_t * pxSocket = ( const FreeRTOS_Socket_t * ) xSocket;
+        BaseType_t xResult;
+
+        if( pxSocket->ucProtocol != ( uint8_t ) FREERTOS_IPPROTO_TCP )
+        {
+            xResult = -pdFREERTOS_ERRNO_EINVAL;
+        }
+        else
+        {
+            /* BSD style sockets communicate IP and port addresses in network
+             * byte order.
+             * IP address of remote machine. */
+            pxAddress->sin_addr = FreeRTOS_htonl( pxSocket->u.xTCP.ulRemoteIP );
+
+            /* Port on remote machine. */
+            pxAddress->sin_port = FreeRTOS_htons( pxSocket->u.xTCP.usRemotePort );
+
+            xResult = ( BaseType_t ) sizeof( *pxAddress );
+        }
+
+        return xResult;
+    }
 
 #endif /* ipconfigUSE_TCP */
 
 /*-----------------------------------------------------------*/
 
-#if( ipconfigUSE_TCP == 1 )
+#if ( ipconfigUSE_TCP == 1 )
 
-	/* Returns the number of bytes that may be added to txStream */
-	BaseType_t FreeRTOS_maywrite( Socket_t xSocket )
-	{
-	const FreeRTOS_Socket_t *pxSocket = ( const FreeRTOS_Socket_t * ) xSocket;
-	BaseType_t xResult;
+    /* Returns the number of bytes that may be added to txStream */
+    BaseType_t FreeRTOS_maywrite( Socket_t xSocket )
+    {
+        const FreeRTOS_Socket_t * pxSocket = ( const FreeRTOS_Socket_t * ) xSocket;
+        BaseType_t xResult;
 
-		if( pxSocket->ucProtocol != ( uint8_t ) FREERTOS_IPPROTO_TCP )
-		{
-			xResult = -pdFREERTOS_ERRNO_EINVAL;
-		}
-		else if( pxSocket->u.xTCP.ucTCPState != ( uint8_t ) eESTABLISHED )
-		{
-			if( ( pxSocket->u.xTCP.ucTCPState < ( uint8_t ) eCONNECT_SYN ) || ( pxSocket->u.xTCP.ucTCPState > ( EventBits_t ) eESTABLISHED ) )
-			{
-				xResult = -1;
-			}
-			else
-			{
-				xResult = 0;
-			}
-		}
-		else if( pxSocket->u.xTCP.txStream == NULL )
-		{
-			xResult = ( BaseType_t ) pxSocket->u.xTCP.uxTxStreamSize;
-		}
-		else
-		{
-			xResult = ( BaseType_t ) uxStreamBufferGetSpace( pxSocket->u.xTCP.txStream );
-		}
+        if( pxSocket->ucProtocol != ( uint8_t ) FREERTOS_IPPROTO_TCP )
+        {
+            xResult = -pdFREERTOS_ERRNO_EINVAL;
+        }
+        else if( pxSocket->u.xTCP.ucTCPState != ( uint8_t ) eESTABLISHED )
+        {
+            if( ( pxSocket->u.xTCP.ucTCPState < ( uint8_t ) eCONNECT_SYN ) || ( pxSocket->u.xTCP.ucTCPState > ( EventBits_t ) eESTABLISHED ) )
+            {
+                xResult = -1;
+            }
+            else
+            {
+                xResult = 0;
+            }
+        }
+        else if( pxSocket->u.xTCP.txStream == NULL )
+        {
+            xResult = ( BaseType_t ) pxSocket->u.xTCP.uxTxStreamSize;
+        }
+        else
+        {
+            xResult = ( BaseType_t ) uxStreamBufferGetSpace( pxSocket->u.xTCP.txStream );
+        }
 
-		return xResult;
-	}
-
-#endif /* ipconfigUSE_TCP */
-/*-----------------------------------------------------------*/
-
-#if( ipconfigUSE_TCP == 1 )
-
-	BaseType_t FreeRTOS_tx_space( Socket_t xSocket )
-	{
-	const FreeRTOS_Socket_t *pxSocket = ( const FreeRTOS_Socket_t * ) xSocket;
-	BaseType_t xReturn;
-
-		if( pxSocket->ucProtocol != ( uint8_t ) FREERTOS_IPPROTO_TCP )
-		{
-			xReturn = -pdFREERTOS_ERRNO_EINVAL;
-		}
-		else
-		{
-			if( pxSocket->u.xTCP.txStream != NULL )
-			{
-				xReturn = ( BaseType_t ) uxStreamBufferGetSpace ( pxSocket->u.xTCP.txStream );
-			}
-			else
-			{
-				xReturn = ( BaseType_t ) pxSocket->u.xTCP.uxTxStreamSize;
-			}
-		}
-
-		return xReturn;
-	}
+        return xResult;
+    }
 
 #endif /* ipconfigUSE_TCP */
 /*-----------------------------------------------------------*/
 
-#if( ipconfigUSE_TCP == 1 )
+#if ( ipconfigUSE_TCP == 1 )
 
-	BaseType_t FreeRTOS_tx_size( Socket_t xSocket )
-	{
-	const FreeRTOS_Socket_t *pxSocket = ( const FreeRTOS_Socket_t * ) xSocket;
-	BaseType_t xReturn;
+    BaseType_t FreeRTOS_tx_space( Socket_t xSocket )
+    {
+        const FreeRTOS_Socket_t * pxSocket = ( const FreeRTOS_Socket_t * ) xSocket;
+        BaseType_t xReturn;
 
-		if( pxSocket->ucProtocol != ( uint8_t ) FREERTOS_IPPROTO_TCP )
-		{
-			xReturn = -pdFREERTOS_ERRNO_EINVAL;
-		}
-		else
-		{
-			if( pxSocket->u.xTCP.txStream != NULL )
-			{
-				xReturn = ( BaseType_t ) uxStreamBufferGetSize ( pxSocket->u.xTCP.txStream );
-			}
-			else
-			{
-				xReturn = 0;
-			}
-		}
+        if( pxSocket->ucProtocol != ( uint8_t ) FREERTOS_IPPROTO_TCP )
+        {
+            xReturn = -pdFREERTOS_ERRNO_EINVAL;
+        }
+        else
+        {
+            if( pxSocket->u.xTCP.txStream != NULL )
+            {
+                xReturn = ( BaseType_t ) uxStreamBufferGetSpace( pxSocket->u.xTCP.txStream );
+            }
+            else
+            {
+                xReturn = ( BaseType_t ) pxSocket->u.xTCP.uxTxStreamSize;
+            }
+        }
 
-		return xReturn;
-	}
-
-#endif /* ipconfigUSE_TCP */
-/*-----------------------------------------------------------*/
-
-#if( ipconfigUSE_TCP == 1 )
-
-	/* Returns pdTRUE if TCP socket is connected. */
-	BaseType_t FreeRTOS_issocketconnected( Socket_t xSocket )
-	{
-	const FreeRTOS_Socket_t *pxSocket = ( const FreeRTOS_Socket_t * ) xSocket;
-	BaseType_t xReturn = pdFALSE;
-
-		if( pxSocket->ucProtocol != ( uint8_t ) FREERTOS_IPPROTO_TCP )
-		{
-			xReturn = -pdFREERTOS_ERRNO_EINVAL;
-		}
-		else
-		{
-			if( pxSocket->u.xTCP.ucTCPState >= ( uint8_t ) eESTABLISHED )
-			{
-				if( pxSocket->u.xTCP.ucTCPState < ( uint8_t ) eCLOSE_WAIT )
-				{
-					xReturn = pdTRUE;
-				}
-			}
-		}
-
-		return xReturn;
-	}
+        return xReturn;
+    }
 
 #endif /* ipconfigUSE_TCP */
 /*-----------------------------------------------------------*/
 
-#if( ipconfigUSE_TCP == 1 )
+#if ( ipconfigUSE_TCP == 1 )
 
-	/* returns the actual size of MSS being used */
-	BaseType_t FreeRTOS_mss( Socket_t xSocket )
-	{
-	const FreeRTOS_Socket_t *pxSocket = ( const FreeRTOS_Socket_t * ) xSocket;
-	BaseType_t xReturn;
+    BaseType_t FreeRTOS_tx_size( Socket_t xSocket )
+    {
+        const FreeRTOS_Socket_t * pxSocket = ( const FreeRTOS_Socket_t * ) xSocket;
+        BaseType_t xReturn;
 
-		if( pxSocket->ucProtocol != ( uint8_t ) FREERTOS_IPPROTO_TCP )
-		{
-			xReturn = -pdFREERTOS_ERRNO_EINVAL;
-		}
-		else
-		{
-			/* usCurMSS is declared as uint16_t to save space.  FreeRTOS_mss()
-			will often be used in signed native-size expressions cast it to
-			BaseType_t. */
-			xReturn = ( BaseType_t ) ( pxSocket->u.xTCP.usCurMSS );
-		}
+        if( pxSocket->ucProtocol != ( uint8_t ) FREERTOS_IPPROTO_TCP )
+        {
+            xReturn = -pdFREERTOS_ERRNO_EINVAL;
+        }
+        else
+        {
+            if( pxSocket->u.xTCP.txStream != NULL )
+            {
+                xReturn = ( BaseType_t ) uxStreamBufferGetSize( pxSocket->u.xTCP.txStream );
+            }
+            else
+            {
+                xReturn = 0;
+            }
+        }
 
-		return xReturn;
-	}
-
-#endif /* ipconfigUSE_TCP */
-/*-----------------------------------------------------------*/
-
-#if( ipconfigUSE_TCP == 1 )
-
-	/* HT: for internal use only: return the connection status */
-	BaseType_t FreeRTOS_connstatus( Socket_t xSocket )
-	{
-	const FreeRTOS_Socket_t *pxSocket = ( const FreeRTOS_Socket_t * ) xSocket;
-	BaseType_t xReturn;
-
-		if( pxSocket->ucProtocol != ( uint8_t ) FREERTOS_IPPROTO_TCP )
-		{
-			xReturn = -pdFREERTOS_ERRNO_EINVAL;
-		}
-		else
-		{
-			/* Cast it to BaseType_t */
-			xReturn = ( BaseType_t ) ( pxSocket->u.xTCP.ucTCPState );
-		}
-
-		return xReturn;
-	}
+        return xReturn;
+    }
 
 #endif /* ipconfigUSE_TCP */
 /*-----------------------------------------------------------*/
 
-#if( ipconfigUSE_TCP == 1 )
+#if ( ipconfigUSE_TCP == 1 )
 
-	/*
-	 * Returns the number of bytes which can be read.
-	 */
-	BaseType_t FreeRTOS_rx_size( Socket_t xSocket )
-	{
-	const FreeRTOS_Socket_t *pxSocket = ( const FreeRTOS_Socket_t * ) xSocket;
-	BaseType_t xReturn;
+    /* Returns pdTRUE if TCP socket is connected. */
+    BaseType_t FreeRTOS_issocketconnected( Socket_t xSocket )
+    {
+        const FreeRTOS_Socket_t * pxSocket = ( const FreeRTOS_Socket_t * ) xSocket;
+        BaseType_t xReturn = pdFALSE;
 
-		if( pxSocket->ucProtocol != ( uint8_t ) FREERTOS_IPPROTO_TCP )
-		{
-			xReturn = -pdFREERTOS_ERRNO_EINVAL;
-		}
-		else if( pxSocket->u.xTCP.rxStream != NULL )
-		{
-			xReturn = ( BaseType_t ) uxStreamBufferGetSize( pxSocket->u.xTCP.rxStream );
-		}
-		else
-		{
-			xReturn = 0;
-		}
+        if( pxSocket->ucProtocol != ( uint8_t ) FREERTOS_IPPROTO_TCP )
+        {
+            xReturn = -pdFREERTOS_ERRNO_EINVAL;
+        }
+        else
+        {
+            if( pxSocket->u.xTCP.ucTCPState >= ( uint8_t ) eESTABLISHED )
+            {
+                if( pxSocket->u.xTCP.ucTCPState < ( uint8_t ) eCLOSE_WAIT )
+                {
+                    xReturn = pdTRUE;
+                }
+            }
+        }
 
-		return xReturn;
-	}
+        return xReturn;
+    }
+
+#endif /* ipconfigUSE_TCP */
+/*-----------------------------------------------------------*/
+
+#if ( ipconfigUSE_TCP == 1 )
+
+    /* returns the actual size of MSS being used */
+    BaseType_t FreeRTOS_mss( Socket_t xSocket )
+    {
+        const FreeRTOS_Socket_t * pxSocket = ( const FreeRTOS_Socket_t * ) xSocket;
+        BaseType_t xReturn;
+
+        if( pxSocket->ucProtocol != ( uint8_t ) FREERTOS_IPPROTO_TCP )
+        {
+            xReturn = -pdFREERTOS_ERRNO_EINVAL;
+        }
+        else
+        {
+            /* usCurMSS is declared as uint16_t to save space.  FreeRTOS_mss()
+             * will often be used in signed native-size expressions cast it to
+             * BaseType_t. */
+            xReturn = ( BaseType_t ) ( pxSocket->u.xTCP.usCurMSS );
+        }
+
+        return xReturn;
+    }
+
+#endif /* ipconfigUSE_TCP */
+/*-----------------------------------------------------------*/
+
+#if ( ipconfigUSE_TCP == 1 )
+
+    /* HT: for internal use only: return the connection status */
+    BaseType_t FreeRTOS_connstatus( Socket_t xSocket )
+    {
+        const FreeRTOS_Socket_t * pxSocket = ( const FreeRTOS_Socket_t * ) xSocket;
+        BaseType_t xReturn;
+
+        if( pxSocket->ucProtocol != ( uint8_t ) FREERTOS_IPPROTO_TCP )
+        {
+            xReturn = -pdFREERTOS_ERRNO_EINVAL;
+        }
+        else
+        {
+            /* Cast it to BaseType_t */
+            xReturn = ( BaseType_t ) ( pxSocket->u.xTCP.ucTCPState );
+        }
+
+        return xReturn;
+    }
+
+#endif /* ipconfigUSE_TCP */
+/*-----------------------------------------------------------*/
+
+#if ( ipconfigUSE_TCP == 1 )
+
+    /*
+     * Returns the number of bytes which can be read.
+     */
+    BaseType_t FreeRTOS_rx_size( Socket_t xSocket )
+    {
+        const FreeRTOS_Socket_t * pxSocket = ( const FreeRTOS_Socket_t * ) xSocket;
+        BaseType_t xReturn;
+
+        if( pxSocket->ucProtocol != ( uint8_t ) FREERTOS_IPPROTO_TCP )
+        {
+            xReturn = -pdFREERTOS_ERRNO_EINVAL;
+        }
+        else if( pxSocket->u.xTCP.rxStream != NULL )
+        {
+            xReturn = ( BaseType_t ) uxStreamBufferGetSize( pxSocket->u.xTCP.rxStream );
+        }
+        else
+        {
+            xReturn = 0;
+        }
+
+        return xReturn;
+    }
 
 #endif /* ipconfigUSE_TCP */
 /*-----------------------------------------------------------*/
 
 #if 0
-BaseType_t FreeRTOS_udp_rx_size( Socket_t xSocket )
-{
-	BaseType_t xReturn = 0;
-	const FreeRTOS_Socket_t *pxSocket = ( const FreeRTOS_Socket_t * ) xSocket;
+    BaseType_t FreeRTOS_udp_rx_size( Socket_t xSocket )
+    {
+        BaseType_t xReturn = 0;
+        const FreeRTOS_Socket_t * pxSocket = ( const FreeRTOS_Socket_t * ) xSocket;
 
-	if( pxSocket->ucProtocol == ( uint8_t ) FREERTOS_IPPROTO_UDP )
-	{
-		xReturn = ( BaseType_t ) listCURRENT_LIST_LENGTH( &( pxSocket->u.xUDP.xWaitingPacketsList ) );
-	}
-	else
-	{
-		xReturn = -pdFREERTOS_ERRNO_EINVAL;
-	}
-	return xReturn;
-}
+        if( pxSocket->ucProtocol == ( uint8_t ) FREERTOS_IPPROTO_UDP )
+        {
+            xReturn = ( BaseType_t ) listCURRENT_LIST_LENGTH( &( pxSocket->u.xUDP.xWaitingPacketsList ) );
+        }
+        else
+        {
+            xReturn = -pdFREERTOS_ERRNO_EINVAL;
+        }
+
+        return xReturn;
+    }
 #endif /* 0 */
 
-#if( ipconfigUSE_TCP == 1 )
+#if ( ipconfigUSE_TCP == 1 )
 
-	void FreeRTOS_netstat( void )
-	{
-	IPStackEvent_t xAskEvent;
+    void FreeRTOS_netstat( void )
+    {
+        IPStackEvent_t xAskEvent;
 
-		/* Ask the IP-task to call vTCPNetStat()
-		 * to avoid accessing xBoundTCPSocketsList
-		 */
-		xAskEvent.eEventType = eTCPNetStat;
-		xAskEvent.pvData = ( void * ) NULL;
-		( void ) xSendEventStructToIPTask( &xAskEvent, pdMS_TO_TICKS( 1000U ) );
-	}
+        /* Ask the IP-task to call vTCPNetStat()
+         * to avoid accessing xBoundTCPSocketsList
+         */
+        xAskEvent.eEventType = eTCPNetStat;
+        xAskEvent.pvData = ( void * ) NULL;
+        ( void ) xSendEventStructToIPTask( &xAskEvent, pdMS_TO_TICKS( 1000U ) );
+    }
 
 #endif /* ipconfigUSE_TCP */
 /*-----------------------------------------------------------*/
 
-#if( ( ipconfigHAS_PRINTF != 0 ) && ( ipconfigUSE_TCP == 1 ) )
+#if ( ( ipconfigHAS_PRINTF != 0 ) && ( ipconfigUSE_TCP == 1 ) )
 
-	void vTCPNetStat( void )
-	{
-	/* Show a simple listing of all created sockets and their connections */
-	const ListItem_t *pxIterator;
-	BaseType_t count = 0;
-	size_t uxMinimum = uxGetMinimumFreeNetworkBuffers();
-	size_t uxCurrent = uxGetNumberOfFreeNetworkBuffers();
+    void vTCPNetStat( void )
+    {
+        /* Show a simple listing of all created sockets and their connections */
+        const ListItem_t * pxIterator;
+        BaseType_t count = 0;
+        size_t uxMinimum = uxGetMinimumFreeNetworkBuffers();
+        size_t uxCurrent = uxGetNumberOfFreeNetworkBuffers();
 
-		if( !listLIST_IS_INITIALISED( &xBoundTCPSocketsList ) )
-		{
-			FreeRTOS_printf( ( "PLUS-TCP not initialized\n" ) );
-		}
-		else
-		{
-		const ListItem_t *pxEndTCP = ipPOINTER_CAST( const ListItem_t *, listGET_END_MARKER( &xBoundTCPSocketsList ) );
-		const ListItem_t *pxEndUDP = ipPOINTER_CAST( const ListItem_t *, listGET_END_MARKER( &xBoundUDPSocketsList ) );
-			FreeRTOS_printf( ( "Prot Port IP-Remote       : Port  R/T Status       Alive  tmout Child\n" ) );
-			for( pxIterator  = listGET_HEAD_ENTRY( &xBoundTCPSocketsList );
-				 pxIterator != pxEndTCP;
-				 pxIterator  = listGET_NEXT( pxIterator ) )
-			{
-				const FreeRTOS_Socket_t *pxSocket = ipPOINTER_CAST( const FreeRTOS_Socket_t *, listGET_LIST_ITEM_OWNER( pxIterator ) );
-				#if( ipconfigTCP_KEEP_ALIVE == 1 )
-					TickType_t age = xTaskGetTickCount() - pxSocket->u.xTCP.xLastAliveTime;
-				#else
-					TickType_t age = 0U;
-				#endif
+        if( !listLIST_IS_INITIALISED( &xBoundTCPSocketsList ) )
+        {
+            FreeRTOS_printf( ( "PLUS-TCP not initialized\n" ) );
+        }
+        else
+        {
+            const ListItem_t * pxEndTCP = ipPOINTER_CAST( const ListItem_t *, listGET_END_MARKER( &xBoundTCPSocketsList ) );
+            const ListItem_t * pxEndUDP = ipPOINTER_CAST( const ListItem_t *, listGET_END_MARKER( &xBoundUDPSocketsList ) );
+            FreeRTOS_printf( ( "Prot Port IP-Remote       : Port  R/T Status       Alive  tmout Child\n" ) );
 
-				char ucChildText[16] = "";
-				if (pxSocket->u.xTCP.ucTCPState == ( uint8_t ) eTCP_LISTEN)
-				{
-					/* Using function "snprintf". */
-					const int32_t copied_len = snprintf( ucChildText, sizeof( ucChildText ), " %d/%d",
-						( int32_t ) pxSocket->u.xTCP.usChildCount,
-						( int32_t ) pxSocket->u.xTCP.usBacklog);
-					( void )copied_len;
-					/* These should never evaluate to false since the buffers are both shorter than 5-6 characters (<=65535) */
-					configASSERT( copied_len >= 0 );
-					configASSERT( copied_len < ( int32_t ) sizeof( ucChildText ) );
-				}
-				FreeRTOS_printf( ( "TCP %5d %-16lxip:%5d %d/%d %-13.13s %6lu %6u%s\n",
-					pxSocket->usLocalPort,		/* Local port on this machine */
-					pxSocket->u.xTCP.ulRemoteIP,	/* IP address of remote machine */
-					pxSocket->u.xTCP.usRemotePort,	/* Port on remote machine */
-					( pxSocket->u.xTCP.rxStream != NULL ) ? 1 : 0,
-					( pxSocket->u.xTCP.txStream != NULL ) ? 1 : 0,
-					FreeRTOS_GetTCPStateName( pxSocket->u.xTCP.ucTCPState ),
-					( age > 999999u ) ? 999999u : age, /* Format 'age' for printing */
-					pxSocket->u.xTCP.usTimeout,
-					ucChildText ) );
-				count++;
-			}
+            for( pxIterator = listGET_HEAD_ENTRY( &xBoundTCPSocketsList );
+                 pxIterator != pxEndTCP;
+                 pxIterator = listGET_NEXT( pxIterator ) )
+            {
+                const FreeRTOS_Socket_t * pxSocket = ipPOINTER_CAST( const FreeRTOS_Socket_t *, listGET_LIST_ITEM_OWNER( pxIterator ) );
+                #if ( ipconfigTCP_KEEP_ALIVE == 1 )
+                    TickType_t age = xTaskGetTickCount() - pxSocket->u.xTCP.xLastAliveTime;
+                #else
+                    TickType_t age = 0U;
+                #endif
 
-			for( pxIterator  = listGET_HEAD_ENTRY( &xBoundUDPSocketsList );
-				 pxIterator != pxEndUDP;
-				 pxIterator  = listGET_NEXT( pxIterator ) )
-			{
-				/* Local port on this machine */
-				FreeRTOS_printf( ( "UDP Port %5u\n",
-					FreeRTOS_ntohs( listGET_LIST_ITEM_VALUE( pxIterator ) ) ) );
-				count++;
-			}
+                char ucChildText[ 16 ] = "";
 
-			FreeRTOS_printf( ( "FreeRTOS_netstat: %lu sockets %lu < %lu < %ld buffers free\n",
-				( UBaseType_t ) count,
-				( UBaseType_t ) uxMinimum,
-				( UBaseType_t ) uxCurrent,
-				( BaseType_t ) ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ) );
-		}
-	}
+                if( pxSocket->u.xTCP.ucTCPState == ( uint8_t ) eTCP_LISTEN )
+                {
+                    /* Using function "snprintf". */
+                    const int32_t copied_len = snprintf( ucChildText, sizeof( ucChildText ), " %d/%d",
+                                                         ( int32_t ) pxSocket->u.xTCP.usChildCount,
+                                                         ( int32_t ) pxSocket->u.xTCP.usBacklog );
+                    ( void ) copied_len;
+                    /* These should never evaluate to false since the buffers are both shorter than 5-6 characters (<=65535) */
+                    configASSERT( copied_len >= 0 );
+                    configASSERT( copied_len < ( int32_t ) sizeof( ucChildText ) );
+                }
+
+                FreeRTOS_printf( ( "TCP %5d %-16lxip:%5d %d/%d %-13.13s %6lu %6u%s\n",
+                                   pxSocket->usLocalPort,         /* Local port on this machine */
+                                   pxSocket->u.xTCP.ulRemoteIP,   /* IP address of remote machine */
+                                   pxSocket->u.xTCP.usRemotePort, /* Port on remote machine */
+                                   ( pxSocket->u.xTCP.rxStream != NULL ) ? 1 : 0,
+                                   ( pxSocket->u.xTCP.txStream != NULL ) ? 1 : 0,
+                                   FreeRTOS_GetTCPStateName( pxSocket->u.xTCP.ucTCPState ),
+                                   ( age > 999999u ) ? 999999u : age, /* Format 'age' for printing */
+                                   pxSocket->u.xTCP.usTimeout,
+                                   ucChildText ) );
+                count++;
+            }
+
+            for( pxIterator = listGET_HEAD_ENTRY( &xBoundUDPSocketsList );
+                 pxIterator != pxEndUDP;
+                 pxIterator = listGET_NEXT( pxIterator ) )
+            {
+                /* Local port on this machine */
+                FreeRTOS_printf( ( "UDP Port %5u\n",
+                                   FreeRTOS_ntohs( listGET_LIST_ITEM_VALUE( pxIterator ) ) ) );
+                count++;
+            }
+
+            FreeRTOS_printf( ( "FreeRTOS_netstat: %lu sockets %lu < %lu < %ld buffers free\n",
+                               ( UBaseType_t ) count,
+                               ( UBaseType_t ) uxMinimum,
+                               ( UBaseType_t ) uxCurrent,
+                               ( BaseType_t ) ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ) );
+        }
+    }
 
 #endif /* ( ( ipconfigHAS_PRINTF != 0 ) && ( ipconfigUSE_TCP == 1 ) ) */
 /*-----------------------------------------------------------*/
 
-#if( ipconfigSUPPORT_SELECT_FUNCTION == 1 )
+#if ( ipconfigSUPPORT_SELECT_FUNCTION == 1 )
 
-	void vSocketSelect( SocketSelect_t *pxSocketSet )
-	{
-	BaseType_t xRound;
-	EventBits_t xSocketBits, xBitsToClear;
-	#if ipconfigUSE_TCP == 1
-		BaseType_t xLastRound = 1;
-	#else
-		BaseType_t xLastRound = 0;
-	#endif
+    void vSocketSelect( SocketSelect_t * pxSocketSet )
+    {
+        BaseType_t xRound;
+        EventBits_t xSocketBits, xBitsToClear;
 
-		/* These flags will be switched on after checking the socket status. */
-		EventBits_t xGroupBits = 0;
+        #if ipconfigUSE_TCP == 1
+            BaseType_t xLastRound = 1;
+        #else
+            BaseType_t xLastRound = 0;
+        #endif
 
-		for( xRound = 0; xRound <= xLastRound; xRound++ )
-		{
-			const ListItem_t *pxIterator;
-			const ListItem_t *pxEnd;
-			if( xRound == 0 )
-			{
-				pxEnd = ipPOINTER_CAST( const ListItem_t *, listGET_END_MARKER( &xBoundUDPSocketsList ) );
-			}
-		#if ipconfigUSE_TCP == 1
-			else
-			{
-				pxEnd = ipPOINTER_CAST( const ListItem_t *, listGET_END_MARKER( &xBoundTCPSocketsList ) );
-			}
-		#endif /* ipconfigUSE_TCP == 1 */
-			for( pxIterator = listGET_NEXT( pxEnd );
-				 pxIterator != pxEnd;
-				 pxIterator = listGET_NEXT( pxIterator ) )
-			{
-				FreeRTOS_Socket_t *pxSocket =  ipPOINTER_CAST( FreeRTOS_Socket_t *, listGET_LIST_ITEM_OWNER( pxIterator ) );
-				if( pxSocket->pxSocketSet != pxSocketSet )
-				{
-					/* Socket does not belong to this select group. */
-					continue;
-				}
-				xSocketBits = 0;
+        /* These flags will be switched on after checking the socket status. */
+        EventBits_t xGroupBits = 0;
 
-			#if( ipconfigUSE_TCP == 1 )
-				if( pxSocket->ucProtocol == ( uint8_t ) FREERTOS_IPPROTO_TCP )
-				{
-					/* Check if the socket has already been accepted by the
-					owner.  If not, it is useless to return it from a
-					select(). */
-					BaseType_t bAccepted = pdFALSE;
+        for( xRound = 0; xRound <= xLastRound; xRound++ )
+        {
+            const ListItem_t * pxIterator;
+            const ListItem_t * pxEnd;
 
-					if( pxSocket->u.xTCP.bits.bPassQueued == pdFALSE_UNSIGNED )
-					{
-						if( pxSocket->u.xTCP.bits.bPassAccept == pdFALSE_UNSIGNED )
-						{
-							bAccepted = pdTRUE;
-						}
-					}
+            if( xRound == 0 )
+            {
+                pxEnd = ipPOINTER_CAST( const ListItem_t *, listGET_END_MARKER( &xBoundUDPSocketsList ) );
+            }
 
-					/* Is the set owner interested in READ events? */
-					if( ( pxSocket->xSelectBits & ( EventBits_t ) eSELECT_READ ) != ( EventBits_t ) 0U )
-					{
-						if( pxSocket->u.xTCP.ucTCPState == ( uint8_t ) eTCP_LISTEN )
-						{
-							if( ( pxSocket->u.xTCP.pxPeerSocket != NULL ) && ( pxSocket->u.xTCP.pxPeerSocket->u.xTCP.bits.bPassAccept != pdFALSE_UNSIGNED ) )
-							{
-								xSocketBits |= ( EventBits_t ) eSELECT_READ;
-							}
-						}
-						else if( ( pxSocket->u.xTCP.bits.bReuseSocket != pdFALSE_UNSIGNED ) && ( pxSocket->u.xTCP.bits.bPassAccept != pdFALSE_UNSIGNED ) )
-						{
-							/* This socket has the re-use flag. After connecting it turns into
-							aconnected socket. Set the READ event, so that accept() will be called. */
-							xSocketBits |= ( EventBits_t ) eSELECT_READ;
-						}
-						else if( ( bAccepted != 0 ) && ( FreeRTOS_recvcount( pxSocket ) > 0 ) )
-						{
-							xSocketBits |= ( EventBits_t ) eSELECT_READ;
-						}
-						else
-						{
-							/* Nothing. */
-						}
-					}
-					/* Is the set owner interested in EXCEPTION events? */
-					if( ( pxSocket->xSelectBits & ( EventBits_t ) eSELECT_EXCEPT ) != 0U )
-					{
-						if( ( pxSocket->u.xTCP.ucTCPState == ( uint8_t ) eCLOSE_WAIT ) || ( pxSocket->u.xTCP.ucTCPState == ( uint8_t ) eCLOSED ) )
-						{
-							xSocketBits |= ( EventBits_t ) eSELECT_EXCEPT;
-						}
-					}
+            #if ipconfigUSE_TCP == 1
+                else
+                {
+                    pxEnd = ipPOINTER_CAST( const ListItem_t *, listGET_END_MARKER( &xBoundTCPSocketsList ) );
+                }
+            #endif /* ipconfigUSE_TCP == 1 */
 
-					/* Is the set owner interested in WRITE events? */
-					if( ( pxSocket->xSelectBits & ( EventBits_t ) eSELECT_WRITE ) != 0U )
-					{
-						BaseType_t bMatch = pdFALSE;
+            for( pxIterator = listGET_NEXT( pxEnd );
+                 pxIterator != pxEnd;
+                 pxIterator = listGET_NEXT( pxIterator ) )
+            {
+                FreeRTOS_Socket_t * pxSocket = ipPOINTER_CAST( FreeRTOS_Socket_t *, listGET_LIST_ITEM_OWNER( pxIterator ) );
 
-						if( bAccepted != 0 )
-						{
-							if( FreeRTOS_tx_space( pxSocket ) > 0 )
-							{
-								bMatch = pdTRUE;
-							}
-						}
+                if( pxSocket->pxSocketSet != pxSocketSet )
+                {
+                    /* Socket does not belong to this select group. */
+                    continue;
+                }
 
-						if( bMatch == pdFALSE )
-						{
-							if( ( pxSocket->u.xTCP.bits.bConnPrepared != pdFALSE_UNSIGNED ) &&
-								( pxSocket->u.xTCP.ucTCPState >= ( uint8_t ) eESTABLISHED ) &&
-								( pxSocket->u.xTCP.bits.bConnPassed == pdFALSE_UNSIGNED ) )
-							{
-								pxSocket->u.xTCP.bits.bConnPassed = pdTRUE;
-								bMatch = pdTRUE;
-							}
-						}
+                xSocketBits = 0;
 
-						if( bMatch != pdFALSE )
-						{
-							xSocketBits |= ( EventBits_t ) eSELECT_WRITE;
-						}
-					}
-				}
-				else
-			#endif /* ipconfigUSE_TCP == 1 */
-				{
-					/* Select events for UDP are simpler. */
-					if( ( ( pxSocket->xSelectBits & ( EventBits_t ) eSELECT_READ ) != 0U ) &&
-						( listCURRENT_LIST_LENGTH( &( pxSocket->u.xUDP.xWaitingPacketsList ) ) > 0U ) )
-					{
-						xSocketBits |= ( EventBits_t ) eSELECT_READ;
-					}
-					/* The WRITE and EXCEPT bits are not used for UDP */
-				}	/* if( pxSocket->ucProtocol == FREERTOS_IPPROTO_TCP ) */
+                #if ( ipconfigUSE_TCP == 1 )
+                    if( pxSocket->ucProtocol == ( uint8_t ) FREERTOS_IPPROTO_TCP )
+                    {
+                        /* Check if the socket has already been accepted by the
+                         * owner.  If not, it is useless to return it from a
+                         * select(). */
+                        BaseType_t bAccepted = pdFALSE;
 
-				/* Each socket keeps its own event flags, which are looked-up
-				by FreeRTOS_FD_ISSSET() */
-				pxSocket->xSocketBits = xSocketBits;
+                        if( pxSocket->u.xTCP.bits.bPassQueued == pdFALSE_UNSIGNED )
+                        {
+                            if( pxSocket->u.xTCP.bits.bPassAccept == pdFALSE_UNSIGNED )
+                            {
+                                bAccepted = pdTRUE;
+                            }
+                        }
 
-				/* The ORed value will be used to set the bits in the event
-				group. */
-				xGroupBits |= xSocketBits;
+                        /* Is the set owner interested in READ events? */
+                        if( ( pxSocket->xSelectBits & ( EventBits_t ) eSELECT_READ ) != ( EventBits_t ) 0U )
+                        {
+                            if( pxSocket->u.xTCP.ucTCPState == ( uint8_t ) eTCP_LISTEN )
+                            {
+                                if( ( pxSocket->u.xTCP.pxPeerSocket != NULL ) && ( pxSocket->u.xTCP.pxPeerSocket->u.xTCP.bits.bPassAccept != pdFALSE_UNSIGNED ) )
+                                {
+                                    xSocketBits |= ( EventBits_t ) eSELECT_READ;
+                                }
+                            }
+                            else if( ( pxSocket->u.xTCP.bits.bReuseSocket != pdFALSE_UNSIGNED ) && ( pxSocket->u.xTCP.bits.bPassAccept != pdFALSE_UNSIGNED ) )
+                            {
+                                /* This socket has the re-use flag. After connecting it turns into
+                                 * aconnected socket. Set the READ event, so that accept() will be called. */
+                                xSocketBits |= ( EventBits_t ) eSELECT_READ;
+                            }
+                            else if( ( bAccepted != 0 ) && ( FreeRTOS_recvcount( pxSocket ) > 0 ) )
+                            {
+                                xSocketBits |= ( EventBits_t ) eSELECT_READ;
+                            }
+                            else
+                            {
+                                /* Nothing. */
+                            }
+                        }
 
-			}	/* for( pxIterator ... ) */
-		}	/* for( xRound = 0; xRound <= xLastRound; xRound++ ) */
+                        /* Is the set owner interested in EXCEPTION events? */
+                        if( ( pxSocket->xSelectBits & ( EventBits_t ) eSELECT_EXCEPT ) != 0U )
+                        {
+                            if( ( pxSocket->u.xTCP.ucTCPState == ( uint8_t ) eCLOSE_WAIT ) || ( pxSocket->u.xTCP.ucTCPState == ( uint8_t ) eCLOSED ) )
+                            {
+                                xSocketBits |= ( EventBits_t ) eSELECT_EXCEPT;
+                            }
+                        }
 
-		xBitsToClear = xEventGroupGetBits( pxSocketSet->xSelectGroup );
+                        /* Is the set owner interested in WRITE events? */
+                        if( ( pxSocket->xSelectBits & ( EventBits_t ) eSELECT_WRITE ) != 0U )
+                        {
+                            BaseType_t bMatch = pdFALSE;
 
-		/* Now set the necessary bits. */
-		xBitsToClear = ( xBitsToClear & ~xGroupBits ) & ( ( EventBits_t ) eSELECT_ALL );
+                            if( bAccepted != 0 )
+                            {
+                                if( FreeRTOS_tx_space( pxSocket ) > 0 )
+                                {
+                                    bMatch = pdTRUE;
+                                }
+                            }
 
-		#if( ipconfigSUPPORT_SIGNALS != 0 )
-		{
-			/* Maybe the socketset was signalled, but don't
-			clear the 'eSELECT_INTR' bit here, as it will be used
-			and cleared in FreeRTOS_select(). */
-			xBitsToClear &= ~( ( EventBits_t ) eSELECT_INTR );
-		}
-		#endif /* ipconfigSUPPORT_SIGNALS */
+                            if( bMatch == pdFALSE )
+                            {
+                                if( ( pxSocket->u.xTCP.bits.bConnPrepared != pdFALSE_UNSIGNED ) &&
+                                    ( pxSocket->u.xTCP.ucTCPState >= ( uint8_t ) eESTABLISHED ) &&
+                                    ( pxSocket->u.xTCP.bits.bConnPassed == pdFALSE_UNSIGNED ) )
+                                {
+                                    pxSocket->u.xTCP.bits.bConnPassed = pdTRUE;
+                                    bMatch = pdTRUE;
+                                }
+                            }
 
-		if( xBitsToClear != 0U )
-		{
-			( void ) xEventGroupClearBits( pxSocketSet->xSelectGroup, xBitsToClear );
-		}
+                            if( bMatch != pdFALSE )
+                            {
+                                xSocketBits |= ( EventBits_t ) eSELECT_WRITE;
+                            }
+                        }
+                    }
+                    else
+                #endif /* ipconfigUSE_TCP == 1 */
+                {
+                    /* Select events for UDP are simpler. */
+                    if( ( ( pxSocket->xSelectBits & ( EventBits_t ) eSELECT_READ ) != 0U ) &&
+                        ( listCURRENT_LIST_LENGTH( &( pxSocket->u.xUDP.xWaitingPacketsList ) ) > 0U ) )
+                    {
+                        xSocketBits |= ( EventBits_t ) eSELECT_READ;
+                    }
 
-		/* Now include eSELECT_CALL_IP to wakeup the caller. */
-		( void ) xEventGroupSetBits( pxSocketSet->xSelectGroup, xGroupBits | ( EventBits_t ) eSELECT_CALL_IP );
-	}
+                    /* The WRITE and EXCEPT bits are not used for UDP */
+                } /* if( pxSocket->ucProtocol == FREERTOS_IPPROTO_TCP ) */
+
+                /* Each socket keeps its own event flags, which are looked-up
+                 * by FreeRTOS_FD_ISSSET() */
+                pxSocket->xSocketBits = xSocketBits;
+
+                /* The ORed value will be used to set the bits in the event
+                 * group. */
+                xGroupBits |= xSocketBits;
+            } /* for( pxIterator ... ) */
+        }     /* for( xRound = 0; xRound <= xLastRound; xRound++ ) */
+
+        xBitsToClear = xEventGroupGetBits( pxSocketSet->xSelectGroup );
+
+        /* Now set the necessary bits. */
+        xBitsToClear = ( xBitsToClear & ~xGroupBits ) & ( ( EventBits_t ) eSELECT_ALL );
+
+        #if ( ipconfigSUPPORT_SIGNALS != 0 )
+            {
+                /* Maybe the socketset was signalled, but don't
+                 * clear the 'eSELECT_INTR' bit here, as it will be used
+                 * and cleared in FreeRTOS_select(). */
+                xBitsToClear &= ~( ( EventBits_t ) eSELECT_INTR );
+            }
+        #endif /* ipconfigSUPPORT_SIGNALS */
+
+        if( xBitsToClear != 0U )
+        {
+            ( void ) xEventGroupClearBits( pxSocketSet->xSelectGroup, xBitsToClear );
+        }
+
+        /* Now include eSELECT_CALL_IP to wakeup the caller. */
+        ( void ) xEventGroupSetBits( pxSocketSet->xSelectGroup, xGroupBits | ( EventBits_t ) eSELECT_CALL_IP );
+    }
 
 #endif /* ipconfigSUPPORT_SELECT_FUNCTION == 1 */
 /*-----------------------------------------------------------*/
 
-#if( ipconfigSUPPORT_SIGNALS != 0 )
+#if ( ipconfigSUPPORT_SIGNALS != 0 )
 
-	/* Send a signal to the task which reads from this socket. */
-	BaseType_t FreeRTOS_SignalSocket( Socket_t xSocket )
-	{
-	FreeRTOS_Socket_t *pxSocket = ( FreeRTOS_Socket_t * ) xSocket;
-	BaseType_t xReturn;
+    /* Send a signal to the task which reads from this socket. */
+    BaseType_t FreeRTOS_SignalSocket( Socket_t xSocket )
+    {
+        FreeRTOS_Socket_t * pxSocket = ( FreeRTOS_Socket_t * ) xSocket;
+        BaseType_t xReturn;
 
-		if( pxSocket == NULL )
-		{
-			xReturn = -pdFREERTOS_ERRNO_EINVAL;
-		}
-		else
-	#if( ipconfigSUPPORT_SELECT_FUNCTION == 1 )
-		if( ( pxSocket->pxSocketSet != NULL ) && ( pxSocket->pxSocketSet->xSelectGroup != NULL ) )
-		{
-			( void ) xEventGroupSetBits( pxSocket->pxSocketSet->xSelectGroup, ( EventBits_t ) eSELECT_INTR );
-			xReturn = 0;
-		}
-		else
-	#endif /* ipconfigSUPPORT_SELECT_FUNCTION */
-		if( pxSocket->xEventGroup != NULL )
-		{
-			( void ) xEventGroupSetBits( pxSocket->xEventGroup, ( EventBits_t ) eSOCKET_INTR );
-			xReturn = 0;
-		}
-		else
-		{
-			xReturn = -pdFREERTOS_ERRNO_EINVAL;
-		}
+        if( pxSocket == NULL )
+        {
+            xReturn = -pdFREERTOS_ERRNO_EINVAL;
+        }
+        else
+        #if ( ipconfigSUPPORT_SELECT_FUNCTION == 1 )
+            if( ( pxSocket->pxSocketSet != NULL ) && ( pxSocket->pxSocketSet->xSelectGroup != NULL ) )
+            {
+                ( void ) xEventGroupSetBits( pxSocket->pxSocketSet->xSelectGroup, ( EventBits_t ) eSELECT_INTR );
+                xReturn = 0;
+            }
+            else
+        #endif /* ipconfigSUPPORT_SELECT_FUNCTION */
+        if( pxSocket->xEventGroup != NULL )
+        {
+            ( void ) xEventGroupSetBits( pxSocket->xEventGroup, ( EventBits_t ) eSOCKET_INTR );
+            xReturn = 0;
+        }
+        else
+        {
+            xReturn = -pdFREERTOS_ERRNO_EINVAL;
+        }
 
-		return xReturn;
-	}
+        return xReturn;
+    }
 
 #endif /* ipconfigSUPPORT_SIGNALS */
 /*-----------------------------------------------------------*/
 
-#if( ipconfigSUPPORT_SIGNALS != 0 )
+#if ( ipconfigSUPPORT_SIGNALS != 0 )
 
-	/* Send a signal to the task which reads from this socket (FromISR version). */
-	BaseType_t FreeRTOS_SignalSocketFromISR( Socket_t xSocket, BaseType_t *pxHigherPriorityTaskWoken )
-	{
-	FreeRTOS_Socket_t *pxSocket = ( FreeRTOS_Socket_t * ) xSocket;
-	BaseType_t xReturn;
-	IPStackEvent_t xEvent;
+    /* Send a signal to the task which reads from this socket (FromISR version). */
+    BaseType_t FreeRTOS_SignalSocketFromISR( Socket_t xSocket,
+                                             BaseType_t * pxHigherPriorityTaskWoken )
+    {
+        FreeRTOS_Socket_t * pxSocket = ( FreeRTOS_Socket_t * ) xSocket;
+        BaseType_t xReturn;
+        IPStackEvent_t xEvent;
 
-		configASSERT( pxSocket != NULL );
-		configASSERT( pxSocket->ucProtocol == ( uint8_t ) FREERTOS_IPPROTO_TCP );
-		configASSERT( pxSocket->xEventGroup != NULL );
+        configASSERT( pxSocket != NULL );
+        configASSERT( pxSocket->ucProtocol == ( uint8_t ) FREERTOS_IPPROTO_TCP );
+        configASSERT( pxSocket->xEventGroup != NULL );
 
-		xEvent.eEventType = eSocketSignalEvent;
-		xEvent.pvData = pxSocket;
+        xEvent.eEventType = eSocketSignalEvent;
+        xEvent.pvData = pxSocket;
 
-		/* The IP-task will call FreeRTOS_SignalSocket for this socket. */
-		xReturn = xQueueSendToBackFromISR( xNetworkEventQueue, &xEvent, pxHigherPriorityTaskWoken );
+        /* The IP-task will call FreeRTOS_SignalSocket for this socket. */
+        xReturn = xQueueSendToBackFromISR( xNetworkEventQueue, &xEvent, pxHigherPriorityTaskWoken );
 
-		return xReturn;
-	}
+        return xReturn;
+    }
 
 #endif /* ipconfigSUPPORT_SIGNALS */
 /*-----------------------------------------------------------*/
 
 #if 0
-#if( ipconfigSUPPORT_SELECT_FUNCTION == 1 )
-struct pollfd {
-	Socket_t fd;	  /* file descriptor */
-	EventBits_t events;	 /* requested events */
-	EventBits_t revents;	/* returned events */
-};
+    #if ( ipconfigSUPPORT_SELECT_FUNCTION == 1 )
+        struct pollfd
+        {
+            Socket_t fd;         /* file descriptor */
+            EventBits_t events;  /* requested events */
+            EventBits_t revents; /* returned events */
+        };
 
-typedef BaseType_t nfds_t;
+        typedef BaseType_t nfds_t;
 
-BaseType_t poll(struct pollfd *fds, nfds_t nfds, BaseType_t timeout);
-BaseType_t poll(struct pollfd *fds, nfds_t nfds, BaseType_t timeout)
-{
-BaseType_t index;
-SocketSelect_t *pxSocketSet = NULL;
-BaseType_t xReturn = 0;
+        BaseType_t poll( struct pollfd * fds,
+                         nfds_t nfds,
+                         BaseType_t timeout );
+        BaseType_t poll( struct pollfd * fds,
+                         nfds_t nfds,
+                         BaseType_t timeout )
+        {
+            BaseType_t index;
+            SocketSelect_t * pxSocketSet = NULL;
+            BaseType_t xReturn = 0;
 
-	/* See which socket-sets have been created and bound to the sockets involved. */
-	for( index = 0; index < nfds; index++ )
-	{
-	FreeRTOS_Socket_t *pxSocket = ( FreeRTOS_Socket_t * )fds[ index ].fd;
+            /* See which socket-sets have been created and bound to the sockets involved. */
+            for( index = 0; index < nfds; index++ )
+            {
+                FreeRTOS_Socket_t * pxSocket = ( FreeRTOS_Socket_t * ) fds[ index ].fd;
 
-		if( pxSocket->pxSocketSet != NULL )
-		{
-			if( pxSocketSet == NULL )
-			{
-				/* Use this socket-set. */
-				pxSocketSet = pxSocket->pxSocketSet;
-				xReturn = 1;
-			}
-			else if( pxSocketSet == pxSocket->pxSocketSet )
-			{
-				/* Good: associated with the same socket-set. */
-			}
-			else
-			{
-				/* More than one socket-set is found: can not do a select on 2 sets. */
-				xReturn = -1;
-				break;
-			}
-		}
-	}
-	if( xReturn == 0 )
-	{
-		/* Create a new socket-set, and attach all sockets to it. */
-		pxSocketSet = FreeRTOS_CreateSocketSet();
-		if( pxSocketSet != NULL )
-		{
-			xReturn = 1;
-		}
-		else
-		{
-			xReturn = -2;
-		}
-		/* Memory leak: when the last socket closes, there is no more reference to
-		this socket-set.  It should be marked as an automatic or anonymous socket-set,
-		so when closing the last member, its memory will be freed. */
-	}
-	if( xReturn > 0 )
-	{
-		/* Only one socket-set is found.  Connect all sockets to this socket-set. */
-		for( index = 0; index < nfds; index++ )
-		{
-		FreeRTOS_Socket_t *pxSocket = ( FreeRTOS_Socket_t * )fds[ index ].fd;
-		EventBits_t xEventBits = fds[ index ].events;
+                if( pxSocket->pxSocketSet != NULL )
+                {
+                    if( pxSocketSet == NULL )
+                    {
+                        /* Use this socket-set. */
+                        pxSocketSet = pxSocket->pxSocketSet;
+                        xReturn = 1;
+                    }
+                    else if( pxSocketSet == pxSocket->pxSocketSet )
+                    {
+                        /* Good: associated with the same socket-set. */
+                    }
+                    else
+                    {
+                        /* More than one socket-set is found: can not do a select on 2 sets. */
+                        xReturn = -1;
+                        break;
+                    }
+                }
+            }
 
-			FreeRTOS_FD_SET( pxSocket, pxSocketSet, xEventBits );
-			FreeRTOS_FD_CLR( pxSocket, pxSocketSet, ( EventBits_t ) ~xEventBits );
-		}
-		/* And sleep until an event happens or a time-out. */
-		xReturn = FreeRTOS_select( pxSocketSet, timeout );
+            if( xReturn == 0 )
+            {
+                /* Create a new socket-set, and attach all sockets to it. */
+                pxSocketSet = FreeRTOS_CreateSocketSet();
 
-		/* Now set the return events, copying from the socked field 'xSocketBits'. */
-		for( index = 0; index < nfds; index++ )
-		{
-		FreeRTOS_Socket_t *pxSocket = ( FreeRTOS_Socket_t * )fds[ index ].fd;
+                if( pxSocketSet != NULL )
+                {
+                    xReturn = 1;
+                }
+                else
+                {
+                    xReturn = -2;
+                }
 
-			fds[ index ].revents = pxSocket->xSocketBits & ( ( EventBits_t ) eSELECT_ALL );
-		}
-	}
-	else
-	{
-		/* -1: Sockets are connected to different socket sets. */
-		/* -2: FreeRTOS_CreateSocketSet() failed. */
-	}
-	return xReturn;
-}
+                /* Memory leak: when the last socket closes, there is no more reference to
+                 * this socket-set.  It should be marked as an automatic or anonymous socket-set,
+                 * so when closing the last member, its memory will be freed. */
+            }
 
-#endif	/* ipconfigSUPPORT_SELECT_FUNCTION */
+            if( xReturn > 0 )
+            {
+                /* Only one socket-set is found.  Connect all sockets to this socket-set. */
+                for( index = 0; index < nfds; index++ )
+                {
+                    FreeRTOS_Socket_t * pxSocket = ( FreeRTOS_Socket_t * ) fds[ index ].fd;
+                    EventBits_t xEventBits = fds[ index ].events;
+
+                    FreeRTOS_FD_SET( pxSocket, pxSocketSet, xEventBits );
+                    FreeRTOS_FD_CLR( pxSocket, pxSocketSet, ( EventBits_t ) ~xEventBits );
+                }
+
+                /* And sleep until an event happens or a time-out. */
+                xReturn = FreeRTOS_select( pxSocketSet, timeout );
+
+                /* Now set the return events, copying from the socked field 'xSocketBits'. */
+                for( index = 0; index < nfds; index++ )
+                {
+                    FreeRTOS_Socket_t * pxSocket = ( FreeRTOS_Socket_t * ) fds[ index ].fd;
+
+                    fds[ index ].revents = pxSocket->xSocketBits & ( ( EventBits_t ) eSELECT_ALL );
+                }
+            }
+            else
+            {
+                /* -1: Sockets are connected to different socket sets. */
+                /* -2: FreeRTOS_CreateSocketSet() failed. */
+            }
+
+            return xReturn;
+        }
+
+    #endif /* ipconfigSUPPORT_SELECT_FUNCTION */
 #endif /* 0 */

--- a/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/FreeRTOS_TCP_IP.c
+++ b/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/FreeRTOS_TCP_IP.c
@@ -62,37 +62,37 @@
 /*
  * The meaning of the TCP flags:
  */
-#define tcpTCP_FLAG_FIN				( ( uint8_t ) 0x01U ) /* No more data from sender */
-#define tcpTCP_FLAG_SYN				( ( uint8_t ) 0x02U ) /* Synchronize sequence numbers */
-#define tcpTCP_FLAG_RST				( ( uint8_t ) 0x04U ) /* Reset the connection */
-#define tcpTCP_FLAG_PSH				( ( uint8_t ) 0x08U ) /* Push function: please push buffered data to the recv application */
-#define tcpTCP_FLAG_ACK				( ( uint8_t ) 0x10U ) /* Acknowledgment field is significant */
-#define tcpTCP_FLAG_URG				( ( uint8_t ) 0x20U ) /* Urgent pointer field is significant */
-#define tcpTCP_FLAG_ECN				( ( uint8_t ) 0x40U ) /* ECN-Echo */
-#define tcpTCP_FLAG_CWR				( ( uint8_t ) 0x80U ) /* Congestion Window Reduced */
+    #define tcpTCP_FLAG_FIN                       ( ( uint8_t ) 0x01U ) /* No more data from sender */
+    #define tcpTCP_FLAG_SYN                       ( ( uint8_t ) 0x02U ) /* Synchronize sequence numbers */
+    #define tcpTCP_FLAG_RST                       ( ( uint8_t ) 0x04U ) /* Reset the connection */
+    #define tcpTCP_FLAG_PSH                       ( ( uint8_t ) 0x08U ) /* Push function: please push buffered data to the recv application */
+    #define tcpTCP_FLAG_ACK                       ( ( uint8_t ) 0x10U ) /* Acknowledgment field is significant */
+    #define tcpTCP_FLAG_URG                       ( ( uint8_t ) 0x20U ) /* Urgent pointer field is significant */
+    #define tcpTCP_FLAG_ECN                       ( ( uint8_t ) 0x40U ) /* ECN-Echo */
+    #define tcpTCP_FLAG_CWR                       ( ( uint8_t ) 0x80U ) /* Congestion Window Reduced */
 
 /* A mask to filter all protocol flags. */
-#define tcpTCP_FLAG_CTRL			( ( uint8_t ) 0x1FU )
+    #define tcpTCP_FLAG_CTRL                      ( ( uint8_t ) 0x1FU )
 
 /*
  * A few values of the TCP options:
  */
-#define tcpTCP_OPT_END				0U   /* End of TCP options list */
-#define tcpTCP_OPT_NOOP				1U   /* "No-operation" TCP option */
-#define tcpTCP_OPT_MSS				2U   /* Maximum segment size TCP option */
-#define tcpTCP_OPT_WSOPT			3U   /* TCP Window Scale Option (3-byte long) */
-#define tcpTCP_OPT_SACK_P			4U   /* Advertize that SACK is permitted */
-#define tcpTCP_OPT_SACK_A			5U   /* SACK option with first/last */
-#define tcpTCP_OPT_TIMESTAMP		8U   /* Time-stamp option */
+    #define tcpTCP_OPT_END                        0U /* End of TCP options list */
+    #define tcpTCP_OPT_NOOP                       1U /* "No-operation" TCP option */
+    #define tcpTCP_OPT_MSS                        2U /* Maximum segment size TCP option */
+    #define tcpTCP_OPT_WSOPT                      3U /* TCP Window Scale Option (3-byte long) */
+    #define tcpTCP_OPT_SACK_P                     4U /* Advertize that SACK is permitted */
+    #define tcpTCP_OPT_SACK_A                     5U /* SACK option with first/last */
+    #define tcpTCP_OPT_TIMESTAMP                  8U /* Time-stamp option */
 
-#define tcpTCP_OPT_MSS_LEN			4U   /* Length of TCP MSS option. */
-#define tcpTCP_OPT_WSOPT_LEN		3U   /* Length of TCP WSOPT option. */
+    #define tcpTCP_OPT_MSS_LEN                    4U /* Length of TCP MSS option. */
+    #define tcpTCP_OPT_WSOPT_LEN                  3U /* Length of TCP WSOPT option. */
 
-#define tcpTCP_OPT_TIMESTAMP_LEN	10	/* fixed length of the time-stamp option */
+    #define tcpTCP_OPT_TIMESTAMP_LEN              10 /* fixed length of the time-stamp option */
 
-#ifndef ipconfigTCP_ACK_EARLIER_PACKET
-	#define ipconfigTCP_ACK_EARLIER_PACKET		1
-#endif
+    #ifndef ipconfigTCP_ACK_EARLIER_PACKET
+        #define ipconfigTCP_ACK_EARLIER_PACKET    1
+    #endif
 
 /*
  * The macro tcpNOW_CONNECTED() is use to determine if the connection makes a
@@ -103,122 +103,128 @@
  * to prevent that the socket will be deleted before the last ACK has been
  * and thus causing a 'RST' packet on either side.
  */
-#define tcpNOW_CONNECTED( status )\
-	( ( ( ( status ) >= ( BaseType_t ) eESTABLISHED ) && ( ( status ) != ( BaseType_t ) eCLOSE_WAIT ) ) ? 1 : 0 )
+    #define tcpNOW_CONNECTED( status ) \
+    ( ( ( ( status ) >= ( BaseType_t ) eESTABLISHED ) && ( ( status ) != ( BaseType_t ) eCLOSE_WAIT ) ) ? 1 : 0 )
 
 /*
  * The highest 4 bits in the TCP offset byte indicate the total length of the
  * TCP header, divided by 4.
  */
-#define tcpVALID_BITS_IN_TCP_OFFSET_BYTE	( 0xF0U )
+    #define tcpVALID_BITS_IN_TCP_OFFSET_BYTE    ( 0xF0U )
 
 /*
  * Acknowledgements to TCP data packets may be delayed as long as more is being expected.
  * A normal delay would be 200ms.  Here a much shorter delay of 20 ms is being used to
  * gain performance.
  */
-#define tcpDELAYED_ACK_SHORT_DELAY_MS			( 2 )	/* Should not become smaller than 1. */
-#define tcpDELAYED_ACK_LONGER_DELAY_MS			( 20 )
+    #define tcpDELAYED_ACK_SHORT_DELAY_MS       ( 2 )   /* Should not become smaller than 1. */
+    #define tcpDELAYED_ACK_LONGER_DELAY_MS      ( 20 )
 
 /*
  * The MSS (Maximum Segment Size) will be taken as large as possible. However, packets with
  * an MSS of 1460 bytes won't be transported through the internet.  The MSS will be reduced
  * to 1400 bytes.
  */
-#define tcpREDUCED_MSS_THROUGH_INTERNET		( 1400 )
+    #define tcpREDUCED_MSS_THROUGH_INTERNET     ( 1400 )
 
 /*
  * When there are no TCP options, the TCP offset equals 20 bytes, which is stored as
  * the number 5 (words) in the higher niblle of the TCP-offset byte.
  */
-#define tcpTCP_OFFSET_LENGTH_BITS			( 0xf0U )
-#define tcpTCP_OFFSET_STANDARD_LENGTH		( 0x50U )
+    #define tcpTCP_OFFSET_LENGTH_BITS           ( 0xf0U )
+    #define tcpTCP_OFFSET_STANDARD_LENGTH       ( 0x50U )
 
 /*
  * Each TCP socket is checked regularly to see if it can send data packets.
  * By default, the maximum number of packets sent during one check is limited to 8.
  * This amount may be further limited by setting the socket's TX window size.
  */
-#if( !defined( SEND_REPEATED_COUNT ) )
-	#define SEND_REPEATED_COUNT		( 8 )
-#endif /* !defined( SEND_REPEATED_COUNT ) */
+    #if ( !defined( SEND_REPEATED_COUNT ) )
+        #define SEND_REPEATED_COUNT    ( 8 )
+    #endif /* !defined( SEND_REPEATED_COUNT ) */
 
 /*
  * Define a maximum perdiod of time (ms) to leave a TCP-socket unattended.
  * When a TCP timer expires, retries and keep-alive messages will be checked.
  */
-#ifndef	tcpMAXIMUM_TCP_WAKEUP_TIME_MS
-	#define	tcpMAXIMUM_TCP_WAKEUP_TIME_MS		20000U
-#endif
+    #ifndef tcpMAXIMUM_TCP_WAKEUP_TIME_MS
+        #define tcpMAXIMUM_TCP_WAKEUP_TIME_MS    20000U
+    #endif
 
 /* Two macro's that were introduced to work with both IPv4 and IPv6. */
-#define xIPHeaderSize( pxNetworkBuffer )	( ipSIZE_OF_IPv4_HEADER )
-#define uxIPHeaderSizeSocket( pxSocket )	( ipSIZE_OF_IPv4_HEADER )
+    #define xIPHeaderSize( pxNetworkBuffer )    ( ipSIZE_OF_IPv4_HEADER )
+    #define uxIPHeaderSizeSocket( pxSocket )    ( ipSIZE_OF_IPv4_HEADER )
 
 /*
  * Returns true if the socket must be checked.  Non-active sockets are waiting
  * for user action, either connect() or close().
  */
-static BaseType_t prvTCPSocketIsActive( eIPTCPState_t xStatus );
+    static BaseType_t prvTCPSocketIsActive( eIPTCPState_t xStatus );
 
 /*
  * Either sends a SYN or calls prvTCPSendRepeated (for regular messages).
  */
-static int32_t prvTCPSendPacket( FreeRTOS_Socket_t *pxSocket );
+    static int32_t prvTCPSendPacket( FreeRTOS_Socket_t * pxSocket );
 
 /*
  * Try to send a series of messages.
  */
-static int32_t prvTCPSendRepeated( FreeRTOS_Socket_t *pxSocket, NetworkBufferDescriptor_t **ppxNetworkBuffer );
+    static int32_t prvTCPSendRepeated( FreeRTOS_Socket_t * pxSocket,
+                                       NetworkBufferDescriptor_t ** ppxNetworkBuffer );
 
 /*
  * Return or send a packet to the other party.
  */
-static void prvTCPReturnPacket( FreeRTOS_Socket_t *pxSocket, NetworkBufferDescriptor_t *pxDescriptor,
-	uint32_t ulLen, BaseType_t xReleaseAfterSend );
+    static void prvTCPReturnPacket( FreeRTOS_Socket_t * pxSocket,
+                                    NetworkBufferDescriptor_t * pxDescriptor,
+                                    uint32_t ulLen,
+                                    BaseType_t xReleaseAfterSend );
 
 /*
  * Initialise the data structures which keep track of the TCP windowing system.
  */
-static void prvTCPCreateWindow( FreeRTOS_Socket_t *pxSocket );
+    static void prvTCPCreateWindow( FreeRTOS_Socket_t * pxSocket );
 
 /*
  * Let ARP look-up the MAC-address of the peer and initialise the first SYN
  * packet.
  */
-static BaseType_t prvTCPPrepareConnect( FreeRTOS_Socket_t *pxSocket );
+    static BaseType_t prvTCPPrepareConnect( FreeRTOS_Socket_t * pxSocket );
 
-#if( ipconfigHAS_DEBUG_PRINTF != 0 )
-	/*
-	 * For logging and debugging: make a string showing the TCP flags.
-	 */
-	static const char *prvTCPFlagMeaning( UBaseType_t xFlags);
-#endif /* ipconfigHAS_DEBUG_PRINTF != 0 */
+    #if ( ipconfigHAS_DEBUG_PRINTF != 0 )
+
+        /*
+         * For logging and debugging: make a string showing the TCP flags.
+         */
+        static const char * prvTCPFlagMeaning( UBaseType_t xFlags );
+    #endif /* ipconfigHAS_DEBUG_PRINTF != 0 */
 
 /*
  * Parse the TCP option(s) received, if present.
  */
-static void prvCheckOptions( FreeRTOS_Socket_t *pxSocket, const NetworkBufferDescriptor_t *pxNetworkBuffer );
+    static void prvCheckOptions( FreeRTOS_Socket_t * pxSocket,
+                                 const NetworkBufferDescriptor_t * pxNetworkBuffer );
 
 /*
  * Identify and deal with a single TCP header option, advancing the pointer to
  * the header. This function returns pdTRUE or pdFALSE depending on whether the
  * caller should continue to parse more header options or break the loop.
  */
-static size_t prvSingleStepTCPHeaderOptions( const uint8_t * const pucPtr,
-											 size_t uxTotalLength,
-											 FreeRTOS_Socket_t * const pxSocket,
-											 BaseType_t xHasSYNFlag );
+    static size_t prvSingleStepTCPHeaderOptions( const uint8_t * const pucPtr,
+                                                 size_t uxTotalLength,
+                                                 FreeRTOS_Socket_t * const pxSocket,
+                                                 BaseType_t xHasSYNFlag );
 
-#if( ipconfigUSE_TCP_WIN == 1 )
-	/*
-	 * Skip past TCP header options when doing Selective ACK, until there are no
-	 * more options left.
-	 */
-	static void prvReadSackOption( const uint8_t * const pucPtr,
-								   size_t uxIndex,
-								   FreeRTOS_Socket_t * const pxSocket );
-#endif/* ( ipconfigUSE_TCP_WIN == 1 ) */
+    #if ( ipconfigUSE_TCP_WIN == 1 )
+
+        /*
+         * Skip past TCP header options when doing Selective ACK, until there are no
+         * more options left.
+         */
+        static void prvReadSackOption( const uint8_t * const pucPtr,
+                                       size_t uxIndex,
+                                       FreeRTOS_Socket_t * const pxSocket );
+    #endif /* ( ipconfigUSE_TCP_WIN == 1 ) */
 
 
 /*
@@ -226,245 +232,272 @@ static size_t prvSingleStepTCPHeaderOptions( const uint8_t * const pucPtr,
  * value of MSS and whether SACK allowed.  Will be transmitted in the state
  * 'eCONNECT_SYN'.
  */
-static UBaseType_t prvSetSynAckOptions( FreeRTOS_Socket_t *pxSocket, TCPHeader_t *pxTCPHeader );
+    static UBaseType_t prvSetSynAckOptions( FreeRTOS_Socket_t * pxSocket,
+                                            TCPHeader_t * pxTCPHeader );
 
 /*
  * For anti-hang protection and TCP keep-alive messages.  Called in two places:
  * after receiving a packet and after a state change.  The socket's alive timer
  * may be reset.
  */
-static void prvTCPTouchSocket( FreeRTOS_Socket_t *pxSocket );
+    static void prvTCPTouchSocket( FreeRTOS_Socket_t * pxSocket );
 
 /*
  * Prepare an outgoing message, if anything has to be sent.
  */
-static int32_t prvTCPPrepareSend( FreeRTOS_Socket_t *pxSocket, NetworkBufferDescriptor_t **ppxNetworkBuffer, UBaseType_t uxOptionsLength );
+    static int32_t prvTCPPrepareSend( FreeRTOS_Socket_t * pxSocket,
+                                      NetworkBufferDescriptor_t ** ppxNetworkBuffer,
+                                      UBaseType_t uxOptionsLength );
 
 /*
  * Calculate when this socket needs to be checked to do (re-)transmissions.
  */
-static TickType_t prvTCPNextTimeout( FreeRTOS_Socket_t *pxSocket );
+    static TickType_t prvTCPNextTimeout( FreeRTOS_Socket_t * pxSocket );
 
 /*
  * The API FreeRTOS_send() adds data to the TX stream.  Add
  * this data to the windowing system to it can be transmitted.
  */
-static void prvTCPAddTxData( FreeRTOS_Socket_t *pxSocket );
+    static void prvTCPAddTxData( FreeRTOS_Socket_t * pxSocket );
 
 /*
  *  Called to handle the closure of a TCP connection.
  */
-static BaseType_t prvTCPHandleFin( FreeRTOS_Socket_t *pxSocket, const NetworkBufferDescriptor_t *pxNetworkBuffer );
+    static BaseType_t prvTCPHandleFin( FreeRTOS_Socket_t * pxSocket,
+                                       const NetworkBufferDescriptor_t * pxNetworkBuffer );
 
 /*
  * Called from prvTCPHandleState().  Find the TCP payload data and check and
  * return its length.
  */
-static BaseType_t prvCheckRxData( const NetworkBufferDescriptor_t *pxNetworkBuffer, uint8_t **ppucRecvData );
+    static BaseType_t prvCheckRxData( const NetworkBufferDescriptor_t * pxNetworkBuffer,
+                                      uint8_t ** ppucRecvData );
 
 /*
  * Called from prvTCPHandleState().  Check if the payload data may be accepted.
  * If so, it will be added to the socket's reception queue.
  */
-static BaseType_t prvStoreRxData( FreeRTOS_Socket_t *pxSocket, const uint8_t *pucRecvData,
-	NetworkBufferDescriptor_t *pxNetworkBuffer, uint32_t ulReceiveLength );
+    static BaseType_t prvStoreRxData( FreeRTOS_Socket_t * pxSocket,
+                                      const uint8_t * pucRecvData,
+                                      NetworkBufferDescriptor_t * pxNetworkBuffer,
+                                      uint32_t ulReceiveLength );
 
 /*
  * Set the TCP options (if any) for the outgoing packet.
  */
-static UBaseType_t prvSetOptions( FreeRTOS_Socket_t *pxSocket, const NetworkBufferDescriptor_t *pxNetworkBuffer );
+    static UBaseType_t prvSetOptions( FreeRTOS_Socket_t * pxSocket,
+                                      const NetworkBufferDescriptor_t * pxNetworkBuffer );
 
 /*
  * Called from prvTCPHandleState() as long as the TCP status is eSYN_RECEIVED to
  * eCONNECT_SYN.
  */
-static BaseType_t prvHandleSynReceived( FreeRTOS_Socket_t *pxSocket, const NetworkBufferDescriptor_t *pxNetworkBuffer,
-	uint32_t ulReceiveLength, UBaseType_t uxOptionsLength );
+    static BaseType_t prvHandleSynReceived( FreeRTOS_Socket_t * pxSocket,
+                                            const NetworkBufferDescriptor_t * pxNetworkBuffer,
+                                            uint32_t ulReceiveLength,
+                                            UBaseType_t uxOptionsLength );
 
 /*
  * Called from prvTCPHandleState() as long as the TCP status is eESTABLISHED.
  */
-static BaseType_t prvHandleEstablished( FreeRTOS_Socket_t *pxSocket, NetworkBufferDescriptor_t **ppxNetworkBuffer,
-	uint32_t ulReceiveLength, UBaseType_t uxOptionsLength );
+    static BaseType_t prvHandleEstablished( FreeRTOS_Socket_t * pxSocket,
+                                            NetworkBufferDescriptor_t ** ppxNetworkBuffer,
+                                            uint32_t ulReceiveLength,
+                                            UBaseType_t uxOptionsLength );
 
 /*
  * Called from prvTCPHandleState().  There is data to be sent.
  * If ipconfigUSE_TCP_WIN is defined, and if only an ACK must be sent, it will
  * be checked if it would better be postponed for efficiency.
  */
-static BaseType_t prvSendData( FreeRTOS_Socket_t *pxSocket, NetworkBufferDescriptor_t **ppxNetworkBuffer,
-	uint32_t ulReceiveLength, BaseType_t xByteCount );
+    static BaseType_t prvSendData( FreeRTOS_Socket_t * pxSocket,
+                                   NetworkBufferDescriptor_t ** ppxNetworkBuffer,
+                                   uint32_t ulReceiveLength,
+                                   BaseType_t xByteCount );
 
 /*
  * The heart of all: check incoming packet for valid data and acks and do what
  * is necessary in each state.
  */
-static BaseType_t prvTCPHandleState( FreeRTOS_Socket_t *pxSocket, NetworkBufferDescriptor_t **ppxNetworkBuffer );
+    static BaseType_t prvTCPHandleState( FreeRTOS_Socket_t * pxSocket,
+                                         NetworkBufferDescriptor_t ** ppxNetworkBuffer );
 
 /*
  * Common code for sending a TCP protocol control packet (i.e. no options, no
  * payload, just flags).
  */
-static BaseType_t prvTCPSendSpecialPacketHelper( NetworkBufferDescriptor_t *pxNetworkBuffer,
-												 uint8_t ucTCPFlags );
+    static BaseType_t prvTCPSendSpecialPacketHelper( NetworkBufferDescriptor_t * pxNetworkBuffer,
+                                                     uint8_t ucTCPFlags );
 
 /*
  * A "challenge ACK" is as per https://tools.ietf.org/html/rfc5961#section-3.2,
  * case #3. In summary, an RST was received with a sequence number that is
  * unexpected but still within the window.
  */
-static BaseType_t prvTCPSendChallengeAck( NetworkBufferDescriptor_t *pxNetworkBuffer );
+    static BaseType_t prvTCPSendChallengeAck( NetworkBufferDescriptor_t * pxNetworkBuffer );
 
 /*
  * Reply to a peer with the RST flag on, in case a packet can not be handled.
  */
-static BaseType_t prvTCPSendReset( NetworkBufferDescriptor_t *pxNetworkBuffer );
+    static BaseType_t prvTCPSendReset( NetworkBufferDescriptor_t * pxNetworkBuffer );
 
 /*
  * Set the initial value for MSS (Maximum Segment Size) to be used.
  */
-static void prvSocketSetMSS( FreeRTOS_Socket_t *pxSocket );
+    static void prvSocketSetMSS( FreeRTOS_Socket_t * pxSocket );
 
 /*
  * Return either a newly created socket, or the current socket in a connected
  * state (depends on the 'bReuseSocket' flag).
  */
-static FreeRTOS_Socket_t *prvHandleListen( FreeRTOS_Socket_t *pxSocket, NetworkBufferDescriptor_t *pxNetworkBuffer );
+    static FreeRTOS_Socket_t * prvHandleListen( FreeRTOS_Socket_t * pxSocket,
+                                                NetworkBufferDescriptor_t * pxNetworkBuffer );
 
 /*
  * After a listening socket receives a new connection, it may duplicate itself.
  * The copying takes place in prvTCPSocketCopy.
  */
-static BaseType_t prvTCPSocketCopy( FreeRTOS_Socket_t *pxNewSocket, FreeRTOS_Socket_t *pxSocket );
+    static BaseType_t prvTCPSocketCopy( FreeRTOS_Socket_t * pxNewSocket,
+                                        FreeRTOS_Socket_t * pxSocket );
 
 /*
  * prvTCPStatusAgeCheck() will see if the socket has been in a non-connected
  * state for too long.  If so, the socket will be closed, and -1 will be
  * returned.
  */
-#if( ipconfigTCP_HANG_PROTECTION == 1 )
-	static BaseType_t prvTCPStatusAgeCheck( FreeRTOS_Socket_t *pxSocket );
-#endif
+    #if ( ipconfigTCP_HANG_PROTECTION == 1 )
+        static BaseType_t prvTCPStatusAgeCheck( FreeRTOS_Socket_t * pxSocket );
+    #endif
 
-static NetworkBufferDescriptor_t *prvTCPBufferResize( const FreeRTOS_Socket_t *pxSocket, NetworkBufferDescriptor_t *pxNetworkBuffer,
-	int32_t lDataLen, UBaseType_t uxOptionsLength );
+    static NetworkBufferDescriptor_t * prvTCPBufferResize( const FreeRTOS_Socket_t * pxSocket,
+                                                           NetworkBufferDescriptor_t * pxNetworkBuffer,
+                                                           int32_t lDataLen,
+                                                           UBaseType_t uxOptionsLength );
 
-#if( ipconfigUSE_TCP_WIN != 0 )
-	static uint8_t prvWinScaleFactor( const FreeRTOS_Socket_t *pxSocket );
-#endif
+    #if ( ipconfigUSE_TCP_WIN != 0 )
+        static uint8_t prvWinScaleFactor( const FreeRTOS_Socket_t * pxSocket );
+    #endif
 
 /*-----------------------------------------------------------*/
 
 /* prvTCPSocketIsActive() returns true if the socket must be checked.
  * Non-active sockets are waiting for user action, either connect()
  * or close(). */
-static BaseType_t prvTCPSocketIsActive( eIPTCPState_t xStatus )
-{
-BaseType_t xResult;
-	switch( xStatus )
-	{
-	case eCLOSED:
-	case eCLOSE_WAIT:
-	case eFIN_WAIT_2:
-	case eCLOSING:
-	case eTIME_WAIT:
-		xResult = pdFALSE;
-		break;
-	case eTCP_LISTEN:
-	case eCONNECT_SYN:
-	case eSYN_FIRST:
-	case eSYN_RECEIVED:
-	case eESTABLISHED:
-	case eFIN_WAIT_1:
-	case eLAST_ACK:
-	default:
-		xResult = pdTRUE;
-		break;
-	}
-	return xResult;
-}
+    static BaseType_t prvTCPSocketIsActive( eIPTCPState_t xStatus )
+    {
+        BaseType_t xResult;
+
+        switch( xStatus )
+        {
+            case eCLOSED:
+            case eCLOSE_WAIT:
+            case eFIN_WAIT_2:
+            case eCLOSING:
+            case eTIME_WAIT:
+                xResult = pdFALSE;
+                break;
+
+            case eTCP_LISTEN:
+            case eCONNECT_SYN:
+            case eSYN_FIRST:
+            case eSYN_RECEIVED:
+            case eESTABLISHED:
+            case eFIN_WAIT_1:
+            case eLAST_ACK:
+            default:
+                xResult = pdTRUE;
+                break;
+        }
+
+        return xResult;
+    }
 /*-----------------------------------------------------------*/
 
-#if( ipconfigTCP_HANG_PROTECTION == 1 )
+    #if ( ipconfigTCP_HANG_PROTECTION == 1 )
 
-	static BaseType_t prvTCPStatusAgeCheck( FreeRTOS_Socket_t *pxSocket )
-	{
-	BaseType_t xResult;
-	eIPTCPState_t eState = ipNUMERIC_CAST( eIPTCPState_t, pxSocket->u.xTCP.ucTCPState );
+        static BaseType_t prvTCPStatusAgeCheck( FreeRTOS_Socket_t * pxSocket )
+        {
+            BaseType_t xResult;
+            eIPTCPState_t eState = ipNUMERIC_CAST( eIPTCPState_t, pxSocket->u.xTCP.ucTCPState );
 
-		switch( eState )
-		{
-		case eESTABLISHED:
-			/* If the 'ipconfigTCP_KEEP_ALIVE' option is enabled, sockets in
-			state ESTABLISHED can be protected using keep-alive messages. */
-			xResult = pdFALSE;
-			break;
-		case eCLOSED:
-		case eTCP_LISTEN:
-		case eCLOSE_WAIT:
-			/* These 3 states may last for ever, up to the owner. */
-			xResult = pdFALSE;
-			break;
-		case eCONNECT_SYN:
-		case eSYN_FIRST:
-		case eSYN_RECEIVED:
-		case eFIN_WAIT_1:
-		case eFIN_WAIT_2:
-		case eCLOSING:
-		case eLAST_ACK:
-		case eTIME_WAIT:
-		default:
-			/* All other (non-connected) states will get anti-hanging
-			protection. */
-			xResult = pdTRUE;
-			break;
-		}
-		if( xResult != pdFALSE )
-		{
-			/* How much time has past since the last active moment which is
-			defined as A) a state change or B) a packet has arrived. */
-			TickType_t xAge = xTaskGetTickCount( ) - pxSocket->u.xTCP.xLastActTime;
+            switch( eState )
+            {
+                case eESTABLISHED:
+                    /* If the 'ipconfigTCP_KEEP_ALIVE' option is enabled, sockets in
+                     *  state ESTABLISHED can be protected using keep-alive messages. */
+                    xResult = pdFALSE;
+                    break;
 
-			/* ipconfigTCP_HANG_PROTECTION_TIME is in units of seconds. */
-			if( xAge > ( ( TickType_t ) ipconfigTCP_HANG_PROTECTION_TIME * ( TickType_t ) configTICK_RATE_HZ ) )
-			{
-				#if( ipconfigHAS_DEBUG_PRINTF == 1 )
-				{
-					FreeRTOS_debug_printf( ( "Inactive socket closed: port %u rem %lxip:%u status %s\n",
-						pxSocket->usLocalPort,
-						pxSocket->u.xTCP.ulRemoteIP,
-						pxSocket->u.xTCP.usRemotePort,
-						FreeRTOS_GetTCPStateName( ( UBaseType_t ) pxSocket->u.xTCP.ucTCPState ) ) );
-				}
-				#endif /* ipconfigHAS_DEBUG_PRINTF */
+                case eCLOSED:
+                case eTCP_LISTEN:
+                case eCLOSE_WAIT:
+                    /* These 3 states may last for ever, up to the owner. */
+                    xResult = pdFALSE;
+                    break;
 
-				/* Move to eCLOSE_WAIT, user may close the socket. */
-				vTCPStateChange( pxSocket, eCLOSE_WAIT );
+                case eCONNECT_SYN:
+                case eSYN_FIRST:
+                case eSYN_RECEIVED:
+                case eFIN_WAIT_1:
+                case eFIN_WAIT_2:
+                case eCLOSING:
+                case eLAST_ACK:
+                case eTIME_WAIT:
+                default:
+                    /* All other (non-connected) states will get anti-hanging
+                     * protection. */
+                    xResult = pdTRUE;
+                    break;
+            }
 
-				/* When 'bPassQueued' true, this socket is an orphan until it
-				gets connected. */
-				if( pxSocket->u.xTCP.bits.bPassQueued != pdFALSE_UNSIGNED )
-				{
-					if( pxSocket->u.xTCP.bits.bReuseSocket == pdFALSE_UNSIGNED )
-					{
-						/* As it did not get connected, and the user can never
-						accept() it anymore, it will be deleted now.  Called from
-						the IP-task, so it's safe to call the internal Close
-						function: vSocketClose(). */
-						( void ) vSocketClose( pxSocket );
-					}
-					/* Return a negative value to tell to inform the caller
-					xTCPTimerCheck()
-					that the socket got closed and may not be accessed anymore. */
-					xResult = -1;
-				}
-			}
-		}
-		return xResult;
-	}
-	/*-----------------------------------------------------------*/
+            if( xResult != pdFALSE )
+            {
+                /* How much time has past since the last active moment which is
+                 * defined as A) a state change or B) a packet has arrived. */
+                TickType_t xAge = xTaskGetTickCount() - pxSocket->u.xTCP.xLastActTime;
 
-#endif
+                /* ipconfigTCP_HANG_PROTECTION_TIME is in units of seconds. */
+                if( xAge > ( ( TickType_t ) ipconfigTCP_HANG_PROTECTION_TIME * ( TickType_t ) configTICK_RATE_HZ ) )
+                {
+                    #if ( ipconfigHAS_DEBUG_PRINTF == 1 )
+                        {
+                            FreeRTOS_debug_printf( ( "Inactive socket closed: port %u rem %lxip:%u status %s\n",
+                                                     pxSocket->usLocalPort,
+                                                     pxSocket->u.xTCP.ulRemoteIP,
+                                                     pxSocket->u.xTCP.usRemotePort,
+                                                     FreeRTOS_GetTCPStateName( ( UBaseType_t ) pxSocket->u.xTCP.ucTCPState ) ) );
+                        }
+                    #endif /* ipconfigHAS_DEBUG_PRINTF */
+
+                    /* Move to eCLOSE_WAIT, user may close the socket. */
+                    vTCPStateChange( pxSocket, eCLOSE_WAIT );
+
+                    /* When 'bPassQueued' true, this socket is an orphan until it
+                     * gets connected. */
+                    if( pxSocket->u.xTCP.bits.bPassQueued != pdFALSE_UNSIGNED )
+                    {
+                        if( pxSocket->u.xTCP.bits.bReuseSocket == pdFALSE_UNSIGNED )
+                        {
+                            /* As it did not get connected, and the user can never
+                             * accept() it anymore, it will be deleted now.  Called from
+                             * the IP-task, so it's safe to call the internal Close
+                             * function: vSocketClose(). */
+                            ( void ) vSocketClose( pxSocket );
+                        }
+
+                        /* Return a negative value to tell to inform the caller
+                         * xTCPTimerCheck()
+                         * that the socket got closed and may not be accessed anymore. */
+                        xResult = -1;
+                    }
+                }
+            }
+
+            return xResult;
+        }
+        /*-----------------------------------------------------------*/
+
+    #endif /* if ( ipconfigTCP_HANG_PROTECTION == 1 ) */
 
 /*
  * As soon as a TCP socket timer expires, this function xTCPSocketCheck
@@ -479,214 +512,218 @@ BaseType_t xResult;
  *			prvTCPReturnPacket()		// Prepare for returning
  *			xNetworkInterfaceOutput()	// Sends data to the NIC ( declared in portable/NetworkInterface/xxx )
  */
-BaseType_t xTCPSocketCheck( FreeRTOS_Socket_t *pxSocket )
-{
-BaseType_t xResult = 0;
-BaseType_t xReady = pdFALSE;
+    BaseType_t xTCPSocketCheck( FreeRTOS_Socket_t * pxSocket )
+    {
+        BaseType_t xResult = 0;
+        BaseType_t xReady = pdFALSE;
 
-	if( ( pxSocket->u.xTCP.ucTCPState >= ( uint8_t ) eESTABLISHED ) && ( pxSocket->u.xTCP.txStream != NULL ) )
-	{
-		/* The API FreeRTOS_send() might have added data to the TX stream.  Add
-		this data to the windowing system so it can be transmitted. */
-		prvTCPAddTxData( pxSocket );
-	}
+        if( ( pxSocket->u.xTCP.ucTCPState >= ( uint8_t ) eESTABLISHED ) && ( pxSocket->u.xTCP.txStream != NULL ) )
+        {
+            /* The API FreeRTOS_send() might have added data to the TX stream.  Add
+             * this data to the windowing system so it can be transmitted. */
+            prvTCPAddTxData( pxSocket );
+        }
 
-	#if( ipconfigUSE_TCP_WIN == 1 )
-	{
-		if( pxSocket->u.xTCP.pxAckMessage != NULL )
-		{
-			/* The first task of this regular socket check is to send-out delayed
-			ACK's. */
-			if( pxSocket->u.xTCP.bits.bUserShutdown == pdFALSE_UNSIGNED )
-			{
-				/* Earlier data was received but not yet acknowledged.  This
-				function is called when the TCP timer for the socket expires, the
-				ACK may be sent now. */
-				if( pxSocket->u.xTCP.ucTCPState != ( uint8_t ) eCLOSED )
-				{
-					if( ( xTCPWindowLoggingLevel > 1 ) && ipconfigTCP_MAY_LOG_PORT( pxSocket->usLocalPort ) )
-					{
-						FreeRTOS_debug_printf( ( "Send[%u->%u] del ACK %lu SEQ %lu (len %u)\n",
-							pxSocket->usLocalPort,
-							pxSocket->u.xTCP.usRemotePort,
-							pxSocket->u.xTCP.xTCPWindow.rx.ulCurrentSequenceNumber - pxSocket->u.xTCP.xTCPWindow.rx.ulFirstSequenceNumber,
-							pxSocket->u.xTCP.xTCPWindow.ulOurSequenceNumber   - pxSocket->u.xTCP.xTCPWindow.tx.ulFirstSequenceNumber,
-							( unsigned ) ipSIZE_OF_IPv4_HEADER + ipSIZE_OF_TCP_HEADER ) );
-					}
+        #if ( ipconfigUSE_TCP_WIN == 1 )
+            {
+                if( pxSocket->u.xTCP.pxAckMessage != NULL )
+                {
+                    /* The first task of this regular socket check is to send-out delayed
+                     * ACK's. */
+                    if( pxSocket->u.xTCP.bits.bUserShutdown == pdFALSE_UNSIGNED )
+                    {
+                        /* Earlier data was received but not yet acknowledged.  This
+                         * function is called when the TCP timer for the socket expires, the
+                         * ACK may be sent now. */
+                        if( pxSocket->u.xTCP.ucTCPState != ( uint8_t ) eCLOSED )
+                        {
+                            if( ( xTCPWindowLoggingLevel > 1 ) && ipconfigTCP_MAY_LOG_PORT( pxSocket->usLocalPort ) )
+                            {
+                                FreeRTOS_debug_printf( ( "Send[%u->%u] del ACK %lu SEQ %lu (len %u)\n",
+                                                         pxSocket->usLocalPort,
+                                                         pxSocket->u.xTCP.usRemotePort,
+                                                         pxSocket->u.xTCP.xTCPWindow.rx.ulCurrentSequenceNumber - pxSocket->u.xTCP.xTCPWindow.rx.ulFirstSequenceNumber,
+                                                         pxSocket->u.xTCP.xTCPWindow.ulOurSequenceNumber - pxSocket->u.xTCP.xTCPWindow.tx.ulFirstSequenceNumber,
+                                                         ( unsigned ) ipSIZE_OF_IPv4_HEADER + ipSIZE_OF_TCP_HEADER ) );
+                            }
 
-					prvTCPReturnPacket( pxSocket, pxSocket->u.xTCP.pxAckMessage, ipSIZE_OF_IPv4_HEADER + ipSIZE_OF_TCP_HEADER, ipconfigZERO_COPY_TX_DRIVER );
+                            prvTCPReturnPacket( pxSocket, pxSocket->u.xTCP.pxAckMessage, ipSIZE_OF_IPv4_HEADER + ipSIZE_OF_TCP_HEADER, ipconfigZERO_COPY_TX_DRIVER );
 
-					#if( ipconfigZERO_COPY_TX_DRIVER != 0 )
-					{
-						/* The ownership has been passed to the SEND routine,
-						clear the pointer to it. */
-						pxSocket->u.xTCP.pxAckMessage = NULL;
-					}
-					#endif /* ipconfigZERO_COPY_TX_DRIVER */
-				}
-				if( prvTCPNextTimeout( pxSocket ) > 1U )
-				{
-					/* Tell the code below that this function is ready. */
-					xReady = pdTRUE;
-				}
-			}
-			else
-			{
-				/* The user wants to perform an active shutdown(), skip sending
-				the	delayed	ACK.  The function prvTCPSendPacket() will send the
-				FIN	along with the ACK's. */
-			}
+                            #if ( ipconfigZERO_COPY_TX_DRIVER != 0 )
+                                {
+                                    /* The ownership has been passed to the SEND routine,
+                                     * clear the pointer to it. */
+                                    pxSocket->u.xTCP.pxAckMessage = NULL;
+                                }
+                            #endif /* ipconfigZERO_COPY_TX_DRIVER */
+                        }
 
-			if( pxSocket->u.xTCP.pxAckMessage != NULL )
-			{
-				vReleaseNetworkBufferAndDescriptor( pxSocket->u.xTCP.pxAckMessage );
-				pxSocket->u.xTCP.pxAckMessage = NULL;
-			}
-		}
-	}
-	#endif /* ipconfigUSE_TCP_WIN */
+                        if( prvTCPNextTimeout( pxSocket ) > 1U )
+                        {
+                            /* Tell the code below that this function is ready. */
+                            xReady = pdTRUE;
+                        }
+                    }
+                    else
+                    {
+                        /* The user wants to perform an active shutdown(), skip sending
+                         * the	delayed	ACK.  The function prvTCPSendPacket() will send the
+                         * FIN	along with the ACK's. */
+                    }
 
-	if( xReady == pdFALSE )
-	{
-		/* The second task of this regular socket check is sending out data. */
-		if( ( pxSocket->u.xTCP.ucTCPState >= ( uint8_t ) eESTABLISHED ) ||
-			( pxSocket->u.xTCP.ucTCPState == ( uint8_t ) eCONNECT_SYN ) )
-		{
-			( void ) prvTCPSendPacket( pxSocket );
-		}
+                    if( pxSocket->u.xTCP.pxAckMessage != NULL )
+                    {
+                        vReleaseNetworkBufferAndDescriptor( pxSocket->u.xTCP.pxAckMessage );
+                        pxSocket->u.xTCP.pxAckMessage = NULL;
+                    }
+                }
+            }
+        #endif /* ipconfigUSE_TCP_WIN */
 
-		/* Set the time-out for the next wakeup for this socket. */
-		( void ) prvTCPNextTimeout( pxSocket );
+        if( xReady == pdFALSE )
+        {
+            /* The second task of this regular socket check is sending out data. */
+            if( ( pxSocket->u.xTCP.ucTCPState >= ( uint8_t ) eESTABLISHED ) ||
+                ( pxSocket->u.xTCP.ucTCPState == ( uint8_t ) eCONNECT_SYN ) )
+            {
+                ( void ) prvTCPSendPacket( pxSocket );
+            }
 
-		#if( ipconfigTCP_HANG_PROTECTION == 1 )
-		{
-			/* In all (non-connected) states in which keep-alive messages can not be sent
-			the anti-hang protocol will close sockets that are 'hanging'. */
-			xResult = prvTCPStatusAgeCheck( pxSocket );
-		}
-		#endif
-	}
+            /* Set the time-out for the next wakeup for this socket. */
+            ( void ) prvTCPNextTimeout( pxSocket );
 
-	return xResult;
-}
+            #if ( ipconfigTCP_HANG_PROTECTION == 1 )
+                {
+                    /* In all (non-connected) states in which keep-alive messages can not be sent
+                     * the anti-hang protocol will close sockets that are 'hanging'. */
+                    xResult = prvTCPStatusAgeCheck( pxSocket );
+                }
+            #endif
+        }
+
+        return xResult;
+    }
 /*-----------------------------------------------------------*/
 
 /*
  * prvTCPSendPacket() will be called when the socket time-out has been reached.
  * It is only called by xTCPSocketCheck().
  */
-static int32_t prvTCPSendPacket( FreeRTOS_Socket_t *pxSocket )
-{
-int32_t lResult = 0;
-UBaseType_t uxOptionsLength;
-NetworkBufferDescriptor_t *pxNetworkBuffer;
+    static int32_t prvTCPSendPacket( FreeRTOS_Socket_t * pxSocket )
+    {
+        int32_t lResult = 0;
+        UBaseType_t uxOptionsLength;
+        NetworkBufferDescriptor_t * pxNetworkBuffer;
 
-	if( pxSocket->u.xTCP.ucTCPState != ( uint8_t ) eCONNECT_SYN )
-	{
-		/* The connection is in a state other than SYN. */
-		pxNetworkBuffer = NULL;
+        if( pxSocket->u.xTCP.ucTCPState != ( uint8_t ) eCONNECT_SYN )
+        {
+            /* The connection is in a state other than SYN. */
+            pxNetworkBuffer = NULL;
 
-		/* prvTCPSendRepeated() will only create a network buffer if necessary,
-		i.e. when data must be sent to the peer. */
-		lResult = prvTCPSendRepeated( pxSocket, &pxNetworkBuffer );
+            /* prvTCPSendRepeated() will only create a network buffer if necessary,
+             * i.e. when data must be sent to the peer. */
+            lResult = prvTCPSendRepeated( pxSocket, &pxNetworkBuffer );
 
-		if( pxNetworkBuffer != NULL )
-		{
-			vReleaseNetworkBufferAndDescriptor( pxNetworkBuffer );
-		}
-	}
-	else
-	{
-		if( pxSocket->u.xTCP.ucRepCount >= 3U )
-		{
-			/* The connection is in the SYN status. The packet will be repeated
-			to most 3 times.  When there is no response, the socket get the
-			status 'eCLOSE_WAIT'. */
-			FreeRTOS_debug_printf( ( "Connect: giving up %lxip:%u\n",
-				pxSocket->u.xTCP.ulRemoteIP,		/* IP address of remote machine. */
-				pxSocket->u.xTCP.usRemotePort ) );	/* Port on remote machine. */
-			vTCPStateChange( pxSocket, eCLOSE_WAIT );
-		}
-		else if( ( pxSocket->u.xTCP.bits.bConnPrepared != pdFALSE_UNSIGNED ) || ( prvTCPPrepareConnect( pxSocket ) == pdTRUE ) )
-		{
-		ProtocolHeaders_t *pxProtocolHeaders;
-		const UBaseType_t uxHeaderSize = ipSIZE_OF_IPv4_HEADER;
-			/* Or else, if the connection has been prepared, or can be prepared
-			now, proceed to send the packet with the SYN flag.
-			prvTCPPrepareConnect() prepares 'xPacket' and returns pdTRUE if
-			the Ethernet address of the peer or the gateway is found. */
-			pxProtocolHeaders = ipPOINTER_CAST( ProtocolHeaders_t *, &( pxSocket->u.xTCP.xPacket.u.ucLastPacket[ ipSIZE_OF_ETH_HEADER + uxHeaderSize ] ) );
+            if( pxNetworkBuffer != NULL )
+            {
+                vReleaseNetworkBufferAndDescriptor( pxNetworkBuffer );
+            }
+        }
+        else
+        {
+            if( pxSocket->u.xTCP.ucRepCount >= 3U )
+            {
+                /* The connection is in the SYN status. The packet will be repeated
+                 * to most 3 times.  When there is no response, the socket get the
+                 * status 'eCLOSE_WAIT'. */
+                FreeRTOS_debug_printf( ( "Connect: giving up %lxip:%u\n",
+                                         pxSocket->u.xTCP.ulRemoteIP,       /* IP address of remote machine. */
+                                         pxSocket->u.xTCP.usRemotePort ) ); /* Port on remote machine. */
+                vTCPStateChange( pxSocket, eCLOSE_WAIT );
+            }
+            else if( ( pxSocket->u.xTCP.bits.bConnPrepared != pdFALSE_UNSIGNED ) || ( prvTCPPrepareConnect( pxSocket ) == pdTRUE ) )
+            {
+                ProtocolHeaders_t * pxProtocolHeaders;
+                const UBaseType_t uxHeaderSize = ipSIZE_OF_IPv4_HEADER;
 
-			/* About to send a SYN packet.  Call prvSetSynAckOptions() to set
-			the proper options: The size of MSS and whether SACK's are
-			allowed. */
-			uxOptionsLength = prvSetSynAckOptions( pxSocket, &( pxProtocolHeaders->xTCPHeader ) );
+                /* Or else, if the connection has been prepared, or can be prepared
+                 * now, proceed to send the packet with the SYN flag.
+                 * prvTCPPrepareConnect() prepares 'xPacket' and returns pdTRUE if
+                 * the Ethernet address of the peer or the gateway is found. */
+                pxProtocolHeaders = ipPOINTER_CAST( ProtocolHeaders_t *, &( pxSocket->u.xTCP.xPacket.u.ucLastPacket[ ipSIZE_OF_ETH_HEADER + uxHeaderSize ] ) );
 
-			/* Return the number of bytes to be sent. */
-			lResult = ipNUMERIC_CAST( BaseType_t, uxIPHeaderSizeSocket( pxSocket ) + ipSIZE_OF_TCP_HEADER + uxOptionsLength );
+                /* About to send a SYN packet.  Call prvSetSynAckOptions() to set
+                 * the proper options: The size of MSS and whether SACK's are
+                 * allowed. */
+                uxOptionsLength = prvSetSynAckOptions( pxSocket, &( pxProtocolHeaders->xTCPHeader ) );
 
-			/* Set the TCP offset field:  ipSIZE_OF_TCP_HEADER equals 20 and
-			uxOptionsLength is always a multiple of 4.  The complete expression
-			would be:
-			ucTCPOffset = ( ( ipSIZE_OF_TCP_HEADER + uxOptionsLength ) / 4 ) << 4 */
-			pxProtocolHeaders->xTCPHeader.ucTCPOffset = ( uint8_t )( ( ipSIZE_OF_TCP_HEADER + uxOptionsLength ) << 2 );
+                /* Return the number of bytes to be sent. */
+                lResult = ipNUMERIC_CAST( BaseType_t, uxIPHeaderSizeSocket( pxSocket ) + ipSIZE_OF_TCP_HEADER + uxOptionsLength );
 
-			/* Repeat Count is used for a connecting socket, to limit the number
-			of tries. */
-			pxSocket->u.xTCP.ucRepCount++;
+                /* Set the TCP offset field:  ipSIZE_OF_TCP_HEADER equals 20 and
+                 * uxOptionsLength is always a multiple of 4.  The complete expression
+                 * would be:
+                 * ucTCPOffset = ( ( ipSIZE_OF_TCP_HEADER + uxOptionsLength ) / 4 ) << 4 */
+                pxProtocolHeaders->xTCPHeader.ucTCPOffset = ( uint8_t ) ( ( ipSIZE_OF_TCP_HEADER + uxOptionsLength ) << 2 );
 
-			/* Send the SYN message to make a connection.  The messages is
-			stored in the socket field 'xPacket'.  It will be wrapped in a
-			pseudo network buffer descriptor before it will be sent. */
-			prvTCPReturnPacket( pxSocket, NULL, ( uint32_t ) lResult, pdFALSE );
-		}
-		else
-		{
-			/* Nothing to do. */
-		}
-	}
+                /* Repeat Count is used for a connecting socket, to limit the number
+                 * of tries. */
+                pxSocket->u.xTCP.ucRepCount++;
 
-	/* Return the total number of bytes sent. */
-	return lResult;
-}
+                /* Send the SYN message to make a connection.  The messages is
+                 * stored in the socket field 'xPacket'.  It will be wrapped in a
+                 * pseudo network buffer descriptor before it will be sent. */
+                prvTCPReturnPacket( pxSocket, NULL, ( uint32_t ) lResult, pdFALSE );
+            }
+            else
+            {
+                /* Nothing to do. */
+            }
+        }
+
+        /* Return the total number of bytes sent. */
+        return lResult;
+    }
 /*-----------------------------------------------------------*/
 
 /*
  * prvTCPSendRepeated will try to send a series of messages, as long as there is
  * data to be sent and as long as the transmit window isn't full.
  */
-static int32_t prvTCPSendRepeated( FreeRTOS_Socket_t *pxSocket, NetworkBufferDescriptor_t **ppxNetworkBuffer )
-{
-UBaseType_t uxIndex;
-int32_t lResult = 0;
-UBaseType_t uxOptionsLength = 0U;
-int32_t xSendLength;
+    static int32_t prvTCPSendRepeated( FreeRTOS_Socket_t * pxSocket,
+                                       NetworkBufferDescriptor_t ** ppxNetworkBuffer )
+    {
+        UBaseType_t uxIndex;
+        int32_t lResult = 0;
+        UBaseType_t uxOptionsLength = 0U;
+        int32_t xSendLength;
 
-	for( uxIndex = 0U; uxIndex < ( UBaseType_t ) SEND_REPEATED_COUNT; uxIndex++ )
-	{
-		/* prvTCPPrepareSend() might allocate a network buffer if there is data
-		to be sent. */
-		xSendLength = prvTCPPrepareSend( pxSocket, ppxNetworkBuffer, uxOptionsLength );
-		if( xSendLength <= 0 )
-		{
-			break;
-		}
+        for( uxIndex = 0U; uxIndex < ( UBaseType_t ) SEND_REPEATED_COUNT; uxIndex++ )
+        {
+            /* prvTCPPrepareSend() might allocate a network buffer if there is data
+             * to be sent. */
+            xSendLength = prvTCPPrepareSend( pxSocket, ppxNetworkBuffer, uxOptionsLength );
 
-		/* And return the packet to the peer. */
-		prvTCPReturnPacket( pxSocket, *ppxNetworkBuffer, ( uint32_t ) xSendLength, ipconfigZERO_COPY_TX_DRIVER );
+            if( xSendLength <= 0 )
+            {
+                break;
+            }
 
-		#if( ipconfigZERO_COPY_TX_DRIVER != 0 )
-		{
-			*ppxNetworkBuffer = NULL;
-		}
-		#endif /* ipconfigZERO_COPY_TX_DRIVER */
+            /* And return the packet to the peer. */
+            prvTCPReturnPacket( pxSocket, *ppxNetworkBuffer, ( uint32_t ) xSendLength, ipconfigZERO_COPY_TX_DRIVER );
 
-		lResult += xSendLength;
-	}
+            #if ( ipconfigZERO_COPY_TX_DRIVER != 0 )
+                {
+                    *ppxNetworkBuffer = NULL;
+                }
+            #endif /* ipconfigZERO_COPY_TX_DRIVER */
 
-	/* Return the total number of bytes sent. */
-	return lResult;
-}
+            lResult += xSendLength;
+        }
+
+        /* Return the total number of bytes sent. */
+        return lResult;
+    }
 /*-----------------------------------------------------------*/
 
 /*
@@ -695,253 +732,264 @@ int32_t xSendLength;
  * called 'xTCP.xPacket'.   A temporary xNetworkBuffer will be used to pass
  * the data to the NIC.
  */
-static void prvTCPReturnPacket( FreeRTOS_Socket_t *pxSocket, NetworkBufferDescriptor_t *pxDescriptor, uint32_t ulLen, BaseType_t xReleaseAfterSend )
-{
-TCPPacket_t * pxTCPPacket;
-IPHeader_t *pxIPHeader;
-BaseType_t xDoRelease = xReleaseAfterSend;
-EthernetHeader_t *pxEthernetHeader;
-uint32_t ulFrontSpace, ulSpace, ulSourceAddress, ulWinSize;
-const TCPWindow_t *pxTCPWindow;
-NetworkBufferDescriptor_t *pxNetworkBuffer = pxDescriptor;	/* To avoid error: "function parameter modified [MISRA 2012 Rule 17.8, advisory]" */
-NetworkBufferDescriptor_t xTempBuffer;
+    static void prvTCPReturnPacket( FreeRTOS_Socket_t * pxSocket,
+                                    NetworkBufferDescriptor_t * pxDescriptor,
+                                    uint32_t ulLen,
+                                    BaseType_t xReleaseAfterSend )
+    {
+        TCPPacket_t * pxTCPPacket;
+        IPHeader_t * pxIPHeader;
+        BaseType_t xDoRelease = xReleaseAfterSend;
+        EthernetHeader_t * pxEthernetHeader;
+        uint32_t ulFrontSpace, ulSpace, ulSourceAddress, ulWinSize;
+        const TCPWindow_t * pxTCPWindow;
+        NetworkBufferDescriptor_t * pxNetworkBuffer = pxDescriptor; /* To avoid error: "function parameter modified [MISRA 2012 Rule 17.8, advisory]" */
+        NetworkBufferDescriptor_t xTempBuffer;
+
 /* For sending, a pseudo network buffer will be used, as explained above. */
 
-	if( pxNetworkBuffer == NULL )
-	{
-		pxNetworkBuffer = &xTempBuffer;
+        if( pxNetworkBuffer == NULL )
+        {
+            pxNetworkBuffer = &xTempBuffer;
 
-		#if( ipconfigUSE_LINKED_RX_MESSAGES != 0 )
-		{
-			xTempBuffer.pxNextBuffer = NULL;
-		}
-		#endif
-		xTempBuffer.pucEthernetBuffer = pxSocket->u.xTCP.xPacket.u.ucLastPacket;
-		xTempBuffer.xDataLength = sizeof( pxSocket->u.xTCP.xPacket.u.ucLastPacket );
-		xDoRelease = pdFALSE;
-	}
+            #if ( ipconfigUSE_LINKED_RX_MESSAGES != 0 )
+                {
+                    xTempBuffer.pxNextBuffer = NULL;
+                }
+            #endif
+            xTempBuffer.pucEthernetBuffer = pxSocket->u.xTCP.xPacket.u.ucLastPacket;
+            xTempBuffer.xDataLength = sizeof( pxSocket->u.xTCP.xPacket.u.ucLastPacket );
+            xDoRelease = pdFALSE;
+        }
 
-	#if( ipconfigZERO_COPY_TX_DRIVER != 0 )
-	{
-		if( xDoRelease == pdFALSE )
-		{
-			pxNetworkBuffer = pxDuplicateNetworkBufferWithDescriptor( pxNetworkBuffer, ( size_t ) pxNetworkBuffer->xDataLength );
-			if( pxNetworkBuffer == NULL )
-			{
-				FreeRTOS_debug_printf( ( "prvTCPReturnPacket: duplicate failed\n" ) );
-			}
-			xDoRelease = pdTRUE;
-		}
-	}
-	#endif /* ipconfigZERO_COPY_TX_DRIVER */
+        #if ( ipconfigZERO_COPY_TX_DRIVER != 0 )
+            {
+                if( xDoRelease == pdFALSE )
+                {
+                    pxNetworkBuffer = pxDuplicateNetworkBufferWithDescriptor( pxNetworkBuffer, ( size_t ) pxNetworkBuffer->xDataLength );
 
-	#ifndef __COVERITY__
-	if( pxNetworkBuffer != NULL )
-	#endif
-	{
-		pxTCPPacket = ipPOINTER_CAST( TCPPacket_t *, pxNetworkBuffer->pucEthernetBuffer );
-		pxIPHeader = &pxTCPPacket->xIPHeader;
-		pxEthernetHeader = &pxTCPPacket->xEthernetHeader;
+                    if( pxNetworkBuffer == NULL )
+                    {
+                        FreeRTOS_debug_printf( ( "prvTCPReturnPacket: duplicate failed\n" ) );
+                    }
 
-		/* Fill the packet, using hton translations. */
-		if( pxSocket != NULL )
-		{
-			/* Calculate the space in the RX buffer in order to advertise the
-			size of this socket's reception window. */
-			pxTCPWindow = &( pxSocket->u.xTCP.xTCPWindow );
+                    xDoRelease = pdTRUE;
+                }
+            }
+        #endif /* ipconfigZERO_COPY_TX_DRIVER */
 
-			if( pxSocket->u.xTCP.rxStream != NULL )
-			{
-				/* An RX stream was created already, see how much space is
-				available. */
-				ulFrontSpace = ( uint32_t ) uxStreamBufferFrontSpace( pxSocket->u.xTCP.rxStream );
-			}
-			else
-			{
-				/* No RX stream has been created, the full stream size is
-				available. */
-				ulFrontSpace = ( uint32_t ) pxSocket->u.xTCP.uxRxStreamSize;
-			}
+        #ifndef __COVERITY__
+            if( pxNetworkBuffer != NULL )
+        #endif
+        {
+            pxTCPPacket = ipPOINTER_CAST( TCPPacket_t *, pxNetworkBuffer->pucEthernetBuffer );
+            pxIPHeader = &pxTCPPacket->xIPHeader;
+            pxEthernetHeader = &pxTCPPacket->xEthernetHeader;
 
-			/* Take the minimum of the RX buffer space and the RX window size. */
-			ulSpace = FreeRTOS_min_uint32( pxTCPWindow->xSize.ulRxWindowLength, ulFrontSpace );
+            /* Fill the packet, using hton translations. */
+            if( pxSocket != NULL )
+            {
+                /* Calculate the space in the RX buffer in order to advertise the
+                 * size of this socket's reception window. */
+                pxTCPWindow = &( pxSocket->u.xTCP.xTCPWindow );
 
-			if( ( pxSocket->u.xTCP.bits.bLowWater != pdFALSE_UNSIGNED ) || ( pxSocket->u.xTCP.bits.bRxStopped != pdFALSE_UNSIGNED ) )
-			{
-				/* The low-water mark was reached, meaning there was little
-				space left.  The socket will wait until the application has read
-				or flushed the incoming data, and 'zero-window' will be
-				advertised. */
-				ulSpace = 0U;
-			}
+                if( pxSocket->u.xTCP.rxStream != NULL )
+                {
+                    /* An RX stream was created already, see how much space is
+                     * available. */
+                    ulFrontSpace = ( uint32_t ) uxStreamBufferFrontSpace( pxSocket->u.xTCP.rxStream );
+                }
+                else
+                {
+                    /* No RX stream has been created, the full stream size is
+                     * available. */
+                    ulFrontSpace = ( uint32_t ) pxSocket->u.xTCP.uxRxStreamSize;
+                }
 
-			/* If possible, advertise an RX window size of at least 1 MSS, otherwise
-			the peer might start 'zero window probing', i.e. sending small packets
-			(1, 2, 4, 8... bytes). */
-			if( ( ulSpace < pxSocket->u.xTCP.usCurMSS ) && ( ulFrontSpace >= pxSocket->u.xTCP.usCurMSS ) )
-			{
-				ulSpace = pxSocket->u.xTCP.usCurMSS;
-			}
+                /* Take the minimum of the RX buffer space and the RX window size. */
+                ulSpace = FreeRTOS_min_uint32( pxTCPWindow->xSize.ulRxWindowLength, ulFrontSpace );
 
-			/* Avoid overflow of the 16-bit win field. */
-			#if( ipconfigUSE_TCP_WIN != 0 )
-			{
-				ulWinSize = ( ulSpace >> pxSocket->u.xTCP.ucMyWinScaleFactor );
-			}
-			#else
-			{
-				ulWinSize = ulSpace;
-			}
-			#endif
-			if( ulWinSize > 0xfffcUL )
-			{
-				ulWinSize = 0xfffcUL;
-			}
+                if( ( pxSocket->u.xTCP.bits.bLowWater != pdFALSE_UNSIGNED ) || ( pxSocket->u.xTCP.bits.bRxStopped != pdFALSE_UNSIGNED ) )
+                {
+                    /* The low-water mark was reached, meaning there was little
+                     * space left.  The socket will wait until the application has read
+                     * or flushed the incoming data, and 'zero-window' will be
+                     * advertised. */
+                    ulSpace = 0U;
+                }
 
-			pxTCPPacket->xTCPHeader.usWindow = FreeRTOS_htons( ( uint16_t ) ulWinSize );
+                /* If possible, advertise an RX window size of at least 1 MSS, otherwise
+                 * the peer might start 'zero window probing', i.e. sending small packets
+                 * (1, 2, 4, 8... bytes). */
+                if( ( ulSpace < pxSocket->u.xTCP.usCurMSS ) && ( ulFrontSpace >= pxSocket->u.xTCP.usCurMSS ) )
+                {
+                    ulSpace = pxSocket->u.xTCP.usCurMSS;
+                }
 
-			/* The new window size has been advertised, switch off the flag. */
-			pxSocket->u.xTCP.bits.bWinChange = pdFALSE_UNSIGNED;
+                /* Avoid overflow of the 16-bit win field. */
+                #if ( ipconfigUSE_TCP_WIN != 0 )
+                    {
+                        ulWinSize = ( ulSpace >> pxSocket->u.xTCP.ucMyWinScaleFactor );
+                    }
+                #else
+                    {
+                        ulWinSize = ulSpace;
+                    }
+                #endif
 
-			/* Later on, when deciding to delay an ACK, a precise estimate is needed
-			of the free RX space.  At this moment, 'ulHighestRxAllowed' would be the
-			highest sequence number minus 1 that the socket will accept. */
-			pxSocket->u.xTCP.ulHighestRxAllowed = pxTCPWindow->rx.ulCurrentSequenceNumber + ulSpace;
+                if( ulWinSize > 0xfffcUL )
+                {
+                    ulWinSize = 0xfffcUL;
+                }
 
-		#if( ipconfigTCP_KEEP_ALIVE == 1 )
-			if( pxSocket->u.xTCP.bits.bSendKeepAlive != pdFALSE_UNSIGNED )
-			{
-				/* Sending a keep-alive packet, send the current sequence number
-				minus 1, which will	be recognised as a keep-alive packet an
-				responded to by acknowledging the last byte. */
-				pxSocket->u.xTCP.bits.bSendKeepAlive = pdFALSE_UNSIGNED;
-				pxSocket->u.xTCP.bits.bWaitKeepAlive = pdTRUE_UNSIGNED;
+                pxTCPPacket->xTCPHeader.usWindow = FreeRTOS_htons( ( uint16_t ) ulWinSize );
 
-				pxTCPPacket->xTCPHeader.ulSequenceNumber = pxSocket->u.xTCP.xTCPWindow.ulOurSequenceNumber - 1UL;
-				pxTCPPacket->xTCPHeader.ulSequenceNumber = FreeRTOS_htonl( pxTCPPacket->xTCPHeader.ulSequenceNumber );
-			}
-			else
-		#endif
-			{
-				pxTCPPacket->xTCPHeader.ulSequenceNumber = FreeRTOS_htonl( pxSocket->u.xTCP.xTCPWindow.ulOurSequenceNumber );
+                /* The new window size has been advertised, switch off the flag. */
+                pxSocket->u.xTCP.bits.bWinChange = pdFALSE_UNSIGNED;
 
-				if( ( pxTCPPacket->xTCPHeader.ucTCPFlags & ( uint8_t ) tcpTCP_FLAG_FIN ) != 0U )
-				{
-					/* Suppress FIN in case this packet carries earlier data to be
-					retransmitted. */
-					uint32_t ulDataLen = ( uint32_t ) ( ulLen - ( ipSIZE_OF_TCP_HEADER + ipSIZE_OF_IPv4_HEADER ) );
-					if( ( pxTCPWindow->ulOurSequenceNumber + ulDataLen ) != pxTCPWindow->tx.ulFINSequenceNumber )
-					{
-						pxTCPPacket->xTCPHeader.ucTCPFlags &= ( ( uint8_t ) ~tcpTCP_FLAG_FIN );
-						FreeRTOS_debug_printf( ( "Suppress FIN for %lu + %lu < %lu\n",
-							pxTCPWindow->ulOurSequenceNumber - pxTCPWindow->tx.ulFirstSequenceNumber,
-							ulDataLen,
-							pxTCPWindow->tx.ulFINSequenceNumber - pxTCPWindow->tx.ulFirstSequenceNumber ) );
-					}
-				}
-			}
+                /* Later on, when deciding to delay an ACK, a precise estimate is needed
+                 * of the free RX space.  At this moment, 'ulHighestRxAllowed' would be the
+                 * highest sequence number minus 1 that the socket will accept. */
+                pxSocket->u.xTCP.ulHighestRxAllowed = pxTCPWindow->rx.ulCurrentSequenceNumber + ulSpace;
 
-			/* Tell which sequence number is expected next time */
-			pxTCPPacket->xTCPHeader.ulAckNr = FreeRTOS_htonl( pxTCPWindow->rx.ulCurrentSequenceNumber );
-		}
-		else
-		{
-			/* Sending data without a socket, probably replying with a RST flag
-			Just swap the two sequence numbers. */
-			vFlip_32( pxTCPPacket->xTCPHeader.ulSequenceNumber, pxTCPPacket->xTCPHeader.ulAckNr );
-		}
+                #if ( ipconfigTCP_KEEP_ALIVE == 1 )
+                    if( pxSocket->u.xTCP.bits.bSendKeepAlive != pdFALSE_UNSIGNED )
+                    {
+                        /* Sending a keep-alive packet, send the current sequence number
+                         * minus 1, which will	be recognised as a keep-alive packet an
+                         * responded to by acknowledging the last byte. */
+                        pxSocket->u.xTCP.bits.bSendKeepAlive = pdFALSE_UNSIGNED;
+                        pxSocket->u.xTCP.bits.bWaitKeepAlive = pdTRUE_UNSIGNED;
 
-		pxIPHeader->ucTimeToLive		   = ( uint8_t ) ipconfigTCP_TIME_TO_LIVE;
-		pxIPHeader->usLength			   = FreeRTOS_htons( ulLen );
-		if( ( pxSocket == NULL ) || ( *ipLOCAL_IP_ADDRESS_POINTER == 0UL ) )
-		{
-			/* When pxSocket is NULL, this function is called by prvTCPSendReset()
-			and the IP-addresses must be swapped.
-			Also swap the IP-addresses in case the IP-tack doesn't have an
-			IP-address yet, i.e. when ( *ipLOCAL_IP_ADDRESS_POINTER == 0UL ). */
-			ulSourceAddress = pxIPHeader->ulDestinationIPAddress;
-		}
-		else
-		{
-			ulSourceAddress = *ipLOCAL_IP_ADDRESS_POINTER;
-		}
-		pxIPHeader->ulDestinationIPAddress = pxIPHeader->ulSourceIPAddress;
-		pxIPHeader->ulSourceIPAddress = ulSourceAddress;
-		vFlip_16( pxTCPPacket->xTCPHeader.usSourcePort, pxTCPPacket->xTCPHeader.usDestinationPort );
+                        pxTCPPacket->xTCPHeader.ulSequenceNumber = pxSocket->u.xTCP.xTCPWindow.ulOurSequenceNumber - 1UL;
+                        pxTCPPacket->xTCPHeader.ulSequenceNumber = FreeRTOS_htonl( pxTCPPacket->xTCPHeader.ulSequenceNumber );
+                    }
+                    else
+                #endif /* if ( ipconfigTCP_KEEP_ALIVE == 1 ) */
+                {
+                    pxTCPPacket->xTCPHeader.ulSequenceNumber = FreeRTOS_htonl( pxSocket->u.xTCP.xTCPWindow.ulOurSequenceNumber );
 
-		/* Just an increasing number. */
-		pxIPHeader->usIdentification = FreeRTOS_htons( usPacketIdentifier );
-		usPacketIdentifier++;
-		pxIPHeader->usFragmentOffset = 0U;
+                    if( ( pxTCPPacket->xTCPHeader.ucTCPFlags & ( uint8_t ) tcpTCP_FLAG_FIN ) != 0U )
+                    {
+                        /* Suppress FIN in case this packet carries earlier data to be
+                         * retransmitted. */
+                        uint32_t ulDataLen = ( uint32_t ) ( ulLen - ( ipSIZE_OF_TCP_HEADER + ipSIZE_OF_IPv4_HEADER ) );
 
-		#if( ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM == 0 )
-		{
-			/* calculate the IP header checksum, in case the driver won't do that. */
-			pxIPHeader->usHeaderChecksum = 0x00U;
-			pxIPHeader->usHeaderChecksum = usGenerateChecksum( 0U, ( uint8_t * ) &( pxIPHeader->ucVersionHeaderLength ), ipSIZE_OF_IPv4_HEADER );
-			pxIPHeader->usHeaderChecksum = ~FreeRTOS_htons( pxIPHeader->usHeaderChecksum );
+                        if( ( pxTCPWindow->ulOurSequenceNumber + ulDataLen ) != pxTCPWindow->tx.ulFINSequenceNumber )
+                        {
+                            pxTCPPacket->xTCPHeader.ucTCPFlags &= ( ( uint8_t ) ~tcpTCP_FLAG_FIN );
+                            FreeRTOS_debug_printf( ( "Suppress FIN for %lu + %lu < %lu\n",
+                                                     pxTCPWindow->ulOurSequenceNumber - pxTCPWindow->tx.ulFirstSequenceNumber,
+                                                     ulDataLen,
+                                                     pxTCPWindow->tx.ulFINSequenceNumber - pxTCPWindow->tx.ulFirstSequenceNumber ) );
+                        }
+                    }
+                }
 
-			/* calculate the TCP checksum for an outgoing packet. */
-			( void ) usGenerateProtocolChecksum( ( uint8_t * ) pxTCPPacket, pxNetworkBuffer->xDataLength, pdTRUE );
+                /* Tell which sequence number is expected next time */
+                pxTCPPacket->xTCPHeader.ulAckNr = FreeRTOS_htonl( pxTCPWindow->rx.ulCurrentSequenceNumber );
+            }
+            else
+            {
+                /* Sending data without a socket, probably replying with a RST flag
+                 * Just swap the two sequence numbers. */
+                vFlip_32( pxTCPPacket->xTCPHeader.ulSequenceNumber, pxTCPPacket->xTCPHeader.ulAckNr );
+            }
 
-			/* A calculated checksum of 0 must be inverted as 0 means the checksum
-			is disabled. */
-			if( pxTCPPacket->xTCPHeader.usChecksum == 0U )
-			{
-				pxTCPPacket->xTCPHeader.usChecksum = 0xffffU;
-			}
-		}
-		#endif
+            pxIPHeader->ucTimeToLive = ( uint8_t ) ipconfigTCP_TIME_TO_LIVE;
+            pxIPHeader->usLength = FreeRTOS_htons( ulLen );
 
-		#if( ipconfigUSE_LINKED_RX_MESSAGES != 0 )
-		{
-			pxNetworkBuffer->pxNextBuffer = NULL;
-		}
-		#endif
+            if( ( pxSocket == NULL ) || ( *ipLOCAL_IP_ADDRESS_POINTER == 0UL ) )
+            {
+                /* When pxSocket is NULL, this function is called by prvTCPSendReset()
+                * and the IP-addresses must be swapped.
+                * Also swap the IP-addresses in case the IP-tack doesn't have an
+                * IP-address yet, i.e. when ( *ipLOCAL_IP_ADDRESS_POINTER == 0UL ). */
+                ulSourceAddress = pxIPHeader->ulDestinationIPAddress;
+            }
+            else
+            {
+                ulSourceAddress = *ipLOCAL_IP_ADDRESS_POINTER;
+            }
 
-		/* Important: tell NIC driver how many bytes must be sent. */
-		pxNetworkBuffer->xDataLength = ulLen + ipSIZE_OF_ETH_HEADER;
+            pxIPHeader->ulDestinationIPAddress = pxIPHeader->ulSourceIPAddress;
+            pxIPHeader->ulSourceIPAddress = ulSourceAddress;
+            vFlip_16( pxTCPPacket->xTCPHeader.usSourcePort, pxTCPPacket->xTCPHeader.usDestinationPort );
 
-		/* Fill in the destination MAC addresses. */
-		( void ) memcpy( &( pxEthernetHeader->xDestinationAddress ),
-						 &( pxEthernetHeader->xSourceAddress ),
-						 sizeof( pxEthernetHeader->xDestinationAddress ) );
+            /* Just an increasing number. */
+            pxIPHeader->usIdentification = FreeRTOS_htons( usPacketIdentifier );
+            usPacketIdentifier++;
+            pxIPHeader->usFragmentOffset = 0U;
 
-		/* The source MAC addresses is fixed to 'ipLOCAL_MAC_ADDRESS'. */
-		( void ) memcpy( &( pxEthernetHeader->xSourceAddress ), ipLOCAL_MAC_ADDRESS, ( size_t ) ipMAC_ADDRESS_LENGTH_BYTES );
- 
-		#if defined( ipconfigETHERNET_MINIMUM_PACKET_BYTES )
-		{
-			if( pxNetworkBuffer->xDataLength < ( size_t ) ipconfigETHERNET_MINIMUM_PACKET_BYTES )
-			{
-			BaseType_t xIndex;
+            #if ( ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM == 0 )
+                {
+                    /* calculate the IP header checksum, in case the driver won't do that. */
+                    pxIPHeader->usHeaderChecksum = 0x00U;
+                    pxIPHeader->usHeaderChecksum = usGenerateChecksum( 0U, ( uint8_t * ) &( pxIPHeader->ucVersionHeaderLength ), ipSIZE_OF_IPv4_HEADER );
+                    pxIPHeader->usHeaderChecksum = ~FreeRTOS_htons( pxIPHeader->usHeaderChecksum );
 
-				for( xIndex = ( BaseType_t ) pxNetworkBuffer->xDataLength; xIndex < ( BaseType_t ) ipconfigETHERNET_MINIMUM_PACKET_BYTES; xIndex++ )
-				{
-					pxNetworkBuffer->pucEthernetBuffer[ xIndex ] = 0U;
-				}
-				pxNetworkBuffer->xDataLength = ( size_t ) ipconfigETHERNET_MINIMUM_PACKET_BYTES;
-			}
-		}
-		#endif
+                    /* calculate the TCP checksum for an outgoing packet. */
+                    ( void ) usGenerateProtocolChecksum( ( uint8_t * ) pxTCPPacket, pxNetworkBuffer->xDataLength, pdTRUE );
 
-		/* Send! */
-		( void ) xNetworkInterfaceOutput( pxNetworkBuffer, xDoRelease );
+                    /* A calculated checksum of 0 must be inverted as 0 means the checksum
+                     * is disabled. */
+                    if( pxTCPPacket->xTCPHeader.usChecksum == 0U )
+                    {
+                        pxTCPPacket->xTCPHeader.usChecksum = 0xffffU;
+                    }
+                }
+            #endif /* if ( ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM == 0 ) */
 
-		if( xDoRelease == pdFALSE )
-		{
-			/* Swap-back some fields, as pxBuffer probably points to a socket field
-			containing the packet header. */
-			vFlip_16( pxTCPPacket->xTCPHeader.usSourcePort, pxTCPPacket->xTCPHeader.usDestinationPort);
-			pxTCPPacket->xIPHeader.ulSourceIPAddress = pxTCPPacket->xIPHeader.ulDestinationIPAddress;
-			( void ) memcpy( pxEthernetHeader->xSourceAddress.ucBytes, pxEthernetHeader->xDestinationAddress.ucBytes, ( size_t ) ipMAC_ADDRESS_LENGTH_BYTES );
-		}
-		else
-		{
-			/* Nothing to do: the buffer has been passed to DMA and will be released after use */
-		}
-	} /* if( pxNetworkBuffer != NULL ) */
-}
+            #if ( ipconfigUSE_LINKED_RX_MESSAGES != 0 )
+                {
+                    pxNetworkBuffer->pxNextBuffer = NULL;
+                }
+            #endif
+
+            /* Important: tell NIC driver how many bytes must be sent. */
+            pxNetworkBuffer->xDataLength = ulLen + ipSIZE_OF_ETH_HEADER;
+
+            /* Fill in the destination MAC addresses. */
+            ( void ) memcpy( &( pxEthernetHeader->xDestinationAddress ),
+                             &( pxEthernetHeader->xSourceAddress ),
+                             sizeof( pxEthernetHeader->xDestinationAddress ) );
+
+            /* The source MAC addresses is fixed to 'ipLOCAL_MAC_ADDRESS'. */
+            ( void ) memcpy( &( pxEthernetHeader->xSourceAddress ), ipLOCAL_MAC_ADDRESS, ( size_t ) ipMAC_ADDRESS_LENGTH_BYTES );
+
+            #if defined( ipconfigETHERNET_MINIMUM_PACKET_BYTES )
+                {
+                    if( pxNetworkBuffer->xDataLength < ( size_t ) ipconfigETHERNET_MINIMUM_PACKET_BYTES )
+                    {
+                        BaseType_t xIndex;
+
+                        for( xIndex = ( BaseType_t ) pxNetworkBuffer->xDataLength; xIndex < ( BaseType_t ) ipconfigETHERNET_MINIMUM_PACKET_BYTES; xIndex++ )
+                        {
+                            pxNetworkBuffer->pucEthernetBuffer[ xIndex ] = 0U;
+                        }
+
+                        pxNetworkBuffer->xDataLength = ( size_t ) ipconfigETHERNET_MINIMUM_PACKET_BYTES;
+                    }
+                }
+            #endif /* if defined( ipconfigETHERNET_MINIMUM_PACKET_BYTES ) */
+
+            /* Send! */
+            ( void ) xNetworkInterfaceOutput( pxNetworkBuffer, xDoRelease );
+
+            if( xDoRelease == pdFALSE )
+            {
+                /* Swap-back some fields, as pxBuffer probably points to a socket field
+                 * containing the packet header. */
+                vFlip_16( pxTCPPacket->xTCPHeader.usSourcePort, pxTCPPacket->xTCPHeader.usDestinationPort );
+                pxTCPPacket->xIPHeader.ulSourceIPAddress = pxTCPPacket->xIPHeader.ulDestinationIPAddress;
+                ( void ) memcpy( pxEthernetHeader->xSourceAddress.ucBytes, pxEthernetHeader->xDestinationAddress.ucBytes, ( size_t ) ipMAC_ADDRESS_LENGTH_BYTES );
+            }
+            else
+            {
+                /* Nothing to do: the buffer has been passed to DMA and will be released after use */
+            }
+        } /* if( pxNetworkBuffer != NULL ) */
+    }
 /*-----------------------------------------------------------*/
 
 /*
@@ -950,24 +998,25 @@ NetworkBufferDescriptor_t xTempBuffer;
  * (in FreeRTOS_TCP_WIN.c) needs to know them, along with the Maximum Segment
  * Size (MSS) in use.
  */
-static void prvTCPCreateWindow( FreeRTOS_Socket_t *pxSocket )
-{
-	if( xTCPWindowLoggingLevel != 0 )
-	{
-		FreeRTOS_debug_printf( ( "Limits (using): TCP Win size %u Water %u <= %u <= %u\n",
-			( unsigned ) pxSocket->u.xTCP.uxRxWinSize * ipconfigTCP_MSS,
-			( unsigned ) pxSocket->u.xTCP.uxLittleSpace ,
-			( unsigned ) pxSocket->u.xTCP.uxEnoughSpace,
-			( unsigned ) pxSocket->u.xTCP.uxRxStreamSize ) );
-	}
-	vTCPWindowCreate(
-		&pxSocket->u.xTCP.xTCPWindow,
-		( ( size_t ) ipconfigTCP_MSS ) * pxSocket->u.xTCP.uxRxWinSize,
-		( ( size_t ) ipconfigTCP_MSS ) * pxSocket->u.xTCP.uxTxWinSize,
-		pxSocket->u.xTCP.xTCPWindow.rx.ulCurrentSequenceNumber,
-		pxSocket->u.xTCP.xTCPWindow.ulOurSequenceNumber,
-		( uint32_t ) pxSocket->u.xTCP.usInitMSS );
-}
+    static void prvTCPCreateWindow( FreeRTOS_Socket_t * pxSocket )
+    {
+        if( xTCPWindowLoggingLevel != 0 )
+        {
+            FreeRTOS_debug_printf( ( "Limits (using): TCP Win size %u Water %u <= %u <= %u\n",
+                                     ( unsigned ) pxSocket->u.xTCP.uxRxWinSize * ipconfigTCP_MSS,
+                                     ( unsigned ) pxSocket->u.xTCP.uxLittleSpace,
+                                     ( unsigned ) pxSocket->u.xTCP.uxEnoughSpace,
+                                     ( unsigned ) pxSocket->u.xTCP.uxRxStreamSize ) );
+        }
+
+        vTCPWindowCreate(
+            &pxSocket->u.xTCP.xTCPWindow,
+            ( ( size_t ) ipconfigTCP_MSS ) * pxSocket->u.xTCP.uxRxWinSize,
+            ( ( size_t ) ipconfigTCP_MSS ) * pxSocket->u.xTCP.uxTxWinSize,
+            pxSocket->u.xTCP.xTCPWindow.rx.ulCurrentSequenceNumber,
+            pxSocket->u.xTCP.xTCPWindow.ulOurSequenceNumber,
+            ( uint32_t ) pxSocket->u.xTCP.usInitMSS );
+    }
 /*-----------------------------------------------------------*/
 
 /*
@@ -976,504 +1025,523 @@ static void prvTCPCreateWindow( FreeRTOS_Socket_t *pxSocket )
  * target IP address is not within the netmask, the hardware address of the
  * gateway will be used.
  */
-static BaseType_t prvTCPPrepareConnect( FreeRTOS_Socket_t *pxSocket )
-{
-TCPPacket_t *pxTCPPacket;
-IPHeader_t *pxIPHeader;
-eARPLookupResult_t eReturned;
-uint32_t ulRemoteIP;
-MACAddress_t xEthAddress;
-BaseType_t xReturn = pdTRUE;
-uint32_t ulInitialSequenceNumber = 0;
+    static BaseType_t prvTCPPrepareConnect( FreeRTOS_Socket_t * pxSocket )
+    {
+        TCPPacket_t * pxTCPPacket;
+        IPHeader_t * pxIPHeader;
+        eARPLookupResult_t eReturned;
+        uint32_t ulRemoteIP;
+        MACAddress_t xEthAddress;
+        BaseType_t xReturn = pdTRUE;
+        uint32_t ulInitialSequenceNumber = 0;
 
-	#if( ipconfigHAS_PRINTF != 0 )
-	{
-		/* Only necessary for nicer logging. */
-		( void ) memset( xEthAddress.ucBytes, 0, sizeof( xEthAddress.ucBytes ) );
-	}
-	#endif /* ipconfigHAS_PRINTF != 0 */
+        #if ( ipconfigHAS_PRINTF != 0 )
+            {
+                /* Only necessary for nicer logging. */
+                ( void ) memset( xEthAddress.ucBytes, 0, sizeof( xEthAddress.ucBytes ) );
+            }
+        #endif /* ipconfigHAS_PRINTF != 0 */
 
-	ulRemoteIP = FreeRTOS_htonl( pxSocket->u.xTCP.ulRemoteIP );
+        ulRemoteIP = FreeRTOS_htonl( pxSocket->u.xTCP.ulRemoteIP );
 
-	/* Determine the ARP cache status for the requested IP address. */
-	eReturned = eARPGetCacheEntry( &( ulRemoteIP ), &( xEthAddress ) );
+        /* Determine the ARP cache status for the requested IP address. */
+        eReturned = eARPGetCacheEntry( &( ulRemoteIP ), &( xEthAddress ) );
 
-	switch( eReturned )
-	{
-	case eARPCacheHit:		/* An ARP table lookup found a valid entry. */
-		break;				/* We can now prepare the SYN packet. */
-	case eARPCacheMiss:		/* An ARP table lookup did not find a valid entry. */
-	case eCantSendPacket:	/* There is no IP address, or an ARP is still in progress. */
-	default:
-		/* Count the number of times it couldn't find the ARP address. */
-		pxSocket->u.xTCP.ucRepCount++;
+        switch( eReturned )
+        {
+            case eARPCacheHit:    /* An ARP table lookup found a valid entry. */
+                break;            /* We can now prepare the SYN packet. */
 
-		FreeRTOS_debug_printf( ( "ARP for %lxip (using %lxip): rc=%d %02X:%02X:%02X %02X:%02X:%02X\n",
-			pxSocket->u.xTCP.ulRemoteIP,
-			FreeRTOS_htonl( ulRemoteIP ),
-			eReturned,
-			xEthAddress.ucBytes[ 0 ],
-			xEthAddress.ucBytes[ 1 ],
-			xEthAddress.ucBytes[ 2 ],
-			xEthAddress.ucBytes[ 3 ],
-			xEthAddress.ucBytes[ 4 ],
-			xEthAddress.ucBytes[ 5 ] ) );
+            case eARPCacheMiss:   /* An ARP table lookup did not find a valid entry. */
+            case eCantSendPacket: /* There is no IP address, or an ARP is still in progress. */
+            default:
+                /* Count the number of times it couldn't find the ARP address. */
+                pxSocket->u.xTCP.ucRepCount++;
 
-		/* And issue a (new) ARP request */
-		FreeRTOS_OutputARPRequest( ulRemoteIP );
-		xReturn = pdFALSE;
-		break;
-	}
+                FreeRTOS_debug_printf( ( "ARP for %lxip (using %lxip): rc=%d %02X:%02X:%02X %02X:%02X:%02X\n",
+                                         pxSocket->u.xTCP.ulRemoteIP,
+                                         FreeRTOS_htonl( ulRemoteIP ),
+                                         eReturned,
+                                         xEthAddress.ucBytes[ 0 ],
+                                         xEthAddress.ucBytes[ 1 ],
+                                         xEthAddress.ucBytes[ 2 ],
+                                         xEthAddress.ucBytes[ 3 ],
+                                         xEthAddress.ucBytes[ 4 ],
+                                         xEthAddress.ucBytes[ 5 ] ) );
 
-	if( xReturn != pdFALSE )
-	{
-		/* Get a difficult-to-predict initial sequence number for this 4-tuple. */
-		ulInitialSequenceNumber = ulApplicationGetNextSequenceNumber( *ipLOCAL_IP_ADDRESS_POINTER,
-																	  pxSocket->usLocalPort,
-																	  pxSocket->u.xTCP.ulRemoteIP,
-																	  pxSocket->u.xTCP.usRemotePort );
+                /* And issue a (new) ARP request */
+                FreeRTOS_OutputARPRequest( ulRemoteIP );
+                xReturn = pdFALSE;
+                break;
+        }
 
-		/* Check for a random number generation error. */
-		if( ulInitialSequenceNumber == 0UL )
-		{
-			xReturn = pdFALSE;
-		}
-	}
+        if( xReturn != pdFALSE )
+        {
+            /* Get a difficult-to-predict initial sequence number for this 4-tuple. */
+            ulInitialSequenceNumber = ulApplicationGetNextSequenceNumber( *ipLOCAL_IP_ADDRESS_POINTER,
+                                                                          pxSocket->usLocalPort,
+                                                                          pxSocket->u.xTCP.ulRemoteIP,
+                                                                          pxSocket->u.xTCP.usRemotePort );
 
-	if( xReturn != pdFALSE )
-	{
-	uint16_t usLength;
+            /* Check for a random number generation error. */
+            if( ulInitialSequenceNumber == 0UL )
+            {
+                xReturn = pdFALSE;
+            }
+        }
 
-		/* The MAC-address of the peer (or gateway) has been found,
-		now prepare the initial TCP packet and some fields in the socket. */
-		pxTCPPacket = ipPOINTER_CAST( TCPPacket_t *, pxSocket->u.xTCP.xPacket.u.ucLastPacket );
-		pxIPHeader = &pxTCPPacket->xIPHeader;
+        if( xReturn != pdFALSE )
+        {
+            uint16_t usLength;
 
-		/* reset the retry counter to zero. */
-		pxSocket->u.xTCP.ucRepCount = 0U;
+            /* The MAC-address of the peer (or gateway) has been found,
+             * now prepare the initial TCP packet and some fields in the socket. */
+            pxTCPPacket = ipPOINTER_CAST( TCPPacket_t *, pxSocket->u.xTCP.xPacket.u.ucLastPacket );
+            pxIPHeader = &pxTCPPacket->xIPHeader;
 
-		/* And remember that the connect/SYN data are prepared. */
-		pxSocket->u.xTCP.bits.bConnPrepared = pdTRUE_UNSIGNED;
+            /* reset the retry counter to zero. */
+            pxSocket->u.xTCP.ucRepCount = 0U;
 
-		/* Now that the Ethernet address is known, the initial packet can be
-		prepared. */
-		( void ) memset( pxSocket->u.xTCP.xPacket.u.ucLastPacket, 0, sizeof( pxSocket->u.xTCP.xPacket.u.ucLastPacket ) );
+            /* And remember that the connect/SYN data are prepared. */
+            pxSocket->u.xTCP.bits.bConnPrepared = pdTRUE_UNSIGNED;
 
-		/* Write the Ethernet address in Source, because it will be swapped by
-		prvTCPReturnPacket(). */
-		( void ) memcpy( &pxTCPPacket->xEthernetHeader.xSourceAddress, &xEthAddress, sizeof( xEthAddress ) );
+            /* Now that the Ethernet address is known, the initial packet can be
+             * prepared. */
+            ( void ) memset( pxSocket->u.xTCP.xPacket.u.ucLastPacket, 0, sizeof( pxSocket->u.xTCP.xPacket.u.ucLastPacket ) );
 
-		/* 'ipIPv4_FRAME_TYPE' is already in network-byte-order. */
-		pxTCPPacket->xEthernetHeader.usFrameType = ipIPv4_FRAME_TYPE;
+            /* Write the Ethernet address in Source, because it will be swapped by
+             * prvTCPReturnPacket(). */
+            ( void ) memcpy( &pxTCPPacket->xEthernetHeader.xSourceAddress, &xEthAddress, sizeof( xEthAddress ) );
 
-		pxIPHeader->ucVersionHeaderLength = 0x45U;
-		usLength = ( uint16_t ) ( sizeof( TCPPacket_t ) - sizeof( pxTCPPacket->xEthernetHeader ) );
-		pxIPHeader->usLength = FreeRTOS_htons( usLength );
-		pxIPHeader->ucTimeToLive = ( uint8_t ) ipconfigTCP_TIME_TO_LIVE;
+            /* 'ipIPv4_FRAME_TYPE' is already in network-byte-order. */
+            pxTCPPacket->xEthernetHeader.usFrameType = ipIPv4_FRAME_TYPE;
 
-		pxIPHeader->ucProtocol = ( uint8_t ) ipPROTOCOL_TCP;
+            pxIPHeader->ucVersionHeaderLength = 0x45U;
+            usLength = ( uint16_t ) ( sizeof( TCPPacket_t ) - sizeof( pxTCPPacket->xEthernetHeader ) );
+            pxIPHeader->usLength = FreeRTOS_htons( usLength );
+            pxIPHeader->ucTimeToLive = ( uint8_t ) ipconfigTCP_TIME_TO_LIVE;
 
-		/* Addresses and ports will be stored swapped because prvTCPReturnPacket
-		will swap them back while replying. */
-		pxIPHeader->ulDestinationIPAddress = *ipLOCAL_IP_ADDRESS_POINTER;
-		pxIPHeader->ulSourceIPAddress = FreeRTOS_htonl( pxSocket->u.xTCP.ulRemoteIP );
+            pxIPHeader->ucProtocol = ( uint8_t ) ipPROTOCOL_TCP;
 
-		pxTCPPacket->xTCPHeader.usSourcePort = FreeRTOS_htons( pxSocket->u.xTCP.usRemotePort );
-		pxTCPPacket->xTCPHeader.usDestinationPort = FreeRTOS_htons( pxSocket->usLocalPort );
+            /* Addresses and ports will be stored swapped because prvTCPReturnPacket
+             * will swap them back while replying. */
+            pxIPHeader->ulDestinationIPAddress = *ipLOCAL_IP_ADDRESS_POINTER;
+            pxIPHeader->ulSourceIPAddress = FreeRTOS_htonl( pxSocket->u.xTCP.ulRemoteIP );
 
-		/* We are actively connecting, so the peer's Initial Sequence Number (ISN)
-		isn't known yet. */
-		pxSocket->u.xTCP.xTCPWindow.rx.ulCurrentSequenceNumber = 0UL;
+            pxTCPPacket->xTCPHeader.usSourcePort = FreeRTOS_htons( pxSocket->u.xTCP.usRemotePort );
+            pxTCPPacket->xTCPHeader.usDestinationPort = FreeRTOS_htons( pxSocket->usLocalPort );
 
-		/* Start with ISN (Initial Sequence Number). */
-		pxSocket->u.xTCP.xTCPWindow.ulOurSequenceNumber = ulInitialSequenceNumber;
+            /* We are actively connecting, so the peer's Initial Sequence Number (ISN)
+             * isn't known yet. */
+            pxSocket->u.xTCP.xTCPWindow.rx.ulCurrentSequenceNumber = 0UL;
 
-		/* The TCP header size is 20 bytes, divided by 4 equals 5, which is put in
-		the high nibble of the TCP offset field. */
-		pxTCPPacket->xTCPHeader.ucTCPOffset = 0x50U;
+            /* Start with ISN (Initial Sequence Number). */
+            pxSocket->u.xTCP.xTCPWindow.ulOurSequenceNumber = ulInitialSequenceNumber;
 
-		/* Only set the SYN flag. */
-		pxTCPPacket->xTCPHeader.ucTCPFlags = tcpTCP_FLAG_SYN;
+            /* The TCP header size is 20 bytes, divided by 4 equals 5, which is put in
+             * the high nibble of the TCP offset field. */
+            pxTCPPacket->xTCPHeader.ucTCPOffset = 0x50U;
 
-		/* Set the values of usInitMSS / usCurMSS for this socket. */
-		prvSocketSetMSS( pxSocket );
+            /* Only set the SYN flag. */
+            pxTCPPacket->xTCPHeader.ucTCPFlags = tcpTCP_FLAG_SYN;
 
-		/* The initial sequence numbers at our side are known.  Later
-		vTCPWindowInit() will be called to fill in the peer's sequence numbers, but
-		first wait for a SYN+ACK reply. */
-		prvTCPCreateWindow( pxSocket );
-	}
+            /* Set the values of usInitMSS / usCurMSS for this socket. */
+            prvSocketSetMSS( pxSocket );
 
-	return xReturn;
-}
+            /* The initial sequence numbers at our side are known.  Later
+             * vTCPWindowInit() will be called to fill in the peer's sequence numbers, but
+             * first wait for a SYN+ACK reply. */
+            prvTCPCreateWindow( pxSocket );
+        }
+
+        return xReturn;
+    }
 /*-----------------------------------------------------------*/
 
 /* For logging and debugging: make a string showing the TCP flags
-*/
-#if( ipconfigHAS_DEBUG_PRINTF != 0 )
+ */
+    #if ( ipconfigHAS_DEBUG_PRINTF != 0 )
 
-	static const char *prvTCPFlagMeaning( UBaseType_t xFlags )
-	{
-		static char retString[10];
-		size_t uxFlags = ( size_t ) xFlags;
-		( void ) snprintf(retString,
-			sizeof( retString ), "%c%c%c%c%c%c%c%c",
-			( ( uxFlags & ( size_t ) tcpTCP_FLAG_FIN ) != 0 )   ? 'F' : '.',	/* 0x0001: No more data from sender */
-			( ( uxFlags & ( size_t ) tcpTCP_FLAG_SYN ) != 0 )   ? 'S' : '.',	/* 0x0002: Synchronize sequence numbers */
-			( ( uxFlags & ( size_t ) tcpTCP_FLAG_RST ) != 0 )   ? 'R' : '.',	/* 0x0004: Reset the connection */
-			( ( uxFlags & ( size_t ) tcpTCP_FLAG_PSH ) != 0 )   ? 'P' : '.',	/* 0x0008: Push function: please push buffered data to the recv application */
-			( ( uxFlags & ( size_t ) tcpTCP_FLAG_ACK ) != 0 )   ? 'A' : '.',	/* 0x0010: Acknowledgment field is significant */
-			( ( uxFlags & ( size_t ) tcpTCP_FLAG_URG ) != 0 )   ? 'U' : '.',	/* 0x0020: Urgent pointer field is significant */
-			( ( uxFlags & ( size_t ) tcpTCP_FLAG_ECN ) != 0 )   ? 'E' : '.',	/* 0x0040: ECN-Echo */
-			( ( uxFlags & ( size_t ) tcpTCP_FLAG_CWR ) != 0 )   ? 'C' : '.');	/* 0x0080: Congestion Window Reduced */
-		return retString;
-	}
-	/*-----------------------------------------------------------*/
+        static const char * prvTCPFlagMeaning( UBaseType_t xFlags )
+        {
+            static char retString[ 10 ];
+            size_t uxFlags = ( size_t ) xFlags;
 
-#endif /* ipconfigHAS_DEBUG_PRINTF */
+            ( void ) snprintf( retString,
+                               sizeof( retString ), "%c%c%c%c%c%c%c%c",
+                               ( ( uxFlags & ( size_t ) tcpTCP_FLAG_FIN ) != 0 ) ? 'F' : '.',   /* 0x0001: No more data from sender */
+                               ( ( uxFlags & ( size_t ) tcpTCP_FLAG_SYN ) != 0 ) ? 'S' : '.',   /* 0x0002: Synchronize sequence numbers */
+                               ( ( uxFlags & ( size_t ) tcpTCP_FLAG_RST ) != 0 ) ? 'R' : '.',   /* 0x0004: Reset the connection */
+                               ( ( uxFlags & ( size_t ) tcpTCP_FLAG_PSH ) != 0 ) ? 'P' : '.',   /* 0x0008: Push function: please push buffered data to the recv application */
+                               ( ( uxFlags & ( size_t ) tcpTCP_FLAG_ACK ) != 0 ) ? 'A' : '.',   /* 0x0010: Acknowledgment field is significant */
+                               ( ( uxFlags & ( size_t ) tcpTCP_FLAG_URG ) != 0 ) ? 'U' : '.',   /* 0x0020: Urgent pointer field is significant */
+                               ( ( uxFlags & ( size_t ) tcpTCP_FLAG_ECN ) != 0 ) ? 'E' : '.',   /* 0x0040: ECN-Echo */
+                               ( ( uxFlags & ( size_t ) tcpTCP_FLAG_CWR ) != 0 ) ? 'C' : '.' ); /* 0x0080: Congestion Window Reduced */
+            return retString;
+        }
+        /*-----------------------------------------------------------*/
+
+    #endif /* ipconfigHAS_DEBUG_PRINTF */
 
 /*
  * Parse the TCP option(s) received, if present.  It has already been verified
  * that: ((pxTCPHeader->ucTCPOffset & 0xf0) > 0x50), meaning that the TP header
  * is longer than the usual 20 (5 x 4) bytes.
  */
-static void prvCheckOptions( FreeRTOS_Socket_t *pxSocket, const NetworkBufferDescriptor_t *pxNetworkBuffer )
-{
-size_t uxTCPHeaderOffset = ipSIZE_OF_ETH_HEADER + xIPHeaderSize( pxNetworkBuffer );
-const ProtocolHeaders_t *pxProtocolHeaders = ipPOINTER_CAST( ProtocolHeaders_t *,
-	&( pxNetworkBuffer->pucEthernetBuffer[ uxTCPHeaderOffset ] ) );
-const TCPHeader_t * pxTCPHeader;
-const uint8_t *pucPtr;
-BaseType_t xHasSYNFlag;
+    static void prvCheckOptions( FreeRTOS_Socket_t * pxSocket,
+                                 const NetworkBufferDescriptor_t * pxNetworkBuffer )
+    {
+        size_t uxTCPHeaderOffset = ipSIZE_OF_ETH_HEADER + xIPHeaderSize( pxNetworkBuffer );
+        const ProtocolHeaders_t * pxProtocolHeaders = ipPOINTER_CAST( ProtocolHeaders_t *,
+                                                                      &( pxNetworkBuffer->pucEthernetBuffer[ uxTCPHeaderOffset ] ) );
+        const TCPHeader_t * pxTCPHeader;
+        const uint8_t * pucPtr;
+        BaseType_t xHasSYNFlag;
 /* Offset in the network packet where the first option byte is stored. */
-size_t uxOptionOffset = uxTCPHeaderOffset + ( sizeof( TCPHeader_t ) - sizeof( pxTCPHeader->ucOptdata ) );
-size_t uxOptionsLength;
-size_t uxResult;
-uint8_t ucLength;
+        size_t uxOptionOffset = uxTCPHeaderOffset + ( sizeof( TCPHeader_t ) - sizeof( pxTCPHeader->ucOptdata ) );
+        size_t uxOptionsLength;
+        size_t uxResult;
+        uint8_t ucLength;
 
-	pxTCPHeader = &( pxProtocolHeaders->xTCPHeader );
+        pxTCPHeader = &( pxProtocolHeaders->xTCPHeader );
 
 
-	/* A character pointer to iterate through the option data */
-	pucPtr = pxTCPHeader->ucOptdata;
-	if( pxTCPHeader->ucTCPOffset <= ( 5U << 4U ) )
-	{
-		/* Avoid integer underflow in computation of ucLength. */
-		return;
-	}
-	ucLength = ( ( ( pxTCPHeader->ucTCPOffset >> 4U ) - 5U ) << 2U );
-	uxOptionsLength = ( size_t ) ucLength;
-	if( pxNetworkBuffer->xDataLength > uxOptionOffset )
-	{
-		/* Validate options size calculation. */
-		if( ( pxNetworkBuffer->xDataLength > uxOptionOffset ) &&
-			( uxOptionsLength <= ( pxNetworkBuffer->xDataLength - uxOptionOffset ) ) )
-		{
-			if( ( pxTCPHeader->ucTCPFlags & tcpTCP_FLAG_SYN ) != ( uint8_t ) 0U )
-			{
-				xHasSYNFlag = pdTRUE;
-			}
-			else
-			{
-				xHasSYNFlag = pdFALSE;
-			}
-			/* The length check is only necessary in case the option data are
-			corrupted, we don't like to run into invalid memory and crash. */
-			for( ;; )
-			{
-				if( uxOptionsLength == 0U )
-				{
-					/* coverity[break_stmt] : Break statement terminating the loop */
-					break;
-				}
-				uxResult = prvSingleStepTCPHeaderOptions( pucPtr, uxOptionsLength, pxSocket, xHasSYNFlag );
-				if( uxResult == 0UL )
-				{
-					break;
-				}
-				uxOptionsLength -= uxResult;
-				pucPtr = &( pucPtr[ uxResult ] );
-			}
-		}
-	}
-}
+        /* A character pointer to iterate through the option data */
+        pucPtr = pxTCPHeader->ucOptdata;
+
+        if( pxTCPHeader->ucTCPOffset <= ( 5U << 4U ) )
+        {
+            /* Avoid integer underflow in computation of ucLength. */
+            return;
+        }
+
+        ucLength = ( ( ( pxTCPHeader->ucTCPOffset >> 4U ) - 5U ) << 2U );
+        uxOptionsLength = ( size_t ) ucLength;
+
+        if( pxNetworkBuffer->xDataLength > uxOptionOffset )
+        {
+            /* Validate options size calculation. */
+            if( ( pxNetworkBuffer->xDataLength > uxOptionOffset ) &&
+                ( uxOptionsLength <= ( pxNetworkBuffer->xDataLength - uxOptionOffset ) ) )
+            {
+                if( ( pxTCPHeader->ucTCPFlags & tcpTCP_FLAG_SYN ) != ( uint8_t ) 0U )
+                {
+                    xHasSYNFlag = pdTRUE;
+                }
+                else
+                {
+                    xHasSYNFlag = pdFALSE;
+                }
+
+                /* The length check is only necessary in case the option data are
+                 *  corrupted, we don't like to run into invalid memory and crash. */
+                for( ; ; )
+                {
+                    if( uxOptionsLength == 0U )
+                    {
+                        /* coverity[break_stmt] : Break statement terminating the loop */
+                        break;
+                    }
+
+                    uxResult = prvSingleStepTCPHeaderOptions( pucPtr, uxOptionsLength, pxSocket, xHasSYNFlag );
+
+                    if( uxResult == 0UL )
+                    {
+                        break;
+                    }
+
+                    uxOptionsLength -= uxResult;
+                    pucPtr = &( pucPtr[ uxResult ] );
+                }
+            }
+        }
+    }
 /*-----------------------------------------------------------*/
 
-static size_t prvSingleStepTCPHeaderOptions( const uint8_t * const pucPtr,
-											 size_t uxTotalLength,
-											 FreeRTOS_Socket_t * const pxSocket,
-											 BaseType_t xHasSYNFlag )
-{
-UBaseType_t uxNewMSS;
-size_t uxRemainingOptionsBytes = uxTotalLength;
-uint8_t ucLen;
-size_t uxIndex = 0U;
-TCPWindow_t *pxTCPWindow = &( pxSocket->u.xTCP.xTCPWindow );
+    static size_t prvSingleStepTCPHeaderOptions( const uint8_t * const pucPtr,
+                                                 size_t uxTotalLength,
+                                                 FreeRTOS_Socket_t * const pxSocket,
+                                                 BaseType_t xHasSYNFlag )
+    {
+        UBaseType_t uxNewMSS;
+        size_t uxRemainingOptionsBytes = uxTotalLength;
+        uint8_t ucLen;
+        size_t uxIndex = 0U;
+        TCPWindow_t * pxTCPWindow = &( pxSocket->u.xTCP.xTCPWindow );
 
-	if( pucPtr[ 0U ] == tcpTCP_OPT_END )
-	{
-		/* End of options. */
-		return 0U;
-	}
-	if( pucPtr[ 0U ] == tcpTCP_OPT_NOOP )
-	{
-		/* NOP option, inserted to make the length a multiple of 4. */
-		return 1U;
-	}
+        if( pucPtr[ 0U ] == tcpTCP_OPT_END )
+        {
+            /* End of options. */
+            return 0U;
+        }
 
-	/* Any other well-formed option must be at least two bytes: the option
-	type byte followed by a length byte. */
-	if( uxRemainingOptionsBytes < 2U )
-	{
-		return 0U;
-	}
-#if( ipconfigUSE_TCP_WIN != 0 )
-	else if( pucPtr[ 0 ] == tcpTCP_OPT_WSOPT )
-	{
-		/* The TCP Window Scale Option. */
-		/* Confirm that the option fits in the remaining buffer space. */
-		if( ( uxRemainingOptionsBytes < tcpTCP_OPT_WSOPT_LEN ) || ( pucPtr[ 1 ] != tcpTCP_OPT_WSOPT_LEN ) )
-		{
-			return 0U;
-		}
-		/* Option is only valid in SYN phase. */
-		if( xHasSYNFlag != 0 )
-		{
-			pxSocket->u.xTCP.ucPeerWinScaleFactor = pucPtr[ 2 ];
-			pxSocket->u.xTCP.bits.bWinScaling = pdTRUE_UNSIGNED;
-		}
-		uxIndex = tcpTCP_OPT_WSOPT_LEN;
-	}
-#endif	/* ipconfigUSE_TCP_WIN */
-	else if( pucPtr[ 0 ] == tcpTCP_OPT_MSS )
-	{
-		/* Confirm that the option fits in the remaining buffer space. */
-		if( ( uxRemainingOptionsBytes < tcpTCP_OPT_MSS_LEN ) || ( pucPtr[ 1 ] != tcpTCP_OPT_MSS_LEN ) )
-		{
-			return 0U;
-		}
+        if( pucPtr[ 0U ] == tcpTCP_OPT_NOOP )
+        {
+            /* NOP option, inserted to make the length a multiple of 4. */
+            return 1U;
+        }
 
-		/* An MSS option with the correct option length.  FreeRTOS_htons()
-		is not needed here because usChar2u16() already returns a host
-		endian number. */
-		uxNewMSS = usChar2u16( &( pucPtr[ 2 ] ) );
+        /* Any other well-formed option must be at least two bytes: the option
+         * type byte followed by a length byte. */
+        if( uxRemainingOptionsBytes < 2U )
+        {
+            return 0U;
+        }
 
-		if( pxSocket->u.xTCP.usInitMSS != uxNewMSS )
-		{
-			/* Perform a basic check on the the new MSS. */
-			if( uxNewMSS == 0U )
-			{
-				return 0U;
-			}
+        #if ( ipconfigUSE_TCP_WIN != 0 )
+            else if( pucPtr[ 0 ] == tcpTCP_OPT_WSOPT )
+            {
+                /* The TCP Window Scale Option. */
+                /* Confirm that the option fits in the remaining buffer space. */
+                if( ( uxRemainingOptionsBytes < tcpTCP_OPT_WSOPT_LEN ) || ( pucPtr[ 1 ] != tcpTCP_OPT_WSOPT_LEN ) )
+                {
+                    return 0U;
+                }
 
-			FreeRTOS_debug_printf( ( "MSS change %u -> %lu\n", pxSocket->u.xTCP.usInitMSS, uxNewMSS ) );
-		}
+                /* Option is only valid in SYN phase. */
+                if( xHasSYNFlag != 0 )
+                {
+                    pxSocket->u.xTCP.ucPeerWinScaleFactor = pucPtr[ 2 ];
+                    pxSocket->u.xTCP.bits.bWinScaling = pdTRUE_UNSIGNED;
+                }
 
-		if( pxSocket->u.xTCP.usInitMSS > uxNewMSS )
-		{
-			/* our MSS was bigger than the MSS of the other party: adapt it. */
-			pxSocket->u.xTCP.bits.bMssChange = pdTRUE_UNSIGNED;
-			if( pxSocket->u.xTCP.usCurMSS > uxNewMSS )
-			{
-				/* The peer advertises a smaller MSS than this socket was
-				using.  Use that as well. */
-				FreeRTOS_debug_printf( ( "Change mss %d => %lu\n", pxSocket->u.xTCP.usCurMSS, uxNewMSS ) );
-				pxSocket->u.xTCP.usCurMSS = ( uint16_t ) uxNewMSS;
-			}
-			pxTCPWindow->xSize.ulRxWindowLength = ( ( uint32_t ) uxNewMSS ) * ( pxTCPWindow->xSize.ulRxWindowLength / ( ( uint32_t ) uxNewMSS ) );
-			pxTCPWindow->usMSSInit = ( uint16_t ) uxNewMSS;
-			pxTCPWindow->usMSS = ( uint16_t ) uxNewMSS;
-			pxSocket->u.xTCP.usInitMSS = ( uint16_t ) uxNewMSS;
-			pxSocket->u.xTCP.usCurMSS = ( uint16_t ) uxNewMSS;
-		}
+                uxIndex = tcpTCP_OPT_WSOPT_LEN;
+            }
+        #endif /* ipconfigUSE_TCP_WIN */
+        else if( pucPtr[ 0 ] == tcpTCP_OPT_MSS )
+        {
+            /* Confirm that the option fits in the remaining buffer space. */
+            if( ( uxRemainingOptionsBytes < tcpTCP_OPT_MSS_LEN ) || ( pucPtr[ 1 ] != tcpTCP_OPT_MSS_LEN ) )
+            {
+                return 0U;
+            }
 
-		uxIndex = tcpTCP_OPT_MSS_LEN;
-	}
-	else
-	{
-		/* All other options have a length field, so that we easily
-		can skip past them. */
-		ucLen = pucPtr[ 1 ];
-		if( ( ucLen < ( uint8_t ) 2U ) || ( uxRemainingOptionsBytes < ( size_t ) ucLen ) )
-		{
-			/* If the length field is too small or too big, the options are
-			 * malformed, don't process them further.
-			 */
-			return 0U;
-		}
+            /* An MSS option with the correct option length.  FreeRTOS_htons()
+             * is not needed here because usChar2u16() already returns a host
+             * endian number. */
+            uxNewMSS = usChar2u16( &( pucPtr[ 2 ] ) );
 
-		#if( ipconfigUSE_TCP_WIN == 1 )
-		{
-			/* Selective ACK: the peer has received a packet but it is missing
-			 * earlier packets. At least this packet does not need retransmission
-			 * anymore. ulTCPWindowTxSack( ) takes care of this administration.
-			 */
-			if( pucPtr[ 0U ] == tcpTCP_OPT_SACK_A )
-			{
-				ucLen -= 2U;
-				uxIndex += 2U;
+            if( pxSocket->u.xTCP.usInitMSS != uxNewMSS )
+            {
+                /* Perform a basic check on the the new MSS. */
+                if( uxNewMSS == 0U )
+                {
+                    return 0U;
+                }
 
-				while( ucLen >= ( uint8_t ) 8U )
-				{
-					prvReadSackOption( pucPtr, uxIndex, pxSocket );
-					uxIndex += 8U;
-					ucLen -= 8U;
-				}
-				/* ucLen should be 0 by now. */
-			}
-		}
-		#endif	/* ipconfigUSE_TCP_WIN == 1 */
+                FreeRTOS_debug_printf( ( "MSS change %u -> %lu\n", pxSocket->u.xTCP.usInitMSS, uxNewMSS ) );
+            }
 
-		uxIndex += ( size_t ) ucLen;
-	}
-	return uxIndex;
-}
+            if( pxSocket->u.xTCP.usInitMSS > uxNewMSS )
+            {
+                /* our MSS was bigger than the MSS of the other party: adapt it. */
+                pxSocket->u.xTCP.bits.bMssChange = pdTRUE_UNSIGNED;
+
+                if( pxSocket->u.xTCP.usCurMSS > uxNewMSS )
+                {
+                    /* The peer advertises a smaller MSS than this socket was
+                     * using.  Use that as well. */
+                    FreeRTOS_debug_printf( ( "Change mss %d => %lu\n", pxSocket->u.xTCP.usCurMSS, uxNewMSS ) );
+                    pxSocket->u.xTCP.usCurMSS = ( uint16_t ) uxNewMSS;
+                }
+
+                pxTCPWindow->xSize.ulRxWindowLength = ( ( uint32_t ) uxNewMSS ) * ( pxTCPWindow->xSize.ulRxWindowLength / ( ( uint32_t ) uxNewMSS ) );
+                pxTCPWindow->usMSSInit = ( uint16_t ) uxNewMSS;
+                pxTCPWindow->usMSS = ( uint16_t ) uxNewMSS;
+                pxSocket->u.xTCP.usInitMSS = ( uint16_t ) uxNewMSS;
+                pxSocket->u.xTCP.usCurMSS = ( uint16_t ) uxNewMSS;
+            }
+
+            uxIndex = tcpTCP_OPT_MSS_LEN;
+        }
+        else
+        {
+            /* All other options have a length field, so that we easily
+             * can skip past them. */
+            ucLen = pucPtr[ 1 ];
+
+            if( ( ucLen < ( uint8_t ) 2U ) || ( uxRemainingOptionsBytes < ( size_t ) ucLen ) )
+            {
+                /* If the length field is too small or too big, the options are
+                 * malformed, don't process them further.
+                 */
+                return 0U;
+            }
+
+            #if ( ipconfigUSE_TCP_WIN == 1 )
+                {
+                    /* Selective ACK: the peer has received a packet but it is missing
+                     * earlier packets. At least this packet does not need retransmission
+                     * anymore. ulTCPWindowTxSack( ) takes care of this administration.
+                     */
+                    if( pucPtr[ 0U ] == tcpTCP_OPT_SACK_A )
+                    {
+                        ucLen -= 2U;
+                        uxIndex += 2U;
+
+                        while( ucLen >= ( uint8_t ) 8U )
+                        {
+                            prvReadSackOption( pucPtr, uxIndex, pxSocket );
+                            uxIndex += 8U;
+                            ucLen -= 8U;
+                        }
+
+                        /* ucLen should be 0 by now. */
+                    }
+                }
+            #endif /* ipconfigUSE_TCP_WIN == 1 */
+
+            uxIndex += ( size_t ) ucLen;
+        }
+        return uxIndex;
+    }
 /*-----------------------------------------------------------*/
 
-#if( ipconfigUSE_TCP_WIN == 1 )
-	static void prvReadSackOption( const uint8_t * const pucPtr,
-								   size_t uxIndex,
-								   FreeRTOS_Socket_t * const pxSocket )
-	{
-	uint32_t ulFirst = ulChar2u32( &( pucPtr[ uxIndex ] ) );
-	uint32_t ulLast  = ulChar2u32( &( pucPtr[ uxIndex + 4U ] ) );
-	uint32_t ulCount = ulTCPWindowTxSack( &( pxSocket->u.xTCP.xTCPWindow ), ulFirst, ulLast );;
+    #if ( ipconfigUSE_TCP_WIN == 1 )
+        static void prvReadSackOption( const uint8_t * const pucPtr,
+                                       size_t uxIndex,
+                                       FreeRTOS_Socket_t * const pxSocket )
+        {
+            uint32_t ulFirst = ulChar2u32( &( pucPtr[ uxIndex ] ) );
+            uint32_t ulLast = ulChar2u32( &( pucPtr[ uxIndex + 4U ] ) );
+            uint32_t ulCount = ulTCPWindowTxSack( &( pxSocket->u.xTCP.xTCPWindow ), ulFirst, ulLast );
 
-		/* ulTCPWindowTxSack( ) returns the number of bytes which have been acked
-		 * starting from the head position.  Advance the tail pointer in txStream.
-		 */
-		if( ( pxSocket->u.xTCP.txStream  != NULL ) && ( ulCount > 0U ) )
-		{
-			/* Just advancing the tail index, 'ulCount' bytes have been confirmed. */
-			( void ) uxStreamBufferGet( pxSocket->u.xTCP.txStream, 0, NULL, ( size_t ) ulCount, pdFALSE );
-			pxSocket->xEventBits |= ( EventBits_t ) eSOCKET_SEND;
+            /* ulTCPWindowTxSack( ) returns the number of bytes which have been acked
+             * starting from the head position.  Advance the tail pointer in txStream.
+             */
+            if( ( pxSocket->u.xTCP.txStream != NULL ) && ( ulCount > 0U ) )
+            {
+                /* Just advancing the tail index, 'ulCount' bytes have been confirmed. */
+                ( void ) uxStreamBufferGet( pxSocket->u.xTCP.txStream, 0, NULL, ( size_t ) ulCount, pdFALSE );
+                pxSocket->xEventBits |= ( EventBits_t ) eSOCKET_SEND;
 
-			#if ipconfigSUPPORT_SELECT_FUNCTION == 1
-			{
-				if( ( pxSocket->xSelectBits & ( EventBits_t ) eSELECT_WRITE ) != 0U )
-				{
-					/* The field 'xEventBits' is used to store regular socket events
-					 * (at most 8), as well as 'select events', which will be left-shifted.
-					 */
-					pxSocket->xEventBits |= ( ( EventBits_t ) eSELECT_WRITE ) << SOCKET_EVENT_BIT_COUNT;
-				}
-			}
-			#endif
+                #if ipconfigSUPPORT_SELECT_FUNCTION == 1
+                    {
+                        if( ( pxSocket->xSelectBits & ( EventBits_t ) eSELECT_WRITE ) != 0U )
+                        {
+                            /* The field 'xEventBits' is used to store regular socket events
+                             * (at most 8), as well as 'select events', which will be left-shifted.
+                             */
+                            pxSocket->xEventBits |= ( ( EventBits_t ) eSELECT_WRITE ) << SOCKET_EVENT_BIT_COUNT;
+                        }
+                    }
+                #endif
 
-			/* In case the socket owner has installed an OnSent handler,
-			call it now. */
-			#if( ipconfigUSE_CALLBACKS == 1 )
-			{
-				if( ipconfigIS_VALID_PROG_ADDRESS( pxSocket->u.xTCP.pxHandleSent ) )
-				{
-					pxSocket->u.xTCP.pxHandleSent( pxSocket, ulCount );
-				}
-			}
-			#endif /* ipconfigUSE_CALLBACKS == 1  */
-		}
-	}
+                /* In case the socket owner has installed an OnSent handler,
+                 * call it now. */
+                #if ( ipconfigUSE_CALLBACKS == 1 )
+                    {
+                        if( ipconfigIS_VALID_PROG_ADDRESS( pxSocket->u.xTCP.pxHandleSent ) )
+                        {
+                            pxSocket->u.xTCP.pxHandleSent( pxSocket, ulCount );
+                        }
+                    }
+                #endif /* ipconfigUSE_CALLBACKS == 1  */
+            }
+        }
 
-#endif	/* ( ipconfigUSE_TCP_WIN != 0 ) */
+    #endif /* ( ipconfigUSE_TCP_WIN != 0 ) */
 /*-----------------------------------------------------------*/
 
-#if( ipconfigUSE_TCP_WIN != 0 )
+    #if ( ipconfigUSE_TCP_WIN != 0 )
 
-	static uint8_t prvWinScaleFactor( const FreeRTOS_Socket_t *pxSocket )
-	{
-	size_t uxWinSize;
-	uint8_t ucFactor;
+        static uint8_t prvWinScaleFactor( const FreeRTOS_Socket_t * pxSocket )
+        {
+            size_t uxWinSize;
+            uint8_t ucFactor;
 
-		/* 'xTCP.uxRxWinSize' is the size of the reception window in units of MSS. */
-		uxWinSize = pxSocket->u.xTCP.uxRxWinSize * ( size_t ) pxSocket->u.xTCP.usInitMSS;
-		ucFactor = 0U;
-		while( uxWinSize > 0xffffUL )
-		{
-			/* Divide by two and increase the binary factor by 1. */
-			uxWinSize >>= 1;
-			ucFactor++;
-		}
+            /* 'xTCP.uxRxWinSize' is the size of the reception window in units of MSS. */
+            uxWinSize = pxSocket->u.xTCP.uxRxWinSize * ( size_t ) pxSocket->u.xTCP.usInitMSS;
+            ucFactor = 0U;
 
-		FreeRTOS_debug_printf( ( "prvWinScaleFactor: uxRxWinSize %u MSS %u Factor %u\n",
-			( unsigned ) pxSocket->u.xTCP.uxRxWinSize,
-			( unsigned ) pxSocket->u.xTCP.usInitMSS,
-			ucFactor ) );
+            while( uxWinSize > 0xffffUL )
+            {
+                /* Divide by two and increase the binary factor by 1. */
+                uxWinSize >>= 1;
+                ucFactor++;
+            }
 
-		return ucFactor;
-	}
+            FreeRTOS_debug_printf( ( "prvWinScaleFactor: uxRxWinSize %u MSS %u Factor %u\n",
+                                     ( unsigned ) pxSocket->u.xTCP.uxRxWinSize,
+                                     ( unsigned ) pxSocket->u.xTCP.usInitMSS,
+                                     ucFactor ) );
 
-#endif
+            return ucFactor;
+        }
+
+    #endif /* if ( ipconfigUSE_TCP_WIN != 0 ) */
 /*-----------------------------------------------------------*/
 
 /*
  * When opening a TCP connection, while SYN's are being sent, the  parties may
  * communicate what MSS (Maximum Segment Size) they intend to use.   MSS is the
  * nett size of the payload, always smaller than MTU.
-*/
-static UBaseType_t prvSetSynAckOptions( FreeRTOS_Socket_t *pxSocket, TCPHeader_t * pxTCPHeader )
-{
-uint16_t usMSS = pxSocket->u.xTCP.usInitMSS;
-UBaseType_t uxOptionsLength;
+ */
+    static UBaseType_t prvSetSynAckOptions( FreeRTOS_Socket_t * pxSocket,
+                                            TCPHeader_t * pxTCPHeader )
+    {
+        uint16_t usMSS = pxSocket->u.xTCP.usInitMSS;
+        UBaseType_t uxOptionsLength;
 
-	/* We send out the TCP Maximum Segment Size option with our SYN[+ACK]. */
+        /* We send out the TCP Maximum Segment Size option with our SYN[+ACK]. */
 
-	pxTCPHeader->ucOptdata[ 0 ] = ( uint8_t ) tcpTCP_OPT_MSS;
-	pxTCPHeader->ucOptdata[ 1 ] = ( uint8_t ) tcpTCP_OPT_MSS_LEN;
-	pxTCPHeader->ucOptdata[ 2 ] = ( uint8_t ) ( usMSS >> 8 );
-	pxTCPHeader->ucOptdata[ 3 ] = ( uint8_t ) ( usMSS & 0xffU );
+        pxTCPHeader->ucOptdata[ 0 ] = ( uint8_t ) tcpTCP_OPT_MSS;
+        pxTCPHeader->ucOptdata[ 1 ] = ( uint8_t ) tcpTCP_OPT_MSS_LEN;
+        pxTCPHeader->ucOptdata[ 2 ] = ( uint8_t ) ( usMSS >> 8 );
+        pxTCPHeader->ucOptdata[ 3 ] = ( uint8_t ) ( usMSS & 0xffU );
 
-	#if( ipconfigUSE_TCP_WIN != 0 )
-	{
-		pxSocket->u.xTCP.ucMyWinScaleFactor = prvWinScaleFactor( pxSocket );
+        #if ( ipconfigUSE_TCP_WIN != 0 )
+            {
+                pxSocket->u.xTCP.ucMyWinScaleFactor = prvWinScaleFactor( pxSocket );
 
-		pxTCPHeader->ucOptdata[ 4 ] = tcpTCP_OPT_NOOP;
-		pxTCPHeader->ucOptdata[ 5 ] = ( uint8_t ) ( tcpTCP_OPT_WSOPT );
-		pxTCPHeader->ucOptdata[ 6 ] = ( uint8_t ) ( tcpTCP_OPT_WSOPT_LEN );
-		pxTCPHeader->ucOptdata[ 7 ] = ( uint8_t ) pxSocket->u.xTCP.ucMyWinScaleFactor;
-		uxOptionsLength = 8U;
-	}
-	#else
-	{
-		uxOptionsLength = 4U;
-	}
-	#endif
+                pxTCPHeader->ucOptdata[ 4 ] = tcpTCP_OPT_NOOP;
+                pxTCPHeader->ucOptdata[ 5 ] = ( uint8_t ) ( tcpTCP_OPT_WSOPT );
+                pxTCPHeader->ucOptdata[ 6 ] = ( uint8_t ) ( tcpTCP_OPT_WSOPT_LEN );
+                pxTCPHeader->ucOptdata[ 7 ] = ( uint8_t ) pxSocket->u.xTCP.ucMyWinScaleFactor;
+                uxOptionsLength = 8U;
+            }
+        #else
+            {
+                uxOptionsLength = 4U;
+            }
+        #endif /* if ( ipconfigUSE_TCP_WIN != 0 ) */
 
-	#if( ipconfigUSE_TCP_WIN != 0 )
-	{
-		pxTCPHeader->ucOptdata[ uxOptionsLength      ] = tcpTCP_OPT_NOOP;
-		pxTCPHeader->ucOptdata[ uxOptionsLength + 1U ] = tcpTCP_OPT_NOOP;
-		pxTCPHeader->ucOptdata[ uxOptionsLength + 2U ] = tcpTCP_OPT_SACK_P;	/* 4: Sack-Permitted Option. */
-		pxTCPHeader->ucOptdata[ uxOptionsLength + 3U ] = 2U;	/* 2: length of this option. */
-		uxOptionsLength += 4U;
-
-	}
-	#endif	/* ipconfigUSE_TCP_WIN == 0 */
-	return uxOptionsLength; /* bytes, not words. */
-}
+        #if ( ipconfigUSE_TCP_WIN != 0 )
+            {
+                pxTCPHeader->ucOptdata[ uxOptionsLength ] = tcpTCP_OPT_NOOP;
+                pxTCPHeader->ucOptdata[ uxOptionsLength + 1U ] = tcpTCP_OPT_NOOP;
+                pxTCPHeader->ucOptdata[ uxOptionsLength + 2U ] = tcpTCP_OPT_SACK_P; /* 4: Sack-Permitted Option. */
+                pxTCPHeader->ucOptdata[ uxOptionsLength + 3U ] = 2U;                /* 2: length of this option. */
+                uxOptionsLength += 4U;
+            }
+        #endif /* ipconfigUSE_TCP_WIN == 0 */
+        return uxOptionsLength; /* bytes, not words. */
+    }
 
 /*
  * For anti-hanging protection and TCP keep-alive messages.  Called in two
  * places: after receiving a packet and after a state change.  The socket's
  * alive timer may be reset.
  */
-static void prvTCPTouchSocket( FreeRTOS_Socket_t *pxSocket )
-{
-	#if( ipconfigTCP_HANG_PROTECTION == 1 )
-	{
-		pxSocket->u.xTCP.xLastActTime = xTaskGetTickCount( );
-	}
-	#endif
+    static void prvTCPTouchSocket( FreeRTOS_Socket_t * pxSocket )
+    {
+        #if ( ipconfigTCP_HANG_PROTECTION == 1 )
+            {
+                pxSocket->u.xTCP.xLastActTime = xTaskGetTickCount();
+            }
+        #endif
 
-	#if( ipconfigTCP_KEEP_ALIVE == 1 )
-	{
-		pxSocket->u.xTCP.bits.bWaitKeepAlive = pdFALSE_UNSIGNED;
-		pxSocket->u.xTCP.bits.bSendKeepAlive = pdFALSE_UNSIGNED;
-		pxSocket->u.xTCP.ucKeepRepCount = 0U;
-		pxSocket->u.xTCP.xLastAliveTime = xTaskGetTickCount();
-	}
-	#endif
+        #if ( ipconfigTCP_KEEP_ALIVE == 1 )
+            {
+                pxSocket->u.xTCP.bits.bWaitKeepAlive = pdFALSE_UNSIGNED;
+                pxSocket->u.xTCP.bits.bSendKeepAlive = pdFALSE_UNSIGNED;
+                pxSocket->u.xTCP.ucKeepRepCount = 0U;
+                pxSocket->u.xTCP.xLastAliveTime = xTaskGetTickCount();
+            }
+        #endif
 
-	( void ) pxSocket;
-}
+        ( void ) pxSocket;
+    }
 /*-----------------------------------------------------------*/
 
 /*
@@ -1482,548 +1550,568 @@ static void prvTCPTouchSocket( FreeRTOS_Socket_t *pxSocket )
  * that a socket has got (dis)connected, and setting bit to unblock a call to
  * FreeRTOS_select()
  */
-void vTCPStateChange( FreeRTOS_Socket_t *pxSocket, enum eTCP_STATE eTCPState )
-{
-FreeRTOS_Socket_t *xParent = NULL;
-BaseType_t bBefore = ipNUMERIC_CAST( BaseType_t, tcpNOW_CONNECTED( ( BaseType_t ) pxSocket->u.xTCP.ucTCPState ) );	/* Was it connected ? */
-BaseType_t bAfter  = ipNUMERIC_CAST( BaseType_t, tcpNOW_CONNECTED( ( BaseType_t ) eTCPState ) );					/* Is it connected now ? */
-#if( ipconfigHAS_DEBUG_PRINTF != 0 )
-	BaseType_t xPreviousState = ( BaseType_t ) pxSocket->u.xTCP.ucTCPState;
-#endif
-#if( ipconfigUSE_CALLBACKS == 1 )
-	FreeRTOS_Socket_t *xConnected = NULL;
-#endif
+    void vTCPStateChange( FreeRTOS_Socket_t * pxSocket,
+                          enum eTCP_STATE eTCPState )
+    {
+        FreeRTOS_Socket_t * xParent = NULL;
+        BaseType_t bBefore = ipNUMERIC_CAST( BaseType_t, tcpNOW_CONNECTED( ( BaseType_t ) pxSocket->u.xTCP.ucTCPState ) ); /* Was it connected ? */
+        BaseType_t bAfter = ipNUMERIC_CAST( BaseType_t, tcpNOW_CONNECTED( ( BaseType_t ) eTCPState ) );                    /* Is it connected now ? */
 
-	/* Has the connected status changed? */
-	if( bBefore != bAfter )
-	{
-		/* Is the socket connected now ? */
-		if( bAfter != pdFALSE )
-		{
-			/* if bPassQueued is true, this socket is an orphan until it gets connected. */
-			if( pxSocket->u.xTCP.bits.bPassQueued != pdFALSE_UNSIGNED )
-			{
-				/* Now that it is connected, find it's parent. */
-				if( pxSocket->u.xTCP.bits.bReuseSocket != pdFALSE_UNSIGNED )
-				{
-					xParent = pxSocket;
-				}
-				else
-				{
-					xParent = pxSocket->u.xTCP.pxPeerSocket;
-					configASSERT( xParent != NULL );
-				}
-				if( xParent != NULL )
-				{
-					if( xParent->u.xTCP.pxPeerSocket == NULL )
-					{
-						xParent->u.xTCP.pxPeerSocket = pxSocket;
-					}
+        #if ( ipconfigHAS_DEBUG_PRINTF != 0 )
+            BaseType_t xPreviousState = ( BaseType_t ) pxSocket->u.xTCP.ucTCPState;
+        #endif
+        #if ( ipconfigUSE_CALLBACKS == 1 )
+            FreeRTOS_Socket_t * xConnected = NULL;
+        #endif
 
-					xParent->xEventBits |= ( EventBits_t ) eSOCKET_ACCEPT;
+        /* Has the connected status changed? */
+        if( bBefore != bAfter )
+        {
+            /* Is the socket connected now ? */
+            if( bAfter != pdFALSE )
+            {
+                /* if bPassQueued is true, this socket is an orphan until it gets connected. */
+                if( pxSocket->u.xTCP.bits.bPassQueued != pdFALSE_UNSIGNED )
+                {
+                    /* Now that it is connected, find it's parent. */
+                    if( pxSocket->u.xTCP.bits.bReuseSocket != pdFALSE_UNSIGNED )
+                    {
+                        xParent = pxSocket;
+                    }
+                    else
+                    {
+                        xParent = pxSocket->u.xTCP.pxPeerSocket;
+                        configASSERT( xParent != NULL );
+                    }
 
-					#if( ipconfigSUPPORT_SELECT_FUNCTION == 1 )
-					{
-						/* Library support FreeRTOS_select().  Receiving a new
-						connection is being translated as a READ event. */
-						if( ( xParent->xSelectBits & ( ( EventBits_t ) eSELECT_READ ) ) != 0U )
-						{
-							xParent->xEventBits |= ( ( EventBits_t ) eSELECT_READ ) << SOCKET_EVENT_BIT_COUNT;
-						}
-					}
-					#endif
+                    if( xParent != NULL )
+                    {
+                        if( xParent->u.xTCP.pxPeerSocket == NULL )
+                        {
+                            xParent->u.xTCP.pxPeerSocket = pxSocket;
+                        }
 
-					#if( ipconfigUSE_CALLBACKS == 1 )
-					{
-						if( ( ipconfigIS_VALID_PROG_ADDRESS( xParent->u.xTCP.pxHandleConnected ) ) &&
-							( xParent->u.xTCP.bits.bReuseSocket == pdFALSE_UNSIGNED ) )
-						{
-							/* The listening socket does not become connected itself, in stead
-							a child socket is created.
-							Postpone a call the OnConnect event until the end of this function. */
-							xConnected = xParent;
-						}
-					}
-					#endif
-				}
+                        xParent->xEventBits |= ( EventBits_t ) eSOCKET_ACCEPT;
 
-				/* Don't need to access the parent socket anymore, so the
-				reference 'pxPeerSocket' may be cleared. */
-				pxSocket->u.xTCP.pxPeerSocket = NULL;
-				pxSocket->u.xTCP.bits.bPassQueued = pdFALSE_UNSIGNED;
+                        #if ( ipconfigSUPPORT_SELECT_FUNCTION == 1 )
+                            {
+                                /* Library support FreeRTOS_select().  Receiving a new
+                                 * connection is being translated as a READ event. */
+                                if( ( xParent->xSelectBits & ( ( EventBits_t ) eSELECT_READ ) ) != 0U )
+                                {
+                                    xParent->xEventBits |= ( ( EventBits_t ) eSELECT_READ ) << SOCKET_EVENT_BIT_COUNT;
+                                }
+                            }
+                        #endif
 
-				/* When true, this socket may be returned in a call to accept(). */
-				pxSocket->u.xTCP.bits.bPassAccept = pdTRUE_UNSIGNED;
-			}
-			else
-			{
-				pxSocket->xEventBits |= ( EventBits_t ) eSOCKET_CONNECT;
+                        #if ( ipconfigUSE_CALLBACKS == 1 )
+                            {
+                                if( ( ipconfigIS_VALID_PROG_ADDRESS( xParent->u.xTCP.pxHandleConnected ) ) &&
+                                    ( xParent->u.xTCP.bits.bReuseSocket == pdFALSE_UNSIGNED ) )
+                                {
+                                    /* The listening socket does not become connected itself, in stead
+                                     * a child socket is created.
+                                     * Postpone a call the OnConnect event until the end of this function. */
+                                    xConnected = xParent;
+                                }
+                            }
+                        #endif
+                    }
 
-				#if( ipconfigSUPPORT_SELECT_FUNCTION == 1 )
-				{
-					if( ( pxSocket->xSelectBits & ( ( EventBits_t ) eSELECT_WRITE ) ) != 0U )
-					{
-						pxSocket->xEventBits |= ( ( EventBits_t ) eSELECT_WRITE ) << SOCKET_EVENT_BIT_COUNT;
-					}
-				}
-				#endif
-			}
-		}
-		else  /* bAfter == pdFALSE, connection is closed. */
-		{
-			/* Notify/wake-up the socket-owner by setting a semaphore. */
-			pxSocket->xEventBits |= ( EventBits_t ) eSOCKET_CLOSED;
+                    /* Don't need to access the parent socket anymore, so the
+                     * reference 'pxPeerSocket' may be cleared. */
+                    pxSocket->u.xTCP.pxPeerSocket = NULL;
+                    pxSocket->u.xTCP.bits.bPassQueued = pdFALSE_UNSIGNED;
 
-			#if( ipconfigSUPPORT_SELECT_FUNCTION == 1 )
-			{
-				if( ( pxSocket->xSelectBits & ( EventBits_t ) eSELECT_EXCEPT ) != 0U )
-				{
-					pxSocket->xEventBits |= ( ( EventBits_t ) eSELECT_EXCEPT ) << SOCKET_EVENT_BIT_COUNT;
-				}
-			}
-			#endif
-		}
-		#if( ipconfigUSE_CALLBACKS == 1 )
-		{
-			if( ( ipconfigIS_VALID_PROG_ADDRESS( pxSocket->u.xTCP.pxHandleConnected ) ) && ( xConnected == NULL ) )
-			{
-				/* The 'connected' state has changed, call the user handler. */
-				xConnected = pxSocket;
-			}
-		}
-		#endif /* ipconfigUSE_CALLBACKS */
+                    /* When true, this socket may be returned in a call to accept(). */
+                    pxSocket->u.xTCP.bits.bPassAccept = pdTRUE_UNSIGNED;
+                }
+                else
+                {
+                    pxSocket->xEventBits |= ( EventBits_t ) eSOCKET_CONNECT;
 
-		if( prvTCPSocketIsActive( ipNUMERIC_CAST( eIPTCPState_t, pxSocket->u.xTCP.ucTCPState ) ) == 0 )
-		{
-			/* Now the socket isn't in an active state anymore so it
-			won't need further attention of the IP-task.
-			Setting time-out to zero means that the socket won't get checked during
-			timer events. */
-			pxSocket->u.xTCP.usTimeout = 0U;
-		}
-	}
-	else
-	{
-		if( ( ( BaseType_t ) eTCPState ) ==  ( ( BaseType_t ) eCLOSED ) )
-		{
-			/* Socket goes to status eCLOSED because of a RST.
-			When nobody owns the socket yet, delete it. */
-			if( ( pxSocket->u.xTCP.bits.bPassQueued != pdFALSE_UNSIGNED ) ||
-				( pxSocket->u.xTCP.bits.bPassAccept != pdFALSE_UNSIGNED ) )
-			{
-				FreeRTOS_debug_printf( ( "vTCPStateChange: Closing socket\n" ) );
-				if( pxSocket->u.xTCP.bits.bReuseSocket == pdFALSE_UNSIGNED )
-				{
-					( void ) FreeRTOS_closesocket( pxSocket );
-				}
-			}
-		}
-	}
+                    #if ( ipconfigSUPPORT_SELECT_FUNCTION == 1 )
+                        {
+                            if( ( pxSocket->xSelectBits & ( ( EventBits_t ) eSELECT_WRITE ) ) != 0U )
+                            {
+                                pxSocket->xEventBits |= ( ( EventBits_t ) eSELECT_WRITE ) << SOCKET_EVENT_BIT_COUNT;
+                            }
+                        }
+                    #endif
+                }
+            }
+            else /* bAfter == pdFALSE, connection is closed. */
+            {
+                /* Notify/wake-up the socket-owner by setting a semaphore. */
+                pxSocket->xEventBits |= ( EventBits_t ) eSOCKET_CLOSED;
 
-	/* Fill in the new state. */
-	pxSocket->u.xTCP.ucTCPState = ( uint8_t ) eTCPState;
+                #if ( ipconfigSUPPORT_SELECT_FUNCTION == 1 )
+                    {
+                        if( ( pxSocket->xSelectBits & ( EventBits_t ) eSELECT_EXCEPT ) != 0U )
+                        {
+                            pxSocket->xEventBits |= ( ( EventBits_t ) eSELECT_EXCEPT ) << SOCKET_EVENT_BIT_COUNT;
+                        }
+                    }
+                #endif
+            }
 
-	/* Touch the alive timers because moving to another state. */
-	prvTCPTouchSocket( pxSocket );
+            #if ( ipconfigUSE_CALLBACKS == 1 )
+                {
+                    if( ( ipconfigIS_VALID_PROG_ADDRESS( pxSocket->u.xTCP.pxHandleConnected ) ) && ( xConnected == NULL ) )
+                    {
+                        /* The 'connected' state has changed, call the user handler. */
+                        xConnected = pxSocket;
+                    }
+                }
+            #endif /* ipconfigUSE_CALLBACKS */
 
-	#if( ipconfigHAS_DEBUG_PRINTF == 1 )
-	{
-		if( ( xTCPWindowLoggingLevel >= 0 ) && ( ipconfigTCP_MAY_LOG_PORT( pxSocket->usLocalPort ) ) )
-		{
-			FreeRTOS_debug_printf( ( "Socket %d -> %lxip:%u State %s->%s\n",
-				pxSocket->usLocalPort,
-				pxSocket->u.xTCP.ulRemoteIP,
-				pxSocket->u.xTCP.usRemotePort,
-				FreeRTOS_GetTCPStateName( ( UBaseType_t ) xPreviousState ),
-				FreeRTOS_GetTCPStateName( ( UBaseType_t ) eTCPState ) ) );
-		}
-	}
-	#endif /* ipconfigHAS_DEBUG_PRINTF */
+            if( prvTCPSocketIsActive( ipNUMERIC_CAST( eIPTCPState_t, pxSocket->u.xTCP.ucTCPState ) ) == 0 )
+            {
+                /* Now the socket isn't in an active state anymore so it
+                 * won't need further attention of the IP-task.
+                 * Setting time-out to zero means that the socket won't get checked during
+                 * timer events. */
+                pxSocket->u.xTCP.usTimeout = 0U;
+            }
+        }
+        else
+        {
+            if( ( ( BaseType_t ) eTCPState ) == ( ( BaseType_t ) eCLOSED ) )
+            {
+                /* Socket goes to status eCLOSED because of a RST.
+                 * When nobody owns the socket yet, delete it. */
+                if( ( pxSocket->u.xTCP.bits.bPassQueued != pdFALSE_UNSIGNED ) ||
+                    ( pxSocket->u.xTCP.bits.bPassAccept != pdFALSE_UNSIGNED ) )
+                {
+                    FreeRTOS_debug_printf( ( "vTCPStateChange: Closing socket\n" ) );
 
-	#if( ipconfigUSE_CALLBACKS == 1 )
-	{
-		if( xConnected != NULL )
-		{
-			/* The 'connected' state has changed, call the OnConnect handler of the parent. */
-			xConnected->u.xTCP.pxHandleConnected( ( Socket_t ) xConnected, bAfter );
-		}
-	}
-	#endif
-	if( xParent != NULL )
-	{
-		vSocketWakeUpUser( xParent );
-	}
-}
+                    if( pxSocket->u.xTCP.bits.bReuseSocket == pdFALSE_UNSIGNED )
+                    {
+                        ( void ) FreeRTOS_closesocket( pxSocket );
+                    }
+                }
+            }
+        }
+
+        /* Fill in the new state. */
+        pxSocket->u.xTCP.ucTCPState = ( uint8_t ) eTCPState;
+
+        /* Touch the alive timers because moving to another state. */
+        prvTCPTouchSocket( pxSocket );
+
+        #if ( ipconfigHAS_DEBUG_PRINTF == 1 )
+            {
+                if( ( xTCPWindowLoggingLevel >= 0 ) && ( ipconfigTCP_MAY_LOG_PORT( pxSocket->usLocalPort ) ) )
+                {
+                    FreeRTOS_debug_printf( ( "Socket %d -> %lxip:%u State %s->%s\n",
+                                             pxSocket->usLocalPort,
+                                             pxSocket->u.xTCP.ulRemoteIP,
+                                             pxSocket->u.xTCP.usRemotePort,
+                                             FreeRTOS_GetTCPStateName( ( UBaseType_t ) xPreviousState ),
+                                             FreeRTOS_GetTCPStateName( ( UBaseType_t ) eTCPState ) ) );
+                }
+            }
+        #endif /* ipconfigHAS_DEBUG_PRINTF */
+
+        #if ( ipconfigUSE_CALLBACKS == 1 )
+            {
+                if( xConnected != NULL )
+                {
+                    /* The 'connected' state has changed, call the OnConnect handler of the parent. */
+                    xConnected->u.xTCP.pxHandleConnected( ( Socket_t ) xConnected, bAfter );
+                }
+            }
+        #endif
+
+        if( xParent != NULL )
+        {
+            vSocketWakeUpUser( xParent );
+        }
+    }
 /*-----------------------------------------------------------*/
 
-static NetworkBufferDescriptor_t *prvTCPBufferResize( const FreeRTOS_Socket_t *pxSocket, NetworkBufferDescriptor_t *pxNetworkBuffer,
-	int32_t lDataLen, UBaseType_t uxOptionsLength )
-{
-NetworkBufferDescriptor_t *pxReturn;
-int32_t lNeeded;
-BaseType_t xResize;
+    static NetworkBufferDescriptor_t * prvTCPBufferResize( const FreeRTOS_Socket_t * pxSocket,
+                                                           NetworkBufferDescriptor_t * pxNetworkBuffer,
+                                                           int32_t lDataLen,
+                                                           UBaseType_t uxOptionsLength )
+    {
+        NetworkBufferDescriptor_t * pxReturn;
+        int32_t lNeeded;
+        BaseType_t xResize;
 
-	if( xBufferAllocFixedSize != pdFALSE )
-	{
-		/* Network buffers are created with a fixed size and can hold the largest
-		MTU. */
-		lNeeded = ( int32_t ) ipTOTAL_ETHERNET_FRAME_SIZE;
-		/* and therefore, the buffer won't be too small.
-		Only ask for a new network buffer in case none was supplied. */
-		if( pxNetworkBuffer == NULL )
-		{
-			xResize = pdTRUE;
-		}
-		else
-		{
-			xResize = pdFALSE;
-		}
-	}
-	else
-	{
-		/* Network buffers are created with a variable size. See if it must
-		grow. */
-		lNeeded = FreeRTOS_max_int32( ( int32_t ) sizeof( pxSocket->u.xTCP.xPacket.u.ucLastPacket ),
-			ipNUMERIC_CAST( int32_t, ipSIZE_OF_ETH_HEADER + uxIPHeaderSizeSocket( pxSocket ) + ipSIZE_OF_TCP_HEADER + uxOptionsLength ) + lDataLen );
-		/* In case we were called from a TCP timer event, a buffer must be
-		created.  Otherwise, test 'xDataLength' of the provided buffer. */
-		if( ( pxNetworkBuffer == NULL ) || ( pxNetworkBuffer->xDataLength < (size_t)lNeeded ) )
-		{
-			xResize = pdTRUE;
-		}
-		else
-		{
-			xResize = pdFALSE;
-		}
-	}
+        if( xBufferAllocFixedSize != pdFALSE )
+        {
+            /* Network buffers are created with a fixed size and can hold the largest
+             * MTU. */
+            lNeeded = ( int32_t ) ipTOTAL_ETHERNET_FRAME_SIZE;
 
-	if( xResize != pdFALSE )
-	{
-		/* The caller didn't provide a network buffer or the provided buffer is
-		too small.  As we must send-out a data packet, a buffer will be created
-		here. */
-		pxReturn = pxGetNetworkBufferWithDescriptor( ( uint32_t ) lNeeded, 0U );
+            /* and therefore, the buffer won't be too small.
+             * Only ask for a new network buffer in case none was supplied. */
+            if( pxNetworkBuffer == NULL )
+            {
+                xResize = pdTRUE;
+            }
+            else
+            {
+                xResize = pdFALSE;
+            }
+        }
+        else
+        {
+            /* Network buffers are created with a variable size. See if it must
+             * grow. */
+            lNeeded = FreeRTOS_max_int32( ( int32_t ) sizeof( pxSocket->u.xTCP.xPacket.u.ucLastPacket ),
+                                          ipNUMERIC_CAST( int32_t, ipSIZE_OF_ETH_HEADER + uxIPHeaderSizeSocket( pxSocket ) + ipSIZE_OF_TCP_HEADER + uxOptionsLength ) + lDataLen );
 
-		if( pxReturn != NULL )
-		{
-			/* Set the actual packet size, in case the returned buffer is larger. */
-			pxReturn->xDataLength = ( size_t ) lNeeded;
+            /* In case we were called from a TCP timer event, a buffer must be
+             *  created.  Otherwise, test 'xDataLength' of the provided buffer. */
+            if( ( pxNetworkBuffer == NULL ) || ( pxNetworkBuffer->xDataLength < ( size_t ) lNeeded ) )
+            {
+                xResize = pdTRUE;
+            }
+            else
+            {
+                xResize = pdFALSE;
+            }
+        }
 
-			/* Copy the existing data to the new created buffer. */
-			if( pxNetworkBuffer != NULL )
-			{
-				/* Either from the previous buffer... */
-				( void ) memcpy( pxReturn->pucEthernetBuffer, pxNetworkBuffer->pucEthernetBuffer, pxNetworkBuffer->xDataLength );
+        if( xResize != pdFALSE )
+        {
+            /* The caller didn't provide a network buffer or the provided buffer is
+             * too small.  As we must send-out a data packet, a buffer will be created
+             * here. */
+            pxReturn = pxGetNetworkBufferWithDescriptor( ( uint32_t ) lNeeded, 0U );
 
-				/* ...and release it. */
-				vReleaseNetworkBufferAndDescriptor( pxNetworkBuffer );
-			}
-			else
-			{
-				/* Or from the socket field 'xTCP.xPacket'. */
-				( void ) memcpy( pxReturn->pucEthernetBuffer, pxSocket->u.xTCP.xPacket.u.ucLastPacket, sizeof( pxSocket->u.xTCP.xPacket.u.ucLastPacket ) );
-			}
-		}
-	}
-	else
-	{
-		/* xResize is false, the network buffer provided was big enough. */
-		configASSERT( pxNetworkBuffer != NULL );	/* to tell lint: when xResize is false, pxNetworkBuffer is not NULL. */
-		pxReturn = pxNetworkBuffer;
+            if( pxReturn != NULL )
+            {
+                /* Set the actual packet size, in case the returned buffer is larger. */
+                pxReturn->xDataLength = ( size_t ) lNeeded;
 
-		/* Thanks to Andrey Ivanov from swissEmbedded for reporting that the
-		xDataLength member must get the correct length too! */
-		pxNetworkBuffer->xDataLength = ( size_t ) ( ipSIZE_OF_ETH_HEADER + uxIPHeaderSizeSocket( pxSocket ) + ipSIZE_OF_TCP_HEADER + uxOptionsLength ) + ( size_t ) lDataLen;
-	}
+                /* Copy the existing data to the new created buffer. */
+                if( pxNetworkBuffer != NULL )
+                {
+                    /* Either from the previous buffer... */
+                    ( void ) memcpy( pxReturn->pucEthernetBuffer, pxNetworkBuffer->pucEthernetBuffer, pxNetworkBuffer->xDataLength );
 
-	return pxReturn;
-}
+                    /* ...and release it. */
+                    vReleaseNetworkBufferAndDescriptor( pxNetworkBuffer );
+                }
+                else
+                {
+                    /* Or from the socket field 'xTCP.xPacket'. */
+                    ( void ) memcpy( pxReturn->pucEthernetBuffer, pxSocket->u.xTCP.xPacket.u.ucLastPacket, sizeof( pxSocket->u.xTCP.xPacket.u.ucLastPacket ) );
+                }
+            }
+        }
+        else
+        {
+            /* xResize is false, the network buffer provided was big enough. */
+            configASSERT( pxNetworkBuffer != NULL ); /* to tell lint: when xResize is false, pxNetworkBuffer is not NULL. */
+            pxReturn = pxNetworkBuffer;
+
+            /* Thanks to Andrey Ivanov from swissEmbedded for reporting that the
+             * xDataLength member must get the correct length too! */
+            pxNetworkBuffer->xDataLength = ( size_t ) ( ipSIZE_OF_ETH_HEADER + uxIPHeaderSizeSocket( pxSocket ) + ipSIZE_OF_TCP_HEADER + uxOptionsLength ) + ( size_t ) lDataLen;
+        }
+
+        return pxReturn;
+    }
 /*-----------------------------------------------------------*/
 
 /*
  * Prepare an outgoing message, in case anything has to be sent.
  */
-static int32_t prvTCPPrepareSend( FreeRTOS_Socket_t *pxSocket, NetworkBufferDescriptor_t **ppxNetworkBuffer, UBaseType_t uxOptionsLength )
-{
-int32_t lDataLen;
-uint8_t *pucEthernetBuffer, *pucSendData;
-ProtocolHeaders_t *pxProtocolHeaders;
-size_t uxOffset;
-uint32_t ulDataGot, ulDistance;
-TCPWindow_t *pxTCPWindow;
-NetworkBufferDescriptor_t *pxNewBuffer;
-int32_t lStreamPos;
+    static int32_t prvTCPPrepareSend( FreeRTOS_Socket_t * pxSocket,
+                                      NetworkBufferDescriptor_t ** ppxNetworkBuffer,
+                                      UBaseType_t uxOptionsLength )
+    {
+        int32_t lDataLen;
+        uint8_t * pucEthernetBuffer, * pucSendData;
+        ProtocolHeaders_t * pxProtocolHeaders;
+        size_t uxOffset;
+        uint32_t ulDataGot, ulDistance;
+        TCPWindow_t * pxTCPWindow;
+        NetworkBufferDescriptor_t * pxNewBuffer;
+        int32_t lStreamPos;
 
-	if( ( *ppxNetworkBuffer ) != NULL )
-	{
-		/* A network buffer descriptor was already supplied */
-		pucEthernetBuffer = ( *ppxNetworkBuffer )->pucEthernetBuffer;
-	}
-	else
-	{
-		/* For now let it point to the last packet header */
-		pucEthernetBuffer = pxSocket->u.xTCP.xPacket.u.ucLastPacket;
-	}
+        if( ( *ppxNetworkBuffer ) != NULL )
+        {
+            /* A network buffer descriptor was already supplied */
+            pucEthernetBuffer = ( *ppxNetworkBuffer )->pucEthernetBuffer;
+        }
+        else
+        {
+            /* For now let it point to the last packet header */
+            pucEthernetBuffer = pxSocket->u.xTCP.xPacket.u.ucLastPacket;
+        }
 
-	pxProtocolHeaders = ipPOINTER_CAST( ProtocolHeaders_t *, &( pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER + uxIPHeaderSizeSocket( pxSocket ) ] ) );
-	pxTCPWindow = &( pxSocket->u.xTCP.xTCPWindow );
-	lDataLen = 0;
-	lStreamPos = 0;
-	pxProtocolHeaders->xTCPHeader.ucTCPFlags |= tcpTCP_FLAG_ACK;
+        pxProtocolHeaders = ipPOINTER_CAST( ProtocolHeaders_t *, &( pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER + uxIPHeaderSizeSocket( pxSocket ) ] ) );
+        pxTCPWindow = &( pxSocket->u.xTCP.xTCPWindow );
+        lDataLen = 0;
+        lStreamPos = 0;
+        pxProtocolHeaders->xTCPHeader.ucTCPFlags |= tcpTCP_FLAG_ACK;
 
-	if( pxSocket->u.xTCP.txStream != NULL )
-	{
-		/* ulTCPWindowTxGet will return the amount of data which may be sent
-		along with the position in the txStream.
-		Why check for MSS > 1 ?
-		Because some TCP-stacks (like uIP) use it for flow-control. */
-		if( pxSocket->u.xTCP.usCurMSS > 1U )
-		{
-			lDataLen = ( int32_t ) ulTCPWindowTxGet( pxTCPWindow, pxSocket->u.xTCP.ulWindowSize, &lStreamPos );
-		}
+        if( pxSocket->u.xTCP.txStream != NULL )
+        {
+            /* ulTCPWindowTxGet will return the amount of data which may be sent
+             * along with the position in the txStream.
+             * Why check for MSS > 1 ?
+             * Because some TCP-stacks (like uIP) use it for flow-control. */
+            if( pxSocket->u.xTCP.usCurMSS > 1U )
+            {
+                lDataLen = ( int32_t ) ulTCPWindowTxGet( pxTCPWindow, pxSocket->u.xTCP.ulWindowSize, &lStreamPos );
+            }
 
-		if( lDataLen > 0 )
-		{
-			/* Check if the current network buffer is big enough, if not,
-			resize it. */
-			pxNewBuffer = prvTCPBufferResize( pxSocket, *ppxNetworkBuffer, lDataLen, uxOptionsLength );
+            if( lDataLen > 0 )
+            {
+                /* Check if the current network buffer is big enough, if not,
+                 * resize it. */
+                pxNewBuffer = prvTCPBufferResize( pxSocket, *ppxNetworkBuffer, lDataLen, uxOptionsLength );
 
-			if( pxNewBuffer != NULL )
-			{
-				*ppxNetworkBuffer = pxNewBuffer;
-				pucEthernetBuffer = pxNewBuffer->pucEthernetBuffer;
-				pxProtocolHeaders = ipPOINTER_CAST( ProtocolHeaders_t *, &( pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER + uxIPHeaderSizeSocket( pxSocket ) ] ) );
+                if( pxNewBuffer != NULL )
+                {
+                    *ppxNetworkBuffer = pxNewBuffer;
+                    pucEthernetBuffer = pxNewBuffer->pucEthernetBuffer;
+                    pxProtocolHeaders = ipPOINTER_CAST( ProtocolHeaders_t *, &( pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER + uxIPHeaderSizeSocket( pxSocket ) ] ) );
 
-				pucSendData = &( pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER + uxIPHeaderSizeSocket( pxSocket ) + ipSIZE_OF_TCP_HEADER + uxOptionsLength ] );
+                    pucSendData = &( pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER + uxIPHeaderSizeSocket( pxSocket ) + ipSIZE_OF_TCP_HEADER + uxOptionsLength ] );
 
-				/* Translate the position in txStream to an offset from the tail
-				marker. */
-				uxOffset = uxStreamBufferDistance( pxSocket->u.xTCP.txStream, pxSocket->u.xTCP.txStream->uxTail, ( size_t ) lStreamPos );
+                    /* Translate the position in txStream to an offset from the tail
+                     * marker. */
+                    uxOffset = uxStreamBufferDistance( pxSocket->u.xTCP.txStream, pxSocket->u.xTCP.txStream->uxTail, ( size_t ) lStreamPos );
 
-				/* Here data is copied from the txStream in 'peek' mode.  Only
-				when the packets are acked, the tail marker will be updated. */
-				ulDataGot = ( uint32_t ) uxStreamBufferGet( pxSocket->u.xTCP.txStream, uxOffset, pucSendData, ( size_t ) lDataLen, pdTRUE );
+                    /* Here data is copied from the txStream in 'peek' mode.  Only
+                     * when the packets are acked, the tail marker will be updated. */
+                    ulDataGot = ( uint32_t ) uxStreamBufferGet( pxSocket->u.xTCP.txStream, uxOffset, pucSendData, ( size_t ) lDataLen, pdTRUE );
 
-				#if( ipconfigHAS_DEBUG_PRINTF != 0 )
-				{
-					if( ulDataGot != ( uint32_t ) lDataLen )
-					{
-						FreeRTOS_debug_printf( ( "uxStreamBufferGet: pos %d offs %u only %u != %d\n",
-							( int ) lStreamPos, ( unsigned ) uxOffset, ( unsigned ) ulDataGot, ( int ) lDataLen ) );
-					}
-				}
-				#endif
+                    #if ( ipconfigHAS_DEBUG_PRINTF != 0 )
+                        {
+                            if( ulDataGot != ( uint32_t ) lDataLen )
+                            {
+                                FreeRTOS_debug_printf( ( "uxStreamBufferGet: pos %d offs %u only %u != %d\n",
+                                                         ( int ) lStreamPos, ( unsigned ) uxOffset, ( unsigned ) ulDataGot, ( int ) lDataLen ) );
+                            }
+                        }
+                    #endif
 
-				/* If the owner of the socket requests a closure, add the FIN
-				flag to the last packet. */
-				if( ( pxSocket->u.xTCP.bits.bCloseRequested != pdFALSE_UNSIGNED ) && ( pxSocket->u.xTCP.bits.bFinSent == pdFALSE_UNSIGNED ) )
-				{
-					ulDistance = ( uint32_t ) uxStreamBufferDistance( pxSocket->u.xTCP.txStream, ( size_t ) lStreamPos, pxSocket->u.xTCP.txStream->uxHead );
+                    /* If the owner of the socket requests a closure, add the FIN
+                     * flag to the last packet. */
+                    if( ( pxSocket->u.xTCP.bits.bCloseRequested != pdFALSE_UNSIGNED ) && ( pxSocket->u.xTCP.bits.bFinSent == pdFALSE_UNSIGNED ) )
+                    {
+                        ulDistance = ( uint32_t ) uxStreamBufferDistance( pxSocket->u.xTCP.txStream, ( size_t ) lStreamPos, pxSocket->u.xTCP.txStream->uxHead );
 
-					if( ulDistance == ulDataGot )
-					{
-						#if (ipconfigHAS_DEBUG_PRINTF == 1)
-						{
-						/* the order of volatile accesses is undefined
-							so such workaround */
-							size_t uxHead = pxSocket->u.xTCP.txStream->uxHead;
-							size_t uxMid = pxSocket->u.xTCP.txStream->uxMid;
-							size_t uxTail = pxSocket->u.xTCP.txStream->uxTail;
+                        if( ulDistance == ulDataGot )
+                        {
+                            #if ( ipconfigHAS_DEBUG_PRINTF == 1 )
+                                {
+                                    /* the order of volatile accesses is undefined
+                                     *  so such workaround */
+                                    size_t uxHead = pxSocket->u.xTCP.txStream->uxHead;
+                                    size_t uxMid = pxSocket->u.xTCP.txStream->uxMid;
+                                    size_t uxTail = pxSocket->u.xTCP.txStream->uxTail;
 
-							FreeRTOS_debug_printf( ( "CheckClose %u <= %u (%u <= %u <= %u)\n",
-								( unsigned ) ulDataGot, ( unsigned ) ulDistance,
-								( unsigned ) uxTail, ( unsigned ) uxMid, ( unsigned ) uxHead ) );
-						}
-						#endif
-						/* Although the socket sends a FIN, it will stay in
-						ESTABLISHED until all current data has been received or
-						delivered. */
-						pxProtocolHeaders->xTCPHeader.ucTCPFlags |= tcpTCP_FLAG_FIN;
-						pxTCPWindow->tx.ulFINSequenceNumber = pxTCPWindow->ulOurSequenceNumber + ( uint32_t ) lDataLen;
-						pxSocket->u.xTCP.bits.bFinSent = pdTRUE_UNSIGNED;
-					}
-				}
-			}
-			else
-			{
-				lDataLen = -1;
-			}
-		}
-	}
+                                    FreeRTOS_debug_printf( ( "CheckClose %u <= %u (%u <= %u <= %u)\n",
+                                                             ( unsigned ) ulDataGot, ( unsigned ) ulDistance,
+                                                             ( unsigned ) uxTail, ( unsigned ) uxMid, ( unsigned ) uxHead ) );
+                                }
+                            #endif /* if ( ipconfigHAS_DEBUG_PRINTF == 1 ) */
 
-	if( ( lDataLen >= 0 ) && ( pxSocket->u.xTCP.ucTCPState == ( uint8_t ) eESTABLISHED ) )
-	{
-		/* See if the socket owner wants to shutdown this connection. */
-		if( ( pxSocket->u.xTCP.bits.bUserShutdown != pdFALSE_UNSIGNED ) &&
-			( xTCPWindowTxDone( pxTCPWindow ) != pdFALSE ) )
-		{
-			pxSocket->u.xTCP.bits.bUserShutdown = pdFALSE_UNSIGNED;
-			pxProtocolHeaders->xTCPHeader.ucTCPFlags |= tcpTCP_FLAG_FIN;
-			pxSocket->u.xTCP.bits.bFinSent = pdTRUE_UNSIGNED;
-			pxSocket->u.xTCP.bits.bWinChange = pdTRUE_UNSIGNED;
-			pxTCPWindow->tx.ulFINSequenceNumber = pxTCPWindow->tx.ulCurrentSequenceNumber;
-			vTCPStateChange( pxSocket, eFIN_WAIT_1 );
-		}
+                            /* Although the socket sends a FIN, it will stay in
+                             * ESTABLISHED until all current data has been received or
+                             * delivered. */
+                            pxProtocolHeaders->xTCPHeader.ucTCPFlags |= tcpTCP_FLAG_FIN;
+                            pxTCPWindow->tx.ulFINSequenceNumber = pxTCPWindow->ulOurSequenceNumber + ( uint32_t ) lDataLen;
+                            pxSocket->u.xTCP.bits.bFinSent = pdTRUE_UNSIGNED;
+                        }
+                    }
+                }
+                else
+                {
+                    lDataLen = -1;
+                }
+            }
+        }
 
-		#if( ipconfigTCP_KEEP_ALIVE != 0 )
-		{
-			if( pxSocket->u.xTCP.ucKeepRepCount > 3U ) /*_RB_ Magic number. */
-			{
-				FreeRTOS_debug_printf( ( "keep-alive: giving up %lxip:%u\n",
-					pxSocket->u.xTCP.ulRemoteIP,			/* IP address of remote machine. */
-					pxSocket->u.xTCP.usRemotePort ) );	/* Port on remote machine. */
-				vTCPStateChange( pxSocket, eCLOSE_WAIT );
-				lDataLen = -1;
-			}
-			if( ( lDataLen == 0 ) && ( pxSocket->u.xTCP.bits.bWinChange == pdFALSE_UNSIGNED ) )
-			{
-				/* If there is no data to be sent, and no window-update message,
-				we might want to send a keep-alive message. */
-				TickType_t xAge = xTaskGetTickCount( ) - pxSocket->u.xTCP.xLastAliveTime;
-				TickType_t xMax;
-				xMax = ( ( TickType_t ) ipconfigTCP_KEEP_ALIVE_INTERVAL * ( TickType_t ) configTICK_RATE_HZ );
-				if( pxSocket->u.xTCP.ucKeepRepCount != ( uint8_t ) 0U )
-				{
-					xMax = ( TickType_t ) ( 3U * configTICK_RATE_HZ );
-				}
-				if( xAge > xMax )
-				{
-					pxSocket->u.xTCP.xLastAliveTime = xTaskGetTickCount( );
-					if( xTCPWindowLoggingLevel != 0 )
-					{
-						FreeRTOS_debug_printf( ( "keep-alive: %lxip:%u count %u\n",
-							pxSocket->u.xTCP.ulRemoteIP,
-							pxSocket->u.xTCP.usRemotePort,
-							pxSocket->u.xTCP.ucKeepRepCount ) );
-					}
-					pxSocket->u.xTCP.bits.bSendKeepAlive = pdTRUE_UNSIGNED;
-					pxSocket->u.xTCP.usTimeout = ( ( uint16_t ) pdMS_TO_TICKS( 2500U ) );
-					pxSocket->u.xTCP.ucKeepRepCount++;
-				}
-			}
-		}
-		#endif /* ipconfigTCP_KEEP_ALIVE */
-	}
+        if( ( lDataLen >= 0 ) && ( pxSocket->u.xTCP.ucTCPState == ( uint8_t ) eESTABLISHED ) )
+        {
+            /* See if the socket owner wants to shutdown this connection. */
+            if( ( pxSocket->u.xTCP.bits.bUserShutdown != pdFALSE_UNSIGNED ) &&
+                ( xTCPWindowTxDone( pxTCPWindow ) != pdFALSE ) )
+            {
+                pxSocket->u.xTCP.bits.bUserShutdown = pdFALSE_UNSIGNED;
+                pxProtocolHeaders->xTCPHeader.ucTCPFlags |= tcpTCP_FLAG_FIN;
+                pxSocket->u.xTCP.bits.bFinSent = pdTRUE_UNSIGNED;
+                pxSocket->u.xTCP.bits.bWinChange = pdTRUE_UNSIGNED;
+                pxTCPWindow->tx.ulFINSequenceNumber = pxTCPWindow->tx.ulCurrentSequenceNumber;
+                vTCPStateChange( pxSocket, eFIN_WAIT_1 );
+            }
 
-	/* Anything to send, a change of the advertised window size, or maybe send a
-	keep-alive message? */
-	if( ( lDataLen > 0 ) ||
-		( pxSocket->u.xTCP.bits.bWinChange != pdFALSE_UNSIGNED ) ||
-		( pxSocket->u.xTCP.bits.bSendKeepAlive != pdFALSE_UNSIGNED ) )
-	{
-		pxProtocolHeaders->xTCPHeader.ucTCPFlags &= ( ( uint8_t ) ~tcpTCP_FLAG_PSH );
-		pxProtocolHeaders->xTCPHeader.ucTCPOffset = ( uint8_t )( ( ipSIZE_OF_TCP_HEADER + uxOptionsLength ) << 2 ); /*_RB_ "2" needs comment. */
+            #if ( ipconfigTCP_KEEP_ALIVE != 0 )
+                {
+                    if( pxSocket->u.xTCP.ucKeepRepCount > 3U ) /*_RB_ Magic number. */
+                    {
+                        FreeRTOS_debug_printf( ( "keep-alive: giving up %lxip:%u\n",
+                                                 pxSocket->u.xTCP.ulRemoteIP,       /* IP address of remote machine. */
+                                                 pxSocket->u.xTCP.usRemotePort ) ); /* Port on remote machine. */
+                        vTCPStateChange( pxSocket, eCLOSE_WAIT );
+                        lDataLen = -1;
+                    }
 
-		pxProtocolHeaders->xTCPHeader.ucTCPFlags |= ( uint8_t ) tcpTCP_FLAG_ACK;
+                    if( ( lDataLen == 0 ) && ( pxSocket->u.xTCP.bits.bWinChange == pdFALSE_UNSIGNED ) )
+                    {
+                        /* If there is no data to be sent, and no window-update message,
+                         * we might want to send a keep-alive message. */
+                        TickType_t xAge = xTaskGetTickCount() - pxSocket->u.xTCP.xLastAliveTime;
+                        TickType_t xMax;
+                        xMax = ( ( TickType_t ) ipconfigTCP_KEEP_ALIVE_INTERVAL * ( TickType_t ) configTICK_RATE_HZ );
 
-		if( lDataLen != 0L )
-		{
-			pxProtocolHeaders->xTCPHeader.ucTCPFlags |= ( uint8_t ) tcpTCP_FLAG_PSH;
-		}
+                        if( pxSocket->u.xTCP.ucKeepRepCount != ( uint8_t ) 0U )
+                        {
+                            xMax = ( TickType_t ) ( 3U * configTICK_RATE_HZ );
+                        }
 
-		lDataLen += ipNUMERIC_CAST( int32_t, uxIPHeaderSizeSocket( pxSocket ) + ipSIZE_OF_TCP_HEADER + uxOptionsLength );
-	}
+                        if( xAge > xMax )
+                        {
+                            pxSocket->u.xTCP.xLastAliveTime = xTaskGetTickCount();
 
-	return lDataLen;
-}
+                            if( xTCPWindowLoggingLevel != 0 )
+                            {
+                                FreeRTOS_debug_printf( ( "keep-alive: %lxip:%u count %u\n",
+                                                         pxSocket->u.xTCP.ulRemoteIP,
+                                                         pxSocket->u.xTCP.usRemotePort,
+                                                         pxSocket->u.xTCP.ucKeepRepCount ) );
+                            }
+
+                            pxSocket->u.xTCP.bits.bSendKeepAlive = pdTRUE_UNSIGNED;
+                            pxSocket->u.xTCP.usTimeout = ( ( uint16_t ) pdMS_TO_TICKS( 2500U ) );
+                            pxSocket->u.xTCP.ucKeepRepCount++;
+                        }
+                    }
+                }
+            #endif /* ipconfigTCP_KEEP_ALIVE */
+        }
+
+        /* Anything to send, a change of the advertised window size, or maybe send a
+         * keep-alive message? */
+        if( ( lDataLen > 0 ) ||
+            ( pxSocket->u.xTCP.bits.bWinChange != pdFALSE_UNSIGNED ) ||
+            ( pxSocket->u.xTCP.bits.bSendKeepAlive != pdFALSE_UNSIGNED ) )
+        {
+            pxProtocolHeaders->xTCPHeader.ucTCPFlags &= ( ( uint8_t ) ~tcpTCP_FLAG_PSH );
+            pxProtocolHeaders->xTCPHeader.ucTCPOffset = ( uint8_t ) ( ( ipSIZE_OF_TCP_HEADER + uxOptionsLength ) << 2 ); /*_RB_ "2" needs comment. */
+
+            pxProtocolHeaders->xTCPHeader.ucTCPFlags |= ( uint8_t ) tcpTCP_FLAG_ACK;
+
+            if( lDataLen != 0L )
+            {
+                pxProtocolHeaders->xTCPHeader.ucTCPFlags |= ( uint8_t ) tcpTCP_FLAG_PSH;
+            }
+
+            lDataLen += ipNUMERIC_CAST( int32_t, uxIPHeaderSizeSocket( pxSocket ) + ipSIZE_OF_TCP_HEADER + uxOptionsLength );
+        }
+
+        return lDataLen;
+    }
 /*-----------------------------------------------------------*/
 
 /*
  * Calculate after how much time this socket needs to be checked again.
  */
-static TickType_t prvTCPNextTimeout ( FreeRTOS_Socket_t *pxSocket )
-{
-TickType_t ulDelayMs = ( TickType_t ) tcpMAXIMUM_TCP_WAKEUP_TIME_MS;
+    static TickType_t prvTCPNextTimeout( FreeRTOS_Socket_t * pxSocket )
+    {
+        TickType_t ulDelayMs = ( TickType_t ) tcpMAXIMUM_TCP_WAKEUP_TIME_MS;
 
-	if( pxSocket->u.xTCP.ucTCPState == ( uint8_t ) eCONNECT_SYN )
-	{
-		/* The socket is actively connecting to a peer. */
-		if( pxSocket->u.xTCP.bits.bConnPrepared != pdFALSE_UNSIGNED )
-		{
-			/* Ethernet address has been found, use progressive timeout for
-			active connect(). */
-			if( pxSocket->u.xTCP.ucRepCount < 3U )
-			{
-				ulDelayMs = ( 3000UL << ( pxSocket->u.xTCP.ucRepCount - 1U ) );
-			}
-			else
-			{
-				ulDelayMs = 11000UL;
-			}
-		}
-		else
-		{
-			/* Still in the ARP phase: check every half second. */
-			ulDelayMs = 500UL;
-		}
+        if( pxSocket->u.xTCP.ucTCPState == ( uint8_t ) eCONNECT_SYN )
+        {
+            /* The socket is actively connecting to a peer. */
+            if( pxSocket->u.xTCP.bits.bConnPrepared != pdFALSE_UNSIGNED )
+            {
+                /* Ethernet address has been found, use progressive timeout for
+                 * active connect(). */
+                if( pxSocket->u.xTCP.ucRepCount < 3U )
+                {
+                    ulDelayMs = ( 3000UL << ( pxSocket->u.xTCP.ucRepCount - 1U ) );
+                }
+                else
+                {
+                    ulDelayMs = 11000UL;
+                }
+            }
+            else
+            {
+                /* Still in the ARP phase: check every half second. */
+                ulDelayMs = 500UL;
+            }
 
-		FreeRTOS_debug_printf( ( "Connect[%lxip:%u]: next timeout %u: %lu ms\n",
-			pxSocket->u.xTCP.ulRemoteIP, pxSocket->u.xTCP.usRemotePort,
-			pxSocket->u.xTCP.ucRepCount, ulDelayMs ) );
-		pxSocket->u.xTCP.usTimeout = ( uint16_t )ipMS_TO_MIN_TICKS( ulDelayMs );
-	}
-	else if( pxSocket->u.xTCP.usTimeout == 0U )
-	{
-		/* Let the sliding window mechanism decide what time-out is appropriate. */
-		BaseType_t xResult = xTCPWindowTxHasData( &pxSocket->u.xTCP.xTCPWindow, pxSocket->u.xTCP.ulWindowSize, &ulDelayMs );
-		if( ulDelayMs == 0U )
-		{
-			if( xResult != ( BaseType_t )0 )
-			{
-				ulDelayMs = 1UL;
-			}
-			else
-			{
-				ulDelayMs = tcpMAXIMUM_TCP_WAKEUP_TIME_MS;
-			}
-		}
-		else
-		{
-			/* ulDelayMs contains the time to wait before a re-transmission. */
-		}
-		pxSocket->u.xTCP.usTimeout = ( uint16_t ) ipMS_TO_MIN_TICKS( ulDelayMs );
-	}
-	else
-	{
-		/* field '.usTimeout' has already been set (by the
-		keep-alive/delayed-ACK mechanism). */
-	}
+            FreeRTOS_debug_printf( ( "Connect[%lxip:%u]: next timeout %u: %lu ms\n",
+                                     pxSocket->u.xTCP.ulRemoteIP, pxSocket->u.xTCP.usRemotePort,
+                                     pxSocket->u.xTCP.ucRepCount, ulDelayMs ) );
+            pxSocket->u.xTCP.usTimeout = ( uint16_t ) ipMS_TO_MIN_TICKS( ulDelayMs );
+        }
+        else if( pxSocket->u.xTCP.usTimeout == 0U )
+        {
+            /* Let the sliding window mechanism decide what time-out is appropriate. */
+            BaseType_t xResult = xTCPWindowTxHasData( &pxSocket->u.xTCP.xTCPWindow, pxSocket->u.xTCP.ulWindowSize, &ulDelayMs );
 
-	/* Return the number of clock ticks before the timer expires. */
-	return ( TickType_t ) pxSocket->u.xTCP.usTimeout;
-}
+            if( ulDelayMs == 0U )
+            {
+                if( xResult != ( BaseType_t ) 0 )
+                {
+                    ulDelayMs = 1UL;
+                }
+                else
+                {
+                    ulDelayMs = tcpMAXIMUM_TCP_WAKEUP_TIME_MS;
+                }
+            }
+            else
+            {
+                /* ulDelayMs contains the time to wait before a re-transmission. */
+            }
+
+            pxSocket->u.xTCP.usTimeout = ( uint16_t ) ipMS_TO_MIN_TICKS( ulDelayMs );
+        }
+        else
+        {
+            /* field '.usTimeout' has already been set (by the
+             * keep-alive/delayed-ACK mechanism). */
+        }
+
+        /* Return the number of clock ticks before the timer expires. */
+        return ( TickType_t ) pxSocket->u.xTCP.usTimeout;
+    }
 /*-----------------------------------------------------------*/
 
-static void prvTCPAddTxData( FreeRTOS_Socket_t *pxSocket )
-{
-int32_t lCount, lLength;
+    static void prvTCPAddTxData( FreeRTOS_Socket_t * pxSocket )
+    {
+        int32_t lCount, lLength;
 
-	/* A txStream has been created already, see if the socket has new data for
-	the sliding window.
-	uxStreamBufferMidSpace() returns the distance between rxHead and rxMid.  It
-	contains new Tx data which has not been passed to the sliding window yet.
-	The oldest data not-yet-confirmed can be found at rxTail. */
-	lLength = ( int32_t ) uxStreamBufferMidSpace( pxSocket->u.xTCP.txStream );
+        /* A txStream has been created already, see if the socket has new data for
+         * the sliding window.
+         * uxStreamBufferMidSpace() returns the distance between rxHead and rxMid.  It
+         * contains new Tx data which has not been passed to the sliding window yet.
+         * The oldest data not-yet-confirmed can be found at rxTail. */
+        lLength = ( int32_t ) uxStreamBufferMidSpace( pxSocket->u.xTCP.txStream );
 
-	if( lLength > 0 )
-	{
-		/* All data between txMid and rxHead will now be passed to the sliding
-		window manager, so it can start transmitting them.
-		Hand over the new data to the sliding window handler.  It will be
-		split-up in chunks of 1460 bytes each (or less, depending on
-		ipconfigTCP_MSS). */
-		lCount = lTCPWindowTxAdd(	&pxSocket->u.xTCP.xTCPWindow,
-								( uint32_t ) lLength,
-								( int32_t ) pxSocket->u.xTCP.txStream->uxMid,
-								( int32_t ) pxSocket->u.xTCP.txStream->LENGTH );
+        if( lLength > 0 )
+        {
+            /* All data between txMid and rxHead will now be passed to the sliding
+             * window manager, so it can start transmitting them.
+             * Hand over the new data to the sliding window handler.  It will be
+             * split-up in chunks of 1460 bytes each (or less, depending on
+             * ipconfigTCP_MSS). */
+            lCount = lTCPWindowTxAdd( &pxSocket->u.xTCP.xTCPWindow,
+                                      ( uint32_t ) lLength,
+                                      ( int32_t ) pxSocket->u.xTCP.txStream->uxMid,
+                                      ( int32_t ) pxSocket->u.xTCP.txStream->LENGTH );
 
-		/* Move the rxMid pointer forward up to rxHead. */
-		if( lCount > 0 )
-		{
-			vStreamBufferMoveMid( pxSocket->u.xTCP.txStream, ( size_t ) lCount );
-		}
-	}
-}
+            /* Move the rxMid pointer forward up to rxHead. */
+            if( lCount > 0 )
+            {
+                vStreamBufferMoveMid( pxSocket->u.xTCP.txStream, ( size_t ) lCount );
+            }
+        }
+    }
 /*-----------------------------------------------------------*/
 
 /*
@@ -2033,94 +2121,97 @@ int32_t lCount, lLength;
  * Before being called, it has been checked that both reception and transmission
  * are complete.
  */
-static BaseType_t prvTCPHandleFin( FreeRTOS_Socket_t *pxSocket, const NetworkBufferDescriptor_t *pxNetworkBuffer )
-{
-ProtocolHeaders_t *pxProtocolHeaders = ipPOINTER_CAST( ProtocolHeaders_t *,
-	&( pxNetworkBuffer->pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER + xIPHeaderSize( pxNetworkBuffer ) ] ) );
-TCPHeader_t *pxTCPHeader = &( pxProtocolHeaders->xTCPHeader );
-uint8_t ucTCPFlags = pxTCPHeader->ucTCPFlags;
-TCPWindow_t *pxTCPWindow = &pxSocket->u.xTCP.xTCPWindow;
-BaseType_t xSendLength = 0;
-uint32_t ulAckNr = FreeRTOS_ntohl( pxTCPHeader->ulAckNr );
+    static BaseType_t prvTCPHandleFin( FreeRTOS_Socket_t * pxSocket,
+                                       const NetworkBufferDescriptor_t * pxNetworkBuffer )
+    {
+        ProtocolHeaders_t * pxProtocolHeaders = ipPOINTER_CAST( ProtocolHeaders_t *,
+                                                                &( pxNetworkBuffer->pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER + xIPHeaderSize( pxNetworkBuffer ) ] ) );
+        TCPHeader_t * pxTCPHeader = &( pxProtocolHeaders->xTCPHeader );
+        uint8_t ucTCPFlags = pxTCPHeader->ucTCPFlags;
+        TCPWindow_t * pxTCPWindow = &pxSocket->u.xTCP.xTCPWindow;
+        BaseType_t xSendLength = 0;
+        uint32_t ulAckNr = FreeRTOS_ntohl( pxTCPHeader->ulAckNr );
 
-	if( ( ucTCPFlags & tcpTCP_FLAG_FIN ) != 0U )
-	{
-		pxTCPWindow->rx.ulCurrentSequenceNumber = pxTCPWindow->rx.ulFINSequenceNumber + 1U;
-	}
-	if( pxSocket->u.xTCP.bits.bFinSent == pdFALSE_UNSIGNED )
-	{
-		/* We haven't yet replied with a FIN, do so now. */
-		pxTCPWindow->tx.ulFINSequenceNumber = pxTCPWindow->tx.ulCurrentSequenceNumber;
-		pxSocket->u.xTCP.bits.bFinSent = pdTRUE_UNSIGNED;
-	}
-	else
-	{
-		/* We did send a FIN already, see if it's ACK'd. */
-		if( ulAckNr == ( pxTCPWindow->tx.ulFINSequenceNumber + 1UL ) )
-		{
-			pxSocket->u.xTCP.bits.bFinAcked = pdTRUE_UNSIGNED;
-		}
-	}
+        if( ( ucTCPFlags & tcpTCP_FLAG_FIN ) != 0U )
+        {
+            pxTCPWindow->rx.ulCurrentSequenceNumber = pxTCPWindow->rx.ulFINSequenceNumber + 1U;
+        }
 
-	if( pxSocket->u.xTCP.bits.bFinAcked == pdFALSE_UNSIGNED )
-	{
-		pxTCPWindow->tx.ulCurrentSequenceNumber = pxTCPWindow->tx.ulFINSequenceNumber;
-		pxTCPHeader->ucTCPFlags = ( uint8_t ) tcpTCP_FLAG_ACK | ( uint8_t ) tcpTCP_FLAG_FIN;
+        if( pxSocket->u.xTCP.bits.bFinSent == pdFALSE_UNSIGNED )
+        {
+            /* We haven't yet replied with a FIN, do so now. */
+            pxTCPWindow->tx.ulFINSequenceNumber = pxTCPWindow->tx.ulCurrentSequenceNumber;
+            pxSocket->u.xTCP.bits.bFinSent = pdTRUE_UNSIGNED;
+        }
+        else
+        {
+            /* We did send a FIN already, see if it's ACK'd. */
+            if( ulAckNr == ( pxTCPWindow->tx.ulFINSequenceNumber + 1UL ) )
+            {
+                pxSocket->u.xTCP.bits.bFinAcked = pdTRUE_UNSIGNED;
+            }
+        }
 
-		/* And wait for the final ACK. */
-		vTCPStateChange( pxSocket, eLAST_ACK );
-	}
-	else
-	{
-		/* Our FIN has been ACK'd, the outgoing sequence number is now fixed. */
-		pxTCPWindow->tx.ulCurrentSequenceNumber = pxTCPWindow->tx.ulFINSequenceNumber + 1U;
-		if( pxSocket->u.xTCP.bits.bFinRecv == pdFALSE_UNSIGNED )
-		{
-			/* We have sent out a FIN but the peer hasn't replied with a FIN
-			yet. Do nothing for the moment. */
-			pxTCPHeader->ucTCPFlags = 0U;
-		}
-		else
-		{
-			if( pxSocket->u.xTCP.bits.bFinLast == pdFALSE_UNSIGNED )
-			{
-				/* This is the third of the three-way hand shake: the last
-				ACK. */
-				pxTCPHeader->ucTCPFlags = tcpTCP_FLAG_ACK;
-			}
-			else
-			{
-				/* The other party started the closure, so we just wait for the
-				last ACK. */
-				pxTCPHeader->ucTCPFlags = 0U;
-			}
+        if( pxSocket->u.xTCP.bits.bFinAcked == pdFALSE_UNSIGNED )
+        {
+            pxTCPWindow->tx.ulCurrentSequenceNumber = pxTCPWindow->tx.ulFINSequenceNumber;
+            pxTCPHeader->ucTCPFlags = ( uint8_t ) tcpTCP_FLAG_ACK | ( uint8_t ) tcpTCP_FLAG_FIN;
 
-			/* And wait for the user to close this socket. */
-			vTCPStateChange( pxSocket, eCLOSE_WAIT );
-		}
-	}
+            /* And wait for the final ACK. */
+            vTCPStateChange( pxSocket, eLAST_ACK );
+        }
+        else
+        {
+            /* Our FIN has been ACK'd, the outgoing sequence number is now fixed. */
+            pxTCPWindow->tx.ulCurrentSequenceNumber = pxTCPWindow->tx.ulFINSequenceNumber + 1U;
 
-	pxTCPWindow->ulOurSequenceNumber = pxTCPWindow->tx.ulCurrentSequenceNumber;
+            if( pxSocket->u.xTCP.bits.bFinRecv == pdFALSE_UNSIGNED )
+            {
+                /* We have sent out a FIN but the peer hasn't replied with a FIN
+                 * yet. Do nothing for the moment. */
+                pxTCPHeader->ucTCPFlags = 0U;
+            }
+            else
+            {
+                if( pxSocket->u.xTCP.bits.bFinLast == pdFALSE_UNSIGNED )
+                {
+                    /* This is the third of the three-way hand shake: the last
+                     * ACK. */
+                    pxTCPHeader->ucTCPFlags = tcpTCP_FLAG_ACK;
+                }
+                else
+                {
+                    /* The other party started the closure, so we just wait for the
+                     * last ACK. */
+                    pxTCPHeader->ucTCPFlags = 0U;
+                }
 
-	if( pxTCPHeader->ucTCPFlags != 0U )
-	{
-		xSendLength = ipNUMERIC_CAST( BaseType_t, uxIPHeaderSizeSocket( pxSocket ) + ipSIZE_OF_TCP_HEADER + pxTCPWindow->ucOptionLength );
-	}
+                /* And wait for the user to close this socket. */
+                vTCPStateChange( pxSocket, eCLOSE_WAIT );
+            }
+        }
 
-	pxTCPHeader->ucTCPOffset = ( uint8_t ) ( ( ipSIZE_OF_TCP_HEADER + pxTCPWindow->ucOptionLength ) << 2 );
+        pxTCPWindow->ulOurSequenceNumber = pxTCPWindow->tx.ulCurrentSequenceNumber;
 
-	if( xTCPWindowLoggingLevel != 0 )
-	{
-		FreeRTOS_debug_printf( ( "TCP: send FIN+ACK (ack %lu, cur/nxt %lu/%lu) ourSeqNr %lu | Rx %lu\n",
-			ulAckNr - pxTCPWindow->tx.ulFirstSequenceNumber,
-			pxTCPWindow->tx.ulCurrentSequenceNumber - pxTCPWindow->tx.ulFirstSequenceNumber,
-			pxTCPWindow->ulNextTxSequenceNumber - pxTCPWindow->tx.ulFirstSequenceNumber,
-			pxTCPWindow->ulOurSequenceNumber - pxTCPWindow->tx.ulFirstSequenceNumber,
-			pxTCPWindow->rx.ulCurrentSequenceNumber - pxTCPWindow->rx.ulFirstSequenceNumber ) );
-	}
+        if( pxTCPHeader->ucTCPFlags != 0U )
+        {
+            xSendLength = ipNUMERIC_CAST( BaseType_t, uxIPHeaderSizeSocket( pxSocket ) + ipSIZE_OF_TCP_HEADER + pxTCPWindow->ucOptionLength );
+        }
 
-	return xSendLength;
-}
+        pxTCPHeader->ucTCPOffset = ( uint8_t ) ( ( ipSIZE_OF_TCP_HEADER + pxTCPWindow->ucOptionLength ) << 2 );
+
+        if( xTCPWindowLoggingLevel != 0 )
+        {
+            FreeRTOS_debug_printf( ( "TCP: send FIN+ACK (ack %lu, cur/nxt %lu/%lu) ourSeqNr %lu | Rx %lu\n",
+                                     ulAckNr - pxTCPWindow->tx.ulFirstSequenceNumber,
+                                     pxTCPWindow->tx.ulCurrentSequenceNumber - pxTCPWindow->tx.ulFirstSequenceNumber,
+                                     pxTCPWindow->ulNextTxSequenceNumber - pxTCPWindow->tx.ulFirstSequenceNumber,
+                                     pxTCPWindow->ulOurSequenceNumber - pxTCPWindow->tx.ulFirstSequenceNumber,
+                                     pxTCPWindow->rx.ulCurrentSequenceNumber - pxTCPWindow->rx.ulFirstSequenceNumber ) );
+        }
+
+        return xSendLength;
+    }
 /*-----------------------------------------------------------*/
 
 /*
@@ -2129,68 +2220,69 @@ uint32_t ulAckNr = FreeRTOS_ntohl( pxTCPHeader->ulAckNr );
  * The first thing that will be done is find the TCP payload data
  * and check the length of this data.
  */
-static BaseType_t prvCheckRxData( const NetworkBufferDescriptor_t *pxNetworkBuffer, uint8_t **ppucRecvData )
-{
-const ProtocolHeaders_t *pxProtocolHeaders = ipPOINTER_CAST( ProtocolHeaders_t *,
-	&( pxNetworkBuffer->pucEthernetBuffer[ ( size_t ) ipSIZE_OF_ETH_HEADER + xIPHeaderSize( pxNetworkBuffer ) ] ) );
-const TCPHeader_t *pxTCPHeader = &( pxProtocolHeaders->xTCPHeader );
-int32_t lLength, lTCPHeaderLength, lReceiveLength, lUrgentLength;
-const IPHeader_t *pxIPHeader = ipPOINTER_CAST( const IPHeader_t *, &( pxNetworkBuffer->pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER ] ) );
-const size_t xIPHeaderLength = ipSIZE_OF_IPv4_HEADER;
-uint16_t usLength;
+    static BaseType_t prvCheckRxData( const NetworkBufferDescriptor_t * pxNetworkBuffer,
+                                      uint8_t ** ppucRecvData )
+    {
+        const ProtocolHeaders_t * pxProtocolHeaders = ipPOINTER_CAST( ProtocolHeaders_t *,
+                                                                      &( pxNetworkBuffer->pucEthernetBuffer[ ( size_t ) ipSIZE_OF_ETH_HEADER + xIPHeaderSize( pxNetworkBuffer ) ] ) );
+        const TCPHeader_t * pxTCPHeader = &( pxProtocolHeaders->xTCPHeader );
+        int32_t lLength, lTCPHeaderLength, lReceiveLength, lUrgentLength;
+        const IPHeader_t * pxIPHeader = ipPOINTER_CAST( const IPHeader_t *, &( pxNetworkBuffer->pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER ] ) );
+        const size_t xIPHeaderLength = ipSIZE_OF_IPv4_HEADER;
+        uint16_t usLength;
 
-	/* Determine the length and the offset of the user-data sent to this
-	node.
-	The size of the TCP header is given in a multiple of 4-byte words (single
-	byte, needs no ntoh() translation).  A shift-right 2: is the same as
-	(offset >> 4) * 4. */
-	lTCPHeaderLength = ipNUMERIC_CAST( BaseType_t, ( pxTCPHeader->ucTCPOffset & tcpVALID_BITS_IN_TCP_OFFSET_BYTE ) >> 2 );
+        /* Determine the length and the offset of the user-data sent to this
+         * node.
+         * The size of the TCP header is given in a multiple of 4-byte words (single
+         * byte, needs no ntoh() translation).  A shift-right 2: is the same as
+         * (offset >> 4) * 4. */
+        lTCPHeaderLength = ipNUMERIC_CAST( BaseType_t, ( pxTCPHeader->ucTCPOffset & tcpVALID_BITS_IN_TCP_OFFSET_BYTE ) >> 2 );
 
-	/* Let pucRecvData point to the first byte received. */
-	*ppucRecvData = &( pxNetworkBuffer->pucEthernetBuffer[ ( size_t ) ipSIZE_OF_ETH_HEADER + xIPHeaderLength + ( size_t ) lTCPHeaderLength ] );
+        /* Let pucRecvData point to the first byte received. */
+        *ppucRecvData = &( pxNetworkBuffer->pucEthernetBuffer[ ( size_t ) ipSIZE_OF_ETH_HEADER + xIPHeaderLength + ( size_t ) lTCPHeaderLength ] );
 
-	/* Calculate lReceiveLength - the length of the TCP data received.  This is
-	equal to the total packet length minus:
-	( LinkLayer length (14) + IP header length (20) + size of TCP header(20 +) ).*/
-	lReceiveLength = ipNUMERIC_CAST( int32_t, pxNetworkBuffer->xDataLength ) - ( int32_t ) ipSIZE_OF_ETH_HEADER;
+        /* Calculate lReceiveLength - the length of the TCP data received.  This is
+         * equal to the total packet length minus:
+         * ( LinkLayer length (14) + IP header length (20) + size of TCP header(20 +) ).*/
+        lReceiveLength = ipNUMERIC_CAST( int32_t, pxNetworkBuffer->xDataLength ) - ( int32_t ) ipSIZE_OF_ETH_HEADER;
 
-	usLength = FreeRTOS_htons( pxIPHeader->usLength );
-	lLength =  ( int32_t ) usLength;
+        usLength = FreeRTOS_htons( pxIPHeader->usLength );
+        lLength = ( int32_t ) usLength;
 
-	if( lReceiveLength > lLength )
-	{
-		/* More bytes were received than the reported length, often because of
-		padding bytes at the end. */
-		lReceiveLength = lLength;
-	}
+        if( lReceiveLength > lLength )
+        {
+            /* More bytes were received than the reported length, often because of
+             * padding bytes at the end. */
+            lReceiveLength = lLength;
+        }
 
-	/* Subtract the size of the TCP and IP headers and the actual data size is
-	known. */
-	if( lReceiveLength > ( lTCPHeaderLength + ( int32_t ) xIPHeaderLength ) )
-	{
-		lReceiveLength -= ( lTCPHeaderLength + ( int32_t ) xIPHeaderLength );
-	}
-	else
-	{
-		lReceiveLength = 0;
-	}
+        /* Subtract the size of the TCP and IP headers and the actual data size is
+         * known. */
+        if( lReceiveLength > ( lTCPHeaderLength + ( int32_t ) xIPHeaderLength ) )
+        {
+            lReceiveLength -= ( lTCPHeaderLength + ( int32_t ) xIPHeaderLength );
+        }
+        else
+        {
+            lReceiveLength = 0;
+        }
 
-	/* Urgent Pointer:
-	This field communicates the current value of the urgent pointer as a
-	positive offset from the sequence number in this segment.  The urgent
-	pointer points to the sequence number of the octet following the urgent
-	data.  This field is only be interpreted in segments with the URG control
-	bit set. */
-	if( ( pxTCPHeader->ucTCPFlags & tcpTCP_FLAG_URG ) != 0U )
-	{
-		/* Although we ignore the urgent data, we have to skip it. */
-		lUrgentLength = ( int32_t ) FreeRTOS_htons( pxTCPHeader->usUrgent );
-		*ppucRecvData += lUrgentLength;
-		lReceiveLength -= FreeRTOS_min_int32( lReceiveLength, lUrgentLength );
-	}
+        /* Urgent Pointer:
+         * This field communicates the current value of the urgent pointer as a
+         * positive offset from the sequence number in this segment.  The urgent
+         * pointer points to the sequence number of the octet following the urgent
+         * data.  This field is only be interpreted in segments with the URG control
+         * bit set. */
+        if( ( pxTCPHeader->ucTCPFlags & tcpTCP_FLAG_URG ) != 0U )
+        {
+            /* Although we ignore the urgent data, we have to skip it. */
+            lUrgentLength = ( int32_t ) FreeRTOS_htons( pxTCPHeader->usUrgent );
+            *ppucRecvData += lUrgentLength;
+            lReceiveLength -= FreeRTOS_min_int32( lReceiveLength, lUrgentLength );
+        }
 
-	return ( BaseType_t ) lReceiveLength;
-}
+        return ( BaseType_t ) lReceiveLength;
+    }
 /*-----------------------------------------------------------*/
 
 /*
@@ -2199,136 +2291,142 @@ uint16_t usLength;
  * The second thing is to do is check if the payload data may be accepted
  * If so, they will be added to the reception queue.
  */
-static BaseType_t prvStoreRxData( FreeRTOS_Socket_t *pxSocket, const uint8_t *pucRecvData,
-	NetworkBufferDescriptor_t *pxNetworkBuffer, uint32_t ulReceiveLength )
-{
-const ProtocolHeaders_t *pxProtocolHeaders = ipPOINTER_CAST( const ProtocolHeaders_t *,
-	&( pxNetworkBuffer->pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER + xIPHeaderSize( pxNetworkBuffer ) ] ) );
-const TCPHeader_t *pxTCPHeader = &pxProtocolHeaders->xTCPHeader;
-TCPWindow_t *pxTCPWindow = &pxSocket->u.xTCP.xTCPWindow;
-uint32_t ulSequenceNumber, ulSpace;
-int32_t lOffset, lStored;
-BaseType_t xResult = 0;
+    static BaseType_t prvStoreRxData( FreeRTOS_Socket_t * pxSocket,
+                                      const uint8_t * pucRecvData,
+                                      NetworkBufferDescriptor_t * pxNetworkBuffer,
+                                      uint32_t ulReceiveLength )
+    {
+        const ProtocolHeaders_t * pxProtocolHeaders = ipPOINTER_CAST( const ProtocolHeaders_t *,
+                                                                      &( pxNetworkBuffer->pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER + xIPHeaderSize( pxNetworkBuffer ) ] ) );
+        const TCPHeader_t * pxTCPHeader = &pxProtocolHeaders->xTCPHeader;
+        TCPWindow_t * pxTCPWindow = &pxSocket->u.xTCP.xTCPWindow;
+        uint32_t ulSequenceNumber, ulSpace;
+        int32_t lOffset, lStored;
+        BaseType_t xResult = 0;
 
-	ulSequenceNumber = FreeRTOS_ntohl( pxTCPHeader->ulSequenceNumber );
+        ulSequenceNumber = FreeRTOS_ntohl( pxTCPHeader->ulSequenceNumber );
 
-	if( ( ulReceiveLength > 0U ) && ( pxSocket->u.xTCP.ucTCPState >= ( uint8_t ) eSYN_RECEIVED ) )
-	{
-		/* See if way may accept the data contents and forward it to the socket
-		owner.
-		If it can't be "accept"ed it may have to be stored and send a selective
-		ack (SACK) option to confirm it.  In that case, lTCPAddRxdata() will be
-		called later to store an out-of-order packet (in case lOffset is
-		negative). */
-		if ( pxSocket->u.xTCP.rxStream != NULL )
-		{
-			ulSpace = ( uint32_t )uxStreamBufferGetSpace ( pxSocket->u.xTCP.rxStream );
-		}
-		else
-		{
-			ulSpace = ( uint32_t )pxSocket->u.xTCP.uxRxStreamSize;
-		}
+        if( ( ulReceiveLength > 0U ) && ( pxSocket->u.xTCP.ucTCPState >= ( uint8_t ) eSYN_RECEIVED ) )
+        {
+            /* See if way may accept the data contents and forward it to the socket
+             * owner.
+             * If it can't be "accept"ed it may have to be stored and send a selective
+             * ack (SACK) option to confirm it.  In that case, lTCPAddRxdata() will be
+             * called later to store an out-of-order packet (in case lOffset is
+             * negative). */
+            if( pxSocket->u.xTCP.rxStream != NULL )
+            {
+                ulSpace = ( uint32_t ) uxStreamBufferGetSpace( pxSocket->u.xTCP.rxStream );
+            }
+            else
+            {
+                ulSpace = ( uint32_t ) pxSocket->u.xTCP.uxRxStreamSize;
+            }
 
-		lOffset = lTCPWindowRxCheck( pxTCPWindow, ulSequenceNumber, ulReceiveLength, ulSpace );
+            lOffset = lTCPWindowRxCheck( pxTCPWindow, ulSequenceNumber, ulReceiveLength, ulSpace );
 
-		if( lOffset >= 0 )
-		{
-			/* New data has arrived and may be made available to the user.  See
-			if the head marker in rxStream may be advanced,	only if lOffset == 0.
-			In case the low-water mark is reached, bLowWater will be set
-			"low-water" here stands for "little space". */
-			lStored = lTCPAddRxdata( pxSocket, ( uint32_t ) lOffset, pucRecvData, ulReceiveLength );
+            if( lOffset >= 0 )
+            {
+                /* New data has arrived and may be made available to the user.  See
+                 * if the head marker in rxStream may be advanced,	only if lOffset == 0.
+                 * In case the low-water mark is reached, bLowWater will be set
+                 * "low-water" here stands for "little space". */
+                lStored = lTCPAddRxdata( pxSocket, ( uint32_t ) lOffset, pucRecvData, ulReceiveLength );
 
-			if( lStored != ( int32_t ) ulReceiveLength )
-			{
-				FreeRTOS_debug_printf( ( "lTCPAddRxdata: stored %ld / %lu bytes? ?\n", lStored, ulReceiveLength ) );
+                if( lStored != ( int32_t ) ulReceiveLength )
+                {
+                    FreeRTOS_debug_printf( ( "lTCPAddRxdata: stored %ld / %lu bytes? ?\n", lStored, ulReceiveLength ) );
 
-				/* Received data could not be stored.  The socket's flag
-				bMallocError has been set.  The socket now has the status
-				eCLOSE_WAIT and a RST packet will be sent back. */
-				( void ) prvTCPSendReset( pxNetworkBuffer );
-				xResult = -1;
-			}
-		}
+                    /* Received data could not be stored.  The socket's flag
+                     * bMallocError has been set.  The socket now has the status
+                     * eCLOSE_WAIT and a RST packet will be sent back. */
+                    ( void ) prvTCPSendReset( pxNetworkBuffer );
+                    xResult = -1;
+                }
+            }
 
-		/* After a missing packet has come in, higher packets may be passed to
-		the user. */
-		#if( ipconfigUSE_TCP_WIN == 1 )
-		{
-			/* Now lTCPAddRxdata() will move the rxHead pointer forward
-			so data becomes available to the user immediately
-			In case the low-water mark is reached, bLowWater will be set. */
-			if( ( xResult == 0 ) && ( pxTCPWindow->ulUserDataLength > 0UL ) )
-			{
-				( void ) lTCPAddRxdata( pxSocket, 0UL, NULL, pxTCPWindow->ulUserDataLength );
-				pxTCPWindow->ulUserDataLength = 0;
-			}
-		}
-		#endif /* ipconfigUSE_TCP_WIN */
-	}
-	else
-	{
-		pxTCPWindow->ucOptionLength = 0U;
-	}
+            /* After a missing packet has come in, higher packets may be passed to
+             * the user. */
+            #if ( ipconfigUSE_TCP_WIN == 1 )
+                {
+                    /* Now lTCPAddRxdata() will move the rxHead pointer forward
+                     * so data becomes available to the user immediately
+                     * In case the low-water mark is reached, bLowWater will be set. */
+                    if( ( xResult == 0 ) && ( pxTCPWindow->ulUserDataLength > 0UL ) )
+                    {
+                        ( void ) lTCPAddRxdata( pxSocket, 0UL, NULL, pxTCPWindow->ulUserDataLength );
+                        pxTCPWindow->ulUserDataLength = 0;
+                    }
+                }
+            #endif /* ipconfigUSE_TCP_WIN */
+        }
+        else
+        {
+            pxTCPWindow->ucOptionLength = 0U;
+        }
 
-	return xResult;
-}
+        return xResult;
+    }
 /*-----------------------------------------------------------*/
 
 /* Set the TCP options (if any) for the outgoing packet. */
-static UBaseType_t prvSetOptions( FreeRTOS_Socket_t *pxSocket, const NetworkBufferDescriptor_t *pxNetworkBuffer )
-{
-ProtocolHeaders_t *pxProtocolHeaders = ipPOINTER_CAST( ProtocolHeaders_t *,
-	&( pxNetworkBuffer->pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER + xIPHeaderSize( pxNetworkBuffer ) ] ) );
-TCPHeader_t *pxTCPHeader = &pxProtocolHeaders->xTCPHeader;
-const TCPWindow_t *pxTCPWindow = &pxSocket->u.xTCP.xTCPWindow;
-UBaseType_t uxOptionsLength = pxTCPWindow->ucOptionLength;
+    static UBaseType_t prvSetOptions( FreeRTOS_Socket_t * pxSocket,
+                                      const NetworkBufferDescriptor_t * pxNetworkBuffer )
+    {
+        ProtocolHeaders_t * pxProtocolHeaders = ipPOINTER_CAST( ProtocolHeaders_t *,
+                                                                &( pxNetworkBuffer->pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER + xIPHeaderSize( pxNetworkBuffer ) ] ) );
+        TCPHeader_t * pxTCPHeader = &pxProtocolHeaders->xTCPHeader;
+        const TCPWindow_t * pxTCPWindow = &pxSocket->u.xTCP.xTCPWindow;
+        UBaseType_t uxOptionsLength = pxTCPWindow->ucOptionLength;
 
-#if(	ipconfigUSE_TCP_WIN == 1 )
-	if( uxOptionsLength != 0U )
-	{
-		/* TCP options must be sent because a packet which is out-of-order
-		was received. */
-		if( xTCPWindowLoggingLevel >= 0 )
-		{
-			FreeRTOS_debug_printf( ( "SACK[%d,%d]: optlen %lu sending %lu - %lu\n",
-				pxSocket->usLocalPort,
-				pxSocket->u.xTCP.usRemotePort,
-				uxOptionsLength,
-				FreeRTOS_ntohl( pxTCPWindow->ulOptionsData[ 1 ] ) - pxSocket->u.xTCP.xTCPWindow.rx.ulFirstSequenceNumber,
-				FreeRTOS_ntohl( pxTCPWindow->ulOptionsData[ 2 ] ) - pxSocket->u.xTCP.xTCPWindow.rx.ulFirstSequenceNumber ) );
-		}
-		( void ) memcpy( pxTCPHeader->ucOptdata, pxTCPWindow->ulOptionsData, ( size_t ) uxOptionsLength );
+        #if ( ipconfigUSE_TCP_WIN == 1 )
+            if( uxOptionsLength != 0U )
+            {
+                /* TCP options must be sent because a packet which is out-of-order
+                 * was received. */
+                if( xTCPWindowLoggingLevel >= 0 )
+                {
+                    FreeRTOS_debug_printf( ( "SACK[%d,%d]: optlen %lu sending %lu - %lu\n",
+                                             pxSocket->usLocalPort,
+                                             pxSocket->u.xTCP.usRemotePort,
+                                             uxOptionsLength,
+                                             FreeRTOS_ntohl( pxTCPWindow->ulOptionsData[ 1 ] ) - pxSocket->u.xTCP.xTCPWindow.rx.ulFirstSequenceNumber,
+                                             FreeRTOS_ntohl( pxTCPWindow->ulOptionsData[ 2 ] ) - pxSocket->u.xTCP.xTCPWindow.rx.ulFirstSequenceNumber ) );
+                }
 
-		/* The header length divided by 4, goes into the higher nibble,
-		effectively a shift-left 2. */
-		pxTCPHeader->ucTCPOffset = ( uint8_t )( ( ipSIZE_OF_TCP_HEADER + uxOptionsLength ) << 2 );
-	}
-	else
-#endif	/* ipconfigUSE_TCP_WIN */
-	if( ( pxSocket->u.xTCP.ucTCPState >= ( EventBits_t ) eESTABLISHED ) && ( pxSocket->u.xTCP.bits.bMssChange != pdFALSE_UNSIGNED ) )
-	{
-		/* TCP options must be sent because the MSS has changed. */
-		pxSocket->u.xTCP.bits.bMssChange = pdFALSE_UNSIGNED;
-		if( xTCPWindowLoggingLevel >= 0 )
-		{
-			FreeRTOS_debug_printf( ( "MSS: sending %d\n", pxSocket->u.xTCP.usCurMSS ) );
-		}
+                ( void ) memcpy( pxTCPHeader->ucOptdata, pxTCPWindow->ulOptionsData, ( size_t ) uxOptionsLength );
 
-		pxTCPHeader->ucOptdata[ 0 ] = tcpTCP_OPT_MSS;
-		pxTCPHeader->ucOptdata[ 1 ] = tcpTCP_OPT_MSS_LEN;
-		pxTCPHeader->ucOptdata[ 2 ] = ( uint8_t ) ( ( pxSocket->u.xTCP.usCurMSS ) >> 8 );
-		pxTCPHeader->ucOptdata[ 3 ] = ( uint8_t ) ( ( pxSocket->u.xTCP.usCurMSS ) & 0xffU );
-		uxOptionsLength = 4U;
-		pxTCPHeader->ucTCPOffset = ( uint8_t )( ( ipSIZE_OF_TCP_HEADER + uxOptionsLength ) << 2 );
-	}
-	else
-	{
-		/* Nothing. */
-	}
+                /* The header length divided by 4, goes into the higher nibble,
+                 * effectively a shift-left 2. */
+                pxTCPHeader->ucTCPOffset = ( uint8_t ) ( ( ipSIZE_OF_TCP_HEADER + uxOptionsLength ) << 2 );
+            }
+            else
+        #endif /* ipconfigUSE_TCP_WIN */
 
-	return uxOptionsLength;
-}
+        if( ( pxSocket->u.xTCP.ucTCPState >= ( EventBits_t ) eESTABLISHED ) && ( pxSocket->u.xTCP.bits.bMssChange != pdFALSE_UNSIGNED ) )
+        {
+            /* TCP options must be sent because the MSS has changed. */
+            pxSocket->u.xTCP.bits.bMssChange = pdFALSE_UNSIGNED;
+
+            if( xTCPWindowLoggingLevel >= 0 )
+            {
+                FreeRTOS_debug_printf( ( "MSS: sending %d\n", pxSocket->u.xTCP.usCurMSS ) );
+            }
+
+            pxTCPHeader->ucOptdata[ 0 ] = tcpTCP_OPT_MSS;
+            pxTCPHeader->ucOptdata[ 1 ] = tcpTCP_OPT_MSS_LEN;
+            pxTCPHeader->ucOptdata[ 2 ] = ( uint8_t ) ( ( pxSocket->u.xTCP.usCurMSS ) >> 8 );
+            pxTCPHeader->ucOptdata[ 3 ] = ( uint8_t ) ( ( pxSocket->u.xTCP.usCurMSS ) & 0xffU );
+            uxOptionsLength = 4U;
+            pxTCPHeader->ucTCPOffset = ( uint8_t ) ( ( ipSIZE_OF_TCP_HEADER + uxOptionsLength ) << 2 );
+        }
+        else
+        {
+            /* Nothing. */
+        }
+
+        return uxOptionsLength;
+    }
 /*-----------------------------------------------------------*/
 
 /*
@@ -2337,112 +2435,118 @@ UBaseType_t uxOptionsLength = pxTCPWindow->ucOptionLength;
  * Called from the states: eSYN_RECEIVED and eCONNECT_SYN
  * If the flags received are correct, the socket will move to eESTABLISHED.
  */
-static BaseType_t prvHandleSynReceived( FreeRTOS_Socket_t *pxSocket, const NetworkBufferDescriptor_t *pxNetworkBuffer,
-	uint32_t ulReceiveLength, UBaseType_t uxOptionsLength )
-{
-ProtocolHeaders_t *pxProtocolHeaders = ipPOINTER_CAST( ProtocolHeaders_t *,
-	&( pxNetworkBuffer->pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER + uxIPHeaderSizeSocket( pxSocket ) ] ) );
-TCPHeader_t *pxTCPHeader = &pxProtocolHeaders->xTCPHeader;
-TCPWindow_t *pxTCPWindow = &pxSocket->u.xTCP.xTCPWindow;
-uint8_t ucTCPFlags = pxTCPHeader->ucTCPFlags;
-uint32_t ulSequenceNumber = FreeRTOS_ntohl( pxTCPHeader->ulSequenceNumber );
-BaseType_t xSendLength = 0;
+    static BaseType_t prvHandleSynReceived( FreeRTOS_Socket_t * pxSocket,
+                                            const NetworkBufferDescriptor_t * pxNetworkBuffer,
+                                            uint32_t ulReceiveLength,
+                                            UBaseType_t uxOptionsLength )
+    {
+        ProtocolHeaders_t * pxProtocolHeaders = ipPOINTER_CAST( ProtocolHeaders_t *,
+                                                                &( pxNetworkBuffer->pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER + uxIPHeaderSizeSocket( pxSocket ) ] ) );
+        TCPHeader_t * pxTCPHeader = &pxProtocolHeaders->xTCPHeader;
+        TCPWindow_t * pxTCPWindow = &pxSocket->u.xTCP.xTCPWindow;
+        uint8_t ucTCPFlags = pxTCPHeader->ucTCPFlags;
+        uint32_t ulSequenceNumber = FreeRTOS_ntohl( pxTCPHeader->ulSequenceNumber );
+        BaseType_t xSendLength = 0;
 
-	/* Either expect a ACK or a SYN+ACK. */
-	uint16_t usExpect = ( uint16_t ) tcpTCP_FLAG_ACK;
-	if( pxSocket->u.xTCP.ucTCPState == ( uint8_t ) eCONNECT_SYN )
-	{
-		usExpect |= ( uint16_t ) tcpTCP_FLAG_SYN;
-	}
+        /* Either expect a ACK or a SYN+ACK. */
+        uint16_t usExpect = ( uint16_t ) tcpTCP_FLAG_ACK;
 
-	if( ipNUMERIC_CAST( uint16_t, ucTCPFlags & 0x17U ) != usExpect )
-	{
-		/* eSYN_RECEIVED: flags 0010 expected, not 0002. */
-		/* eSYN_RECEIVED: flags ACK  expected, not SYN. */
-		FreeRTOS_debug_printf( ( "%s: flags %04X expected, not %04X\n",
-			( pxSocket->u.xTCP.ucTCPState == ( uint8_t ) eSYN_RECEIVED ) ? "eSYN_RECEIVED" : "eCONNECT_SYN",
-			usExpect, ucTCPFlags ) );
-		vTCPStateChange( pxSocket, eCLOSE_WAIT );
-		/* Send RST with the expected sequence and ACK numbers,
-		otherwise the packet will be ignored. */
-		pxTCPWindow->ulOurSequenceNumber = FreeRTOS_htonl( pxTCPHeader->ulAckNr );
-		pxTCPWindow->rx.ulCurrentSequenceNumber = ulSequenceNumber;
+        if( pxSocket->u.xTCP.ucTCPState == ( uint8_t ) eCONNECT_SYN )
+        {
+            usExpect |= ( uint16_t ) tcpTCP_FLAG_SYN;
+        }
 
-		pxTCPHeader->ucTCPFlags |= tcpTCP_FLAG_RST;
-		xSendLength = ipNUMERIC_CAST( BaseType_t, uxIPHeaderSizeSocket( pxSocket ) + ipSIZE_OF_TCP_HEADER + uxOptionsLength );
-		pxTCPHeader->ucTCPOffset = ( uint8_t )( ( ipSIZE_OF_TCP_HEADER + uxOptionsLength ) << 2 );
-	}
-	else
-	{
-		pxTCPWindow->usPeerPortNumber = pxSocket->u.xTCP.usRemotePort;
-		pxTCPWindow->usOurPortNumber = pxSocket->usLocalPort;
+        if( ipNUMERIC_CAST( uint16_t, ucTCPFlags & 0x17U ) != usExpect )
+        {
+            /* eSYN_RECEIVED: flags 0010 expected, not 0002. */
+            /* eSYN_RECEIVED: flags ACK  expected, not SYN. */
+            FreeRTOS_debug_printf( ( "%s: flags %04X expected, not %04X\n",
+                                     ( pxSocket->u.xTCP.ucTCPState == ( uint8_t ) eSYN_RECEIVED ) ? "eSYN_RECEIVED" : "eCONNECT_SYN",
+                                     usExpect, ucTCPFlags ) );
+            vTCPStateChange( pxSocket, eCLOSE_WAIT );
 
-		if( pxSocket->u.xTCP.ucTCPState == ( uint8_t ) eCONNECT_SYN )
-		{
-		ProtocolHeaders_t *pxLastHeaders = ipPOINTER_CAST( ProtocolHeaders_t *,
-			&( pxSocket->u.xTCP.xPacket.u.ucLastPacket[ ipSIZE_OF_ETH_HEADER + uxIPHeaderSizeSocket( pxSocket ) ] ) );
+            /* Send RST with the expected sequence and ACK numbers,
+             * otherwise the packet will be ignored. */
+            pxTCPWindow->ulOurSequenceNumber = FreeRTOS_htonl( pxTCPHeader->ulAckNr );
+            pxTCPWindow->rx.ulCurrentSequenceNumber = ulSequenceNumber;
 
-			/* Clear the SYN flag in lastPacket. */
-			pxLastHeaders->xTCPHeader.ucTCPFlags = tcpTCP_FLAG_ACK;
-			pxProtocolHeaders->xTCPHeader.ucTCPFlags = tcpTCP_FLAG_ACK;
+            pxTCPHeader->ucTCPFlags |= tcpTCP_FLAG_RST;
+            xSendLength = ipNUMERIC_CAST( BaseType_t, uxIPHeaderSizeSocket( pxSocket ) + ipSIZE_OF_TCP_HEADER + uxOptionsLength );
+            pxTCPHeader->ucTCPOffset = ( uint8_t ) ( ( ipSIZE_OF_TCP_HEADER + uxOptionsLength ) << 2 );
+        }
+        else
+        {
+            pxTCPWindow->usPeerPortNumber = pxSocket->u.xTCP.usRemotePort;
+            pxTCPWindow->usOurPortNumber = pxSocket->usLocalPort;
 
-			/* This socket was the one connecting actively so now perform the
-			synchronisation. */
-			vTCPWindowInit( &pxSocket->u.xTCP.xTCPWindow,
-				ulSequenceNumber, pxSocket->u.xTCP.xTCPWindow.ulOurSequenceNumber, ( uint32_t ) pxSocket->u.xTCP.usCurMSS );
-			pxTCPWindow->rx.ulHighestSequenceNumber = ulSequenceNumber + 1U;
-			pxTCPWindow->rx.ulCurrentSequenceNumber = ulSequenceNumber + 1U;
-			pxTCPWindow->tx.ulCurrentSequenceNumber++; /* because we send a TCP_SYN [ | TCP_ACK ]; */
-			pxTCPWindow->ulNextTxSequenceNumber++;
-		}
-		else if( ulReceiveLength == 0U )
-		{
-			pxTCPWindow->rx.ulCurrentSequenceNumber = ulSequenceNumber;
-		}
-		else
-		{
-			/* Nothing. */
-		}
+            if( pxSocket->u.xTCP.ucTCPState == ( uint8_t ) eCONNECT_SYN )
+            {
+                ProtocolHeaders_t * pxLastHeaders = ipPOINTER_CAST( ProtocolHeaders_t *,
+                                                                    &( pxSocket->u.xTCP.xPacket.u.ucLastPacket[ ipSIZE_OF_ETH_HEADER + uxIPHeaderSizeSocket( pxSocket ) ] ) );
 
-		/* The SYN+ACK has been confirmed, increase the next sequence number by
-		1. */
-		pxTCPWindow->ulOurSequenceNumber = pxTCPWindow->tx.ulFirstSequenceNumber + 1U;
+                /* Clear the SYN flag in lastPacket. */
+                pxLastHeaders->xTCPHeader.ucTCPFlags = tcpTCP_FLAG_ACK;
+                pxProtocolHeaders->xTCPHeader.ucTCPFlags = tcpTCP_FLAG_ACK;
 
-		#if( ipconfigUSE_TCP_WIN == 1 )
-		{
-			FreeRTOS_debug_printf( ( "TCP: %s %d => %lxip:%d set ESTAB (scaling %u)\n",
-				( pxSocket->u.xTCP.ucTCPState == ( uint8_t )  eCONNECT_SYN ) ? "active" : "passive",
-				pxSocket->usLocalPort,
-				pxSocket->u.xTCP.ulRemoteIP,
-				pxSocket->u.xTCP.usRemotePort,
-				( unsigned ) pxSocket->u.xTCP.bits.bWinScaling ) );
-		}
-		#endif /* ipconfigUSE_TCP_WIN */
+                /* This socket was the one connecting actively so now perform the
+                 * synchronisation. */
+                vTCPWindowInit( &pxSocket->u.xTCP.xTCPWindow,
+                                ulSequenceNumber, pxSocket->u.xTCP.xTCPWindow.ulOurSequenceNumber, ( uint32_t ) pxSocket->u.xTCP.usCurMSS );
+                pxTCPWindow->rx.ulHighestSequenceNumber = ulSequenceNumber + 1U;
+                pxTCPWindow->rx.ulCurrentSequenceNumber = ulSequenceNumber + 1U;
+                pxTCPWindow->tx.ulCurrentSequenceNumber++; /* because we send a TCP_SYN [ | TCP_ACK ]; */
+                pxTCPWindow->ulNextTxSequenceNumber++;
+            }
+            else if( ulReceiveLength == 0U )
+            {
+                pxTCPWindow->rx.ulCurrentSequenceNumber = ulSequenceNumber;
+            }
+            else
+            {
+                /* Nothing. */
+            }
 
-		if( ( pxSocket->u.xTCP.ucTCPState == ( EventBits_t ) eCONNECT_SYN ) || ( ulReceiveLength != 0UL ) )
-		{
-			pxTCPHeader->ucTCPFlags = tcpTCP_FLAG_ACK;
-			xSendLength = ipNUMERIC_CAST( BaseType_t, uxIPHeaderSizeSocket( pxSocket ) + ( size_t ) ipSIZE_OF_TCP_HEADER + uxOptionsLength );
-			pxTCPHeader->ucTCPOffset = ( uint8_t ) ( ( ipSIZE_OF_TCP_HEADER + uxOptionsLength ) << 2 );
-		}
-		#if( ipconfigUSE_TCP_WIN != 0 )
-		{
-			if( pxSocket->u.xTCP.bits.bWinScaling == pdFALSE_UNSIGNED )
-			{
-				/* The other party did not send a scaling factor.
-				A shifting factor in this side must be canceled. */
-				pxSocket->u.xTCP.ucMyWinScaleFactor = 0;
-				pxSocket->u.xTCP.ucPeerWinScaleFactor = 0;
-			}
-		}
-		#endif /* ipconfigUSE_TCP_WIN */
-		/* This was the third step of connecting: SYN, SYN+ACK, ACK	so now the
-		connection is established. */
-		vTCPStateChange( pxSocket, eESTABLISHED );
-	}
+            /* The SYN+ACK has been confirmed, increase the next sequence number by
+             * 1. */
+            pxTCPWindow->ulOurSequenceNumber = pxTCPWindow->tx.ulFirstSequenceNumber + 1U;
 
-	return xSendLength;
-}
+            #if ( ipconfigUSE_TCP_WIN == 1 )
+                {
+                    FreeRTOS_debug_printf( ( "TCP: %s %d => %lxip:%d set ESTAB (scaling %u)\n",
+                                             ( pxSocket->u.xTCP.ucTCPState == ( uint8_t ) eCONNECT_SYN ) ? "active" : "passive",
+                                             pxSocket->usLocalPort,
+                                             pxSocket->u.xTCP.ulRemoteIP,
+                                             pxSocket->u.xTCP.usRemotePort,
+                                             ( unsigned ) pxSocket->u.xTCP.bits.bWinScaling ) );
+                }
+            #endif /* ipconfigUSE_TCP_WIN */
+
+            if( ( pxSocket->u.xTCP.ucTCPState == ( EventBits_t ) eCONNECT_SYN ) || ( ulReceiveLength != 0UL ) )
+            {
+                pxTCPHeader->ucTCPFlags = tcpTCP_FLAG_ACK;
+                xSendLength = ipNUMERIC_CAST( BaseType_t, uxIPHeaderSizeSocket( pxSocket ) + ( size_t ) ipSIZE_OF_TCP_HEADER + uxOptionsLength );
+                pxTCPHeader->ucTCPOffset = ( uint8_t ) ( ( ipSIZE_OF_TCP_HEADER + uxOptionsLength ) << 2 );
+            }
+
+            #if ( ipconfigUSE_TCP_WIN != 0 )
+                {
+                    if( pxSocket->u.xTCP.bits.bWinScaling == pdFALSE_UNSIGNED )
+                    {
+                        /* The other party did not send a scaling factor.
+                         * A shifting factor in this side must be canceled. */
+                        pxSocket->u.xTCP.ucMyWinScaleFactor = 0;
+                        pxSocket->u.xTCP.ucPeerWinScaleFactor = 0;
+                    }
+                }
+            #endif /* ipconfigUSE_TCP_WIN */
+
+            /* This was the third step of connecting: SYN, SYN+ACK, ACK	so now the
+             * connection is established. */
+            vTCPStateChange( pxSocket, eESTABLISHED );
+        }
+
+        return xSendLength;
+    }
 /*-----------------------------------------------------------*/
 
 /*
@@ -2453,162 +2557,167 @@ BaseType_t xSendLength = 0;
  * the code will check if it may be accepted, i.e. if all expected data has been
  * completely received.
  */
-static BaseType_t prvHandleEstablished( FreeRTOS_Socket_t *pxSocket, NetworkBufferDescriptor_t **ppxNetworkBuffer,
-	uint32_t ulReceiveLength, UBaseType_t uxOptionsLength )
-{
-ProtocolHeaders_t *pxProtocolHeaders = ipPOINTER_CAST( ProtocolHeaders_t *,
-	&( ( *ppxNetworkBuffer )->pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER + uxIPHeaderSizeSocket( pxSocket ) ] ) );
-TCPHeader_t *pxTCPHeader = &pxProtocolHeaders->xTCPHeader;
-TCPWindow_t *pxTCPWindow = &pxSocket->u.xTCP.xTCPWindow;
-uint8_t ucTCPFlags = pxTCPHeader->ucTCPFlags;
-uint32_t ulSequenceNumber = FreeRTOS_ntohl( pxTCPHeader->ulSequenceNumber ), ulCount;
-BaseType_t xSendLength = 0, xMayClose = pdFALSE, bRxComplete, bTxDone;
-int32_t lDistance, lSendResult;
-uint16_t usWindow;
+    static BaseType_t prvHandleEstablished( FreeRTOS_Socket_t * pxSocket,
+                                            NetworkBufferDescriptor_t ** ppxNetworkBuffer,
+                                            uint32_t ulReceiveLength,
+                                            UBaseType_t uxOptionsLength )
+    {
+        ProtocolHeaders_t * pxProtocolHeaders = ipPOINTER_CAST( ProtocolHeaders_t *,
+                                                                &( ( *ppxNetworkBuffer )->pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER + uxIPHeaderSizeSocket( pxSocket ) ] ) );
+        TCPHeader_t * pxTCPHeader = &pxProtocolHeaders->xTCPHeader;
+        TCPWindow_t * pxTCPWindow = &pxSocket->u.xTCP.xTCPWindow;
+        uint8_t ucTCPFlags = pxTCPHeader->ucTCPFlags;
+        uint32_t ulSequenceNumber = FreeRTOS_ntohl( pxTCPHeader->ulSequenceNumber ), ulCount;
+        BaseType_t xSendLength = 0, xMayClose = pdFALSE, bRxComplete, bTxDone;
+        int32_t lDistance, lSendResult;
+        uint16_t usWindow;
 
-	/* Remember the window size the peer is advertising. */
-	usWindow = FreeRTOS_ntohs( pxTCPHeader->usWindow );
-	pxSocket->u.xTCP.ulWindowSize = ( uint32_t ) usWindow;
-	#if( ipconfigUSE_TCP_WIN != 0 )
-	{
-		pxSocket->u.xTCP.ulWindowSize =
-			( pxSocket->u.xTCP.ulWindowSize << pxSocket->u.xTCP.ucPeerWinScaleFactor );
-	}
-	#endif /* ipconfigUSE_TCP_WIN */
+        /* Remember the window size the peer is advertising. */
+        usWindow = FreeRTOS_ntohs( pxTCPHeader->usWindow );
+        pxSocket->u.xTCP.ulWindowSize = ( uint32_t ) usWindow;
+        #if ( ipconfigUSE_TCP_WIN != 0 )
+            {
+                pxSocket->u.xTCP.ulWindowSize =
+                    ( pxSocket->u.xTCP.ulWindowSize << pxSocket->u.xTCP.ucPeerWinScaleFactor );
+            }
+        #endif /* ipconfigUSE_TCP_WIN */
 
-	if( ( ucTCPFlags & ( uint8_t ) tcpTCP_FLAG_ACK ) != 0U )
-	{
-		ulCount = ulTCPWindowTxAck( pxTCPWindow, FreeRTOS_ntohl( pxTCPHeader->ulAckNr ) );
+        if( ( ucTCPFlags & ( uint8_t ) tcpTCP_FLAG_ACK ) != 0U )
+        {
+            ulCount = ulTCPWindowTxAck( pxTCPWindow, FreeRTOS_ntohl( pxTCPHeader->ulAckNr ) );
 
-		/* ulTCPWindowTxAck() returns the number of bytes which have been acked,
-		starting at 'tx.ulCurrentSequenceNumber'.  Advance the tail pointer in
-		txStream. */
-		if( ( pxSocket->u.xTCP.txStream != NULL ) && ( ulCount > 0U ) )
-		{
-			/* Just advancing the tail index, 'ulCount' bytes have been
-			confirmed, and because there is new space in the txStream, the
-			user/owner should be woken up. */
-			/* _HT_ : only in case the socket's waiting? */
-			if( uxStreamBufferGet( pxSocket->u.xTCP.txStream, 0U, NULL, ( size_t ) ulCount, pdFALSE ) != 0U )
-			{
-				pxSocket->xEventBits |= ( EventBits_t ) eSOCKET_SEND;
+            /* ulTCPWindowTxAck() returns the number of bytes which have been acked,
+             * starting at 'tx.ulCurrentSequenceNumber'.  Advance the tail pointer in
+             * txStream. */
+            if( ( pxSocket->u.xTCP.txStream != NULL ) && ( ulCount > 0U ) )
+            {
+                /* Just advancing the tail index, 'ulCount' bytes have been
+                 * confirmed, and because there is new space in the txStream, the
+                 * user/owner should be woken up. */
+                /* _HT_ : only in case the socket's waiting? */
+                if( uxStreamBufferGet( pxSocket->u.xTCP.txStream, 0U, NULL, ( size_t ) ulCount, pdFALSE ) != 0U )
+                {
+                    pxSocket->xEventBits |= ( EventBits_t ) eSOCKET_SEND;
 
-				#if ipconfigSUPPORT_SELECT_FUNCTION == 1
-				{
-					if( ( pxSocket->xSelectBits & ( ( EventBits_t ) eSELECT_WRITE ) ) != 0U )
-					{
-						pxSocket->xEventBits |= ( ( EventBits_t ) eSELECT_WRITE ) << SOCKET_EVENT_BIT_COUNT;
-					}
-				}
-				#endif
-				/* In case the socket owner has installed an OnSent handler,
-				call it now. */
-				#if( ipconfigUSE_CALLBACKS == 1 )
-				{
-					if( ipconfigIS_VALID_PROG_ADDRESS( pxSocket->u.xTCP.pxHandleSent ) )
-					{
-						pxSocket->u.xTCP.pxHandleSent( ( Socket_t ) pxSocket, ulCount );
-					}
-				}
-				#endif /* ipconfigUSE_CALLBACKS == 1  */
-			}
-		}
-	}
+                    #if ipconfigSUPPORT_SELECT_FUNCTION == 1
+                        {
+                            if( ( pxSocket->xSelectBits & ( ( EventBits_t ) eSELECT_WRITE ) ) != 0U )
+                            {
+                                pxSocket->xEventBits |= ( ( EventBits_t ) eSELECT_WRITE ) << SOCKET_EVENT_BIT_COUNT;
+                            }
+                        }
+                    #endif
 
-	/* If this socket has a stream for transmission, add the data to the
-	outgoing segment(s). */
-	if( pxSocket->u.xTCP.txStream != NULL )
-	{
-		prvTCPAddTxData( pxSocket );
-	}
+                    /* In case the socket owner has installed an OnSent handler,
+                     * call it now. */
+                    #if ( ipconfigUSE_CALLBACKS == 1 )
+                        {
+                            if( ipconfigIS_VALID_PROG_ADDRESS( pxSocket->u.xTCP.pxHandleSent ) )
+                            {
+                                pxSocket->u.xTCP.pxHandleSent( ( Socket_t ) pxSocket, ulCount );
+                            }
+                        }
+                    #endif /* ipconfigUSE_CALLBACKS == 1  */
+                }
+            }
+        }
 
-	pxSocket->u.xTCP.xTCPWindow.ulOurSequenceNumber = pxTCPWindow->tx.ulCurrentSequenceNumber;
+        /* If this socket has a stream for transmission, add the data to the
+         * outgoing segment(s). */
+        if( pxSocket->u.xTCP.txStream != NULL )
+        {
+            prvTCPAddTxData( pxSocket );
+        }
 
-	if( ( pxSocket->u.xTCP.bits.bFinAccepted != pdFALSE_UNSIGNED ) || ( ( ucTCPFlags & ( uint8_t ) tcpTCP_FLAG_FIN ) != 0U ) )
-	{
-		/* Peer is requesting to stop, see if we're really finished. */
-		xMayClose = pdTRUE;
+        pxSocket->u.xTCP.xTCPWindow.ulOurSequenceNumber = pxTCPWindow->tx.ulCurrentSequenceNumber;
 
-		/* Checks are only necessary if we haven't sent a FIN yet. */
-		if( pxSocket->u.xTCP.bits.bFinSent == pdFALSE_UNSIGNED )
-		{
-			/* xTCPWindowTxDone returns true when all Tx queues are empty. */
-			bRxComplete = xTCPWindowRxEmpty( pxTCPWindow );
-			bTxDone		= xTCPWindowTxDone( pxTCPWindow );
+        if( ( pxSocket->u.xTCP.bits.bFinAccepted != pdFALSE_UNSIGNED ) || ( ( ucTCPFlags & ( uint8_t ) tcpTCP_FLAG_FIN ) != 0U ) )
+        {
+            /* Peer is requesting to stop, see if we're really finished. */
+            xMayClose = pdTRUE;
 
-			if( ( bRxComplete == 0 ) || ( bTxDone == 0 ) )
-			{
-				/* Refusing FIN: Rx incomp 1 optlen 4 tx done 1. */
-				FreeRTOS_debug_printf( ( "Refusing FIN[%u,%u]: RxCompl %lu tx done %ld\n",
-					pxSocket->usLocalPort,
-					pxSocket->u.xTCP.usRemotePort,
-					bRxComplete, bTxDone ) );
-				xMayClose = pdFALSE;
-			}
-			else
-			{
-				lDistance = ipNUMERIC_CAST( int32_t, ulSequenceNumber + ulReceiveLength - pxTCPWindow->rx.ulCurrentSequenceNumber );
+            /* Checks are only necessary if we haven't sent a FIN yet. */
+            if( pxSocket->u.xTCP.bits.bFinSent == pdFALSE_UNSIGNED )
+            {
+                /* xTCPWindowTxDone returns true when all Tx queues are empty. */
+                bRxComplete = xTCPWindowRxEmpty( pxTCPWindow );
+                bTxDone = xTCPWindowTxDone( pxTCPWindow );
 
-				if( lDistance > 1 )
-				{
-					FreeRTOS_debug_printf( ( "Refusing FIN: Rx not complete %ld (cur %lu high %lu)\n",
-						lDistance, pxTCPWindow->rx.ulCurrentSequenceNumber - pxTCPWindow->rx.ulFirstSequenceNumber,
-						pxTCPWindow->rx.ulHighestSequenceNumber - pxTCPWindow->rx.ulFirstSequenceNumber ) );
+                if( ( bRxComplete == 0 ) || ( bTxDone == 0 ) )
+                {
+                    /* Refusing FIN: Rx incomp 1 optlen 4 tx done 1. */
+                    FreeRTOS_debug_printf( ( "Refusing FIN[%u,%u]: RxCompl %lu tx done %ld\n",
+                                             pxSocket->usLocalPort,
+                                             pxSocket->u.xTCP.usRemotePort,
+                                             bRxComplete, bTxDone ) );
+                    xMayClose = pdFALSE;
+                }
+                else
+                {
+                    lDistance = ipNUMERIC_CAST( int32_t, ulSequenceNumber + ulReceiveLength - pxTCPWindow->rx.ulCurrentSequenceNumber );
 
-					xMayClose = pdFALSE;
-				}
-			}
-		}
+                    if( lDistance > 1 )
+                    {
+                        FreeRTOS_debug_printf( ( "Refusing FIN: Rx not complete %ld (cur %lu high %lu)\n",
+                                                 lDistance, pxTCPWindow->rx.ulCurrentSequenceNumber - pxTCPWindow->rx.ulFirstSequenceNumber,
+                                                 pxTCPWindow->rx.ulHighestSequenceNumber - pxTCPWindow->rx.ulFirstSequenceNumber ) );
 
-		if( xTCPWindowLoggingLevel > 0 )
-		{
-			FreeRTOS_debug_printf( ( "TCP: FIN received, mayClose = %ld (Rx %lu Len %ld, Tx %lu)\n",
-				xMayClose, ulSequenceNumber - pxSocket->u.xTCP.xTCPWindow.rx.ulFirstSequenceNumber, ulReceiveLength,
-				pxTCPWindow->tx.ulCurrentSequenceNumber - pxSocket->u.xTCP.xTCPWindow.tx.ulFirstSequenceNumber ) );
-		}
+                        xMayClose = pdFALSE;
+                    }
+                }
+            }
 
-		if( xMayClose != pdFALSE )
-		{
-			pxSocket->u.xTCP.bits.bFinAccepted = pdTRUE_UNSIGNED;
-			xSendLength = prvTCPHandleFin( pxSocket, *ppxNetworkBuffer );
-		}
-	}
+            if( xTCPWindowLoggingLevel > 0 )
+            {
+                FreeRTOS_debug_printf( ( "TCP: FIN received, mayClose = %ld (Rx %lu Len %ld, Tx %lu)\n",
+                                         xMayClose, ulSequenceNumber - pxSocket->u.xTCP.xTCPWindow.rx.ulFirstSequenceNumber, ulReceiveLength,
+                                         pxTCPWindow->tx.ulCurrentSequenceNumber - pxSocket->u.xTCP.xTCPWindow.tx.ulFirstSequenceNumber ) );
+            }
 
-	if( xMayClose == pdFALSE )
-	{
-		pxTCPHeader->ucTCPFlags = tcpTCP_FLAG_ACK;
+            if( xMayClose != pdFALSE )
+            {
+                pxSocket->u.xTCP.bits.bFinAccepted = pdTRUE_UNSIGNED;
+                xSendLength = prvTCPHandleFin( pxSocket, *ppxNetworkBuffer );
+            }
+        }
 
-		if( ulReceiveLength != 0U )
-		{
-			xSendLength = ipNUMERIC_CAST( BaseType_t, uxIPHeaderSizeSocket( pxSocket ) + ipSIZE_OF_TCP_HEADER + uxOptionsLength );
-			/* TCP-offsett equals '( ( length / 4 ) << 4 )', resulting in a shift-left 2 */
-			pxTCPHeader->ucTCPOffset = ( uint8_t )( ( ipSIZE_OF_TCP_HEADER + uxOptionsLength ) << 2 );
+        if( xMayClose == pdFALSE )
+        {
+            pxTCPHeader->ucTCPFlags = tcpTCP_FLAG_ACK;
 
-			if( pxSocket->u.xTCP.bits.bFinSent != pdFALSE_UNSIGNED )
-			{
-				pxTCPWindow->tx.ulCurrentSequenceNumber = pxTCPWindow->tx.ulFINSequenceNumber;
-			}
-		}
+            if( ulReceiveLength != 0U )
+            {
+                xSendLength = ipNUMERIC_CAST( BaseType_t, uxIPHeaderSizeSocket( pxSocket ) + ipSIZE_OF_TCP_HEADER + uxOptionsLength );
+                /* TCP-offsett equals '( ( length / 4 ) << 4 )', resulting in a shift-left 2 */
+                pxTCPHeader->ucTCPOffset = ( uint8_t ) ( ( ipSIZE_OF_TCP_HEADER + uxOptionsLength ) << 2 );
 
-		/* Now get data to be transmitted. */
-		/* _HT_ patch: since the MTU has be fixed at 1500 in stead of 1526, TCP
-		can not	send-out both TCP options and also a full packet. Sending
-		options (SACK) is always more urgent than sending data, which can be
-		sent later. */
-		if( uxOptionsLength == 0U )
-		{
-			/* prvTCPPrepareSend might allocate a bigger network buffer, if
-			necessary. */
-			lSendResult = prvTCPPrepareSend( pxSocket, ppxNetworkBuffer, uxOptionsLength );
-			if( lSendResult > 0 )
-			{
-				xSendLength = ( BaseType_t ) lSendResult;
-			}
-		}
-	}
+                if( pxSocket->u.xTCP.bits.bFinSent != pdFALSE_UNSIGNED )
+                {
+                    pxTCPWindow->tx.ulCurrentSequenceNumber = pxTCPWindow->tx.ulFINSequenceNumber;
+                }
+            }
 
-	return xSendLength;
-}
+            /* Now get data to be transmitted. */
+
+            /* _HT_ patch: since the MTU has be fixed at 1500 in stead of 1526, TCP
+             * can not	send-out both TCP options and also a full packet. Sending
+             * options (SACK) is always more urgent than sending data, which can be
+             * sent later. */
+            if( uxOptionsLength == 0U )
+            {
+                /* prvTCPPrepareSend might allocate a bigger network buffer, if
+                 * necessary. */
+                lSendResult = prvTCPPrepareSend( pxSocket, ppxNetworkBuffer, uxOptionsLength );
+
+                if( lSendResult > 0 )
+                {
+                    xSendLength = ( BaseType_t ) lSendResult;
+                }
+            }
+        }
+
+        return xSendLength;
+    }
 /*-----------------------------------------------------------*/
 
 /*
@@ -2616,133 +2725,136 @@ uint16_t usWindow;
  * ipconfigUSE_TCP_WIN is defined, and if only an ACK must be sent, it will be
  * checked if it would better be postponed for efficiency.
  */
-static BaseType_t prvSendData( FreeRTOS_Socket_t *pxSocket, NetworkBufferDescriptor_t **ppxNetworkBuffer,
-	uint32_t ulReceiveLength, BaseType_t xByteCount )
-{
-const ProtocolHeaders_t *pxProtocolHeaders = ipPOINTER_CAST( ProtocolHeaders_t *,
-	&( ( *ppxNetworkBuffer )->pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER + xIPHeaderSize( *ppxNetworkBuffer ) ] ) );
-const TCPHeader_t *pxTCPHeader = &pxProtocolHeaders->xTCPHeader;
-const TCPWindow_t *pxTCPWindow = &pxSocket->u.xTCP.xTCPWindow;
+    static BaseType_t prvSendData( FreeRTOS_Socket_t * pxSocket,
+                                   NetworkBufferDescriptor_t ** ppxNetworkBuffer,
+                                   uint32_t ulReceiveLength,
+                                   BaseType_t xByteCount )
+    {
+        const ProtocolHeaders_t * pxProtocolHeaders = ipPOINTER_CAST( ProtocolHeaders_t *,
+                                                                      &( ( *ppxNetworkBuffer )->pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER + xIPHeaderSize( *ppxNetworkBuffer ) ] ) );
+        const TCPHeader_t * pxTCPHeader = &pxProtocolHeaders->xTCPHeader;
+        const TCPWindow_t * pxTCPWindow = &pxSocket->u.xTCP.xTCPWindow;
 /* Find out what window size we may advertised. */
-int32_t lRxSpace;
-BaseType_t xSendLength = xByteCount;
-#if( ipconfigUSE_TCP_WIN == 1 )
-	#if( ipconfigTCP_ACK_EARLIER_PACKET == 0 )
-		const int32_t lMinLength = 0;
-	#else
-		int32_t lMinLength;
-	#endif
-#endif
+        int32_t lRxSpace;
+        BaseType_t xSendLength = xByteCount;
 
-	/* Set the time-out field, so that we'll be called by the IP-task in case no
-	next message will be received. */
-	lRxSpace = ipNUMERIC_CAST( int32_t, pxSocket->u.xTCP.ulHighestRxAllowed - pxTCPWindow->rx.ulCurrentSequenceNumber );
-	#if ipconfigUSE_TCP_WIN == 1
-	{
+        #if ( ipconfigUSE_TCP_WIN == 1 )
+            #if ( ipconfigTCP_ACK_EARLIER_PACKET == 0 )
+                const int32_t lMinLength = 0;
+            #else
+                int32_t lMinLength;
+            #endif
+        #endif
 
-		#if( ipconfigTCP_ACK_EARLIER_PACKET != 0 )
-		{
-			lMinLength = ( ( int32_t ) 2 ) * ( ( int32_t ) pxSocket->u.xTCP.usCurMSS );
-		}
-		#endif /* ipconfigTCP_ACK_EARLIER_PACKET */
+        /* Set the time-out field, so that we'll be called by the IP-task in case no
+         * next message will be received. */
+        lRxSpace = ipNUMERIC_CAST( int32_t, pxSocket->u.xTCP.ulHighestRxAllowed - pxTCPWindow->rx.ulCurrentSequenceNumber );
+        #if ipconfigUSE_TCP_WIN == 1
+            {
+                #if ( ipconfigTCP_ACK_EARLIER_PACKET != 0 )
+                    {
+                        lMinLength = ( ( int32_t ) 2 ) * ( ( int32_t ) pxSocket->u.xTCP.usCurMSS );
+                    }
+                #endif /* ipconfigTCP_ACK_EARLIER_PACKET */
 
-		/* In case we're receiving data continuously, we might postpone sending
-		an ACK to gain performance. */
-		/* lint e9007 is OK because 'uxIPHeaderSizeSocket()' has no side-effects. */
-		if( ( ulReceiveLength > 0U ) &&							/* Data was sent to this socket. */
-			( lRxSpace >= lMinLength ) &&						/* There is Rx space for more data. */
-			( pxSocket->u.xTCP.bits.bFinSent == pdFALSE_UNSIGNED ) &&	/* Not in a closure phase. */
-			( xSendLength == ipNUMERIC_CAST( BaseType_t, uxIPHeaderSizeSocket( pxSocket ) + ipSIZE_OF_TCP_HEADER ) ) && /* No Tx data or options to be sent. */
-			( pxSocket->u.xTCP.ucTCPState == ( uint8_t ) eESTABLISHED ) &&	/* Connection established. */
-			( pxTCPHeader->ucTCPFlags == tcpTCP_FLAG_ACK ) )		/* There are no other flags than an ACK. */
-		{
-			if( pxSocket->u.xTCP.pxAckMessage != *ppxNetworkBuffer )
-			{
-				/* There was still a delayed in queue, delete it. */
-				if( pxSocket->u.xTCP.pxAckMessage != NULL )
-				{
-					vReleaseNetworkBufferAndDescriptor( pxSocket->u.xTCP.pxAckMessage );
-				}
+                /* In case we're receiving data continuously, we might postpone sending
+                 * an ACK to gain performance. */
+                /* lint e9007 is OK because 'uxIPHeaderSizeSocket()' has no side-effects. */
+                if( ( ulReceiveLength > 0U ) &&                                                                                 /* Data was sent to this socket. */
+                    ( lRxSpace >= lMinLength ) &&                                                                               /* There is Rx space for more data. */
+                    ( pxSocket->u.xTCP.bits.bFinSent == pdFALSE_UNSIGNED ) &&                                                   /* Not in a closure phase. */
+                    ( xSendLength == ipNUMERIC_CAST( BaseType_t, uxIPHeaderSizeSocket( pxSocket ) + ipSIZE_OF_TCP_HEADER ) ) && /* No Tx data or options to be sent. */
+                    ( pxSocket->u.xTCP.ucTCPState == ( uint8_t ) eESTABLISHED ) &&                                              /* Connection established. */
+                    ( pxTCPHeader->ucTCPFlags == tcpTCP_FLAG_ACK ) )                                                            /* There are no other flags than an ACK. */
+                {
+                    if( pxSocket->u.xTCP.pxAckMessage != *ppxNetworkBuffer )
+                    {
+                        /* There was still a delayed in queue, delete it. */
+                        if( pxSocket->u.xTCP.pxAckMessage != NULL )
+                        {
+                            vReleaseNetworkBufferAndDescriptor( pxSocket->u.xTCP.pxAckMessage );
+                        }
 
-				pxSocket->u.xTCP.pxAckMessage = *ppxNetworkBuffer;
-			}
-			if( ( ulReceiveLength < ( uint32_t ) pxSocket->u.xTCP.usCurMSS ) ||	/* Received a small message. */
-				( lRxSpace < ipNUMERIC_CAST( int32_t, 2U * pxSocket->u.xTCP.usCurMSS ) ) )	/* There are less than 2 x MSS space in the Rx buffer. */
-			{
-				pxSocket->u.xTCP.usTimeout = ( uint16_t ) tcpDELAYED_ACK_SHORT_DELAY_MS;
-			}
-			else
-			{
-				/* Normally a delayed ACK should wait 200 ms for a next incoming
-				packet.  Only wait 20 ms here to gain performance.  A slow ACK
-				for full-size message. */
-				pxSocket->u.xTCP.usTimeout = ( uint16_t ) ipMS_TO_MIN_TICKS( tcpDELAYED_ACK_LONGER_DELAY_MS );
-			}
+                        pxSocket->u.xTCP.pxAckMessage = *ppxNetworkBuffer;
+                    }
 
-			if( ( xTCPWindowLoggingLevel > 1 ) && ( ipconfigTCP_MAY_LOG_PORT( pxSocket->usLocalPort ) ) )
-			{
-				FreeRTOS_debug_printf( ( "Send[%u->%u] del ACK %lu SEQ %lu (len %lu) tmout %u d %lu\n",
-					pxSocket->usLocalPort,
-					pxSocket->u.xTCP.usRemotePort,
-					pxTCPWindow->rx.ulCurrentSequenceNumber - pxTCPWindow->rx.ulFirstSequenceNumber,
-					pxSocket->u.xTCP.xTCPWindow.ulOurSequenceNumber - pxTCPWindow->tx.ulFirstSequenceNumber,
-					xSendLength,
-					pxSocket->u.xTCP.usTimeout, lRxSpace ) );
-			}
+                    if( ( ulReceiveLength < ( uint32_t ) pxSocket->u.xTCP.usCurMSS ) ||            /* Received a small message. */
+                        ( lRxSpace < ipNUMERIC_CAST( int32_t, 2U * pxSocket->u.xTCP.usCurMSS ) ) ) /* There are less than 2 x MSS space in the Rx buffer. */
+                    {
+                        pxSocket->u.xTCP.usTimeout = ( uint16_t ) tcpDELAYED_ACK_SHORT_DELAY_MS;
+                    }
+                    else
+                    {
+                        /* Normally a delayed ACK should wait 200 ms for a next incoming
+                         * packet.  Only wait 20 ms here to gain performance.  A slow ACK
+                         * for full-size message. */
+                        pxSocket->u.xTCP.usTimeout = ( uint16_t ) ipMS_TO_MIN_TICKS( tcpDELAYED_ACK_LONGER_DELAY_MS );
+                    }
 
-			*ppxNetworkBuffer = NULL;
-			xSendLength = 0;
-		}
-		else if( pxSocket->u.xTCP.pxAckMessage != NULL )
-		{
-			/* As an ACK is not being delayed, remove any earlier delayed ACK
-			message. */
-			if( pxSocket->u.xTCP.pxAckMessage != *ppxNetworkBuffer )
-			{
-				vReleaseNetworkBufferAndDescriptor( pxSocket->u.xTCP.pxAckMessage );
-			}
+                    if( ( xTCPWindowLoggingLevel > 1 ) && ( ipconfigTCP_MAY_LOG_PORT( pxSocket->usLocalPort ) ) )
+                    {
+                        FreeRTOS_debug_printf( ( "Send[%u->%u] del ACK %lu SEQ %lu (len %lu) tmout %u d %lu\n",
+                                                 pxSocket->usLocalPort,
+                                                 pxSocket->u.xTCP.usRemotePort,
+                                                 pxTCPWindow->rx.ulCurrentSequenceNumber - pxTCPWindow->rx.ulFirstSequenceNumber,
+                                                 pxSocket->u.xTCP.xTCPWindow.ulOurSequenceNumber - pxTCPWindow->tx.ulFirstSequenceNumber,
+                                                 xSendLength,
+                                                 pxSocket->u.xTCP.usTimeout, lRxSpace ) );
+                    }
 
-			pxSocket->u.xTCP.pxAckMessage = NULL;
-		}
-		else
-		{
-			/* The ack will not be postponed, and there was no stored ack ( in 'pxAckMessage' ). */
-		}
-	}
-	#else
-	{
-		/* Remove compiler warnings. */
-		( void ) ulReceiveLength;
-		( void ) pxTCPHeader;
-		( void ) lRxSpace;
-	}
-	#endif /* ipconfigUSE_TCP_WIN */
+                    *ppxNetworkBuffer = NULL;
+                    xSendLength = 0;
+                }
+                else if( pxSocket->u.xTCP.pxAckMessage != NULL )
+                {
+                    /* As an ACK is not being delayed, remove any earlier delayed ACK
+                     * message. */
+                    if( pxSocket->u.xTCP.pxAckMessage != *ppxNetworkBuffer )
+                    {
+                        vReleaseNetworkBufferAndDescriptor( pxSocket->u.xTCP.pxAckMessage );
+                    }
 
-	if( xSendLength != 0 )
-	{
-		if( ( xTCPWindowLoggingLevel > 1 ) && ( ipconfigTCP_MAY_LOG_PORT( pxSocket->usLocalPort ) ) )
-		{
-			FreeRTOS_debug_printf( ( "Send[%u->%u] imm ACK %lu SEQ %lu (len %lu)\n",
-				pxSocket->usLocalPort,
-				pxSocket->u.xTCP.usRemotePort,
-				pxTCPWindow->rx.ulCurrentSequenceNumber - pxTCPWindow->rx.ulFirstSequenceNumber,
-				pxTCPWindow->ulOurSequenceNumber - pxTCPWindow->tx.ulFirstSequenceNumber,
-				xSendLength ) );
-		}
+                    pxSocket->u.xTCP.pxAckMessage = NULL;
+                }
+                else
+                {
+                    /* The ack will not be postponed, and there was no stored ack ( in 'pxAckMessage' ). */
+                }
+            }
+        #else /* if ipconfigUSE_TCP_WIN == 1 */
+            {
+                /* Remove compiler warnings. */
+                ( void ) ulReceiveLength;
+                ( void ) pxTCPHeader;
+                ( void ) lRxSpace;
+            }
+        #endif /* ipconfigUSE_TCP_WIN */
 
-		/* Set the parameter 'xReleaseAfterSend' to the value of
-		ipconfigZERO_COPY_TX_DRIVER. */
-		prvTCPReturnPacket( pxSocket, *ppxNetworkBuffer, ( uint32_t ) xSendLength, ipconfigZERO_COPY_TX_DRIVER );
-		#if( ipconfigZERO_COPY_TX_DRIVER != 0 )
-		{
-			/* The driver has taken ownership of the Network Buffer. */
-			*ppxNetworkBuffer = NULL;
-		}
-		#endif
-	}
+        if( xSendLength != 0 )
+        {
+            if( ( xTCPWindowLoggingLevel > 1 ) && ( ipconfigTCP_MAY_LOG_PORT( pxSocket->usLocalPort ) ) )
+            {
+                FreeRTOS_debug_printf( ( "Send[%u->%u] imm ACK %lu SEQ %lu (len %lu)\n",
+                                         pxSocket->usLocalPort,
+                                         pxSocket->u.xTCP.usRemotePort,
+                                         pxTCPWindow->rx.ulCurrentSequenceNumber - pxTCPWindow->rx.ulFirstSequenceNumber,
+                                         pxTCPWindow->ulOurSequenceNumber - pxTCPWindow->tx.ulFirstSequenceNumber,
+                                         xSendLength ) );
+            }
 
-	return xSendLength;
-}
+            /* Set the parameter 'xReleaseAfterSend' to the value of
+             * ipconfigZERO_COPY_TX_DRIVER. */
+            prvTCPReturnPacket( pxSocket, *ppxNetworkBuffer, ( uint32_t ) xSendLength, ipconfigZERO_COPY_TX_DRIVER );
+            #if ( ipconfigZERO_COPY_TX_DRIVER != 0 )
+                {
+                    /* The driver has taken ownership of the Network Buffer. */
+                    *ppxNetworkBuffer = NULL;
+                }
+            #endif
+        }
+
+        return xSendLength;
+    }
 /*-----------------------------------------------------------*/
 
 /*
@@ -2761,237 +2873,237 @@ BaseType_t xSendLength = xByteCount;
  * As these functions are declared static, and they're called from one location
  * only, most compilers will inline them, thus avoiding a call and return.
  */
-static BaseType_t prvTCPHandleState( FreeRTOS_Socket_t *pxSocket, NetworkBufferDescriptor_t **ppxNetworkBuffer )
-{
-ProtocolHeaders_t *pxProtocolHeaders = ipPOINTER_CAST( ProtocolHeaders_t *,
-	&( ( *ppxNetworkBuffer )->pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER + xIPHeaderSize( *ppxNetworkBuffer ) ] ) );
-TCPHeader_t *pxTCPHeader = &( pxProtocolHeaders->xTCPHeader );
-BaseType_t xSendLength = 0;
-uint32_t ulReceiveLength;	/* Number of bytes contained in the TCP message. */
-uint8_t *pucRecvData;
-uint32_t ulSequenceNumber = FreeRTOS_ntohl (pxTCPHeader->ulSequenceNumber);
+    static BaseType_t prvTCPHandleState( FreeRTOS_Socket_t * pxSocket,
+                                         NetworkBufferDescriptor_t ** ppxNetworkBuffer )
+    {
+        ProtocolHeaders_t * pxProtocolHeaders = ipPOINTER_CAST( ProtocolHeaders_t *,
+                                                                &( ( *ppxNetworkBuffer )->pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER + xIPHeaderSize( *ppxNetworkBuffer ) ] ) );
+        TCPHeader_t * pxTCPHeader = &( pxProtocolHeaders->xTCPHeader );
+        BaseType_t xSendLength = 0;
+        uint32_t ulReceiveLength; /* Number of bytes contained in the TCP message. */
+        uint8_t * pucRecvData;
+        uint32_t ulSequenceNumber = FreeRTOS_ntohl( pxTCPHeader->ulSequenceNumber );
 
-	/* uxOptionsLength: the size of the options to be sent (always a multiple of
-	4 bytes)
-	1. in the SYN phase, we shall communicate the MSS
-	2. in case of a SACK, Selective ACK, ack a segment which comes in
-	out-of-order. */
-UBaseType_t uxOptionsLength = 0U;
-uint8_t ucTCPFlags = pxTCPHeader->ucTCPFlags;
-TCPWindow_t *pxTCPWindow = &( pxSocket->u.xTCP.xTCPWindow );
+        /* uxOptionsLength: the size of the options to be sent (always a multiple of
+         * 4 bytes)
+         * 1. in the SYN phase, we shall communicate the MSS
+         * 2. in case of a SACK, Selective ACK, ack a segment which comes in
+         * out-of-order. */
+        UBaseType_t uxOptionsLength = 0U;
+        uint8_t ucTCPFlags = pxTCPHeader->ucTCPFlags;
+        TCPWindow_t * pxTCPWindow = &( pxSocket->u.xTCP.xTCPWindow );
 
-	/* First get the length and the position of the received data, if any.
-	pucRecvData will point to the first byte of the TCP payload. */
-	ulReceiveLength = ( uint32_t ) prvCheckRxData( *ppxNetworkBuffer, &pucRecvData );
+        /* First get the length and the position of the received data, if any.
+         * pucRecvData will point to the first byte of the TCP payload. */
+        ulReceiveLength = ( uint32_t ) prvCheckRxData( *ppxNetworkBuffer, &pucRecvData );
 
-	if( pxSocket->u.xTCP.ucTCPState >= ( uint8_t ) eESTABLISHED )
-	{
-		if ( pxTCPWindow->rx.ulCurrentSequenceNumber == ( ulSequenceNumber + 1UL ) )
-		{
-			/* This is most probably a keep-alive message from peer.  Setting
-			'bWinChange' doesn't cause a window-size-change, the flag is used
-			here to force sending an immediate ACK. */
-			pxSocket->u.xTCP.bits.bWinChange = pdTRUE_UNSIGNED;
-		}
-	}
+        if( pxSocket->u.xTCP.ucTCPState >= ( uint8_t ) eESTABLISHED )
+        {
+            if( pxTCPWindow->rx.ulCurrentSequenceNumber == ( ulSequenceNumber + 1UL ) )
+            {
+                /* This is most probably a keep-alive message from peer.  Setting
+                 * 'bWinChange' doesn't cause a window-size-change, the flag is used
+                 * here to force sending an immediate ACK. */
+                pxSocket->u.xTCP.bits.bWinChange = pdTRUE_UNSIGNED;
+            }
+        }
 
-	/* Keep track of the highest sequence number that might be expected within
-	this connection. */
-	if( ( ipNUMERIC_CAST( int32_t, ulSequenceNumber + ulReceiveLength - pxTCPWindow->rx.ulHighestSequenceNumber ) ) > 0L )
-	{
-		pxTCPWindow->rx.ulHighestSequenceNumber = ulSequenceNumber + ulReceiveLength;
-	}
+        /* Keep track of the highest sequence number that might be expected within
+         * this connection. */
+        if( ( ipNUMERIC_CAST( int32_t, ulSequenceNumber + ulReceiveLength - pxTCPWindow->rx.ulHighestSequenceNumber ) ) > 0L )
+        {
+            pxTCPWindow->rx.ulHighestSequenceNumber = ulSequenceNumber + ulReceiveLength;
+        }
 
-	/* Storing data may result in a fatal error if malloc() fails. */
-	if( prvStoreRxData( pxSocket, pucRecvData, *ppxNetworkBuffer, ulReceiveLength ) < 0 )
-	{
-		xSendLength = -1;
-	}
-	else
-	{
-		uxOptionsLength = prvSetOptions( pxSocket, *ppxNetworkBuffer );
+        /* Storing data may result in a fatal error if malloc() fails. */
+        if( prvStoreRxData( pxSocket, pucRecvData, *ppxNetworkBuffer, ulReceiveLength ) < 0 )
+        {
+            xSendLength = -1;
+        }
+        else
+        {
+            uxOptionsLength = prvSetOptions( pxSocket, *ppxNetworkBuffer );
 
-		if( ( pxSocket->u.xTCP.ucTCPState == ( uint8_t ) eSYN_RECEIVED ) && ( ( ucTCPFlags & ( uint8_t ) tcpTCP_FLAG_CTRL ) == ( uint8_t ) tcpTCP_FLAG_SYN ) )
-		{
-			FreeRTOS_debug_printf( ( "eSYN_RECEIVED: ACK expected, not SYN: peer missed our SYN+ACK\n" ) );
+            if( ( pxSocket->u.xTCP.ucTCPState == ( uint8_t ) eSYN_RECEIVED ) && ( ( ucTCPFlags & ( uint8_t ) tcpTCP_FLAG_CTRL ) == ( uint8_t ) tcpTCP_FLAG_SYN ) )
+            {
+                FreeRTOS_debug_printf( ( "eSYN_RECEIVED: ACK expected, not SYN: peer missed our SYN+ACK\n" ) );
 
-			/* In eSYN_RECEIVED a simple ACK is expected, but apparently the
-			'SYN+ACK' didn't arrive.  Step back to the previous state in which
-			a first incoming SYN is handled.  The SYN was counted already so
-			decrease it first. */
-			vTCPStateChange( pxSocket, eSYN_FIRST );
-		}
+                /* In eSYN_RECEIVED a simple ACK is expected, but apparently the
+                 * 'SYN+ACK' didn't arrive.  Step back to the previous state in which
+                 * a first incoming SYN is handled.  The SYN was counted already so
+                 * decrease it first. */
+                vTCPStateChange( pxSocket, eSYN_FIRST );
+            }
 
-		if( ( ( ucTCPFlags & tcpTCP_FLAG_FIN ) != 0U ) && ( pxSocket->u.xTCP.bits.bFinRecv == pdFALSE_UNSIGNED ) )
-		{
-			/* It's the first time a FIN has been received, remember its
-			sequence number. */
-			pxTCPWindow->rx.ulFINSequenceNumber = ulSequenceNumber + ulReceiveLength;
-			pxSocket->u.xTCP.bits.bFinRecv = pdTRUE_UNSIGNED;
+            if( ( ( ucTCPFlags & tcpTCP_FLAG_FIN ) != 0U ) && ( pxSocket->u.xTCP.bits.bFinRecv == pdFALSE_UNSIGNED ) )
+            {
+                /* It's the first time a FIN has been received, remember its
+                 * sequence number. */
+                pxTCPWindow->rx.ulFINSequenceNumber = ulSequenceNumber + ulReceiveLength;
+                pxSocket->u.xTCP.bits.bFinRecv = pdTRUE_UNSIGNED;
 
-			/* Was peer the first one to send a FIN? */
-			if( pxSocket->u.xTCP.bits.bFinSent == pdFALSE_UNSIGNED )
-			{
-				/* If so, don't send the-last-ACK. */
-				pxSocket->u.xTCP.bits.bFinLast = pdTRUE_UNSIGNED;
-			}
-		}
+                /* Was peer the first one to send a FIN? */
+                if( pxSocket->u.xTCP.bits.bFinSent == pdFALSE_UNSIGNED )
+                {
+                    /* If so, don't send the-last-ACK. */
+                    pxSocket->u.xTCP.bits.bFinLast = pdTRUE_UNSIGNED;
+                }
+            }
 
-		switch( ipNUMERIC_CAST( eIPTCPState_t, pxSocket->u.xTCP.ucTCPState ) )
-		{
-		case eCLOSED:		/* (server + client) no connection state at all. */
-			/* Nothing to do for a closed socket, except waiting for the
-			owner. */
-			break;
+            switch( ipNUMERIC_CAST( eIPTCPState_t, pxSocket->u.xTCP.ucTCPState ) )
+            {
+                case eCLOSED: /* (server + client) no connection state at all. */
+                    /* Nothing to do for a closed socket, except waiting for the
+                     * owner. */
+                    break;
 
-		case eTCP_LISTEN:	/* (server) waiting for a connection request from
-							any remote TCP and port. */
-			/* The listen state was handled in xProcessReceivedTCPPacket().
-			Should not come here. */
-			break;
+                case eTCP_LISTEN: /* (server) waiting for a connection request from
+                                   * any remote TCP and port. */
+                    /* The listen state was handled in xProcessReceivedTCPPacket().
+                     * Should not come here. */
+                    break;
 
-		case eSYN_FIRST:	/* (server) Just received a SYN request for a server
-							socket. */
-			{
-				/* A new socket has been created, reply with a SYN+ACK.
-				Acknowledge with seq+1 because the SYN is seen as pseudo data
-				with len = 1. */
-				uxOptionsLength = prvSetSynAckOptions( pxSocket, pxTCPHeader );
-				pxTCPHeader->ucTCPFlags = ( uint8_t ) tcpTCP_FLAG_SYN | ( uint8_t ) tcpTCP_FLAG_ACK;
+                case eSYN_FIRST: /* (server) Just received a SYN request for a server
+                                  * socket. */
+                    /* A new socket has been created, reply with a SYN+ACK.
+                     * Acknowledge with seq+1 because the SYN is seen as pseudo data
+                     * with len = 1. */
+                    uxOptionsLength = prvSetSynAckOptions( pxSocket, pxTCPHeader );
+                    pxTCPHeader->ucTCPFlags = ( uint8_t ) tcpTCP_FLAG_SYN | ( uint8_t ) tcpTCP_FLAG_ACK;
 
-				xSendLength = ipNUMERIC_CAST( BaseType_t, uxIPHeaderSizeSocket( pxSocket ) + ipSIZE_OF_TCP_HEADER + uxOptionsLength );
+                    xSendLength = ipNUMERIC_CAST( BaseType_t, uxIPHeaderSizeSocket( pxSocket ) + ipSIZE_OF_TCP_HEADER + uxOptionsLength );
 
-				/* Set the TCP offset field:  ipSIZE_OF_TCP_HEADER equals 20 and
-				uxOptionsLength is a multiple of 4.  The complete expression is:
-				ucTCPOffset = ( ( ipSIZE_OF_TCP_HEADER + uxOptionsLength ) / 4 ) << 4 */
-				pxTCPHeader->ucTCPOffset = ( uint8_t )( ( ipSIZE_OF_TCP_HEADER + uxOptionsLength ) << 2 );
-				vTCPStateChange( pxSocket, eSYN_RECEIVED );
+                    /* Set the TCP offset field:  ipSIZE_OF_TCP_HEADER equals 20 and
+                     * uxOptionsLength is a multiple of 4.  The complete expression is:
+                     * ucTCPOffset = ( ( ipSIZE_OF_TCP_HEADER + uxOptionsLength ) / 4 ) << 4 */
+                    pxTCPHeader->ucTCPOffset = ( uint8_t ) ( ( ipSIZE_OF_TCP_HEADER + uxOptionsLength ) << 2 );
+                    vTCPStateChange( pxSocket, eSYN_RECEIVED );
 
-				pxTCPWindow->rx.ulHighestSequenceNumber = ulSequenceNumber + 1UL;
-				pxTCPWindow->rx.ulCurrentSequenceNumber = ulSequenceNumber + 1UL;
-				pxTCPWindow->ulNextTxSequenceNumber     = pxTCPWindow->tx.ulFirstSequenceNumber + 1UL;
-				pxTCPWindow->tx.ulCurrentSequenceNumber = pxTCPWindow->tx.ulFirstSequenceNumber + 1UL; /* because we send a TCP_SYN. */
-			}
-			break;
+                    pxTCPWindow->rx.ulHighestSequenceNumber = ulSequenceNumber + 1UL;
+                    pxTCPWindow->rx.ulCurrentSequenceNumber = ulSequenceNumber + 1UL;
+                    pxTCPWindow->ulNextTxSequenceNumber = pxTCPWindow->tx.ulFirstSequenceNumber + 1UL;
+                    pxTCPWindow->tx.ulCurrentSequenceNumber = pxTCPWindow->tx.ulFirstSequenceNumber + 1UL; /* because we send a TCP_SYN. */
+                    break;
 
-		case eCONNECT_SYN:	/* (client) also called SYN_SENT: we've just send a
-							SYN, expect	a SYN+ACK and send a ACK now. */
-			/* Fall through */
-		case eSYN_RECEIVED:	/* (server) we've had a SYN, replied with SYN+SCK
-							expect a ACK and do nothing. */
-			xSendLength = prvHandleSynReceived( pxSocket, *( ppxNetworkBuffer ), ulReceiveLength, uxOptionsLength );
-			break;
+                case eCONNECT_SYN:  /* (client) also called SYN_SENT: we've just send a
+                                     * SYN, expect	a SYN+ACK and send a ACK now. */
+                /* Fall through */
+                case eSYN_RECEIVED: /* (server) we've had a SYN, replied with SYN+SCK
+                                     * expect a ACK and do nothing. */
+                    xSendLength = prvHandleSynReceived( pxSocket, *( ppxNetworkBuffer ), ulReceiveLength, uxOptionsLength );
+                    break;
 
-		case eESTABLISHED:	/* (server + client) an open connection, data
-							received can be	delivered to the user. The normal
-							state for the data transfer phase of the connection
-							The closing states are also handled here with the
-							use of some flags. */
-			xSendLength = prvHandleEstablished( pxSocket, ppxNetworkBuffer, ulReceiveLength, uxOptionsLength );
-			break;
+                case eESTABLISHED: /* (server + client) an open connection, data
+                                    * received can be	delivered to the user. The normal
+                                    * state for the data transfer phase of the connection
+                                    * The closing states are also handled here with the
+                                    * use of some flags. */
+                    xSendLength = prvHandleEstablished( pxSocket, ppxNetworkBuffer, ulReceiveLength, uxOptionsLength );
+                    break;
 
-		case eLAST_ACK:		/* (server + client) waiting for an acknowledgement
-							of the connection termination request previously
-							sent to the remote TCP (which includes an
-							acknowledgement of its connection termination
-							request). */
-			/* Fall through */
-		case eFIN_WAIT_1:	/* (server + client) waiting for a connection termination request from the remote TCP,
-							 * or an acknowledgement of the connection termination request previously sent. */
-			/* Fall through */
-		case eFIN_WAIT_2:	/* (server + client) waiting for a connection termination request from the remote TCP. */
-			xSendLength = prvTCPHandleFin( pxSocket, *ppxNetworkBuffer );
-			break;
+                case eLAST_ACK:   /* (server + client) waiting for an acknowledgement
+                                   * of the connection termination request previously
+                                   * sent to the remote TCP (which includes an
+                                   * acknowledgement of its connection termination
+                                   * request). */
+                /* Fall through */
+                case eFIN_WAIT_1: /* (server + client) waiting for a connection termination request from the remote TCP,
+                                   * or an acknowledgement of the connection termination request previously sent. */
+                /* Fall through */
+                case eFIN_WAIT_2: /* (server + client) waiting for a connection termination request from the remote TCP. */
+                    xSendLength = prvTCPHandleFin( pxSocket, *ppxNetworkBuffer );
+                    break;
 
-		case eCLOSE_WAIT:	/* (server + client) waiting for a connection
-							termination request from the local user.  Nothing to
-							do, connection is closed, wait for owner to close
-							this socket. */
-			break;
+                case eCLOSE_WAIT: /* (server + client) waiting for a connection
+                                   * termination request from the local user.  Nothing to
+                                   * do, connection is closed, wait for owner to close
+                                   * this socket. */
+                    break;
 
-		case eCLOSING:		/* (server + client) waiting for a connection
-							termination request acknowledgement from the remote
-							TCP. */
-			break;
+                case eCLOSING: /* (server + client) waiting for a connection
+                                * termination request acknowledgement from the remote
+                                * TCP. */
+                    break;
 
-		case eTIME_WAIT:	/* (either server or client) waiting for enough time
-							to pass to be sure the remote TCP received the
-							acknowledgement of its connection termination
-							request. [According to RFC 793 a connection can stay
-							in TIME-WAIT for a maximum of four minutes known as
-							a MSL (maximum segment lifetime).]  These states are
-							implemented implicitly by settings flags like
-							'bFinSent', 'bFinRecv', and 'bFinAcked'. */
-			break;
-		default:
-			/* No more known states. */
-			break;
-		}
-	}
+                case eTIME_WAIT: /* (either server or client) waiting for enough time
+                                  * to pass to be sure the remote TCP received the
+                                  * acknowledgement of its connection termination
+                                  * request. [According to RFC 793 a connection can stay
+                                  * in TIME-WAIT for a maximum of four minutes known as
+                                  * a MSL (maximum segment lifetime).]  These states are
+                                  * implemented implicitly by settings flags like
+                                  * 'bFinSent', 'bFinRecv', and 'bFinAcked'. */
+                    break;
 
-	if( xSendLength > 0 )
-	{
-		xSendLength = prvSendData( pxSocket, ppxNetworkBuffer, ulReceiveLength, xSendLength );
-	}
+                default:
+                    /* No more known states. */
+                    break;
+            }
+        }
 
-	return xSendLength;
-}
+        if( xSendLength > 0 )
+        {
+            xSendLength = prvSendData( pxSocket, ppxNetworkBuffer, ulReceiveLength, xSendLength );
+        }
+
+        return xSendLength;
+    }
 /*-----------------------------------------------------------*/
 
-static BaseType_t prvTCPSendSpecialPacketHelper( NetworkBufferDescriptor_t *pxNetworkBuffer,
-												 uint8_t ucTCPFlags )
-{
-#if( ipconfigIGNORE_UNKNOWN_PACKETS == 1 )
-	/* Configured to ignore unknown packets just suppress a compiler warning. */
-	( void ) pxNetworkBuffer;
-	( void ) ucTCPFlags;
-#else
-	{
-		TCPPacket_t *pxTCPPacket = ipPOINTER_CAST( TCPPacket_t *, pxNetworkBuffer->pucEthernetBuffer );
-		const BaseType_t xSendLength = ( BaseType_t )
-			( ipSIZE_OF_IPv4_HEADER + ipSIZE_OF_TCP_HEADER ); /* Plus 0 options. */
+    static BaseType_t prvTCPSendSpecialPacketHelper( NetworkBufferDescriptor_t * pxNetworkBuffer,
+                                                     uint8_t ucTCPFlags )
+    {
+        #if ( ipconfigIGNORE_UNKNOWN_PACKETS == 1 )
+            /* Configured to ignore unknown packets just suppress a compiler warning. */
+            ( void ) pxNetworkBuffer;
+            ( void ) ucTCPFlags;
+        #else
+            {
+                TCPPacket_t * pxTCPPacket = ipPOINTER_CAST( TCPPacket_t *, pxNetworkBuffer->pucEthernetBuffer );
+                const BaseType_t xSendLength = ( BaseType_t )
+                                               ( ipSIZE_OF_IPv4_HEADER + ipSIZE_OF_TCP_HEADER ); /* Plus 0 options. */
 
-		pxTCPPacket->xTCPHeader.ucTCPFlags = ucTCPFlags;
-		pxTCPPacket->xTCPHeader.ucTCPOffset = ( ipSIZE_OF_TCP_HEADER ) << 2;
+                pxTCPPacket->xTCPHeader.ucTCPFlags = ucTCPFlags;
+                pxTCPPacket->xTCPHeader.ucTCPOffset = ( ipSIZE_OF_TCP_HEADER ) << 2;
 
-		prvTCPReturnPacket( NULL, pxNetworkBuffer, ( uint32_t )xSendLength, pdFALSE );
-	}
-#endif /* !ipconfigIGNORE_UNKNOWN_PACKETS */
+                prvTCPReturnPacket( NULL, pxNetworkBuffer, ( uint32_t ) xSendLength, pdFALSE );
+            }
+        #endif /* !ipconfigIGNORE_UNKNOWN_PACKETS */
 
-	/* The packet was not consumed. */
-	return pdFAIL;
-}
+        /* The packet was not consumed. */
+        return pdFAIL;
+    }
 /*-----------------------------------------------------------*/
 
-static BaseType_t prvTCPSendChallengeAck( NetworkBufferDescriptor_t *pxNetworkBuffer )
-{
-	return prvTCPSendSpecialPacketHelper( pxNetworkBuffer, tcpTCP_FLAG_ACK );
-}
+    static BaseType_t prvTCPSendChallengeAck( NetworkBufferDescriptor_t * pxNetworkBuffer )
+    {
+        return prvTCPSendSpecialPacketHelper( pxNetworkBuffer, tcpTCP_FLAG_ACK );
+    }
 /*-----------------------------------------------------------*/
 
-static BaseType_t prvTCPSendReset( NetworkBufferDescriptor_t *pxNetworkBuffer )
-{
-	return prvTCPSendSpecialPacketHelper( pxNetworkBuffer,
-										  ( uint8_t ) tcpTCP_FLAG_ACK | ( uint8_t ) tcpTCP_FLAG_RST );
-}
+    static BaseType_t prvTCPSendReset( NetworkBufferDescriptor_t * pxNetworkBuffer )
+    {
+        return prvTCPSendSpecialPacketHelper( pxNetworkBuffer,
+                                              ( uint8_t ) tcpTCP_FLAG_ACK | ( uint8_t ) tcpTCP_FLAG_RST );
+    }
 /*-----------------------------------------------------------*/
 
-static void prvSocketSetMSS( FreeRTOS_Socket_t *pxSocket )
-{
-uint32_t ulMSS = ipconfigTCP_MSS;
+    static void prvSocketSetMSS( FreeRTOS_Socket_t * pxSocket )
+    {
+        uint32_t ulMSS = ipconfigTCP_MSS;
 
-	if( ( ( FreeRTOS_ntohl( pxSocket->u.xTCP.ulRemoteIP ) ^ *ipLOCAL_IP_ADDRESS_POINTER ) & xNetworkAddressing.ulNetMask ) != 0UL )
-	{
-		/* Data for this peer will pass through a router, and maybe through
-		the internet.  Limit the MSS to 1400 bytes or less. */
-		ulMSS = FreeRTOS_min_uint32( ( uint32_t ) tcpREDUCED_MSS_THROUGH_INTERNET, ulMSS );
-	}
+        if( ( ( FreeRTOS_ntohl( pxSocket->u.xTCP.ulRemoteIP ) ^ *ipLOCAL_IP_ADDRESS_POINTER ) & xNetworkAddressing.ulNetMask ) != 0UL )
+        {
+            /* Data for this peer will pass through a router, and maybe through
+             * the internet.  Limit the MSS to 1400 bytes or less. */
+            ulMSS = FreeRTOS_min_uint32( ( uint32_t ) tcpREDUCED_MSS_THROUGH_INTERNET, ulMSS );
+        }
 
-	FreeRTOS_debug_printf( ( "prvSocketSetMSS: %lu bytes for %lxip:%u\n", ulMSS, pxSocket->u.xTCP.ulRemoteIP, pxSocket->u.xTCP.usRemotePort ) );
+        FreeRTOS_debug_printf( ( "prvSocketSetMSS: %lu bytes for %lxip:%u\n", ulMSS, pxSocket->u.xTCP.ulRemoteIP, pxSocket->u.xTCP.usRemotePort ) );
 
-	pxSocket->u.xTCP.usInitMSS = ( uint16_t ) ulMSS;
-	pxSocket->u.xTCP.usCurMSS  = ( uint16_t ) ulMSS;
-}
+        pxSocket->u.xTCP.usInitMSS = ( uint16_t ) ulMSS;
+        pxSocket->u.xTCP.usCurMSS = ( uint16_t ) ulMSS;
+    }
 /*-----------------------------------------------------------*/
 
 /*
@@ -3004,503 +3116,514 @@ uint32_t ulMSS = ipconfigTCP_MSS;
  *		prvTCPSendRepeated()
  *			prvTCPReturnPacket()		// Prepare for returning
  *			xNetworkInterfaceOutput()	// Sends data to the NIC
-*/
-BaseType_t xProcessReceivedTCPPacket( NetworkBufferDescriptor_t *pxDescriptor )
-{
+ */
+    BaseType_t xProcessReceivedTCPPacket( NetworkBufferDescriptor_t * pxDescriptor )
+    {
 /* Function might modify the parameter. */
-NetworkBufferDescriptor_t *pxNetworkBuffer = pxDescriptor;
-const ProtocolHeaders_t *pxProtocolHeaders = ipPOINTER_CAST( const ProtocolHeaders_t *,
-	&( pxNetworkBuffer->pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER + xIPHeaderSize( pxNetworkBuffer ) ] ) );
-FreeRTOS_Socket_t *pxSocket;
-uint16_t ucTCPFlags = pxProtocolHeaders->xTCPHeader.ucTCPFlags;
-uint32_t ulLocalIP;
-uint16_t xLocalPort = FreeRTOS_htons( pxProtocolHeaders->xTCPHeader.usDestinationPort );
-uint16_t xRemotePort = FreeRTOS_htons( pxProtocolHeaders->xTCPHeader.usSourcePort );
-uint32_t ulRemoteIP;
-uint32_t ulSequenceNumber = FreeRTOS_ntohl( pxProtocolHeaders->xTCPHeader.ulSequenceNumber );
-uint32_t ulAckNumber = FreeRTOS_ntohl( pxProtocolHeaders->xTCPHeader.ulAckNr );;
-BaseType_t xResult = pdPASS;
-configASSERT( pxNetworkBuffer != NULL );
-configASSERT( pxNetworkBuffer->pucEthernetBuffer != NULL );
-const IPHeader_t *pxIPHeader;
+        NetworkBufferDescriptor_t * pxNetworkBuffer = pxDescriptor;
+        const ProtocolHeaders_t * pxProtocolHeaders = ipPOINTER_CAST( const ProtocolHeaders_t *,
+                                                                      &( pxNetworkBuffer->pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER + xIPHeaderSize( pxNetworkBuffer ) ] ) );
+        FreeRTOS_Socket_t * pxSocket;
+        uint16_t ucTCPFlags = pxProtocolHeaders->xTCPHeader.ucTCPFlags;
+        uint32_t ulLocalIP;
+        uint16_t xLocalPort = FreeRTOS_htons( pxProtocolHeaders->xTCPHeader.usDestinationPort );
+        uint16_t xRemotePort = FreeRTOS_htons( pxProtocolHeaders->xTCPHeader.usSourcePort );
+        uint32_t ulRemoteIP;
+        uint32_t ulSequenceNumber = FreeRTOS_ntohl( pxProtocolHeaders->xTCPHeader.ulSequenceNumber );
+        uint32_t ulAckNumber = FreeRTOS_ntohl( pxProtocolHeaders->xTCPHeader.ulAckNr );
+        BaseType_t xResult = pdPASS;
 
-	/* Check for a minimum packet size. */
-	if( pxNetworkBuffer->xDataLength < ( ipSIZE_OF_ETH_HEADER + xIPHeaderSize( pxNetworkBuffer ) + ipSIZE_OF_TCP_HEADER ) )
-	{
-		return pdFAIL;
-	}
+        configASSERT( pxNetworkBuffer != NULL );
+        configASSERT( pxNetworkBuffer->pucEthernetBuffer != NULL );
+        const IPHeader_t * pxIPHeader;
 
-	pxIPHeader = ipPOINTER_CAST( const IPHeader_t *, &( pxNetworkBuffer->pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER ] ) );
-	ulLocalIP = FreeRTOS_htonl( pxIPHeader->ulDestinationIPAddress );
-	ulRemoteIP = FreeRTOS_htonl( pxIPHeader->ulSourceIPAddress );
+        /* Check for a minimum packet size. */
+        if( pxNetworkBuffer->xDataLength < ( ipSIZE_OF_ETH_HEADER + xIPHeaderSize( pxNetworkBuffer ) + ipSIZE_OF_TCP_HEADER ) )
+        {
+            return pdFAIL;
+        }
 
-	/* Find the destination socket, and if not found: return a socket listing to
-	the destination PORT. */
-	pxSocket = ( FreeRTOS_Socket_t * ) pxTCPSocketLookup( ulLocalIP, xLocalPort, ulRemoteIP, xRemotePort );
+        pxIPHeader = ipPOINTER_CAST( const IPHeader_t *, &( pxNetworkBuffer->pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER ] ) );
+        ulLocalIP = FreeRTOS_htonl( pxIPHeader->ulDestinationIPAddress );
+        ulRemoteIP = FreeRTOS_htonl( pxIPHeader->ulSourceIPAddress );
 
-	if( ( pxSocket == NULL ) || ( prvTCPSocketIsActive( ipNUMERIC_CAST( eIPTCPState_t, pxSocket->u.xTCP.ucTCPState ) ) == pdFALSE ) )
-	{
-		/* A TCP messages is received but either there is no socket with the
-		given port number or the there is a socket, but it is in one of these
-		non-active states:  eCLOSED, eCLOSE_WAIT, eFIN_WAIT_2, eCLOSING, or
-		eTIME_WAIT. */
+        /* Find the destination socket, and if not found: return a socket listing to
+         * the destination PORT. */
+        pxSocket = ( FreeRTOS_Socket_t * ) pxTCPSocketLookup( ulLocalIP, xLocalPort, ulRemoteIP, xRemotePort );
 
-		FreeRTOS_debug_printf( ( "TCP: No active socket on port %d (%lxip:%d)\n", xLocalPort, ulRemoteIP, xRemotePort ) );
+        if( ( pxSocket == NULL ) || ( prvTCPSocketIsActive( ipNUMERIC_CAST( eIPTCPState_t, pxSocket->u.xTCP.ucTCPState ) ) == pdFALSE ) )
+        {
+            /* A TCP messages is received but either there is no socket with the
+             * given port number or the there is a socket, but it is in one of these
+             * non-active states:  eCLOSED, eCLOSE_WAIT, eFIN_WAIT_2, eCLOSING, or
+             * eTIME_WAIT. */
 
-		/* Send a RST to all packets that can not be handled.  As a result
-		the other party will get a ECONN error.  There are two exceptions:
-		1) A packet that already has the RST flag set.
-		2) A packet that only has the ACK flag set.
-		A packet with only the ACK flag set might be the last ACK in
-	 	a three-way hand-shake that closes a connection. */
-		if( ( ( ucTCPFlags & tcpTCP_FLAG_CTRL ) != tcpTCP_FLAG_ACK ) &&
-			( ( ucTCPFlags & tcpTCP_FLAG_RST ) == 0U ) )
-		{
-			( void ) prvTCPSendReset( pxNetworkBuffer );
-		}
+            FreeRTOS_debug_printf( ( "TCP: No active socket on port %d (%lxip:%d)\n", xLocalPort, ulRemoteIP, xRemotePort ) );
 
-		/* The packet can't be handled. */
-		xResult = pdFAIL;
-	}
-	else
-	{
-		pxSocket->u.xTCP.ucRepCount = 0U;
+            /* Send a RST to all packets that can not be handled.  As a result
+             * the other party will get a ECONN error.  There are two exceptions:
+             * 1) A packet that already has the RST flag set.
+             * 2) A packet that only has the ACK flag set.
+             * A packet with only the ACK flag set might be the last ACK in
+             * a three-way hand-shake that closes a connection. */
+            if( ( ( ucTCPFlags & tcpTCP_FLAG_CTRL ) != tcpTCP_FLAG_ACK ) &&
+                ( ( ucTCPFlags & tcpTCP_FLAG_RST ) == 0U ) )
+            {
+                ( void ) prvTCPSendReset( pxNetworkBuffer );
+            }
 
-		if( pxSocket->u.xTCP.ucTCPState == ( uint8_t ) eTCP_LISTEN )
-		{
-			/* The matching socket is in a listening state.  Test if the peer
-			has set the SYN flag. */
-			if( ( ucTCPFlags & tcpTCP_FLAG_CTRL ) != tcpTCP_FLAG_SYN )
-			{
-				/* What happens: maybe after a reboot, a client doesn't know the
-				connection had gone.  Send a RST in order to get a new connect
-				request. */
-				#if( ipconfigHAS_DEBUG_PRINTF == 1 )
-				{
-				FreeRTOS_debug_printf( ( "TCP: Server can't handle flags: %s from %lxip:%u to port %u\n",
-					prvTCPFlagMeaning( ( UBaseType_t ) ucTCPFlags ), ulRemoteIP, xRemotePort, xLocalPort ) );
-				}
-				#endif /* ipconfigHAS_DEBUG_PRINTF */
+            /* The packet can't be handled. */
+            xResult = pdFAIL;
+        }
+        else
+        {
+            pxSocket->u.xTCP.ucRepCount = 0U;
 
-				if( ( ucTCPFlags & tcpTCP_FLAG_RST ) == 0U )
-				{
-					( void ) prvTCPSendReset( pxNetworkBuffer );
-				}
-				xResult = pdFAIL;
-			}
-			else
-			{
-				/* prvHandleListen() will either return a newly created socket
-				(if bReuseSocket is false), otherwise it returns the current
-				socket which will later get connected. */
-				pxSocket = prvHandleListen( pxSocket, pxNetworkBuffer );
+            if( pxSocket->u.xTCP.ucTCPState == ( uint8_t ) eTCP_LISTEN )
+            {
+                /* The matching socket is in a listening state.  Test if the peer
+                 * has set the SYN flag. */
+                if( ( ucTCPFlags & tcpTCP_FLAG_CTRL ) != tcpTCP_FLAG_SYN )
+                {
+                    /* What happens: maybe after a reboot, a client doesn't know the
+                     * connection had gone.  Send a RST in order to get a new connect
+                     * request. */
+                    #if ( ipconfigHAS_DEBUG_PRINTF == 1 )
+                        {
+                            FreeRTOS_debug_printf( ( "TCP: Server can't handle flags: %s from %lxip:%u to port %u\n",
+                                                     prvTCPFlagMeaning( ( UBaseType_t ) ucTCPFlags ), ulRemoteIP, xRemotePort, xLocalPort ) );
+                        }
+                    #endif /* ipconfigHAS_DEBUG_PRINTF */
 
-				if( pxSocket == NULL )
-				{
-					xResult = pdFAIL;
-				}
-			}
-		}	/* if( pxSocket->u.xTCP.ucTCPState == eTCP_LISTEN ). */
-		else
-		{
-			/* This is not a socket in listening mode. Check for the RST
-			flag. */
-			if( ( ucTCPFlags & tcpTCP_FLAG_RST ) != 0U )
-			{
-				FreeRTOS_debug_printf( ( "TCP: RST received from %lxip:%u for %u\n", ulRemoteIP, xRemotePort, xLocalPort ) );
+                    if( ( ucTCPFlags & tcpTCP_FLAG_RST ) == 0U )
+                    {
+                        ( void ) prvTCPSendReset( pxNetworkBuffer );
+                    }
 
-				/* Implement https://tools.ietf.org/html/rfc5961#section-3.2. */
-				if( pxSocket->u.xTCP.ucTCPState == ( uint8_t ) eCONNECT_SYN )
-				{
-					/* Per the above RFC, "In the SYN-SENT state ... the RST is
-					acceptable if the ACK field acknowledges the SYN." */
-					if( ulAckNumber == ( pxSocket->u.xTCP.xTCPWindow.ulOurSequenceNumber + 1UL ) )
-					{
-						vTCPStateChange( pxSocket, eCLOSED );
-					}
-				}
-				else
-				{
-					/* Check whether the packet matches the next expected sequence number. */
-					if( ulSequenceNumber == pxSocket->u.xTCP.xTCPWindow.rx.ulCurrentSequenceNumber )
-					{
-						vTCPStateChange( pxSocket, eCLOSED );
-					}
-					/* Otherwise, check whether the packet is within the receive window. */
-					else if( ( ulSequenceNumber > pxSocket->u.xTCP.xTCPWindow.rx.ulCurrentSequenceNumber ) &&
-							 ( ulSequenceNumber < ( pxSocket->u.xTCP.xTCPWindow.rx.ulCurrentSequenceNumber +
-												  pxSocket->u.xTCP.xTCPWindow.xSize.ulRxWindowLength ) ) )
-					{
-						/* Send a challenge ACK. */
-						( void ) prvTCPSendChallengeAck( pxNetworkBuffer );
-					}
-					else
-					{
-						/* Nothing. */
-					}
-				}
+                    xResult = pdFAIL;
+                }
+                else
+                {
+                    /* prvHandleListen() will either return a newly created socket
+                     * (if bReuseSocket is false), otherwise it returns the current
+                     * socket which will later get connected. */
+                    pxSocket = prvHandleListen( pxSocket, pxNetworkBuffer );
 
-				/* Otherwise, do nothing. In any case, the packet cannot be handled. */
-				xResult = pdFAIL;
-			}
-			else if( ( ( ucTCPFlags & tcpTCP_FLAG_CTRL ) == tcpTCP_FLAG_SYN ) && ( pxSocket->u.xTCP.ucTCPState >= ( uint8_t ) eESTABLISHED ) )
-			{
-				/* SYN flag while this socket is already connected. */
-				FreeRTOS_debug_printf( ( "TCP: SYN unexpected from %lxip:%u\n", ulRemoteIP, xRemotePort ) );
+                    if( pxSocket == NULL )
+                    {
+                        xResult = pdFAIL;
+                    }
+                }
+            } /* if( pxSocket->u.xTCP.ucTCPState == eTCP_LISTEN ). */
+            else
+            {
+                /* This is not a socket in listening mode. Check for the RST
+                 * flag. */
+                if( ( ucTCPFlags & tcpTCP_FLAG_RST ) != 0U )
+                {
+                    FreeRTOS_debug_printf( ( "TCP: RST received from %lxip:%u for %u\n", ulRemoteIP, xRemotePort, xLocalPort ) );
 
-				/* The packet cannot be handled. */
-				xResult = pdFAIL;
-			}
-			else
-			{
-				/* Update the copy of the TCP header only (skipping eth and IP
-				headers).  It might be used later on, whenever data must be sent
-				to the peer. */
-				const BaseType_t lOffset = ipNUMERIC_CAST( BaseType_t, ipSIZE_OF_ETH_HEADER + uxIPHeaderSizeSocket( pxSocket ) );
-				( void ) memcpy( &( pxSocket->u.xTCP.xPacket.u.ucLastPacket[ lOffset ] ),
-								 &( pxNetworkBuffer->pucEthernetBuffer[ lOffset ] ),
-								 ipSIZE_OF_TCP_HEADER );
-			}
-		}
-	}
+                    /* Implement https://tools.ietf.org/html/rfc5961#section-3.2. */
+                    if( pxSocket->u.xTCP.ucTCPState == ( uint8_t ) eCONNECT_SYN )
+                    {
+                        /* Per the above RFC, "In the SYN-SENT state ... the RST is
+                         * acceptable if the ACK field acknowledges the SYN." */
+                        if( ulAckNumber == ( pxSocket->u.xTCP.xTCPWindow.ulOurSequenceNumber + 1UL ) )
+                        {
+                            vTCPStateChange( pxSocket, eCLOSED );
+                        }
+                    }
+                    else
+                    {
+                        /* Check whether the packet matches the next expected sequence number. */
+                        if( ulSequenceNumber == pxSocket->u.xTCP.xTCPWindow.rx.ulCurrentSequenceNumber )
+                        {
+                            vTCPStateChange( pxSocket, eCLOSED );
+                        }
+                        /* Otherwise, check whether the packet is within the receive window. */
+                        else if( ( ulSequenceNumber > pxSocket->u.xTCP.xTCPWindow.rx.ulCurrentSequenceNumber ) &&
+                                 ( ulSequenceNumber < ( pxSocket->u.xTCP.xTCPWindow.rx.ulCurrentSequenceNumber +
+                                                        pxSocket->u.xTCP.xTCPWindow.xSize.ulRxWindowLength ) ) )
+                        {
+                            /* Send a challenge ACK. */
+                            ( void ) prvTCPSendChallengeAck( pxNetworkBuffer );
+                        }
+                        else
+                        {
+                            /* Nothing. */
+                        }
+                    }
 
-	if( xResult != pdFAIL )
-	{
-	uint16_t usWindow;
+                    /* Otherwise, do nothing. In any case, the packet cannot be handled. */
+                    xResult = pdFAIL;
+                }
+                else if( ( ( ucTCPFlags & tcpTCP_FLAG_CTRL ) == tcpTCP_FLAG_SYN ) && ( pxSocket->u.xTCP.ucTCPState >= ( uint8_t ) eESTABLISHED ) )
+                {
+                    /* SYN flag while this socket is already connected. */
+                    FreeRTOS_debug_printf( ( "TCP: SYN unexpected from %lxip:%u\n", ulRemoteIP, xRemotePort ) );
 
-		/* pxSocket is not NULL when xResult != pdFAIL. */
-		configASSERT( pxSocket != NULL );
-		/* Touch the alive timers because we received a message	for this
-		socket. */
-		prvTCPTouchSocket( pxSocket );
+                    /* The packet cannot be handled. */
+                    xResult = pdFAIL;
+                }
+                else
+                {
+                    /* Update the copy of the TCP header only (skipping eth and IP
+                     * headers).  It might be used later on, whenever data must be sent
+                     * to the peer. */
+                    const BaseType_t lOffset = ipNUMERIC_CAST( BaseType_t, ipSIZE_OF_ETH_HEADER + uxIPHeaderSizeSocket( pxSocket ) );
+                    ( void ) memcpy( &( pxSocket->u.xTCP.xPacket.u.ucLastPacket[ lOffset ] ),
+                                     &( pxNetworkBuffer->pucEthernetBuffer[ lOffset ] ),
+                                     ipSIZE_OF_TCP_HEADER );
+                }
+            }
+        }
 
-		/* Parse the TCP option(s), if present. */
-		/* _HT_ : if we're in the SYN phase, and peer does not send a MSS option,
-		then we MUST assume an MSS size of 536 bytes for backward compatibility. */
+        if( xResult != pdFAIL )
+        {
+            uint16_t usWindow;
 
-		/* When there are no TCP options, the TCP offset equals 20 bytes, which is stored as
-		the number 5 (words) in the higher nibble of the TCP-offset byte. */
-		if( ( pxProtocolHeaders->xTCPHeader.ucTCPOffset & tcpTCP_OFFSET_LENGTH_BITS ) > tcpTCP_OFFSET_STANDARD_LENGTH )
-		{
-			prvCheckOptions( pxSocket, pxNetworkBuffer );
-		}
+            /* pxSocket is not NULL when xResult != pdFAIL. */
+            configASSERT( pxSocket != NULL );
 
-		usWindow = FreeRTOS_ntohs( pxProtocolHeaders->xTCPHeader.usWindow );
-		pxSocket->u.xTCP.ulWindowSize = (uint32_t ) usWindow;
-		#if( ipconfigUSE_TCP_WIN == 1 )
-		{
-			/* rfc1323 : The Window field in a SYN (i.e., a <SYN> or <SYN,ACK>)
-			segment itself is never scaled. */
-			if( ( ucTCPFlags & ( uint8_t ) tcpTCP_FLAG_SYN ) == 0U )
-			{
-				pxSocket->u.xTCP.ulWindowSize =
-					( pxSocket->u.xTCP.ulWindowSize << pxSocket->u.xTCP.ucPeerWinScaleFactor );
-			}
-		}
-		#endif /* ipconfigUSE_TCP_WIN */
+            /* Touch the alive timers because we received a message	for this
+             * socket. */
+            prvTCPTouchSocket( pxSocket );
 
-		/* In prvTCPHandleState() the incoming messages will be handled
-		depending on the current state of the connection. */
-		if( prvTCPHandleState( pxSocket, &pxNetworkBuffer ) > 0 )
-		{
-			/* prvTCPHandleState() has sent a message, see if there are more to
-			be transmitted. */
-			#if( ipconfigUSE_TCP_WIN == 1 )
-			{
-				( void ) prvTCPSendRepeated( pxSocket, &pxNetworkBuffer );
-			}
-			#endif /* ipconfigUSE_TCP_WIN */
-		}
+            /* Parse the TCP option(s), if present. */
 
-		if( pxNetworkBuffer != NULL )
-		{
-			/* We must check if the buffer is unequal to NULL, because the
-			socket might keep a reference to it in case a delayed ACK must be
-			sent. */
-			vReleaseNetworkBufferAndDescriptor( pxNetworkBuffer );
-			#ifndef _lint
-			/* Clear pointers that are freed. */
-			pxNetworkBuffer = NULL;
-			#endif
-		}
+            /* _HT_ : if we're in the SYN phase, and peer does not send a MSS option,
+             * then we MUST assume an MSS size of 536 bytes for backward compatibility. */
 
-		/* And finally, calculate when this socket wants to be woken up. */
-		( void ) prvTCPNextTimeout ( pxSocket );
-		/* Return pdPASS to tell that the network buffer is 'consumed'. */
-		xResult = pdPASS;
-	}
+            /* When there are no TCP options, the TCP offset equals 20 bytes, which is stored as
+             * the number 5 (words) in the higher nibble of the TCP-offset byte. */
+            if( ( pxProtocolHeaders->xTCPHeader.ucTCPOffset & tcpTCP_OFFSET_LENGTH_BITS ) > tcpTCP_OFFSET_STANDARD_LENGTH )
+            {
+                prvCheckOptions( pxSocket, pxNetworkBuffer );
+            }
 
-	/* pdPASS being returned means the buffer has been consumed. */
-	return xResult;
-}
+            usWindow = FreeRTOS_ntohs( pxProtocolHeaders->xTCPHeader.usWindow );
+            pxSocket->u.xTCP.ulWindowSize = ( uint32_t ) usWindow;
+            #if ( ipconfigUSE_TCP_WIN == 1 )
+                {
+                    /* rfc1323 : The Window field in a SYN (i.e., a <SYN> or <SYN,ACK>)
+                     * segment itself is never scaled. */
+                    if( ( ucTCPFlags & ( uint8_t ) tcpTCP_FLAG_SYN ) == 0U )
+                    {
+                        pxSocket->u.xTCP.ulWindowSize =
+                            ( pxSocket->u.xTCP.ulWindowSize << pxSocket->u.xTCP.ucPeerWinScaleFactor );
+                    }
+                }
+            #endif /* ipconfigUSE_TCP_WIN */
+
+            /* In prvTCPHandleState() the incoming messages will be handled
+             * depending on the current state of the connection. */
+            if( prvTCPHandleState( pxSocket, &pxNetworkBuffer ) > 0 )
+            {
+                /* prvTCPHandleState() has sent a message, see if there are more to
+                 * be transmitted. */
+                #if ( ipconfigUSE_TCP_WIN == 1 )
+                    {
+                        ( void ) prvTCPSendRepeated( pxSocket, &pxNetworkBuffer );
+                    }
+                #endif /* ipconfigUSE_TCP_WIN */
+            }
+
+            if( pxNetworkBuffer != NULL )
+            {
+                /* We must check if the buffer is unequal to NULL, because the
+                 * socket might keep a reference to it in case a delayed ACK must be
+                 * sent. */
+                vReleaseNetworkBufferAndDescriptor( pxNetworkBuffer );
+                #ifndef _lint
+                    /* Clear pointers that are freed. */
+                    pxNetworkBuffer = NULL;
+                #endif
+            }
+
+            /* And finally, calculate when this socket wants to be woken up. */
+            ( void ) prvTCPNextTimeout( pxSocket );
+            /* Return pdPASS to tell that the network buffer is 'consumed'. */
+            xResult = pdPASS;
+        }
+
+        /* pdPASS being returned means the buffer has been consumed. */
+        return xResult;
+    }
 /*-----------------------------------------------------------*/
 
-static FreeRTOS_Socket_t *prvHandleListen( FreeRTOS_Socket_t *pxSocket, NetworkBufferDescriptor_t *pxNetworkBuffer )
-{
-const TCPPacket_t * pxTCPPacket = ipPOINTER_CAST( const TCPPacket_t *, pxNetworkBuffer->pucEthernetBuffer );
-FreeRTOS_Socket_t *pxReturn = NULL;
-uint32_t ulInitialSequenceNumber;
+    static FreeRTOS_Socket_t * prvHandleListen( FreeRTOS_Socket_t * pxSocket,
+                                                NetworkBufferDescriptor_t * pxNetworkBuffer )
+    {
+        const TCPPacket_t * pxTCPPacket = ipPOINTER_CAST( const TCPPacket_t *, pxNetworkBuffer->pucEthernetBuffer );
+        FreeRTOS_Socket_t * pxReturn = NULL;
+        uint32_t ulInitialSequenceNumber;
 
-	/* Assume that a new Initial Sequence Number will be required. Request
-	it now in order to fail out if necessary. */
-	ulInitialSequenceNumber = ulApplicationGetNextSequenceNumber( *ipLOCAL_IP_ADDRESS_POINTER,
-																  pxSocket->usLocalPort,
-																  pxTCPPacket->xIPHeader.ulSourceIPAddress,
-																  pxTCPPacket->xTCPHeader.usSourcePort );
+        /* Assume that a new Initial Sequence Number will be required. Request
+         * it now in order to fail out if necessary. */
+        ulInitialSequenceNumber = ulApplicationGetNextSequenceNumber( *ipLOCAL_IP_ADDRESS_POINTER,
+                                                                      pxSocket->usLocalPort,
+                                                                      pxTCPPacket->xIPHeader.ulSourceIPAddress,
+                                                                      pxTCPPacket->xTCPHeader.usSourcePort );
 
-	/* A pure SYN (without ACK) has come in, create a new socket to answer
-	it. */
-	if( ulInitialSequenceNumber != 0UL )
-	{
-		if( pxSocket->u.xTCP.bits.bReuseSocket != pdFALSE_UNSIGNED )
-		{
-			/* The flag bReuseSocket indicates that the same instance of the
-			listening socket should be used for the connection. */
-			pxReturn = pxSocket;
-			pxSocket->u.xTCP.bits.bPassQueued = pdTRUE_UNSIGNED;
-			pxSocket->u.xTCP.pxPeerSocket = pxSocket;
-		}
-		else
-		{
-			/* The socket does not have the bReuseSocket flag set meaning create a
-			new socket when a connection comes in. */
-			pxReturn = NULL;
+        /* A pure SYN (without ACK) has come in, create a new socket to answer
+         * it. */
+        if( ulInitialSequenceNumber != 0UL )
+        {
+            if( pxSocket->u.xTCP.bits.bReuseSocket != pdFALSE_UNSIGNED )
+            {
+                /* The flag bReuseSocket indicates that the same instance of the
+                 * listening socket should be used for the connection. */
+                pxReturn = pxSocket;
+                pxSocket->u.xTCP.bits.bPassQueued = pdTRUE_UNSIGNED;
+                pxSocket->u.xTCP.pxPeerSocket = pxSocket;
+            }
+            else
+            {
+                /* The socket does not have the bReuseSocket flag set meaning create a
+                 * new socket when a connection comes in. */
+                pxReturn = NULL;
 
-			if( pxSocket->u.xTCP.usChildCount >= pxSocket->u.xTCP.usBacklog )
-			{
-				FreeRTOS_printf( ( "Check: Socket %u already has %u / %u child%s\n",
-					pxSocket->usLocalPort,
-					pxSocket->u.xTCP.usChildCount,
-					pxSocket->u.xTCP.usBacklog,
-					( pxSocket->u.xTCP.usChildCount == 1U ) ? "" : "ren" ) );
-				( void ) prvTCPSendReset( pxNetworkBuffer );
-			}
-			else
-			{
-				FreeRTOS_Socket_t *pxNewSocket = ( FreeRTOS_Socket_t * )
-					FreeRTOS_socket( FREERTOS_AF_INET, FREERTOS_SOCK_STREAM, FREERTOS_IPPROTO_TCP );
+                if( pxSocket->u.xTCP.usChildCount >= pxSocket->u.xTCP.usBacklog )
+                {
+                    FreeRTOS_printf( ( "Check: Socket %u already has %u / %u child%s\n",
+                                       pxSocket->usLocalPort,
+                                       pxSocket->u.xTCP.usChildCount,
+                                       pxSocket->u.xTCP.usBacklog,
+                                       ( pxSocket->u.xTCP.usChildCount == 1U ) ? "" : "ren" ) );
+                    ( void ) prvTCPSendReset( pxNetworkBuffer );
+                }
+                else
+                {
+                    FreeRTOS_Socket_t * pxNewSocket = ( FreeRTOS_Socket_t * )
+                                                      FreeRTOS_socket( FREERTOS_AF_INET, FREERTOS_SOCK_STREAM, FREERTOS_IPPROTO_TCP );
 
-				if( ( pxNewSocket == NULL ) || ( pxNewSocket == FREERTOS_INVALID_SOCKET ) )
-				{
-					FreeRTOS_debug_printf( ( "TCP: Listen: new socket failed\n" ) );
-					( void ) prvTCPSendReset( pxNetworkBuffer );
-				}
-				else if( prvTCPSocketCopy( pxNewSocket, pxSocket ) != pdFALSE )
-				{
-					/* The socket will be connected immediately, no time for the
-					owner to setsockopt's, therefore copy properties of the server
-					socket to the new socket.  Only the binding might fail (due to
-					lack of resources). */
-					pxReturn = pxNewSocket;
-				}
-				else
-				{
-					/* Copying failed somehow. */
-				}
-			}
-		}
-	}
+                    if( ( pxNewSocket == NULL ) || ( pxNewSocket == FREERTOS_INVALID_SOCKET ) )
+                    {
+                        FreeRTOS_debug_printf( ( "TCP: Listen: new socket failed\n" ) );
+                        ( void ) prvTCPSendReset( pxNetworkBuffer );
+                    }
+                    else if( prvTCPSocketCopy( pxNewSocket, pxSocket ) != pdFALSE )
+                    {
+                        /* The socket will be connected immediately, no time for the
+                         * owner to setsockopt's, therefore copy properties of the server
+                         * socket to the new socket.  Only the binding might fail (due to
+                         * lack of resources). */
+                        pxReturn = pxNewSocket;
+                    }
+                    else
+                    {
+                        /* Copying failed somehow. */
+                    }
+                }
+            }
+        }
 
-	if( ( ulInitialSequenceNumber != 0U ) && ( pxReturn != NULL ) )
-	{
-	const ProtocolHeaders_t *pxProtocolHeaders = ipPOINTER_CAST( const ProtocolHeaders_t *,
-		&( pxNetworkBuffer->pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER + xIPHeaderSize( pxNetworkBuffer ) ] ) );
+        if( ( ulInitialSequenceNumber != 0U ) && ( pxReturn != NULL ) )
+        {
+            const ProtocolHeaders_t * pxProtocolHeaders = ipPOINTER_CAST( const ProtocolHeaders_t *,
+                                                                          &( pxNetworkBuffer->pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER + xIPHeaderSize( pxNetworkBuffer ) ] ) );
 
-		pxReturn->u.xTCP.usRemotePort = FreeRTOS_htons( pxTCPPacket->xTCPHeader.usSourcePort );
-		pxReturn->u.xTCP.ulRemoteIP = FreeRTOS_htonl( pxTCPPacket->xIPHeader.ulSourceIPAddress );
-		pxReturn->u.xTCP.xTCPWindow.ulOurSequenceNumber = ulInitialSequenceNumber;
+            pxReturn->u.xTCP.usRemotePort = FreeRTOS_htons( pxTCPPacket->xTCPHeader.usSourcePort );
+            pxReturn->u.xTCP.ulRemoteIP = FreeRTOS_htonl( pxTCPPacket->xIPHeader.ulSourceIPAddress );
+            pxReturn->u.xTCP.xTCPWindow.ulOurSequenceNumber = ulInitialSequenceNumber;
 
-		/* Here is the SYN action. */
-		pxReturn->u.xTCP.xTCPWindow.rx.ulCurrentSequenceNumber = FreeRTOS_ntohl( pxProtocolHeaders->xTCPHeader.ulSequenceNumber );
-		prvSocketSetMSS( pxReturn );
+            /* Here is the SYN action. */
+            pxReturn->u.xTCP.xTCPWindow.rx.ulCurrentSequenceNumber = FreeRTOS_ntohl( pxProtocolHeaders->xTCPHeader.ulSequenceNumber );
+            prvSocketSetMSS( pxReturn );
 
-		prvTCPCreateWindow( pxReturn );
+            prvTCPCreateWindow( pxReturn );
 
-		vTCPStateChange( pxReturn, eSYN_FIRST );
+            vTCPStateChange( pxReturn, eSYN_FIRST );
 
-		/* Make a copy of the header up to the TCP header.  It is needed later
-		on, whenever data must be sent to the peer. */
-		( void ) memcpy( pxReturn->u.xTCP.xPacket.u.ucLastPacket, pxNetworkBuffer->pucEthernetBuffer, sizeof( pxReturn->u.xTCP.xPacket.u.ucLastPacket ) );
-	}
-	return pxReturn;
-}
+            /* Make a copy of the header up to the TCP header.  It is needed later
+             * on, whenever data must be sent to the peer. */
+            ( void ) memcpy( pxReturn->u.xTCP.xPacket.u.ucLastPacket, pxNetworkBuffer->pucEthernetBuffer, sizeof( pxReturn->u.xTCP.xPacket.u.ucLastPacket ) );
+        }
+
+        return pxReturn;
+    }
 /*-----------------------------------------------------------*/
 
 /*
  * Duplicates a socket after a listening socket receives a connection.
  */
-static BaseType_t prvTCPSocketCopy( FreeRTOS_Socket_t *pxNewSocket, FreeRTOS_Socket_t *pxSocket )
-{
-struct freertos_sockaddr xAddress;
-BaseType_t xResult;
+    static BaseType_t prvTCPSocketCopy( FreeRTOS_Socket_t * pxNewSocket,
+                                        FreeRTOS_Socket_t * pxSocket )
+    {
+        struct freertos_sockaddr xAddress;
+        BaseType_t xResult;
 
-	pxNewSocket->xReceiveBlockTime = pxSocket->xReceiveBlockTime;
-	pxNewSocket->xSendBlockTime = pxSocket->xSendBlockTime;
-	pxNewSocket->ucSocketOptions = pxSocket->ucSocketOptions;
-	pxNewSocket->u.xTCP.uxRxStreamSize = pxSocket->u.xTCP.uxRxStreamSize;
-	pxNewSocket->u.xTCP.uxTxStreamSize = pxSocket->u.xTCP.uxTxStreamSize;
-	pxNewSocket->u.xTCP.uxLittleSpace = pxSocket->u.xTCP.uxLittleSpace;
-	pxNewSocket->u.xTCP.uxEnoughSpace = pxSocket->u.xTCP.uxEnoughSpace;
-	pxNewSocket->u.xTCP.uxRxWinSize  = pxSocket->u.xTCP.uxRxWinSize;
-	pxNewSocket->u.xTCP.uxTxWinSize  = pxSocket->u.xTCP.uxTxWinSize;
+        pxNewSocket->xReceiveBlockTime = pxSocket->xReceiveBlockTime;
+        pxNewSocket->xSendBlockTime = pxSocket->xSendBlockTime;
+        pxNewSocket->ucSocketOptions = pxSocket->ucSocketOptions;
+        pxNewSocket->u.xTCP.uxRxStreamSize = pxSocket->u.xTCP.uxRxStreamSize;
+        pxNewSocket->u.xTCP.uxTxStreamSize = pxSocket->u.xTCP.uxTxStreamSize;
+        pxNewSocket->u.xTCP.uxLittleSpace = pxSocket->u.xTCP.uxLittleSpace;
+        pxNewSocket->u.xTCP.uxEnoughSpace = pxSocket->u.xTCP.uxEnoughSpace;
+        pxNewSocket->u.xTCP.uxRxWinSize = pxSocket->u.xTCP.uxRxWinSize;
+        pxNewSocket->u.xTCP.uxTxWinSize = pxSocket->u.xTCP.uxTxWinSize;
 
-	#if( ipconfigSOCKET_HAS_USER_SEMAPHORE == 1 )
-	{
-		pxNewSocket->pxUserSemaphore = pxSocket->pxUserSemaphore;
-	}
-	#endif /* ipconfigSOCKET_HAS_USER_SEMAPHORE */
+        #if ( ipconfigSOCKET_HAS_USER_SEMAPHORE == 1 )
+            {
+                pxNewSocket->pxUserSemaphore = pxSocket->pxUserSemaphore;
+            }
+        #endif /* ipconfigSOCKET_HAS_USER_SEMAPHORE */
 
-	#if( ipconfigUSE_CALLBACKS == 1 )
-	{
-		/* In case call-backs are used, copy them from parent to child. */
-		pxNewSocket->u.xTCP.pxHandleConnected = pxSocket->u.xTCP.pxHandleConnected;
-		pxNewSocket->u.xTCP.pxHandleReceive = pxSocket->u.xTCP.pxHandleReceive;
-		pxNewSocket->u.xTCP.pxHandleSent = pxSocket->u.xTCP.pxHandleSent;
-	}
-	#endif /* ipconfigUSE_CALLBACKS */
+        #if ( ipconfigUSE_CALLBACKS == 1 )
+            {
+                /* In case call-backs are used, copy them from parent to child. */
+                pxNewSocket->u.xTCP.pxHandleConnected = pxSocket->u.xTCP.pxHandleConnected;
+                pxNewSocket->u.xTCP.pxHandleReceive = pxSocket->u.xTCP.pxHandleReceive;
+                pxNewSocket->u.xTCP.pxHandleSent = pxSocket->u.xTCP.pxHandleSent;
+            }
+        #endif /* ipconfigUSE_CALLBACKS */
 
-	#if( ipconfigSUPPORT_SELECT_FUNCTION == 1 )
-	{
-		/* Child socket of listening sockets will inherit the Socket Set
-		Otherwise the owner has no chance of including it into the set. */
-		if( pxSocket->pxSocketSet != NULL )
-		{
-			pxNewSocket->pxSocketSet = pxSocket->pxSocketSet;
-			pxNewSocket->xSelectBits = pxSocket->xSelectBits | ( ( EventBits_t ) eSELECT_READ ) | ( ( EventBits_t ) eSELECT_EXCEPT );
-		}
-	}
-	#endif /* ipconfigSUPPORT_SELECT_FUNCTION */
+        #if ( ipconfigSUPPORT_SELECT_FUNCTION == 1 )
+            {
+                /* Child socket of listening sockets will inherit the Socket Set
+                 * Otherwise the owner has no chance of including it into the set. */
+                if( pxSocket->pxSocketSet != NULL )
+                {
+                    pxNewSocket->pxSocketSet = pxSocket->pxSocketSet;
+                    pxNewSocket->xSelectBits = pxSocket->xSelectBits | ( ( EventBits_t ) eSELECT_READ ) | ( ( EventBits_t ) eSELECT_EXCEPT );
+                }
+            }
+        #endif /* ipconfigSUPPORT_SELECT_FUNCTION */
 
-	/* And bind it to the same local port as its parent. */
-	xAddress.sin_addr = *ipLOCAL_IP_ADDRESS_POINTER;
-	xAddress.sin_port = FreeRTOS_htons( pxSocket->usLocalPort );
+        /* And bind it to the same local port as its parent. */
+        xAddress.sin_addr = *ipLOCAL_IP_ADDRESS_POINTER;
+        xAddress.sin_port = FreeRTOS_htons( pxSocket->usLocalPort );
 
-	#if( ipconfigTCP_HANG_PROTECTION == 1 )
-	{
-		/* Only when there is anti-hanging protection, a socket may become an
-		orphan temporarily.  Once this socket is really connected, the owner of
-		the server socket will be notified. */
+        #if ( ipconfigTCP_HANG_PROTECTION == 1 )
+            {
+                /* Only when there is anti-hanging protection, a socket may become an
+                 * orphan temporarily.  Once this socket is really connected, the owner of
+                 * the server socket will be notified. */
 
-		/* When bPassQueued is true, the socket is an orphan until it gets
-		connected. */
-		pxNewSocket->u.xTCP.bits.bPassQueued = pdTRUE_UNSIGNED;
-		pxNewSocket->u.xTCP.pxPeerSocket = pxSocket;
-	}
-	#else
-	{
-		/* A reference to the new socket may be stored and the socket is marked
-		as 'passable'. */
+                /* When bPassQueued is true, the socket is an orphan until it gets
+                 * connected. */
+                pxNewSocket->u.xTCP.bits.bPassQueued = pdTRUE_UNSIGNED;
+                pxNewSocket->u.xTCP.pxPeerSocket = pxSocket;
+            }
+        #else
+            {
+                /* A reference to the new socket may be stored and the socket is marked
+                 * as 'passable'. */
 
-		/* When bPassAccept is true, this socket may be returned in a call to
-		accept(). */
-		pxNewSocket->u.xTCP.bits.bPassAccept = pdTRUE_UNSIGNED;
-		if(pxSocket->u.xTCP.pxPeerSocket == NULL )
-		{
-			pxSocket->u.xTCP.pxPeerSocket = pxNewSocket;
-		}
-	}
-	#endif
+                /* When bPassAccept is true, this socket may be returned in a call to
+                 * accept(). */
+                pxNewSocket->u.xTCP.bits.bPassAccept = pdTRUE_UNSIGNED;
 
-	pxSocket->u.xTCP.usChildCount++;
+                if( pxSocket->u.xTCP.pxPeerSocket == NULL )
+                {
+                    pxSocket->u.xTCP.pxPeerSocket = pxNewSocket;
+                }
+            }
+        #endif /* if ( ipconfigTCP_HANG_PROTECTION == 1 ) */
 
-	FreeRTOS_debug_printf( ( "Gain: Socket %u now has %u / %u child%s\n",
-		pxSocket->usLocalPort,
-		pxSocket->u.xTCP.usChildCount,
-		pxSocket->u.xTCP.usBacklog,
-		( pxSocket->u.xTCP.usChildCount == 1U ) ? "" : "ren" ) );
+        pxSocket->u.xTCP.usChildCount++;
 
-	/* Now bind the child socket to the same port as the listening socket. */
-	if( vSocketBind ( pxNewSocket, &xAddress, sizeof( xAddress ), pdTRUE ) != 0 )
-	{
-		FreeRTOS_debug_printf( ( "TCP: Listen: new socket bind error\n" ) );
-		( void ) vSocketClose( pxNewSocket );
-		xResult = pdFALSE;
-	}
-	else
-	{
-		xResult = pdTRUE;
-	}
+        FreeRTOS_debug_printf( ( "Gain: Socket %u now has %u / %u child%s\n",
+                                 pxSocket->usLocalPort,
+                                 pxSocket->u.xTCP.usChildCount,
+                                 pxSocket->u.xTCP.usBacklog,
+                                 ( pxSocket->u.xTCP.usChildCount == 1U ) ? "" : "ren" ) );
 
-	return xResult;
-}
+        /* Now bind the child socket to the same port as the listening socket. */
+        if( vSocketBind( pxNewSocket, &xAddress, sizeof( xAddress ), pdTRUE ) != 0 )
+        {
+            FreeRTOS_debug_printf( ( "TCP: Listen: new socket bind error\n" ) );
+            ( void ) vSocketClose( pxNewSocket );
+            xResult = pdFALSE;
+        }
+        else
+        {
+            xResult = pdTRUE;
+        }
+
+        return xResult;
+    }
 /*-----------------------------------------------------------*/
 
-#if( ( ipconfigHAS_DEBUG_PRINTF != 0 ) || ( ipconfigHAS_PRINTF != 0 ) )
+    #if ( ( ipconfigHAS_DEBUG_PRINTF != 0 ) || ( ipconfigHAS_PRINTF != 0 ) )
 
-	const char *FreeRTOS_GetTCPStateName( UBaseType_t ulState )
-	{
-	static const char * const pcStateNames[] =
-	{
-		"eCLOSED",
-		"eTCP_LISTEN",
-		"eCONNECT_SYN",
-		"eSYN_FIRST",
-		"eSYN_RECEIVED",
-		"eESTABLISHED",
-		"eFIN_WAIT_1",
-		"eFIN_WAIT_2",
-		"eCLOSE_WAIT",
-		"eCLOSING",
-		"eLAST_ACK",
-		"eTIME_WAIT",
-		"eUNKNOWN",
-	};
-	BaseType_t xIndex = ( BaseType_t ) ulState;
+        const char * FreeRTOS_GetTCPStateName( UBaseType_t ulState )
+        {
+            static const char * const pcStateNames[] =
+            {
+                "eCLOSED",
+                "eTCP_LISTEN",
+                "eCONNECT_SYN",
+                "eSYN_FIRST",
+                "eSYN_RECEIVED",
+                "eESTABLISHED",
+                "eFIN_WAIT_1",
+                "eFIN_WAIT_2",
+                "eCLOSE_WAIT",
+                "eCLOSING",
+                "eLAST_ACK",
+                "eTIME_WAIT",
+                "eUNKNOWN",
+            };
+            BaseType_t xIndex = ( BaseType_t ) ulState;
 
-		if( ( xIndex < 0 ) || ( xIndex >= ARRAY_SIZE( pcStateNames ) ) )
-		{
-			/* The last item is called 'eUNKNOWN' */
-			xIndex = ARRAY_SIZE( pcStateNames );
-			xIndex--;
-		}
-		return pcStateNames[ xIndex ];
-	}
+            if( ( xIndex < 0 ) || ( xIndex >= ARRAY_SIZE( pcStateNames ) ) )
+            {
+                /* The last item is called 'eUNKNOWN' */
+                xIndex = ARRAY_SIZE( pcStateNames );
+                xIndex--;
+            }
 
-#endif /* ( ( ipconfigHAS_DEBUG_PRINTF != 0 ) || ( ipconfigHAS_PRINTF != 0 ) ) */
+            return pcStateNames[ xIndex ];
+        }
+
+    #endif /* ( ( ipconfigHAS_DEBUG_PRINTF != 0 ) || ( ipconfigHAS_PRINTF != 0 ) ) */
 /*-----------------------------------------------------------*/
 
 /*
  * In the API accept(), the user asks is there is a new client?  As API's can
  * not walk through the xBoundTCPSocketsList the IP-task will do this.
  */
-BaseType_t xTCPCheckNewClient( FreeRTOS_Socket_t *pxSocket )
-{
-TickType_t uxLocalPort = ( TickType_t ) FreeRTOS_htons( pxSocket->usLocalPort );
-const ListItem_t *pxIterator;
-FreeRTOS_Socket_t *pxFound;
-BaseType_t xResult = pdFALSE;
-const ListItem_t *pxEndTCP = ipPOINTER_CAST( const ListItem_t *, listGET_END_MARKER( &xBoundTCPSocketsList ) );
+    BaseType_t xTCPCheckNewClient( FreeRTOS_Socket_t * pxSocket )
+    {
+        TickType_t uxLocalPort = ( TickType_t ) FreeRTOS_htons( pxSocket->usLocalPort );
+        const ListItem_t * pxIterator;
+        FreeRTOS_Socket_t * pxFound;
+        BaseType_t xResult = pdFALSE;
+        const ListItem_t * pxEndTCP = ipPOINTER_CAST( const ListItem_t *, listGET_END_MARKER( &xBoundTCPSocketsList ) );
 
-	/* Here xBoundTCPSocketsList can be accessed safely IP-task is the only one
-	who has access. */
-	for( pxIterator = ( const ListItem_t * ) listGET_HEAD_ENTRY( &xBoundTCPSocketsList );
-		pxIterator != pxEndTCP;
-		pxIterator = ( const ListItem_t * ) listGET_NEXT( pxIterator ) )
-	{
-		if( listGET_LIST_ITEM_VALUE( pxIterator ) == ( configLIST_VOLATILE TickType_t ) uxLocalPort )
-		{
-			pxFound = ipPOINTER_CAST( FreeRTOS_Socket_t *, listGET_LIST_ITEM_OWNER( pxIterator ) );
-			if( ( pxFound->ucProtocol == ( uint8_t ) FREERTOS_IPPROTO_TCP ) && ( pxFound->u.xTCP.bits.bPassAccept != pdFALSE_UNSIGNED ) )
-			{
-				pxSocket->u.xTCP.pxPeerSocket = pxFound;
-				FreeRTOS_debug_printf( ( "xTCPCheckNewClient[0]: client on port %u\n", pxSocket->usLocalPort ) );
-				xResult = pdTRUE;
-				break;
-			}
-		}
-	}
-	return xResult;
-}
+        /* Here xBoundTCPSocketsList can be accessed safely IP-task is the only one
+         * who has access. */
+        for( pxIterator = ( const ListItem_t * ) listGET_HEAD_ENTRY( &xBoundTCPSocketsList );
+             pxIterator != pxEndTCP;
+             pxIterator = ( const ListItem_t * ) listGET_NEXT( pxIterator ) )
+        {
+            if( listGET_LIST_ITEM_VALUE( pxIterator ) == ( configLIST_VOLATILE TickType_t ) uxLocalPort )
+            {
+                pxFound = ipPOINTER_CAST( FreeRTOS_Socket_t *, listGET_LIST_ITEM_OWNER( pxIterator ) );
+
+                if( ( pxFound->ucProtocol == ( uint8_t ) FREERTOS_IPPROTO_TCP ) && ( pxFound->u.xTCP.bits.bPassAccept != pdFALSE_UNSIGNED ) )
+                {
+                    pxSocket->u.xTCP.pxPeerSocket = pxFound;
+                    FreeRTOS_debug_printf( ( "xTCPCheckNewClient[0]: client on port %u\n", pxSocket->usLocalPort ) );
+                    xResult = pdTRUE;
+                    break;
+                }
+            }
+        }
+
+        return xResult;
+    }
 /*-----------------------------------------------------------*/
 
 #endif /* ipconfigUSE_TCP == 1 */
 
 /* Provide access to private members for testing. */
 #ifdef FREERTOS_ENABLE_UNIT_TESTS
-	#include "freertos_tcp_test_access_tcp_define.h"
+    #include "freertos_tcp_test_access_tcp_define.h"
 #endif
 
 /* Provide access to private members for verification. */
 #ifdef FREERTOS_TCP_ENABLE_VERIFICATION
-	#include "aws_freertos_tcp_verification_access_tcp_define.h"
+    #include "aws_freertos_tcp_verification_access_tcp_define.h"
 #endif

--- a/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/FreeRTOS_TCP_WIN.c
+++ b/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/FreeRTOS_TCP_WIN.c
@@ -47,46 +47,48 @@
 #include "FreeRTOS_IP_Private.h"
 
 /* Constants used for Smoothed Round Trip Time (SRTT). */
-#define	winSRTT_INCREMENT_NEW 		2
-#define winSRTT_INCREMENT_CURRENT 	6
-#define	winSRTT_DECREMENT_NEW 		1
-#define winSRTT_DECREMENT_CURRENT 	7
-#define winSRTT_CAP_mS				50
+#define winSRTT_INCREMENT_NEW        2
+#define winSRTT_INCREMENT_CURRENT    6
+#define winSRTT_DECREMENT_NEW        1
+#define winSRTT_DECREMENT_CURRENT    7
+#define winSRTT_CAP_mS               50
 
-#if( ipconfigUSE_TCP_WIN == 1 )
+#if ( ipconfigUSE_TCP_WIN == 1 )
 
-	#define xTCPWindowRxNew( pxWindow, ulSequenceNumber, lCount ) xTCPWindowNew( pxWindow, ulSequenceNumber, lCount, pdTRUE )
+    #define xTCPWindowRxNew( pxWindow, ulSequenceNumber, lCount )    xTCPWindowNew( pxWindow, ulSequenceNumber, lCount, pdTRUE )
 
-	#define xTCPWindowTxNew( pxWindow, ulSequenceNumber, lCount ) xTCPWindowNew( pxWindow, ulSequenceNumber, lCount, pdFALSE )
+    #define xTCPWindowTxNew( pxWindow, ulSequenceNumber, lCount )    xTCPWindowNew( pxWindow, ulSequenceNumber, lCount, pdFALSE )
 
-	/* The code to send a single Selective ACK (SACK):
-	 * NOP (0x01), NOP (0x01), SACK (0x05), LEN (0x0a),
-	 * followed by a lower and a higher sequence number,
-	 * where LEN is 2 + 2*4 = 10 bytes. */
-	#if( ipconfigBYTE_ORDER == pdFREERTOS_BIG_ENDIAN )
-		#define OPTION_CODE_SINGLE_SACK		( 0x0101050aUL )
-	#else
-		#define OPTION_CODE_SINGLE_SACK		( 0x0a050101UL )
-	#endif
+    /* The code to send a single Selective ACK (SACK):
+     * NOP (0x01), NOP (0x01), SACK (0x05), LEN (0x0a),
+     * followed by a lower and a higher sequence number,
+     * where LEN is 2 + 2*4 = 10 bytes. */
+    #if ( ipconfigBYTE_ORDER == pdFREERTOS_BIG_ENDIAN )
+        #define OPTION_CODE_SINGLE_SACK    ( 0x0101050aUL )
+    #else
+        #define OPTION_CODE_SINGLE_SACK    ( 0x0a050101UL )
+    #endif
 
-	/* Normal retransmission:
-	 * A packet will be retransmitted after a Retransmit Time-Out (RTO).
-	 * Fast retransmission:
-	 * When 3 packets with a higher sequence number have been acknowledged
-	 * by the peer, it is very unlikely a current packet will ever arrive.
-	 * It will be retransmitted far before the RTO.
-	 */
-	#define	DUPLICATE_ACKS_BEFORE_FAST_RETRANSMIT		( 3U )
+    /* Normal retransmission:
+     * A packet will be retransmitted after a Retransmit Time-Out (RTO).
+     * Fast retransmission:
+     * When 3 packets with a higher sequence number have been acknowledged
+     * by the peer, it is very unlikely a current packet will ever arrive.
+     * It will be retransmitted far before the RTO.
+     */
+    #define DUPLICATE_ACKS_BEFORE_FAST_RETRANSMIT    ( 3U )
 
-	/* If there have been several retransmissions (4), decrease the
-	 * size of the transmission window to at most 2 times MSS.
-	 */
-	#define MAX_TRANSMIT_COUNT_USING_LARGE_WINDOW		( 4U )
+    /* If there have been several retransmissions (4), decrease the
+     * size of the transmission window to at most 2 times MSS.
+     */
+    #define MAX_TRANSMIT_COUNT_USING_LARGE_WINDOW    ( 4U )
 
 #endif /* configUSE_TCP_WIN */
 /*-----------------------------------------------------------*/
 
-extern void vListInsertGeneric( List_t * const pxList, ListItem_t * const pxNewListItem, MiniListItem_t * const pxWhere );
+extern void vListInsertGeneric( List_t * const pxList,
+                                ListItem_t * const pxNewListItem,
+                                MiniListItem_t * const pxWhere );
 
 /*
  * All TCP sockets share a pool of segment descriptors (TCPSegment_t)
@@ -96,16 +98,17 @@ extern void vListInsertGeneric( List_t * const pxList, ListItem_t * const pxNewL
  * As soon as a package has been confirmed, the descriptor will be returned
  * to the segment pool
  */
-#if( ipconfigUSE_TCP_WIN == 1 )
-	static BaseType_t prvCreateSectors( void );
+#if ( ipconfigUSE_TCP_WIN == 1 )
+    static BaseType_t prvCreateSectors( void );
 #endif /* ipconfigUSE_TCP_WIN == 1 */
 
 /*
  * Find a segment with a given sequence number in the list of received
  * segments: 'pxWindow->xRxSegments'.
  */
-#if( ipconfigUSE_TCP_WIN == 1 )
-	static TCPSegment_t *xTCPWindowRxFind( const TCPWindow_t *pxWindow, uint32_t ulSequenceNumber );
+#if ( ipconfigUSE_TCP_WIN == 1 )
+    static TCPSegment_t * xTCPWindowRxFind( const TCPWindow_t * pxWindow,
+                                            uint32_t ulSequenceNumber );
 #endif /* ipconfigUSE_TCP_WIN == 1 */
 
 /*
@@ -113,30 +116,33 @@ extern void vListInsertGeneric( List_t * const pxList, ListItem_t * const pxNewL
  * The socket will borrow all segments from a common pool: 'xSegmentList',
  * which is a list of 'TCPSegment_t'
  */
-#if( ipconfigUSE_TCP_WIN == 1 )
-	static TCPSegment_t *xTCPWindowNew( TCPWindow_t *pxWindow, uint32_t ulSequenceNumber, int32_t lCount, BaseType_t xIsForRx );
+#if ( ipconfigUSE_TCP_WIN == 1 )
+    static TCPSegment_t * xTCPWindowNew( TCPWindow_t * pxWindow,
+                                         uint32_t ulSequenceNumber,
+                                         int32_t lCount,
+                                         BaseType_t xIsForRx );
 #endif /* ipconfigUSE_TCP_WIN == 1 */
 
 /*
  * Detaches and returns the head of a queue
  */
-#if( ipconfigUSE_TCP_WIN == 1 )
-	static TCPSegment_t *xTCPWindowGetHead( const List_t *pxList );
+#if ( ipconfigUSE_TCP_WIN == 1 )
+    static TCPSegment_t * xTCPWindowGetHead( const List_t * pxList );
 #endif /* ipconfigUSE_TCP_WIN == 1 */
 
 /*
  * Returns the head of a queue but it won't be detached
  */
-#if( ipconfigUSE_TCP_WIN == 1 )
-	static TCPSegment_t *xTCPWindowPeekHead( const List_t *pxList );
+#if ( ipconfigUSE_TCP_WIN == 1 )
+    static TCPSegment_t * xTCPWindowPeekHead( const List_t * pxList );
 #endif /* ipconfigUSE_TCP_WIN == 1 */
 
 /*
  *  Free entry pxSegment because it's not used anymore
  *	The ownership will be passed back to the segment pool
  */
-#if( ipconfigUSE_TCP_WIN == 1 )
-	static void vTCPWindowFree( TCPSegment_t *pxSegment );
+#if ( ipconfigUSE_TCP_WIN == 1 )
+    static void vTCPWindowFree( TCPSegment_t * pxSegment );
 #endif /* ipconfigUSE_TCP_WIN == 1 */
 
 /*
@@ -147,561 +153,596 @@ extern void vListInsertGeneric( List_t * const pxList, ListItem_t * const pxNewL
  * (ulSequenceNumber+xLength).  Normally none will be found, because the next Rx
  * segment should have a sequence number equal to '(ulSequenceNumber+xLength)'.
  */
-#if( ipconfigUSE_TCP_WIN == 1 )
-	static TCPSegment_t *xTCPWindowRxConfirm( const TCPWindow_t *pxWindow, uint32_t ulSequenceNumber, uint32_t ulLength );
+#if ( ipconfigUSE_TCP_WIN == 1 )
+    static TCPSegment_t * xTCPWindowRxConfirm( const TCPWindow_t * pxWindow,
+                                               uint32_t ulSequenceNumber,
+                                               uint32_t ulLength );
 #endif /* ipconfigUSE_TCP_WIN == 1 */
 
 /*
  * FreeRTOS+TCP stores data in circular buffers.  Calculate the next position to
  * store.
  */
-#if( ipconfigUSE_TCP_WIN == 1 )
-	static int32_t lTCPIncrementTxPosition( int32_t lPosition, int32_t lMax, int32_t lCount );
+#if ( ipconfigUSE_TCP_WIN == 1 )
+    static int32_t lTCPIncrementTxPosition( int32_t lPosition,
+                                            int32_t lMax,
+                                            int32_t lCount );
 #endif /* ipconfigUSE_TCP_WIN == 1 */
 
 /*
  * This function will look if there is new transmission data.  It will return
  * true if there is data to be sent.
  */
-#if( ipconfigUSE_TCP_WIN == 1 )
-	static BaseType_t prvTCPWindowTxHasSpace( TCPWindow_t const * pxWindow, uint32_t ulWindowSize );
+#if ( ipconfigUSE_TCP_WIN == 1 )
+    static BaseType_t prvTCPWindowTxHasSpace( TCPWindow_t const * pxWindow,
+                                              uint32_t ulWindowSize );
 #endif /* ipconfigUSE_TCP_WIN == 1 */
 
 /*
  * An acknowledge was received.  See if some outstanding data may be removed
  * from the transmission queue(s).
  */
-#if( ipconfigUSE_TCP_WIN == 1 )
-	static uint32_t prvTCPWindowTxCheckAck( TCPWindow_t *pxWindow, uint32_t ulFirst, uint32_t ulLast );
+#if ( ipconfigUSE_TCP_WIN == 1 )
+    static uint32_t prvTCPWindowTxCheckAck( TCPWindow_t * pxWindow,
+                                            uint32_t ulFirst,
+                                            uint32_t ulLast );
 #endif /* ipconfigUSE_TCP_WIN == 1 */
 
 /*
  * A higher Tx block has been acknowledged.  Now iterate through the xWaitQueue
  * to find a possible condition for a FAST retransmission.
  */
-#if( ipconfigUSE_TCP_WIN == 1 )
-	static uint32_t prvTCPWindowFastRetransmit( TCPWindow_t *pxWindow, uint32_t ulFirst );
+#if ( ipconfigUSE_TCP_WIN == 1 )
+    static uint32_t prvTCPWindowFastRetransmit( TCPWindow_t * pxWindow,
+                                                uint32_t ulFirst );
 #endif /* ipconfigUSE_TCP_WIN == 1 */
 
 /*-----------------------------------------------------------*/
 
 /* TCP segment pool. */
-#if( ipconfigUSE_TCP_WIN == 1 )
-	static TCPSegment_t *xTCPSegments = NULL;
+#if ( ipconfigUSE_TCP_WIN == 1 )
+    static TCPSegment_t * xTCPSegments = NULL;
 #endif /* ipconfigUSE_TCP_WIN == 1 */
 
 /* List of free TCP segments. */
-#if( ipconfigUSE_TCP_WIN == 1 )
-	static List_t xSegmentList;
+#if ( ipconfigUSE_TCP_WIN == 1 )
+    static List_t xSegmentList;
 #endif
 
 /* Logging verbosity level. */
 BaseType_t xTCPWindowLoggingLevel = 0;
 
-#if( ipconfigUSE_TCP_WIN == 1 )
-	/* Some 32-bit arithmetic: comparing sequence numbers */
-	static portINLINE BaseType_t xSequenceLessThanOrEqual( uint32_t a, uint32_t b );
-	static portINLINE BaseType_t xSequenceLessThanOrEqual( uint32_t a, uint32_t b )
-	{
-	BaseType_t xResult;
+#if ( ipconfigUSE_TCP_WIN == 1 )
+    /* Some 32-bit arithmetic: comparing sequence numbers */
+    static portINLINE BaseType_t xSequenceLessThanOrEqual( uint32_t a,
+                                                           uint32_t b );
+    static portINLINE BaseType_t xSequenceLessThanOrEqual( uint32_t a,
+                                                           uint32_t b )
+    {
+        BaseType_t xResult;
 
-		/* Test if a <= b
-		Return true if the unsigned subtraction of (b-a) doesn't generate an
-		arithmetic overflow. */
-		if( ( ( b - a ) & 0x80000000UL ) == 0UL )
-		{
-			xResult = pdTRUE;
-		}
-		else
-		{
-			xResult = pdFALSE;
-		}
-		return xResult;
-	}
+        /* Test if a <= b
+         * Return true if the unsigned subtraction of (b-a) doesn't generate an
+         * arithmetic overflow. */
+        if( ( ( b - a ) & 0x80000000UL ) == 0UL )
+        {
+            xResult = pdTRUE;
+        }
+        else
+        {
+            xResult = pdFALSE;
+        }
+
+        return xResult;
+    }
 #endif /* ipconfigUSE_TCP_WIN */
 /*-----------------------------------------------------------*/
 
-#if( ipconfigUSE_TCP_WIN == 1 )
-	static portINLINE BaseType_t xSequenceLessThan( uint32_t a, uint32_t b );
-	static portINLINE BaseType_t xSequenceLessThan( uint32_t a, uint32_t b )
-	{
-	BaseType_t xResult;
+#if ( ipconfigUSE_TCP_WIN == 1 )
+    static portINLINE BaseType_t xSequenceLessThan( uint32_t a,
+                                                    uint32_t b );
+    static portINLINE BaseType_t xSequenceLessThan( uint32_t a,
+                                                    uint32_t b )
+    {
+        BaseType_t xResult;
 
-		/* Test if a < b */
-		if( ( ( b - ( a + 1UL ) ) & 0x80000000UL ) == 0UL )
-		{
-			xResult = pdTRUE;
-		}
-		else
-		{
-			xResult = pdFALSE;
-		}
-		return xResult;
-	}
+        /* Test if a < b */
+        if( ( ( b - ( a + 1UL ) ) & 0x80000000UL ) == 0UL )
+        {
+            xResult = pdTRUE;
+        }
+        else
+        {
+            xResult = pdFALSE;
+        }
+
+        return xResult;
+    }
 #endif /* ipconfigUSE_TCP_WIN */
 /*-----------------------------------------------------------*/
 
-#if( ipconfigUSE_TCP_WIN == 1 )
-	static portINLINE BaseType_t xSequenceGreaterThan( uint32_t a, uint32_t b );
-	static portINLINE BaseType_t xSequenceGreaterThan( uint32_t a, uint32_t b )
-	{
-	BaseType_t xResult;
+#if ( ipconfigUSE_TCP_WIN == 1 )
+    static portINLINE BaseType_t xSequenceGreaterThan( uint32_t a,
+                                                       uint32_t b );
+    static portINLINE BaseType_t xSequenceGreaterThan( uint32_t a,
+                                                       uint32_t b )
+    {
+        BaseType_t xResult;
 
-		/* Test if a > b */
-		if( ( ( a - ( b + 1UL ) ) & 0x80000000UL ) == 0UL )
-		{
-			xResult = pdTRUE;
-		}
-		else
-		{
-			xResult = pdFALSE;
-		}
-		return xResult;
-	}
+        /* Test if a > b */
+        if( ( ( a - ( b + 1UL ) ) & 0x80000000UL ) == 0UL )
+        {
+            xResult = pdTRUE;
+        }
+        else
+        {
+            xResult = pdFALSE;
+        }
+
+        return xResult;
+    }
 #endif /* ipconfigUSE_TCP_WIN */
 
 /*-----------------------------------------------------------*/
-static portINLINE BaseType_t xSequenceGreaterThanOrEqual( uint32_t a, uint32_t b );
-static portINLINE BaseType_t xSequenceGreaterThanOrEqual( uint32_t a, uint32_t b )
+static portINLINE BaseType_t xSequenceGreaterThanOrEqual( uint32_t a,
+                                                          uint32_t b );
+static portINLINE BaseType_t xSequenceGreaterThanOrEqual( uint32_t a,
+                                                          uint32_t b )
 {
-BaseType_t xResult;
+    BaseType_t xResult;
 
-	/* Test if a >= b */
-	if( ( ( a - b ) & 0x80000000UL ) == 0UL )
-	{
-		xResult = pdTRUE;
-	}
-	else
-	{
-		xResult = pdFALSE;
-	}
-	return xResult;
+    /* Test if a >= b */
+    if( ( ( a - b ) & 0x80000000UL ) == 0UL )
+    {
+        xResult = pdTRUE;
+    }
+    else
+    {
+        xResult = pdFALSE;
+    }
+
+    return xResult;
 }
 /*-----------------------------------------------------------*/
 
-#if( ipconfigUSE_TCP_WIN == 1 )
-	static portINLINE void vListInsertFifo( List_t * const pxList, ListItem_t * const pxNewListItem );
-	static portINLINE void vListInsertFifo( List_t * const pxList, ListItem_t * const pxNewListItem )
-	{
-		vListInsertGeneric( pxList, pxNewListItem, &pxList->xListEnd );
-	}
+#if ( ipconfigUSE_TCP_WIN == 1 )
+    static portINLINE void vListInsertFifo( List_t * const pxList,
+                                            ListItem_t * const pxNewListItem );
+    static portINLINE void vListInsertFifo( List_t * const pxList,
+                                            ListItem_t * const pxNewListItem )
+    {
+        vListInsertGeneric( pxList, pxNewListItem, &pxList->xListEnd );
+    }
 #endif
 /*-----------------------------------------------------------*/
 
-static portINLINE void vTCPTimerSet( TCPTimer_t *pxTimer );
-static portINLINE void vTCPTimerSet( TCPTimer_t *pxTimer )
+static portINLINE void vTCPTimerSet( TCPTimer_t * pxTimer );
+static portINLINE void vTCPTimerSet( TCPTimer_t * pxTimer )
 {
-	pxTimer->ulBorn = xTaskGetTickCount ( );
+    pxTimer->ulBorn = xTaskGetTickCount();
 }
 /*-----------------------------------------------------------*/
 
-static portINLINE uint32_t ulTimerGetAge( const TCPTimer_t *pxTimer );
-static portINLINE uint32_t ulTimerGetAge( const TCPTimer_t *pxTimer )
+static portINLINE uint32_t ulTimerGetAge( const TCPTimer_t * pxTimer );
+static portINLINE uint32_t ulTimerGetAge( const TCPTimer_t * pxTimer )
 {
-	return ( ( xTaskGetTickCount() - ( ( TickType_t ) pxTimer->ulBorn ) ) * portTICK_PERIOD_MS );
+    return( ( xTaskGetTickCount() - ( ( TickType_t ) pxTimer->ulBorn ) ) * portTICK_PERIOD_MS );
 }
 /*-----------------------------------------------------------*/
 
-void vListInsertGeneric( List_t * const pxList, ListItem_t * const pxNewListItem, MiniListItem_t * const pxWhere )
+void vListInsertGeneric( List_t * const pxList,
+                         ListItem_t * const pxNewListItem,
+                         MiniListItem_t * const pxWhere )
 {
-	/* Insert a new list item into pxList, it does not sort the list,
-	but it puts the item just before xListEnd, so it will be the last item
-	returned by listGET_HEAD_ENTRY() */
-	pxNewListItem->pxNext = ipPOINTER_CAST(struct xLIST_ITEM * configLIST_VOLATILE, pxWhere );
-	pxNewListItem->pxPrevious = pxWhere->pxPrevious;
-	pxWhere->pxPrevious->pxNext = pxNewListItem;
-	pxWhere->pxPrevious = pxNewListItem;
+    /* Insert a new list item into pxList, it does not sort the list,
+     * but it puts the item just before xListEnd, so it will be the last item
+     * returned by listGET_HEAD_ENTRY() */
+    pxNewListItem->pxNext = ipPOINTER_CAST( struct xLIST_ITEM * configLIST_VOLATILE, pxWhere );
+    pxNewListItem->pxPrevious = pxWhere->pxPrevious;
+    pxWhere->pxPrevious->pxNext = pxNewListItem;
+    pxWhere->pxPrevious = pxNewListItem;
 
-	/* Remember which list the item is in. */
-	listLIST_ITEM_CONTAINER( pxNewListItem ) = ( struct xLIST * configLIST_VOLATILE )pxList;
+    /* Remember which list the item is in. */
+    listLIST_ITEM_CONTAINER( pxNewListItem ) = ( struct xLIST * configLIST_VOLATILE ) pxList;
 
-	( pxList->uxNumberOfItems )++;
+    ( pxList->uxNumberOfItems )++;
 }
 /*-----------------------------------------------------------*/
 
-#if( ipconfigUSE_TCP_WIN == 1 )
+#if ( ipconfigUSE_TCP_WIN == 1 )
 
-	static BaseType_t prvCreateSectors( void )
-	{
-	BaseType_t xIndex, xReturn;
+    static BaseType_t prvCreateSectors( void )
+    {
+        BaseType_t xIndex, xReturn;
 
-		/* Allocate space for 'xTCPSegments' and store them in 'xSegmentList'. */
+        /* Allocate space for 'xTCPSegments' and store them in 'xSegmentList'. */
 
-		vListInitialise( &xSegmentList );
-		xTCPSegments = ipPOINTER_CAST( TCPSegment_t *, pvPortMallocLarge( ( size_t ) ipconfigTCP_WIN_SEG_COUNT * sizeof( xTCPSegments[ 0 ] ) ) );
+        vListInitialise( &xSegmentList );
+        xTCPSegments = ipPOINTER_CAST( TCPSegment_t *, pvPortMallocLarge( ( size_t ) ipconfigTCP_WIN_SEG_COUNT * sizeof( xTCPSegments[ 0 ] ) ) );
 
-		if( xTCPSegments == NULL )
-		{
-			FreeRTOS_debug_printf( ( "prvCreateSectors: malloc %u failed\n",
-				( unsigned ) ipconfigTCP_WIN_SEG_COUNT * sizeof( xTCPSegments[ 0 ] ) ) );
+        if( xTCPSegments == NULL )
+        {
+            FreeRTOS_debug_printf( ( "prvCreateSectors: malloc %u failed\n",
+                                     ( unsigned ) ipconfigTCP_WIN_SEG_COUNT * sizeof( xTCPSegments[ 0 ] ) ) );
 
-			xReturn = pdFAIL;
-		}
-		else
-		{
-			/* Clear the allocated space. */
-			( void ) memset( xTCPSegments, 0, ( size_t ) ipconfigTCP_WIN_SEG_COUNT * sizeof( xTCPSegments[ 0 ] ) );
+            xReturn = pdFAIL;
+        }
+        else
+        {
+            /* Clear the allocated space. */
+            ( void ) memset( xTCPSegments, 0, ( size_t ) ipconfigTCP_WIN_SEG_COUNT * sizeof( xTCPSegments[ 0 ] ) );
 
-			for( xIndex = 0; xIndex < ipconfigTCP_WIN_SEG_COUNT; xIndex++ )
-			{
-				/* Could call vListInitialiseItem here but all data has been
-				nulled already.  Set the owner to a segment descriptor. */
-				listSET_LIST_ITEM_OWNER( &( xTCPSegments[ xIndex ].xSegmentItem  ), ipPOINTER_CAST( void *, &( xTCPSegments[ xIndex ] ) ) );
-				listSET_LIST_ITEM_OWNER( &( xTCPSegments[ xIndex ].xQueueItem ), ipPOINTER_CAST( void *, &( xTCPSegments[ xIndex ] ) ) );
+            for( xIndex = 0; xIndex < ipconfigTCP_WIN_SEG_COUNT; xIndex++ )
+            {
+                /* Could call vListInitialiseItem here but all data has been
+                * nulled already.  Set the owner to a segment descriptor. */
+                listSET_LIST_ITEM_OWNER( &( xTCPSegments[ xIndex ].xSegmentItem ), ipPOINTER_CAST( void *, &( xTCPSegments[ xIndex ] ) ) );
+                listSET_LIST_ITEM_OWNER( &( xTCPSegments[ xIndex ].xQueueItem ), ipPOINTER_CAST( void *, &( xTCPSegments[ xIndex ] ) ) );
 
-				/* And add it to the pool of available segments */
-				vListInsertFifo( &xSegmentList, &( xTCPSegments[xIndex].xSegmentItem ) );
-			}
+                /* And add it to the pool of available segments */
+                vListInsertFifo( &xSegmentList, &( xTCPSegments[ xIndex ].xSegmentItem ) );
+            }
 
-			xReturn = pdPASS;
-		}
+            xReturn = pdPASS;
+        }
 
-		return xReturn;
-	}
-
-#endif /* ipconfigUSE_TCP_WIN == 1 */
-/*-----------------------------------------------------------*/
-
-#if( ipconfigUSE_TCP_WIN == 1 )
-
-	static TCPSegment_t *xTCPWindowRxFind( const TCPWindow_t *pxWindow, uint32_t ulSequenceNumber )
-	{
-	const ListItem_t *pxIterator;
-	const ListItem_t* pxEnd;
-	TCPSegment_t *pxSegment, *pxReturn = NULL;
-
-		/* Find a segment with a given sequence number in the list of received
-		segments. */
-
-		pxEnd = ipPOINTER_CAST( const ListItem_t *, listGET_END_MARKER( &pxWindow->xRxSegments ) );
-
-		for( pxIterator  = listGET_NEXT( pxEnd );
-			 pxIterator != pxEnd;
-			 pxIterator  = listGET_NEXT( pxIterator ) )
-		{
-			pxSegment = ipPOINTER_CAST( TCPSegment_t *, listGET_LIST_ITEM_OWNER( pxIterator ) );
-
-			if( pxSegment->ulSequenceNumber == ulSequenceNumber )
-			{
-				pxReturn = pxSegment;
-				break;
-			}
-		}
-
-		return pxReturn;
-	}
+        return xReturn;
+    }
 
 #endif /* ipconfigUSE_TCP_WIN == 1 */
 /*-----------------------------------------------------------*/
 
-#if( ipconfigUSE_TCP_WIN == 1 )
+#if ( ipconfigUSE_TCP_WIN == 1 )
 
-	static TCPSegment_t *xTCPWindowNew( TCPWindow_t *pxWindow, uint32_t ulSequenceNumber, int32_t lCount, BaseType_t xIsForRx )
-	{
-	TCPSegment_t *pxSegment;
-	ListItem_t * pxItem;
+    static TCPSegment_t * xTCPWindowRxFind( const TCPWindow_t * pxWindow,
+                                            uint32_t ulSequenceNumber )
+    {
+        const ListItem_t * pxIterator;
+        const ListItem_t * pxEnd;
+        TCPSegment_t * pxSegment, * pxReturn = NULL;
 
-		/* Allocate a new segment.  The socket will borrow all segments from a
-		common pool: 'xSegmentList', which is a list of 'TCPSegment_t' */
-		if( listLIST_IS_EMPTY( &xSegmentList ) != pdFALSE )
-		{
-			/* If the TCP-stack runs out of segments, you might consider
-			increasing 'ipconfigTCP_WIN_SEG_COUNT'. */
-			FreeRTOS_debug_printf( ( "xTCPWindow%cxNew: Error: all segments occupied\n", ( xIsForRx != 0 ) ? 'R' : 'T' ) );
-			pxSegment = NULL;
-		}
-		else
-		{
-			/* Pop the item at the head of the list.  Semaphore protection is
-			not required as only the IP task will call these functions.  */
-			pxItem = ( ListItem_t * ) listGET_HEAD_ENTRY( &xSegmentList );
-			pxSegment = ipPOINTER_CAST( TCPSegment_t *, listGET_LIST_ITEM_OWNER( pxItem ) );
+        /* Find a segment with a given sequence number in the list of received
+         * segments. */
 
-			configASSERT( pxItem != NULL );
-			configASSERT( pxSegment != NULL );
+        pxEnd = ipPOINTER_CAST( const ListItem_t *, listGET_END_MARKER( &pxWindow->xRxSegments ) );
 
-			/* Remove the item from xSegmentList. */
-			( void ) uxListRemove( pxItem );
+        for( pxIterator = listGET_NEXT( pxEnd );
+             pxIterator != pxEnd;
+             pxIterator = listGET_NEXT( pxIterator ) )
+        {
+            pxSegment = ipPOINTER_CAST( TCPSegment_t *, listGET_LIST_ITEM_OWNER( pxIterator ) );
 
-			/* Add it to either the connections' Rx or Tx queue. */
-			if( xIsForRx != 0 )
-			{
-				vListInsertFifo( &pxWindow->xRxSegments, pxItem );
-			}
-			else
-			{
-				vListInsertFifo( &pxWindow->xTxSegments, pxItem );
-			}
+            if( pxSegment->ulSequenceNumber == ulSequenceNumber )
+            {
+                pxReturn = pxSegment;
+                break;
+            }
+        }
 
-			/* And set the segment's timer to zero */
-			vTCPTimerSet( &pxSegment->xTransmitTimer );
-
-			pxSegment->u.ulFlags = 0;
-			pxSegment->u.bits.bIsForRx = ( xIsForRx != 0 ) ? 1U : 0U;
-			pxSegment->lMaxLength = lCount;
-			pxSegment->lDataLength = lCount;
-			pxSegment->ulSequenceNumber = ulSequenceNumber;
-			#if( ipconfigHAS_DEBUG_PRINTF != 0 )
-			{
-			static UBaseType_t xLowestLength = ipconfigTCP_WIN_SEG_COUNT;
-			UBaseType_t xLength = listCURRENT_LIST_LENGTH( &xSegmentList );
-
-				if( xLowestLength > xLength )
-				{
-					xLowestLength = xLength;
-				}
-			}
-			#endif /* ipconfigHAS_DEBUG_PRINTF */
-		}
-
-		return pxSegment;
-	}
+        return pxReturn;
+    }
 
 #endif /* ipconfigUSE_TCP_WIN == 1 */
 /*-----------------------------------------------------------*/
 
-#if( ipconfigUSE_TCP_WIN == 1 )
+#if ( ipconfigUSE_TCP_WIN == 1 )
 
-	BaseType_t xTCPWindowRxEmpty( const TCPWindow_t *pxWindow )
-	{
-	BaseType_t xReturn;
+    static TCPSegment_t * xTCPWindowNew( TCPWindow_t * pxWindow,
+                                         uint32_t ulSequenceNumber,
+                                         int32_t lCount,
+                                         BaseType_t xIsForRx )
+    {
+        TCPSegment_t * pxSegment;
+        ListItem_t * pxItem;
 
-		/* When the peer has a close request (FIN flag), the driver will check
-		if there are missing packets in the Rx-queue.  It will accept the
-		closure of the connection if both conditions are true:
-		  - the Rx-queue is empty
-		  - the highest Rx sequence number has been ACK'ed */
-		if( listLIST_IS_EMPTY( ( &pxWindow->xRxSegments ) ) == pdFALSE )
-		{
-			/* Rx data has been stored while earlier packets were missing. */
-			xReturn = pdFALSE;
-		}
-		else if( xSequenceGreaterThanOrEqual( pxWindow->rx.ulCurrentSequenceNumber, pxWindow->rx.ulHighestSequenceNumber ) != pdFALSE )
-		{
-			/* No Rx packets are being stored and the highest sequence number
-			that has been received has been ACKed. */
-			xReturn = pdTRUE;
-		}
-		else
-		{
-			FreeRTOS_debug_printf( ( "xTCPWindowRxEmpty: cur %lu highest %lu (empty)\n",
-				( pxWindow->rx.ulCurrentSequenceNumber - pxWindow->rx.ulFirstSequenceNumber ),
-				( pxWindow->rx.ulHighestSequenceNumber - pxWindow->rx.ulFirstSequenceNumber ) ) );
-			xReturn = pdFALSE;
-		}
+        /* Allocate a new segment.  The socket will borrow all segments from a
+         * common pool: 'xSegmentList', which is a list of 'TCPSegment_t' */
+        if( listLIST_IS_EMPTY( &xSegmentList ) != pdFALSE )
+        {
+            /* If the TCP-stack runs out of segments, you might consider
+             * increasing 'ipconfigTCP_WIN_SEG_COUNT'. */
+            FreeRTOS_debug_printf( ( "xTCPWindow%cxNew: Error: all segments occupied\n", ( xIsForRx != 0 ) ? 'R' : 'T' ) );
+            pxSegment = NULL;
+        }
+        else
+        {
+            /* Pop the item at the head of the list.  Semaphore protection is
+            * not required as only the IP task will call these functions.  */
+            pxItem = ( ListItem_t * ) listGET_HEAD_ENTRY( &xSegmentList );
+            pxSegment = ipPOINTER_CAST( TCPSegment_t *, listGET_LIST_ITEM_OWNER( pxItem ) );
 
-		return xReturn;
-	}
+            configASSERT( pxItem != NULL );
+            configASSERT( pxSegment != NULL );
 
-#endif /* ipconfigUSE_TCP_WIN == 1 */
-/*-----------------------------------------------------------*/
+            /* Remove the item from xSegmentList. */
+            ( void ) uxListRemove( pxItem );
 
-#if( ipconfigUSE_TCP_WIN == 1 )
+            /* Add it to either the connections' Rx or Tx queue. */
+            if( xIsForRx != 0 )
+            {
+                vListInsertFifo( &pxWindow->xRxSegments, pxItem );
+            }
+            else
+            {
+                vListInsertFifo( &pxWindow->xTxSegments, pxItem );
+            }
 
-	static TCPSegment_t *xTCPWindowGetHead( const List_t *pxList )
-	{
-	TCPSegment_t *pxSegment;
-	ListItem_t * pxItem;
+            /* And set the segment's timer to zero */
+            vTCPTimerSet( &pxSegment->xTransmitTimer );
 
-		/* Detaches and returns the head of a queue. */
-		if( listLIST_IS_EMPTY( pxList ) != pdFALSE )
-		{
-			pxSegment = NULL;
-		}
-		else
-		{
-			pxItem = ( ListItem_t * ) listGET_HEAD_ENTRY( pxList );
-			pxSegment = ipPOINTER_CAST( TCPSegment_t *, listGET_LIST_ITEM_OWNER( pxItem ) );
+            pxSegment->u.ulFlags = 0;
+            pxSegment->u.bits.bIsForRx = ( xIsForRx != 0 ) ? 1U : 0U;
+            pxSegment->lMaxLength = lCount;
+            pxSegment->lDataLength = lCount;
+            pxSegment->ulSequenceNumber = ulSequenceNumber;
+            #if ( ipconfigHAS_DEBUG_PRINTF != 0 )
+                {
+                    static UBaseType_t xLowestLength = ipconfigTCP_WIN_SEG_COUNT;
+                    UBaseType_t xLength = listCURRENT_LIST_LENGTH( &xSegmentList );
 
-			( void ) uxListRemove( pxItem );
-		}
+                    if( xLowestLength > xLength )
+                    {
+                        xLowestLength = xLength;
+                    }
+                }
+            #endif /* ipconfigHAS_DEBUG_PRINTF */
+        }
 
-		return pxSegment;
-	}
-
-#endif /* ipconfigUSE_TCP_WIN == 1 */
-/*-----------------------------------------------------------*/
-
-#if( ipconfigUSE_TCP_WIN == 1 )
-
-	static TCPSegment_t *xTCPWindowPeekHead( const List_t *pxList )
-	{
-	const ListItem_t *pxItem;
-	TCPSegment_t *pxReturn;
-
-		/* Returns the head of a queue but it won't be detached. */
-		if( listLIST_IS_EMPTY( pxList ) != pdFALSE )
-		{
-			pxReturn = NULL;
-		}
-		else
-		{
-			pxItem = ( ListItem_t * ) listGET_HEAD_ENTRY( pxList );
-			pxReturn = ipPOINTER_CAST( TCPSegment_t *, listGET_LIST_ITEM_OWNER( pxItem ) );
-		}
-
-		return pxReturn;
-	}
+        return pxSegment;
+    }
 
 #endif /* ipconfigUSE_TCP_WIN == 1 */
 /*-----------------------------------------------------------*/
 
-#if( ipconfigUSE_TCP_WIN == 1 )
+#if ( ipconfigUSE_TCP_WIN == 1 )
 
-	static void vTCPWindowFree( TCPSegment_t *pxSegment )
-	{
-		/*  Free entry pxSegment because it's not used any more.  The ownership
-		will be passed back to the segment pool.
+    BaseType_t xTCPWindowRxEmpty( const TCPWindow_t * pxWindow )
+    {
+        BaseType_t xReturn;
 
-		Unlink it from one of the queues, if any. */
-		if( listLIST_ITEM_CONTAINER( &( pxSegment->xQueueItem ) ) != NULL )
-		{
-			( void ) uxListRemove( &( pxSegment->xQueueItem ) );
-		}
+        /* When the peer has a close request (FIN flag), the driver will check
+         * if there are missing packets in the Rx-queue.  It will accept the
+         * closure of the connection if both conditions are true:
+         * - the Rx-queue is empty
+         * - the highest Rx sequence number has been ACK'ed */
+        if( listLIST_IS_EMPTY( ( &pxWindow->xRxSegments ) ) == pdFALSE )
+        {
+            /* Rx data has been stored while earlier packets were missing. */
+            xReturn = pdFALSE;
+        }
+        else if( xSequenceGreaterThanOrEqual( pxWindow->rx.ulCurrentSequenceNumber, pxWindow->rx.ulHighestSequenceNumber ) != pdFALSE )
+        {
+            /* No Rx packets are being stored and the highest sequence number
+             * that has been received has been ACKed. */
+            xReturn = pdTRUE;
+        }
+        else
+        {
+            FreeRTOS_debug_printf( ( "xTCPWindowRxEmpty: cur %lu highest %lu (empty)\n",
+                                     ( pxWindow->rx.ulCurrentSequenceNumber - pxWindow->rx.ulFirstSequenceNumber ),
+                                     ( pxWindow->rx.ulHighestSequenceNumber - pxWindow->rx.ulFirstSequenceNumber ) ) );
+            xReturn = pdFALSE;
+        }
 
-		pxSegment->ulSequenceNumber = 0UL;
-		pxSegment->lDataLength = 0L;
-		pxSegment->u.ulFlags = 0UL;
-
-		/* Take it out of xRxSegments/xTxSegments */
-		if( listLIST_ITEM_CONTAINER( &( pxSegment->xSegmentItem ) ) != NULL )
-		{
-			( void ) uxListRemove( &( pxSegment->xSegmentItem ) );
-		}
-
-		/* Return it to xSegmentList */
-		vListInsertFifo( &xSegmentList, &( pxSegment->xSegmentItem ) );
-	}
-
-#endif /* ipconfigUSE_TCP_WIN == 1 */
-/*-----------------------------------------------------------*/
-
-#if( ipconfigUSE_TCP_WIN == 1 )
-
-	void vTCPWindowDestroy( TCPWindow_t const * pxWindow )
-	{
-	const List_t * pxSegments;
-	BaseType_t xRound;
-	TCPSegment_t *pxSegment;
-
-		/*  Destroy a window.  A TCP window doesn't serve any more.  Return all
-		owned segments to the pool.  In order to save code, it will make 2 rounds,
-		one to remove the segments from xRxSegments, and a second round to clear
-		xTxSegments*/
-		for( xRound = 0; xRound < 2; xRound++ )
-		{
-			if( xRound != 0 )
-			{
-				pxSegments = &( pxWindow->xRxSegments );
-			}
-			else
-			{
-				pxSegments = &( pxWindow->xTxSegments );
-			}
-
-			if( listLIST_IS_INITIALISED( pxSegments ) )
-			{
-				while( listCURRENT_LIST_LENGTH( pxSegments ) > 0U )
-				{
-					pxSegment = ipPOINTER_CAST( TCPSegment_t *, listGET_OWNER_OF_HEAD_ENTRY( pxSegments ) );
-					vTCPWindowFree( pxSegment );
-				}
-			}
-		}
-	}
+        return xReturn;
+    }
 
 #endif /* ipconfigUSE_TCP_WIN == 1 */
 /*-----------------------------------------------------------*/
 
-void vTCPWindowCreate( TCPWindow_t *pxWindow, uint32_t ulRxWindowLength,
-	uint32_t ulTxWindowLength, uint32_t ulAckNumber, uint32_t ulSequenceNumber, uint32_t ulMSS )
+#if ( ipconfigUSE_TCP_WIN == 1 )
+
+    static TCPSegment_t * xTCPWindowGetHead( const List_t * pxList )
+    {
+        TCPSegment_t * pxSegment;
+        ListItem_t * pxItem;
+
+        /* Detaches and returns the head of a queue. */
+        if( listLIST_IS_EMPTY( pxList ) != pdFALSE )
+        {
+            pxSegment = NULL;
+        }
+        else
+        {
+            pxItem = ( ListItem_t * ) listGET_HEAD_ENTRY( pxList );
+            pxSegment = ipPOINTER_CAST( TCPSegment_t *, listGET_LIST_ITEM_OWNER( pxItem ) );
+
+            ( void ) uxListRemove( pxItem );
+        }
+
+        return pxSegment;
+    }
+
+#endif /* ipconfigUSE_TCP_WIN == 1 */
+/*-----------------------------------------------------------*/
+
+#if ( ipconfigUSE_TCP_WIN == 1 )
+
+    static TCPSegment_t * xTCPWindowPeekHead( const List_t * pxList )
+    {
+        const ListItem_t * pxItem;
+        TCPSegment_t * pxReturn;
+
+        /* Returns the head of a queue but it won't be detached. */
+        if( listLIST_IS_EMPTY( pxList ) != pdFALSE )
+        {
+            pxReturn = NULL;
+        }
+        else
+        {
+            pxItem = ( ListItem_t * ) listGET_HEAD_ENTRY( pxList );
+            pxReturn = ipPOINTER_CAST( TCPSegment_t *, listGET_LIST_ITEM_OWNER( pxItem ) );
+        }
+
+        return pxReturn;
+    }
+
+#endif /* ipconfigUSE_TCP_WIN == 1 */
+/*-----------------------------------------------------------*/
+
+#if ( ipconfigUSE_TCP_WIN == 1 )
+
+    static void vTCPWindowFree( TCPSegment_t * pxSegment )
+    {
+        /*  Free entry pxSegment because it's not used any more.  The ownership
+         * will be passed back to the segment pool.
+         *
+         * Unlink it from one of the queues, if any. */
+        if( listLIST_ITEM_CONTAINER( &( pxSegment->xQueueItem ) ) != NULL )
+        {
+            ( void ) uxListRemove( &( pxSegment->xQueueItem ) );
+        }
+
+        pxSegment->ulSequenceNumber = 0UL;
+        pxSegment->lDataLength = 0L;
+        pxSegment->u.ulFlags = 0UL;
+
+        /* Take it out of xRxSegments/xTxSegments */
+        if( listLIST_ITEM_CONTAINER( &( pxSegment->xSegmentItem ) ) != NULL )
+        {
+            ( void ) uxListRemove( &( pxSegment->xSegmentItem ) );
+        }
+
+        /* Return it to xSegmentList */
+        vListInsertFifo( &xSegmentList, &( pxSegment->xSegmentItem ) );
+    }
+
+#endif /* ipconfigUSE_TCP_WIN == 1 */
+/*-----------------------------------------------------------*/
+
+#if ( ipconfigUSE_TCP_WIN == 1 )
+
+    void vTCPWindowDestroy( TCPWindow_t const * pxWindow )
+    {
+        const List_t * pxSegments;
+        BaseType_t xRound;
+        TCPSegment_t * pxSegment;
+
+        /*  Destroy a window.  A TCP window doesn't serve any more.  Return all
+         * owned segments to the pool.  In order to save code, it will make 2 rounds,
+         * one to remove the segments from xRxSegments, and a second round to clear
+         * xTxSegments*/
+        for( xRound = 0; xRound < 2; xRound++ )
+        {
+            if( xRound != 0 )
+            {
+                pxSegments = &( pxWindow->xRxSegments );
+            }
+            else
+            {
+                pxSegments = &( pxWindow->xTxSegments );
+            }
+
+            if( listLIST_IS_INITIALISED( pxSegments ) )
+            {
+                while( listCURRENT_LIST_LENGTH( pxSegments ) > 0U )
+                {
+                    pxSegment = ipPOINTER_CAST( TCPSegment_t *, listGET_OWNER_OF_HEAD_ENTRY( pxSegments ) );
+                    vTCPWindowFree( pxSegment );
+                }
+            }
+        }
+    }
+
+#endif /* ipconfigUSE_TCP_WIN == 1 */
+/*-----------------------------------------------------------*/
+
+void vTCPWindowCreate( TCPWindow_t * pxWindow,
+                       uint32_t ulRxWindowLength,
+                       uint32_t ulTxWindowLength,
+                       uint32_t ulAckNumber,
+                       uint32_t ulSequenceNumber,
+                       uint32_t ulMSS )
 {
-	/* Create and initialize a window. */
+    /* Create and initialize a window. */
 
-	#if( ipconfigUSE_TCP_WIN == 1 )
-	{
-		if( xTCPSegments == NULL )
-		{
-			( void ) prvCreateSectors();
-		}
+    #if ( ipconfigUSE_TCP_WIN == 1 )
+        {
+            if( xTCPSegments == NULL )
+            {
+                ( void ) prvCreateSectors();
+            }
 
-		vListInitialise( &( pxWindow->xTxSegments ) );
-		vListInitialise( &( pxWindow->xRxSegments ) );
+            vListInitialise( &( pxWindow->xTxSegments ) );
+            vListInitialise( &( pxWindow->xRxSegments ) );
 
-		vListInitialise( &( pxWindow->xPriorityQueue ) );	/* Priority queue: segments which must be sent immediately */
-		vListInitialise( &( pxWindow->xTxQueue ) );			/* Transmit queue: segments queued for transmission */
-		vListInitialise( &( pxWindow->xWaitQueue ) );		/* Waiting queue:  outstanding segments */
-	}
-	#endif /* ipconfigUSE_TCP_WIN == 1 */
+            vListInitialise( &( pxWindow->xPriorityQueue ) ); /* Priority queue: segments which must be sent immediately */
+            vListInitialise( &( pxWindow->xTxQueue ) );       /* Transmit queue: segments queued for transmission */
+            vListInitialise( &( pxWindow->xWaitQueue ) );     /* Waiting queue:  outstanding segments */
+        }
+    #endif /* ipconfigUSE_TCP_WIN == 1 */
 
-	if( xTCPWindowLoggingLevel != 0 )
-	{
-		FreeRTOS_debug_printf( ( "vTCPWindowCreate: for WinLen = Rx/Tx: %lu/%lu\n",
-			ulRxWindowLength, ulTxWindowLength ) );
-	}
+    if( xTCPWindowLoggingLevel != 0 )
+    {
+        FreeRTOS_debug_printf( ( "vTCPWindowCreate: for WinLen = Rx/Tx: %lu/%lu\n",
+                                 ulRxWindowLength, ulTxWindowLength ) );
+    }
 
-	pxWindow->xSize.ulRxWindowLength = ulRxWindowLength;
-	pxWindow->xSize.ulTxWindowLength = ulTxWindowLength;
+    pxWindow->xSize.ulRxWindowLength = ulRxWindowLength;
+    pxWindow->xSize.ulTxWindowLength = ulTxWindowLength;
 
-	vTCPWindowInit( pxWindow, ulAckNumber, ulSequenceNumber, ulMSS );
+    vTCPWindowInit( pxWindow, ulAckNumber, ulSequenceNumber, ulMSS );
 }
 /*-----------------------------------------------------------*/
 
-void vTCPWindowInit( TCPWindow_t *pxWindow, uint32_t ulAckNumber, uint32_t ulSequenceNumber, uint32_t ulMSS )
+void vTCPWindowInit( TCPWindow_t * pxWindow,
+                     uint32_t ulAckNumber,
+                     uint32_t ulSequenceNumber,
+                     uint32_t ulMSS )
 {
-const int32_t l500ms = 500;
+    const int32_t l500ms = 500;
 
-	pxWindow->u.ulFlags = 0UL;
-	pxWindow->u.bits.bHasInit = pdTRUE_UNSIGNED;
+    pxWindow->u.ulFlags = 0UL;
+    pxWindow->u.bits.bHasInit = pdTRUE_UNSIGNED;
 
-	if( ulMSS != 0UL )
-	{
-		if( pxWindow->usMSSInit != 0U )
-		{
-			pxWindow->usMSSInit = ( uint16_t ) ulMSS;
-		}
+    if( ulMSS != 0UL )
+    {
+        if( pxWindow->usMSSInit != 0U )
+        {
+            pxWindow->usMSSInit = ( uint16_t ) ulMSS;
+        }
 
-		if( ( ulMSS < ( uint32_t ) pxWindow->usMSS ) || ( pxWindow->usMSS == 0U ) )
-		{
-			pxWindow->xSize.ulRxWindowLength = ( pxWindow->xSize.ulRxWindowLength / ulMSS ) * ulMSS;
-			pxWindow->usMSS = ( uint16_t ) ulMSS;
-		}
-	}
+        if( ( ulMSS < ( uint32_t ) pxWindow->usMSS ) || ( pxWindow->usMSS == 0U ) )
+        {
+            pxWindow->xSize.ulRxWindowLength = ( pxWindow->xSize.ulRxWindowLength / ulMSS ) * ulMSS;
+            pxWindow->usMSS = ( uint16_t ) ulMSS;
+        }
+    }
 
-	#if( ipconfigUSE_TCP_WIN == 0 )
-	{
-		pxWindow->xTxSegment.lMaxLength = ( int32_t ) pxWindow->usMSS;
-	}
-	#endif /* ipconfigUSE_TCP_WIN == 1 */
+    #if ( ipconfigUSE_TCP_WIN == 0 )
+        {
+            pxWindow->xTxSegment.lMaxLength = ( int32_t ) pxWindow->usMSS;
+        }
+    #endif /* ipconfigUSE_TCP_WIN == 1 */
 
-	/*Start with a timeout of 2 * 500 ms (1 sec). */
-	pxWindow->lSRTT = l500ms;
+    /*Start with a timeout of 2 * 500 ms (1 sec). */
+    pxWindow->lSRTT = l500ms;
 
-	/* Just for logging, to print relative sequence numbers. */
-	pxWindow->rx.ulFirstSequenceNumber = ulAckNumber;
+    /* Just for logging, to print relative sequence numbers. */
+    pxWindow->rx.ulFirstSequenceNumber = ulAckNumber;
 
-	/* The segment asked for in the next transmission. */
-	pxWindow->rx.ulCurrentSequenceNumber = ulAckNumber;
+    /* The segment asked for in the next transmission. */
+    pxWindow->rx.ulCurrentSequenceNumber = ulAckNumber;
 
-	/* The right-hand side of the receive window. */
-	pxWindow->rx.ulHighestSequenceNumber = ulAckNumber;
+    /* The right-hand side of the receive window. */
+    pxWindow->rx.ulHighestSequenceNumber = ulAckNumber;
 
-	pxWindow->tx.ulFirstSequenceNumber = ulSequenceNumber;
+    pxWindow->tx.ulFirstSequenceNumber = ulSequenceNumber;
 
-	/* The segment asked for in next transmission. */
-	pxWindow->tx.ulCurrentSequenceNumber = ulSequenceNumber;
+    /* The segment asked for in next transmission. */
+    pxWindow->tx.ulCurrentSequenceNumber = ulSequenceNumber;
 
-	/* The sequence number given to the next outgoing byte to be added is
-	maintained by lTCPWindowTxAdd(). */
-	pxWindow->ulNextTxSequenceNumber = ulSequenceNumber;
+    /* The sequence number given to the next outgoing byte to be added is
+     * maintained by lTCPWindowTxAdd(). */
+    pxWindow->ulNextTxSequenceNumber = ulSequenceNumber;
 
-	/* The right-hand side of the transmit window. */
-	pxWindow->tx.ulHighestSequenceNumber = ulSequenceNumber;
-	pxWindow->ulOurSequenceNumber = ulSequenceNumber;
+    /* The right-hand side of the transmit window. */
+    pxWindow->tx.ulHighestSequenceNumber = ulSequenceNumber;
+    pxWindow->ulOurSequenceNumber = ulSequenceNumber;
 }
 /*-----------------------------------------------------------*/
 
-#if( ipconfigUSE_TCP_WIN == 1 )
+#if ( ipconfigUSE_TCP_WIN == 1 )
 
     void vTCPSegmentCleanup( void )
     {
@@ -733,279 +774,290 @@ const int32_t l500ms = 500;
  *
  *=============================================================================*/
 
-#if( ipconfigUSE_TCP_WIN == 1 )
+#if ( ipconfigUSE_TCP_WIN == 1 )
 
-	static TCPSegment_t *xTCPWindowRxConfirm( const TCPWindow_t *pxWindow, uint32_t ulSequenceNumber, uint32_t ulLength )
-	{
-	TCPSegment_t *pxBest = NULL;
-	const ListItem_t *pxIterator;
-	uint32_t ulNextSequenceNumber = ulSequenceNumber + ulLength;
-	const ListItem_t * pxEnd = ipPOINTER_CAST( const ListItem_t *, listGET_END_MARKER( &pxWindow->xRxSegments ) );
-	TCPSegment_t *pxSegment;
+    static TCPSegment_t * xTCPWindowRxConfirm( const TCPWindow_t * pxWindow,
+                                               uint32_t ulSequenceNumber,
+                                               uint32_t ulLength )
+    {
+        TCPSegment_t * pxBest = NULL;
+        const ListItem_t * pxIterator;
+        uint32_t ulNextSequenceNumber = ulSequenceNumber + ulLength;
+        const ListItem_t * pxEnd = ipPOINTER_CAST( const ListItem_t *, listGET_END_MARKER( &pxWindow->xRxSegments ) );
+        TCPSegment_t * pxSegment;
 
-		/* A segment has been received with sequence number 'ulSequenceNumber',
-		where 'ulCurrentSequenceNumber == ulSequenceNumber', which means that
-		exactly this segment was expected.  xTCPWindowRxConfirm() will check if
-		there is already another segment with a sequence number between (ulSequenceNumber)
-		and (ulSequenceNumber+ulLength).  Normally none will be found, because
-		the next RX segment should have a sequence number equal to
-		'(ulSequenceNumber+ulLength)'. */
+        /* A segment has been received with sequence number 'ulSequenceNumber',
+         * where 'ulCurrentSequenceNumber == ulSequenceNumber', which means that
+         * exactly this segment was expected.  xTCPWindowRxConfirm() will check if
+         * there is already another segment with a sequence number between (ulSequenceNumber)
+         * and (ulSequenceNumber+ulLength).  Normally none will be found, because
+         * the next RX segment should have a sequence number equal to
+         * '(ulSequenceNumber+ulLength)'. */
 
-		/* Iterate through all RX segments that are stored: */
-		for( pxIterator  = listGET_NEXT( pxEnd );
-			 pxIterator != pxEnd;
-			 pxIterator  = listGET_NEXT( pxIterator ) )
-		{
-			pxSegment = ipPOINTER_CAST( TCPSegment_t *, listGET_LIST_ITEM_OWNER( pxIterator ) );
-			/* And see if there is a segment for which:
-			'ulSequenceNumber' <= 'pxSegment->ulSequenceNumber' < 'ulNextSequenceNumber'
-			If there are more matching segments, the one with the lowest sequence number
-			shall be taken */
-			if( ( xSequenceGreaterThanOrEqual( pxSegment->ulSequenceNumber, ulSequenceNumber ) != 0 ) &&
-				( xSequenceLessThan( pxSegment->ulSequenceNumber, ulNextSequenceNumber ) != 0 ) )
-			{
-				if( ( pxBest == NULL ) || ( xSequenceLessThan( pxSegment->ulSequenceNumber, pxBest->ulSequenceNumber ) != 0 ) )
-				{
-					pxBest = pxSegment;
-				}
-			}
-		}
+        /* Iterate through all RX segments that are stored: */
+        for( pxIterator = listGET_NEXT( pxEnd );
+             pxIterator != pxEnd;
+             pxIterator = listGET_NEXT( pxIterator ) )
+        {
+            pxSegment = ipPOINTER_CAST( TCPSegment_t *, listGET_LIST_ITEM_OWNER( pxIterator ) );
 
-		if( ( pxBest != NULL ) &&
-			( ( pxBest->ulSequenceNumber != ulSequenceNumber ) || ( pxBest->lDataLength != ( int32_t ) ulLength ) ) )
-		{
-			FreeRTOS_debug_printf( ( "xTCPWindowRxConfirm[%u]: search %lu (+%ld=%lu) found %lu (+%ld=%lu)\n",
-				pxWindow->usPeerPortNumber,
-				ulSequenceNumber - pxWindow->rx.ulFirstSequenceNumber,
-				ulLength,
-				ulSequenceNumber + ulLength - pxWindow->rx.ulFirstSequenceNumber,
-				pxBest->ulSequenceNumber - pxWindow->rx.ulFirstSequenceNumber,
-				pxBest->lDataLength,
-				pxBest->ulSequenceNumber + ( ( uint32_t ) pxBest->lDataLength ) - pxWindow->rx.ulFirstSequenceNumber ) );
-		}
+            /* And see if there is a segment for which:
+             * 'ulSequenceNumber' <= 'pxSegment->ulSequenceNumber' < 'ulNextSequenceNumber'
+             * If there are more matching segments, the one with the lowest sequence number
+             * shall be taken */
+            if( ( xSequenceGreaterThanOrEqual( pxSegment->ulSequenceNumber, ulSequenceNumber ) != 0 ) &&
+                ( xSequenceLessThan( pxSegment->ulSequenceNumber, ulNextSequenceNumber ) != 0 ) )
+            {
+                if( ( pxBest == NULL ) || ( xSequenceLessThan( pxSegment->ulSequenceNumber, pxBest->ulSequenceNumber ) != 0 ) )
+                {
+                    pxBest = pxSegment;
+                }
+            }
+        }
 
-		return pxBest;
-	}
+        if( ( pxBest != NULL ) &&
+            ( ( pxBest->ulSequenceNumber != ulSequenceNumber ) || ( pxBest->lDataLength != ( int32_t ) ulLength ) ) )
+        {
+            FreeRTOS_debug_printf( ( "xTCPWindowRxConfirm[%u]: search %lu (+%ld=%lu) found %lu (+%ld=%lu)\n",
+                                     pxWindow->usPeerPortNumber,
+                                     ulSequenceNumber - pxWindow->rx.ulFirstSequenceNumber,
+                                     ulLength,
+                                     ulSequenceNumber + ulLength - pxWindow->rx.ulFirstSequenceNumber,
+                                     pxBest->ulSequenceNumber - pxWindow->rx.ulFirstSequenceNumber,
+                                     pxBest->lDataLength,
+                                     pxBest->ulSequenceNumber + ( ( uint32_t ) pxBest->lDataLength ) - pxWindow->rx.ulFirstSequenceNumber ) );
+        }
+
+        return pxBest;
+    }
 
 #endif /* ipconfgiUSE_TCP_WIN == 1 */
 /*-----------------------------------------------------------*/
 
-#if( ipconfigUSE_TCP_WIN == 1 )
+#if ( ipconfigUSE_TCP_WIN == 1 )
 
-	int32_t lTCPWindowRxCheck( TCPWindow_t *pxWindow, uint32_t ulSequenceNumber, uint32_t ulLength, uint32_t ulSpace )
-	{
-	uint32_t ulCurrentSequenceNumber, ulLast, ulSavedSequenceNumber;
-	int32_t lReturn, lDistance;
-	TCPSegment_t *pxFound;
+    int32_t lTCPWindowRxCheck( TCPWindow_t * pxWindow,
+                               uint32_t ulSequenceNumber,
+                               uint32_t ulLength,
+                               uint32_t ulSpace )
+    {
+        uint32_t ulCurrentSequenceNumber, ulLast, ulSavedSequenceNumber;
+        int32_t lReturn, lDistance;
+        TCPSegment_t * pxFound;
 
-		/* If lTCPWindowRxCheck( ) returns == 0, the packet will be passed
-		directly to user (segment is expected).  If it returns a positive
-		number, an earlier packet is missing, but this packet may be stored.
-		If negative, the packet has already been stored, or it is out-of-order,
-		or there is not enough space.
+        /* If lTCPWindowRxCheck( ) returns == 0, the packet will be passed
+         * directly to user (segment is expected).  If it returns a positive
+         * number, an earlier packet is missing, but this packet may be stored.
+         * If negative, the packet has already been stored, or it is out-of-order,
+         * or there is not enough space.
+         *
+         * As a side-effect, pxWindow->ulUserDataLength will get set to non-zero,
+         * if more Rx data may be passed to the user after this packet. */
 
-		As a side-effect, pxWindow->ulUserDataLength will get set to non-zero,
-		if more Rx data may be passed to the user after this packet. */
+        ulCurrentSequenceNumber = pxWindow->rx.ulCurrentSequenceNumber;
 
-		ulCurrentSequenceNumber = pxWindow->rx.ulCurrentSequenceNumber;
+        /* For Selective Ack (SACK), used when out-of-sequence data come in. */
+        pxWindow->ucOptionLength = 0U;
 
-		/* For Selective Ack (SACK), used when out-of-sequence data come in. */
-		pxWindow->ucOptionLength = 0U;
+        /* Non-zero if TCP-windows contains data which must be popped. */
+        pxWindow->ulUserDataLength = 0UL;
 
-		/* Non-zero if TCP-windows contains data which must be popped. */
-		pxWindow->ulUserDataLength = 0UL;
+        if( ulCurrentSequenceNumber == ulSequenceNumber )
+        {
+            /* This is the packet with the lowest sequence number we're waiting
+             * for.  It can be passed directly to the rx stream. */
+            if( ulLength > ulSpace )
+            {
+                FreeRTOS_debug_printf( ( "lTCPWindowRxCheck: Refuse %lu bytes, due to lack of space (%lu)\n", ulLength, ulSpace ) );
+                lReturn = -1;
+            }
+            else
+            {
+                ulCurrentSequenceNumber += ulLength;
 
-		if( ulCurrentSequenceNumber == ulSequenceNumber )
-		{
-			/* This is the packet with the lowest sequence number we're waiting
-			for.  It can be passed directly to the rx stream. */
-			if( ulLength > ulSpace )
-			{
-				FreeRTOS_debug_printf( ( "lTCPWindowRxCheck: Refuse %lu bytes, due to lack of space (%lu)\n", ulLength, ulSpace ) );
-				lReturn = -1;
-			}
-			else
-			{
-				ulCurrentSequenceNumber += ulLength;
-
-				if( listCURRENT_LIST_LENGTH( &( pxWindow->xRxSegments ) ) != 0U )
-				{
-					ulSavedSequenceNumber = ulCurrentSequenceNumber;
+                if( listCURRENT_LIST_LENGTH( &( pxWindow->xRxSegments ) ) != 0U )
+                {
+                    ulSavedSequenceNumber = ulCurrentSequenceNumber;
 
                     /* Clean up all sequence received between ulSequenceNumber and ulSequenceNumber + ulLength since they are duplicated.
-                    If the server is forced to retransmit packets several time in a row it might send a batch of concatenated packet for speed.
-                    So we cannot rely on the packets between ulSequenceNumber and ulSequenceNumber + ulLength to be sequential and it is better to just
-                    clean them out. */
+                     * If the server is forced to retransmit packets several time in a row it might send a batch of concatenated packet for speed.
+                     * So we cannot rely on the packets between ulSequenceNumber and ulSequenceNumber + ulLength to be sequential and it is better to just
+                     * clean them out. */
                     do
                     {
                         pxFound = xTCPWindowRxConfirm( pxWindow, ulSequenceNumber, ulLength );
 
-                        if ( pxFound != NULL )
+                        if( pxFound != NULL )
                         {
                             /* Remove it because it will be passed to user directly. */
                             vTCPWindowFree( pxFound );
                         }
                     } while ( pxFound != NULL );
 
-					/*  Check for following segments that are already in the
-					queue and increment ulCurrentSequenceNumber. */
-					for( ;; )
-					{
-						pxFound = xTCPWindowRxFind( pxWindow, ulCurrentSequenceNumber );
-						if( pxFound == NULL )
-						{
-							break;
-						}
-						ulCurrentSequenceNumber += ( uint32_t ) pxFound->lDataLength;
+                    /*  Check for following segments that are already in the
+                     * queue and increment ulCurrentSequenceNumber. */
+                    for( ; ; )
+                    {
+                        pxFound = xTCPWindowRxFind( pxWindow, ulCurrentSequenceNumber );
 
-						/* As all packet below this one have been passed to the
-						user it can be discarded. */
-						vTCPWindowFree( pxFound );
-					}
+                        if( pxFound == NULL )
+                        {
+                            break;
+                        }
 
-					if( ulSavedSequenceNumber != ulCurrentSequenceNumber )
-					{
-						/*  After the current data-package, there is more data
-						to be popped. */
-						pxWindow->ulUserDataLength = ulCurrentSequenceNumber - ulSavedSequenceNumber;
+                        ulCurrentSequenceNumber += ( uint32_t ) pxFound->lDataLength;
 
-						if( xTCPWindowLoggingLevel >= 1 )
-						{
-							FreeRTOS_debug_printf( ( "lTCPWindowRxCheck[%d,%d]: retran %lu (Found %lu bytes at %lu cnt %ld)\n",
-								pxWindow->usPeerPortNumber, pxWindow->usOurPortNumber,
-								ulSequenceNumber - pxWindow->rx.ulFirstSequenceNumber,
-								pxWindow->ulUserDataLength,
-								ulSavedSequenceNumber - pxWindow->rx.ulFirstSequenceNumber,
-								listCURRENT_LIST_LENGTH( &pxWindow->xRxSegments ) ) );
-						}
-					}
-				}
+                        /* As all packet below this one have been passed to the
+                         * user it can be discarded. */
+                        vTCPWindowFree( pxFound );
+                    }
 
-				pxWindow->rx.ulCurrentSequenceNumber = ulCurrentSequenceNumber;
+                    if( ulSavedSequenceNumber != ulCurrentSequenceNumber )
+                    {
+                        /*  After the current data-package, there is more data
+                         * to be popped. */
+                        pxWindow->ulUserDataLength = ulCurrentSequenceNumber - ulSavedSequenceNumber;
 
-				/* Packet was expected, may be passed directly to the socket
-				buffer or application.  Store the packet at offset 0. */
-				lReturn = 0;
-			}
-		}
-		else if( ulCurrentSequenceNumber == ( ulSequenceNumber + 1UL ) )
-		{
-			/* Looks like a TCP keep-alive message.  Do not accept/store Rx data
-			ulUserDataLength = 0. Not packet out-of-sync.  Just reply to it. */
-			lReturn = -1;
-		}
-		else
-		{
-			/* The packet is not the one expected.  See if it falls within the Rx
-			window so it can be stored. */
+                        if( xTCPWindowLoggingLevel >= 1 )
+                        {
+                            FreeRTOS_debug_printf( ( "lTCPWindowRxCheck[%d,%d]: retran %lu (Found %lu bytes at %lu cnt %ld)\n",
+                                                     pxWindow->usPeerPortNumber, pxWindow->usOurPortNumber,
+                                                     ulSequenceNumber - pxWindow->rx.ulFirstSequenceNumber,
+                                                     pxWindow->ulUserDataLength,
+                                                     ulSavedSequenceNumber - pxWindow->rx.ulFirstSequenceNumber,
+                                                     listCURRENT_LIST_LENGTH( &pxWindow->xRxSegments ) ) );
+                        }
+                    }
+                }
 
-			/*  An "out-of-sequence" segment was received, must have missed one.
-			Prepare a SACK (Selective ACK). */
-			ulLast = ulSequenceNumber + ulLength;
-			/* The cast from unsigned long to signed long is on purpose.
-			The macro 'ipNUMERIC_CAST' will prevent PC-lint from complaining. */
-			lDistance = ipNUMERIC_CAST( int32_t, ulLast - ulCurrentSequenceNumber );
+                pxWindow->rx.ulCurrentSequenceNumber = ulCurrentSequenceNumber;
 
-			if( lDistance <= 0 )
-			{
-				/* An earlier has been received, must be a retransmission of a
-				packet that has been accepted already.  No need to send out a
-				Selective ACK (SACK). */
-				lReturn = -1;
-			}
-			else if( lDistance > ( int32_t ) ulSpace )
-			{
-				/* The new segment is ahead of rx.ulCurrentSequenceNumber.  The
-				sequence number of this packet is too far ahead, ignore it. */
-				FreeRTOS_debug_printf( ( "lTCPWindowRxCheck: Refuse %lu+%lu bytes, due to lack of space (%lu)\n", lDistance, ulLength, ulSpace ) );
-				lReturn = -1;
-			}
-			else
-			{
-				/* See if there is more data in a contiguous block to make the
-				SACK describe a longer range of data. */
+                /* Packet was expected, may be passed directly to the socket
+                 * buffer or application.  Store the packet at offset 0. */
+                lReturn = 0;
+            }
+        }
+        else if( ulCurrentSequenceNumber == ( ulSequenceNumber + 1UL ) )
+        {
+            /* Looks like a TCP keep-alive message.  Do not accept/store Rx data
+             * ulUserDataLength = 0. Not packet out-of-sync.  Just reply to it. */
+            lReturn = -1;
+        }
+        else
+        {
+            /* The packet is not the one expected.  See if it falls within the Rx
+             * window so it can be stored. */
 
-				/* TODO: SACK's may also be delayed for a short period
-				 * This is useful because subsequent packets will be SACK'd with
-				 * single one message
-				 */
-				for( ;; )
-				{
-					pxFound = xTCPWindowRxFind( pxWindow, ulLast );
-					if( pxFound == NULL )
-					{
-						break;
-					}
-					ulLast += ( uint32_t ) pxFound->lDataLength;
-				}
+            /*  An "out-of-sequence" segment was received, must have missed one.
+             * Prepare a SACK (Selective ACK). */
+            ulLast = ulSequenceNumber + ulLength;
 
-				if( xTCPWindowLoggingLevel >= 1 )
-				{
-					FreeRTOS_debug_printf( ( "lTCPWindowRxCheck[%d,%d]: seqnr %u exp %u (dist %d) SACK to %u\n",
-						( int ) pxWindow->usPeerPortNumber,
-						( int ) pxWindow->usOurPortNumber,
-						( unsigned ) ulSequenceNumber - pxWindow->rx.ulFirstSequenceNumber,
-						( unsigned ) ulCurrentSequenceNumber - pxWindow->rx.ulFirstSequenceNumber,
-						( unsigned ) ( ulSequenceNumber - ulCurrentSequenceNumber ),	/* want this signed */
-						( unsigned ) ( ulLast - pxWindow->rx.ulFirstSequenceNumber ) ) );
-				}
+            /* The cast from unsigned long to signed long is on purpose.
+             * The macro 'ipNUMERIC_CAST' will prevent PC-lint from complaining. */
+            lDistance = ipNUMERIC_CAST( int32_t, ulLast - ulCurrentSequenceNumber );
 
-				/* Now prepare the SACK message.
-				Code OPTION_CODE_SINGLE_SACK already in network byte order. */
-				pxWindow->ulOptionsData[0] = OPTION_CODE_SINGLE_SACK;
+            if( lDistance <= 0 )
+            {
+                /* An earlier has been received, must be a retransmission of a
+                 * packet that has been accepted already.  No need to send out a
+                 * Selective ACK (SACK). */
+                lReturn = -1;
+            }
+            else if( lDistance > ( int32_t ) ulSpace )
+            {
+                /* The new segment is ahead of rx.ulCurrentSequenceNumber.  The
+                 * sequence number of this packet is too far ahead, ignore it. */
+                FreeRTOS_debug_printf( ( "lTCPWindowRxCheck: Refuse %lu+%lu bytes, due to lack of space (%lu)\n", lDistance, ulLength, ulSpace ) );
+                lReturn = -1;
+            }
+            else
+            {
+                /* See if there is more data in a contiguous block to make the
+                 * SACK describe a longer range of data. */
 
-				/* First sequence number that we received. */
-				pxWindow->ulOptionsData[1] = FreeRTOS_htonl( ulSequenceNumber );
+                /* TODO: SACK's may also be delayed for a short period
+                 * This is useful because subsequent packets will be SACK'd with
+                 * single one message
+                 */
+                for( ; ; )
+                {
+                    pxFound = xTCPWindowRxFind( pxWindow, ulLast );
 
-				/* Last + 1 */
-				pxWindow->ulOptionsData[2] = FreeRTOS_htonl( ulLast );
+                    if( pxFound == NULL )
+                    {
+                        break;
+                    }
 
-				/* Which make 12 (3*4) option bytes. */
-				pxWindow->ucOptionLength = ( uint8_t ) ( 3U * sizeof( pxWindow->ulOptionsData[ 0 ] ) );
+                    ulLast += ( uint32_t ) pxFound->lDataLength;
+                }
 
-				pxFound = xTCPWindowRxFind( pxWindow, ulSequenceNumber );
+                if( xTCPWindowLoggingLevel >= 1 )
+                {
+                    FreeRTOS_debug_printf( ( "lTCPWindowRxCheck[%d,%d]: seqnr %u exp %u (dist %d) SACK to %u\n",
+                                             ( int ) pxWindow->usPeerPortNumber,
+                                             ( int ) pxWindow->usOurPortNumber,
+                                             ( unsigned ) ulSequenceNumber - pxWindow->rx.ulFirstSequenceNumber,
+                                             ( unsigned ) ulCurrentSequenceNumber - pxWindow->rx.ulFirstSequenceNumber,
+                                             ( unsigned ) ( ulSequenceNumber - ulCurrentSequenceNumber ), /* want this signed */
+                                             ( unsigned ) ( ulLast - pxWindow->rx.ulFirstSequenceNumber ) ) );
+                }
 
-				if( pxFound != NULL )
-				{
-					/* This out-of-sequence packet has been received for a
-					second time.  It is already stored but do send a SACK
-					again. */
-					lReturn = -1;
-				}
-				else
-				{
-					pxFound = xTCPWindowRxNew( pxWindow, ulSequenceNumber, ( int32_t ) ulLength );
+                /* Now prepare the SACK message.
+                 * Code OPTION_CODE_SINGLE_SACK already in network byte order. */
+                pxWindow->ulOptionsData[ 0 ] = OPTION_CODE_SINGLE_SACK;
 
-					if( pxFound == NULL )
-					{
-						/* Can not send a SACK, because the segment cannot be
-						stored. */
-						pxWindow->ucOptionLength = 0U;
+                /* First sequence number that we received. */
+                pxWindow->ulOptionsData[ 1 ] = FreeRTOS_htonl( ulSequenceNumber );
 
-						/* Needs to be stored but there is no segment
-						available. */
-						lReturn = -1;
-					}
-					else
-					{
-						if( xTCPWindowLoggingLevel != 0 )
-						{
-							FreeRTOS_debug_printf( ( "lTCPWindowRxCheck[%u,%u]: seqnr %lu (cnt %lu)\n",
-								pxWindow->usPeerPortNumber, pxWindow->usOurPortNumber, ulSequenceNumber - pxWindow->rx.ulFirstSequenceNumber,
-								listCURRENT_LIST_LENGTH( &pxWindow->xRxSegments ) ) );
-							FreeRTOS_flush_logging( );
-						}
+                /* Last + 1 */
+                pxWindow->ulOptionsData[ 2 ] = FreeRTOS_htonl( ulLast );
 
-						/* Return a positive value.  The packet may be accepted
-						and stored but an earlier packet is still missing. */
-						lReturn = ipNUMERIC_CAST( int32_t, ulSequenceNumber - ulCurrentSequenceNumber );
-					}
-				}
-			}
-		}
+                /* Which make 12 (3*4) option bytes. */
+                pxWindow->ucOptionLength = ( uint8_t ) ( 3U * sizeof( pxWindow->ulOptionsData[ 0 ] ) );
 
-		return lReturn;
-	}
+                pxFound = xTCPWindowRxFind( pxWindow, ulSequenceNumber );
+
+                if( pxFound != NULL )
+                {
+                    /* This out-of-sequence packet has been received for a
+                     * second time.  It is already stored but do send a SACK
+                     * again. */
+                    lReturn = -1;
+                }
+                else
+                {
+                    pxFound = xTCPWindowRxNew( pxWindow, ulSequenceNumber, ( int32_t ) ulLength );
+
+                    if( pxFound == NULL )
+                    {
+                        /* Can not send a SACK, because the segment cannot be
+                         * stored. */
+                        pxWindow->ucOptionLength = 0U;
+
+                        /* Needs to be stored but there is no segment
+                         * available. */
+                        lReturn = -1;
+                    }
+                    else
+                    {
+                        if( xTCPWindowLoggingLevel != 0 )
+                        {
+                            FreeRTOS_debug_printf( ( "lTCPWindowRxCheck[%u,%u]: seqnr %lu (cnt %lu)\n",
+                                                     pxWindow->usPeerPortNumber, pxWindow->usOurPortNumber, ulSequenceNumber - pxWindow->rx.ulFirstSequenceNumber,
+                                                     listCURRENT_LIST_LENGTH( &pxWindow->xRxSegments ) ) );
+                            FreeRTOS_flush_logging();
+                        }
+
+                        /* Return a positive value.  The packet may be accepted
+                        * and stored but an earlier packet is still missing. */
+                        lReturn = ipNUMERIC_CAST( int32_t, ulSequenceNumber - ulCurrentSequenceNumber );
+                    }
+                }
+            }
+        }
+
+        return lReturn;
+    }
 
 #endif /* ipconfgiUSE_TCP_WIN == 1 */
 /*-----------------------------------------------------------*/
@@ -1026,1025 +1078,1060 @@ const int32_t l500ms = 500;
  *
  *=============================================================================*/
 
-#if( ipconfigUSE_TCP_WIN == 1 )
+#if ( ipconfigUSE_TCP_WIN == 1 )
 
-	static int32_t lTCPIncrementTxPosition( int32_t lPosition, int32_t lMax, int32_t lCount )
-	{
-	int32_t lReturn;
+    static int32_t lTCPIncrementTxPosition( int32_t lPosition,
+                                            int32_t lMax,
+                                            int32_t lCount )
+    {
+        int32_t lReturn;
 
-		/* +TCP stores data in circular buffers.  Calculate the next position to
-		store. */
-		lReturn = lPosition + lCount;
-		if( lReturn >= lMax )
-		{
-			lReturn -= lMax;
-		}
+        /* +TCP stores data in circular buffers.  Calculate the next position to
+         * store. */
+        lReturn = lPosition + lCount;
 
-		return lReturn;
-	}
+        if( lReturn >= lMax )
+        {
+            lReturn -= lMax;
+        }
 
-#endif /* ipconfigUSE_TCP_WIN == 1 */
-/*-----------------------------------------------------------*/
-
-#if( ipconfigUSE_TCP_WIN == 1 )
-
-	int32_t lTCPWindowTxAdd( TCPWindow_t *pxWindow, uint32_t ulLength, int32_t lPosition, int32_t lMax )
-	{
-	int32_t lBytesLeft = ( int32_t ) ulLength, lToWrite;
-	int32_t lDone = 0;
-	int32_t lBufferIndex = lPosition;
-	TCPSegment_t *pxSegment = pxWindow->pxHeadSegment;
-
-		/* Puts a message in the Tx-window (after buffer size has been
-		verified). */
-		if( pxSegment != NULL )
-		{
-			if( pxSegment->lDataLength < pxSegment->lMaxLength )
-			{
-				if( ( pxSegment->u.bits.bOutstanding == pdFALSE_UNSIGNED ) && ( pxSegment->lDataLength != 0 ) )
-				{
-					/* Adding data to a segment that was already in the TX queue.  It
-					will be filled-up to a maximum of MSS (maximum segment size). */
-					lToWrite = FreeRTOS_min_int32( lBytesLeft, pxSegment->lMaxLength - pxSegment->lDataLength );
-
-					pxSegment->lDataLength += lToWrite;
-
-					if( pxSegment->lDataLength >= pxSegment->lMaxLength )
-					{
-						/* This segment is full, don't add more bytes. */
-						pxWindow->pxHeadSegment = NULL;
-					}
-
-					lBytesLeft -= lToWrite;
-
-					/* ulNextTxSequenceNumber is the sequence number of the next byte to
-					be stored for transmission. */
-					pxWindow->ulNextTxSequenceNumber += ( uint32_t ) lToWrite;
-
-					/* Increased the return value. */
-					lDone += lToWrite;
-
-					/* Some detailed logging, for those who're interested. */
-					if( ( xTCPWindowLoggingLevel >= 2 ) && ipconfigTCP_MAY_LOG_PORT( pxWindow->usOurPortNumber ) )
-					{
-						FreeRTOS_debug_printf( ( "lTCPWindowTxAdd: Add %4lu bytes for seqNr %lu len %4lu (nxt %lu) pos %lu\n",
-							ulLength,
-							pxSegment->ulSequenceNumber - pxWindow->tx.ulFirstSequenceNumber,
-							pxSegment->lDataLength,
-							pxWindow->ulNextTxSequenceNumber - pxWindow->tx.ulFirstSequenceNumber,
-							pxSegment->lStreamPos ) );
-						FreeRTOS_flush_logging( );
-					}
-
-					/* Calculate the next position in the circular data buffer, knowing
-					its maximum length 'lMax'. */
-					lBufferIndex = lTCPIncrementTxPosition( lBufferIndex, lMax, lToWrite );
-				}
-			}
-		}
-
-		while( lBytesLeft > 0 )
-		{
-			/* The current transmission segment is full, create new segments as
-			needed. */
-			pxSegment = xTCPWindowTxNew( pxWindow, pxWindow->ulNextTxSequenceNumber, ( int32_t ) pxWindow->usMSS );
-
-			if( pxSegment != NULL )
-			{
-				/* Store as many as needed, but no more than the maximum
-				(MSS). */
-				lToWrite = FreeRTOS_min_int32( lBytesLeft, pxSegment->lMaxLength );
-
-				pxSegment->lDataLength = lToWrite;
-				pxSegment->lStreamPos = lBufferIndex;
-				lBytesLeft -= lToWrite;
-				lBufferIndex = lTCPIncrementTxPosition( lBufferIndex, lMax, lToWrite );
-				pxWindow->ulNextTxSequenceNumber += ( uint32_t ) lToWrite;
-				lDone += lToWrite;
-
-				/* Link this segment in the Tx-Queue. */
-				vListInsertFifo( &( pxWindow->xTxQueue ), &( pxSegment->xQueueItem ) );
-
-				/* Let 'pxHeadSegment' point to this segment if there is still
-				space. */
-				if( pxSegment->lDataLength < pxSegment->lMaxLength )
-				{
-					pxWindow->pxHeadSegment = pxSegment;
-				}
-				else
-				{
-					pxWindow->pxHeadSegment = NULL;
-				}
-
-				if( ipconfigTCP_MAY_LOG_PORT( pxWindow->usOurPortNumber ) )
-				{
-					if( ( xTCPWindowLoggingLevel >= 3 ) ||
-						( ( xTCPWindowLoggingLevel >= 2 ) && ( pxWindow->pxHeadSegment != NULL ) ) )
-					{
-						FreeRTOS_debug_printf( ( "lTCPWindowTxAdd: New %4ld bytes for seqNr %lu len %4lu (nxt %lu) pos %lu\n",
-							ulLength,
-							pxSegment->ulSequenceNumber - pxWindow->tx.ulFirstSequenceNumber,
-							pxSegment->lDataLength,
-							pxWindow->ulNextTxSequenceNumber - pxWindow->tx.ulFirstSequenceNumber,
-							pxSegment->lStreamPos ) );
-						FreeRTOS_flush_logging( );
-					}
-				}
-			}
-			else
-			{
-				/* A sever situation: running out of segments for transmission.
-				No more data can be sent at the moment. */
-				if( lDone != 0 )
-				{
-					FreeRTOS_debug_printf( ( "lTCPWindowTxAdd: Sorry all buffers full (cancel %ld bytes)\n", lBytesLeft ) );
-				}
-				break;
-			}
-		}
-
-		return lDone;
-	}
+        return lReturn;
+    }
 
 #endif /* ipconfigUSE_TCP_WIN == 1 */
 /*-----------------------------------------------------------*/
 
-#if( ipconfigUSE_TCP_WIN == 1 )
+#if ( ipconfigUSE_TCP_WIN == 1 )
 
-	BaseType_t xTCPWindowTxDone( const TCPWindow_t *pxWindow )
-	{
-		return listLIST_IS_EMPTY( ( &pxWindow->xTxSegments) );
-	}
+    int32_t lTCPWindowTxAdd( TCPWindow_t * pxWindow,
+                             uint32_t ulLength,
+                             int32_t lPosition,
+                             int32_t lMax )
+    {
+        int32_t lBytesLeft = ( int32_t ) ulLength, lToWrite;
+        int32_t lDone = 0;
+        int32_t lBufferIndex = lPosition;
+        TCPSegment_t * pxSegment = pxWindow->pxHeadSegment;
 
-#endif /* ipconfigUSE_TCP_WIN == 1 */
-/*-----------------------------------------------------------*/
+        /* Puts a message in the Tx-window (after buffer size has been
+         * verified). */
+        if( pxSegment != NULL )
+        {
+            if( pxSegment->lDataLength < pxSegment->lMaxLength )
+            {
+                if( ( pxSegment->u.bits.bOutstanding == pdFALSE_UNSIGNED ) && ( pxSegment->lDataLength != 0 ) )
+                {
+                    /* Adding data to a segment that was already in the TX queue.  It
+                     * will be filled-up to a maximum of MSS (maximum segment size). */
+                    lToWrite = FreeRTOS_min_int32( lBytesLeft, pxSegment->lMaxLength - pxSegment->lDataLength );
 
-#if( ipconfigUSE_TCP_WIN == 1 )
+                    pxSegment->lDataLength += lToWrite;
 
-	static BaseType_t prvTCPWindowTxHasSpace( TCPWindow_t const * pxWindow, uint32_t ulWindowSize )
-	{
-	uint32_t ulTxOutstanding;
-	BaseType_t xHasSpace;
-	const TCPSegment_t *pxSegment;
-	uint32_t ulNettSize;
+                    if( pxSegment->lDataLength >= pxSegment->lMaxLength )
+                    {
+                        /* This segment is full, don't add more bytes. */
+                        pxWindow->pxHeadSegment = NULL;
+                    }
 
-		/* This function will look if there is new transmission data.  It will
-		return true if there is data to be sent. */
+                    lBytesLeft -= lToWrite;
 
-		pxSegment = xTCPWindowPeekHead( &( pxWindow->xTxQueue ) );
+                    /* ulNextTxSequenceNumber is the sequence number of the next byte to
+                     * be stored for transmission. */
+                    pxWindow->ulNextTxSequenceNumber += ( uint32_t ) lToWrite;
 
-		if( pxSegment == NULL )
-		{
-			xHasSpace = pdFALSE;
-		}
-		else
-		{
-			/* How much data is outstanding, i.e. how much data has been sent
-			but not yet acknowledged ? */
-			if( pxWindow->tx.ulHighestSequenceNumber >= pxWindow->tx.ulCurrentSequenceNumber )
-			{
-				ulTxOutstanding = pxWindow->tx.ulHighestSequenceNumber - pxWindow->tx.ulCurrentSequenceNumber;
-			}
-			else
-			{
-				ulTxOutstanding = 0UL;
-			}
+                    /* Increased the return value. */
+                    lDone += lToWrite;
 
-			/* Subtract this from the peer's space. */
-			ulNettSize = ulWindowSize - FreeRTOS_min_uint32( ulWindowSize, ulTxOutstanding );
+                    /* Some detailed logging, for those who're interested. */
+                    if( ( xTCPWindowLoggingLevel >= 2 ) && ipconfigTCP_MAY_LOG_PORT( pxWindow->usOurPortNumber ) )
+                    {
+                        FreeRTOS_debug_printf( ( "lTCPWindowTxAdd: Add %4lu bytes for seqNr %lu len %4lu (nxt %lu) pos %lu\n",
+                                                 ulLength,
+                                                 pxSegment->ulSequenceNumber - pxWindow->tx.ulFirstSequenceNumber,
+                                                 pxSegment->lDataLength,
+                                                 pxWindow->ulNextTxSequenceNumber - pxWindow->tx.ulFirstSequenceNumber,
+                                                 pxSegment->lStreamPos ) );
+                        FreeRTOS_flush_logging();
+                    }
 
-			/* See if the next segment may be sent. */
-			if( ulNettSize >= ( uint32_t ) pxSegment->lDataLength )
-			{
-				xHasSpace = pdTRUE;
-			}
-			else
-			{
-				xHasSpace = pdFALSE;
-			}
+                    /* Calculate the next position in the circular data buffer, knowing
+                     * its maximum length 'lMax'. */
+                    lBufferIndex = lTCPIncrementTxPosition( lBufferIndex, lMax, lToWrite );
+                }
+            }
+        }
 
-			/* If 'xHasSpace', it looks like the peer has at least space for 1
-			more new segment of size MSS.  xSize.ulTxWindowLength is the self-imposed
-			limitation of the transmission window (in case of many resends it
-			may be decreased). */
-			if( ( ulTxOutstanding != 0UL ) && ( pxWindow->xSize.ulTxWindowLength < ( ulTxOutstanding + ( ( uint32_t ) pxSegment->lDataLength ) ) ) )
-			{
-				xHasSpace = pdFALSE;
-			}
-		}
+        while( lBytesLeft > 0 )
+        {
+            /* The current transmission segment is full, create new segments as
+             * needed. */
+            pxSegment = xTCPWindowTxNew( pxWindow, pxWindow->ulNextTxSequenceNumber, ( int32_t ) pxWindow->usMSS );
 
-		return xHasSpace;
-	}
+            if( pxSegment != NULL )
+            {
+                /* Store as many as needed, but no more than the maximum
+                 * (MSS). */
+                lToWrite = FreeRTOS_min_int32( lBytesLeft, pxSegment->lMaxLength );
 
-#endif /* ipconfigUSE_TCP_WIN == 1 */
-/*-----------------------------------------------------------*/
+                pxSegment->lDataLength = lToWrite;
+                pxSegment->lStreamPos = lBufferIndex;
+                lBytesLeft -= lToWrite;
+                lBufferIndex = lTCPIncrementTxPosition( lBufferIndex, lMax, lToWrite );
+                pxWindow->ulNextTxSequenceNumber += ( uint32_t ) lToWrite;
+                lDone += lToWrite;
 
-#if( ipconfigUSE_TCP_WIN == 1 )
+                /* Link this segment in the Tx-Queue. */
+                vListInsertFifo( &( pxWindow->xTxQueue ), &( pxSegment->xQueueItem ) );
 
-	BaseType_t xTCPWindowTxHasData( TCPWindow_t const * pxWindow, uint32_t ulWindowSize, TickType_t *pulDelay )
-	{
-	TCPSegment_t const * pxSegment;
-	BaseType_t xReturn;
-	TickType_t ulAge, ulMaxAge;
+                /* Let 'pxHeadSegment' point to this segment if there is still
+                 * space. */
+                if( pxSegment->lDataLength < pxSegment->lMaxLength )
+                {
+                    pxWindow->pxHeadSegment = pxSegment;
+                }
+                else
+                {
+                    pxWindow->pxHeadSegment = NULL;
+                }
 
-		*pulDelay = 0U;
+                if( ipconfigTCP_MAY_LOG_PORT( pxWindow->usOurPortNumber ) )
+                {
+                    if( ( xTCPWindowLoggingLevel >= 3 ) ||
+                        ( ( xTCPWindowLoggingLevel >= 2 ) && ( pxWindow->pxHeadSegment != NULL ) ) )
+                    {
+                        FreeRTOS_debug_printf( ( "lTCPWindowTxAdd: New %4ld bytes for seqNr %lu len %4lu (nxt %lu) pos %lu\n",
+                                                 ulLength,
+                                                 pxSegment->ulSequenceNumber - pxWindow->tx.ulFirstSequenceNumber,
+                                                 pxSegment->lDataLength,
+                                                 pxWindow->ulNextTxSequenceNumber - pxWindow->tx.ulFirstSequenceNumber,
+                                                 pxSegment->lStreamPos ) );
+                        FreeRTOS_flush_logging();
+                    }
+                }
+            }
+            else
+            {
+                /* A sever situation: running out of segments for transmission.
+                 * No more data can be sent at the moment. */
+                if( lDone != 0 )
+                {
+                    FreeRTOS_debug_printf( ( "lTCPWindowTxAdd: Sorry all buffers full (cancel %ld bytes)\n", lBytesLeft ) );
+                }
 
-		if( listLIST_IS_EMPTY( &pxWindow->xPriorityQueue ) == pdFALSE )
-		{
-			/* No need to look at retransmissions or new transmission as long as
-			there are priority segments.  *pulDelay equals zero, meaning it must
-			be sent out immediately. */
-			xReturn = pdTRUE;
-		}
-		else
-		{
-			pxSegment = xTCPWindowPeekHead( &( pxWindow->xWaitQueue ) );
+                break;
+            }
+        }
 
-			if( pxSegment != NULL )
-			{
-				/* There is an outstanding segment, see if it is time to resend
-				it. */
-				ulAge = ulTimerGetAge( &pxSegment->xTransmitTimer );
-
-				/* After a packet has been sent for the first time, it will wait
-				'1 * lSRTT' ms for an ACK. A second time it will wait '2 * lSRTT' ms,
-				each time doubling the time-out */
-				ulMaxAge = ( 1UL << pxSegment->u.bits.ucTransmitCount ) * ( ( uint32_t ) pxWindow->lSRTT );
-
-				if( ulMaxAge > ulAge )
-				{
-					/* A segment must be sent after this amount of msecs */
-					*pulDelay = ulMaxAge - ulAge;
-				}
-
-				xReturn = pdTRUE;
-			}
-			else
-			{
-				/* No priority segment, no outstanding data, see if there is new
-				transmission data. */
-				pxSegment = xTCPWindowPeekHead( &pxWindow->xTxQueue );
-
-				/* See if it fits in the peer's reception window. */
-				if( pxSegment == NULL )
-				{
-					xReturn = pdFALSE;
-				}
-				else if( prvTCPWindowTxHasSpace( pxWindow, ulWindowSize ) == pdFALSE )
-				{
-					/* Too many outstanding messages. */
-					xReturn = pdFALSE;
-				}
-				else if( ( pxWindow->u.bits.bSendFullSize != pdFALSE_UNSIGNED ) && ( pxSegment->lDataLength < pxSegment->lMaxLength ) )
-				{
-					/* 'bSendFullSize' is a special optimisation.  If true, the
-					driver will only sent completely filled packets (of MSS
-					bytes). */
-					xReturn = pdFALSE;
-				}
-				else
-				{
-					xReturn = pdTRUE;
-				}
-			}
-		}
-
-		return xReturn;
-	}
+        return lDone;
+    }
 
 #endif /* ipconfigUSE_TCP_WIN == 1 */
 /*-----------------------------------------------------------*/
 
-#if( ipconfigUSE_TCP_WIN == 1 )
+#if ( ipconfigUSE_TCP_WIN == 1 )
 
-	uint32_t ulTCPWindowTxGet( TCPWindow_t *pxWindow, uint32_t ulWindowSize, int32_t *plPosition )
-	{
-	TCPSegment_t *pxSegment;
-	uint32_t ulMaxTime;
-	uint32_t ulReturn  = ~0UL;
-
-
-		/* Fetches data to be sent-out now.
-
-		Priority messages: segments with a resend need no check current sliding
-		window size. */
-		pxSegment = xTCPWindowGetHead( &( pxWindow->xPriorityQueue ) );
-		pxWindow->ulOurSequenceNumber = pxWindow->tx.ulHighestSequenceNumber;
-
-		if( pxSegment == NULL )
-		{
-			/* Waiting messages: outstanding messages with a running timer
-			neither check peer's reception window size because these packets
-			have been sent earlier. */
-			pxSegment = xTCPWindowPeekHead( &( pxWindow->xWaitQueue ) );
-
-			if( pxSegment != NULL )
-			{
-				/* Do check the timing. */
-				ulMaxTime = ( 1UL << pxSegment->u.bits.ucTransmitCount ) * ( ( uint32_t ) pxWindow->lSRTT );
-
-				if( ulTimerGetAge( &pxSegment->xTransmitTimer ) > ulMaxTime )
-				{
-					/* A normal (non-fast) retransmission.  Move it from the
-					head of the waiting queue. */
-					pxSegment = xTCPWindowGetHead( &( pxWindow->xWaitQueue ) );
-					pxSegment->u.bits.ucDupAckCount = ( uint8_t ) pdFALSE_UNSIGNED;
-
-					/* Some detailed logging. */
-					if( ( xTCPWindowLoggingLevel != 0 ) && ( ipconfigTCP_MAY_LOG_PORT( pxWindow->usOurPortNumber ) ) )
-					{
-						FreeRTOS_debug_printf( ( "ulTCPWindowTxGet[%u,%u]: WaitQueue %ld bytes for sequence number %lu (%lX)\n",
-							pxWindow->usPeerPortNumber,
-							pxWindow->usOurPortNumber,
-							pxSegment->lDataLength,
-							pxSegment->ulSequenceNumber - pxWindow->tx.ulFirstSequenceNumber,
-							pxSegment->ulSequenceNumber ) );
-						FreeRTOS_flush_logging( );
-					}
-				}
-				else
-				{
-					pxSegment = NULL;
-				}
-			}
-
-			if( pxSegment == NULL )
-			{
-				/* New messages: sent-out for the first time.  Check current
-				sliding window size of peer. */
-				pxSegment = xTCPWindowPeekHead( &( pxWindow->xTxQueue ) );
-
-				if( pxSegment == NULL )
-				{
-					/* No segments queued. */
-					ulReturn = 0UL;
-				}
-				else if( ( pxWindow->u.bits.bSendFullSize != pdFALSE_UNSIGNED ) && ( pxSegment->lDataLength < pxSegment->lMaxLength ) )
-				{
-					/* A segment has been queued but the driver waits until it
-					has a full size of MSS. */
-					ulReturn = 0;
-				}
-				else if( prvTCPWindowTxHasSpace( pxWindow, ulWindowSize ) == pdFALSE )
-				{
-					/* Peer has no more space at this moment. */
-					ulReturn = 0;
-				}
-				else
-				{
-					/* Move it out of the Tx queue. */
-					pxSegment = xTCPWindowGetHead( &( pxWindow->xTxQueue ) );
-
-					/* Don't let pxHeadSegment point to this segment any more,
-					so no more data will be added. */
-					if( pxWindow->pxHeadSegment == pxSegment )
-					{
-						pxWindow->pxHeadSegment = NULL;
-					}
-
-					/* pxWindow->tx.highest registers the highest sequence
-					number in our transmission window. */
-					pxWindow->tx.ulHighestSequenceNumber = pxSegment->ulSequenceNumber + ( ( uint32_t ) pxSegment->lDataLength );
-
-					/* ...and more detailed logging */
-					if( ( xTCPWindowLoggingLevel >= 2 ) && ( ipconfigTCP_MAY_LOG_PORT( pxWindow->usOurPortNumber ) ) )
-					{
-						FreeRTOS_debug_printf( ( "ulTCPWindowTxGet[%u,%u]: XmitQueue %ld bytes for sequence number %lu (ws %lu)\n",
-							pxWindow->usPeerPortNumber,
-							pxWindow->usOurPortNumber,
-							pxSegment->lDataLength,
-							pxSegment->ulSequenceNumber - pxWindow->tx.ulFirstSequenceNumber,
-							ulWindowSize ) );
-						FreeRTOS_flush_logging( );
-					}
-				}
-			}
-		}
-		else
-		{
-			/* There is a priority segment. It doesn't need any checking for
-			space or timeouts. */
-			if( xTCPWindowLoggingLevel != 0 )
-			{
-				FreeRTOS_debug_printf( ( "ulTCPWindowTxGet[%u,%u]: PrioQueue %ld bytes for sequence number %lu (ws %lu)\n",
-					pxWindow->usPeerPortNumber,
-					pxWindow->usOurPortNumber,
-					pxSegment->lDataLength,
-					pxSegment->ulSequenceNumber - pxWindow->tx.ulFirstSequenceNumber,
-					ulWindowSize ) );
-				FreeRTOS_flush_logging( );
-			}
-		}
-
-		/* See if it has already been determined to return 0. */
-		if( ulReturn != 0UL )
-		{
-			/* pxSegment is not NULL when ulReturn != 0UL. */
-			configASSERT( pxSegment != NULL );
-			configASSERT( listLIST_ITEM_CONTAINER( &(pxSegment->xQueueItem ) ) == NULL );
-
-			/* Now that the segment will be transmitted, add it to the tail of
-			the waiting queue. */
-			vListInsertFifo( &pxWindow->xWaitQueue, &pxSegment->xQueueItem );
-
-			/* And mark it as outstanding. */
-			pxSegment->u.bits.bOutstanding = pdTRUE_UNSIGNED;
-
-			/* Administer the transmit count, needed for fast
-			retransmissions. */
-			( pxSegment->u.bits.ucTransmitCount )++;
-
-			/* If there have been several retransmissions (4), decrease the
-			size of the transmission window to at most 2 times MSS. */
-			if( pxSegment->u.bits.ucTransmitCount == MAX_TRANSMIT_COUNT_USING_LARGE_WINDOW )
-			{
-				if( pxWindow->xSize.ulTxWindowLength > ( 2U * ( ( uint32_t ) pxWindow->usMSS ) ) )
-				{
-					FreeRTOS_debug_printf( ( "ulTCPWindowTxGet[%u - %d]: Change Tx window: %lu -> %u\n",
-						pxWindow->usPeerPortNumber,
-						pxWindow->usOurPortNumber,
-						pxWindow->xSize.ulTxWindowLength,
-						2U * pxWindow->usMSS ) );
-					pxWindow->xSize.ulTxWindowLength = ( 2UL * pxWindow->usMSS );
-				}
-			}
-
-			/* Clear the transmit timer. */
-			vTCPTimerSet( &( pxSegment->xTransmitTimer ) );
-
-			pxWindow->ulOurSequenceNumber = pxSegment->ulSequenceNumber;
-
-			/* Inform the caller where to find the data within the queue. */
-			*plPosition = pxSegment->lStreamPos;
-
-			/* And return the length of the data segment */
-			ulReturn = ( uint32_t ) pxSegment->lDataLength;
-		}
-
-		return ulReturn;
-	}
+    BaseType_t xTCPWindowTxDone( const TCPWindow_t * pxWindow )
+    {
+        return listLIST_IS_EMPTY( ( &pxWindow->xTxSegments ) );
+    }
 
 #endif /* ipconfigUSE_TCP_WIN == 1 */
 /*-----------------------------------------------------------*/
 
-#if( ipconfigUSE_TCP_WIN == 1 )
+#if ( ipconfigUSE_TCP_WIN == 1 )
 
-	static uint32_t prvTCPWindowTxCheckAck( TCPWindow_t *pxWindow, uint32_t ulFirst, uint32_t ulLast )
-	{
-	uint32_t ulBytesConfirmed = 0U;
-	uint32_t ulSequenceNumber = ulFirst, ulDataLength;
-	const ListItem_t *pxIterator;
-	const ListItem_t *pxEnd = ipPOINTER_CAST( const ListItem_t *, listGET_END_MARKER( &pxWindow->xTxSegments ) );
-	BaseType_t xDoUnlink;
-	TCPSegment_t *pxSegment;
-		/* An acknowledgement or a selective ACK (SACK) was received.  See if some outstanding data
-		may be removed from the transmission queue(s).
-		All TX segments for which
-		( ( ulSequenceNumber >= ulFirst ) && ( ulSequenceNumber < ulLast ) in a
-		contiguous block.  Note that the segments are stored in xTxSegments in a
-		strict sequential order. */
+    static BaseType_t prvTCPWindowTxHasSpace( TCPWindow_t const * pxWindow,
+                                              uint32_t ulWindowSize )
+    {
+        uint32_t ulTxOutstanding;
+        BaseType_t xHasSpace;
+        const TCPSegment_t * pxSegment;
+        uint32_t ulNettSize;
 
-		/* SRTT[i] = (1-a) * SRTT[i-1] + a * RTT
+        /* This function will look if there is new transmission data.  It will
+         * return true if there is data to be sent. */
 
-		0 < a < 1; usually a = 1/8
+        pxSegment = xTCPWindowPeekHead( &( pxWindow->xTxQueue ) );
 
-		RTO = 2 * SRTT
+        if( pxSegment == NULL )
+        {
+            xHasSpace = pdFALSE;
+        }
+        else
+        {
+            /* How much data is outstanding, i.e. how much data has been sent
+             * but not yet acknowledged ? */
+            if( pxWindow->tx.ulHighestSequenceNumber >= pxWindow->tx.ulCurrentSequenceNumber )
+            {
+                ulTxOutstanding = pxWindow->tx.ulHighestSequenceNumber - pxWindow->tx.ulCurrentSequenceNumber;
+            }
+            else
+            {
+                ulTxOutstanding = 0UL;
+            }
 
-		where:
-		  RTT is Round Trip Time
-		  SRTT is Smoothed RTT
-		  RTO is Retransmit timeout
+            /* Subtract this from the peer's space. */
+            ulNettSize = ulWindowSize - FreeRTOS_min_uint32( ulWindowSize, ulTxOutstanding );
 
-		 A Smoothed RTT will increase quickly, but it is conservative when
-		 becoming smaller. */
+            /* See if the next segment may be sent. */
+            if( ulNettSize >= ( uint32_t ) pxSegment->lDataLength )
+            {
+                xHasSpace = pdTRUE;
+            }
+            else
+            {
+                xHasSpace = pdFALSE;
+            }
 
-		pxIterator  = listGET_NEXT( pxEnd );
-		while( ( pxIterator != pxEnd ) && ( xSequenceLessThan( ulSequenceNumber, ulLast ) != 0 ) )
-		{
-			xDoUnlink = pdFALSE;
-			pxSegment = ipPOINTER_CAST( TCPSegment_t *, listGET_LIST_ITEM_OWNER( pxIterator ) );
+            /* If 'xHasSpace', it looks like the peer has at least space for 1
+             * more new segment of size MSS.  xSize.ulTxWindowLength is the self-imposed
+             * limitation of the transmission window (in case of many resends it
+             * may be decreased). */
+            if( ( ulTxOutstanding != 0UL ) && ( pxWindow->xSize.ulTxWindowLength < ( ulTxOutstanding + ( ( uint32_t ) pxSegment->lDataLength ) ) ) )
+            {
+                xHasSpace = pdFALSE;
+            }
+        }
 
-			/* Move to the next item because the current item might get
-			removed. */
-			pxIterator = ( const ListItem_t * ) listGET_NEXT( pxIterator );
-
-			/* Continue if this segment does not fall within the ACK'd range. */
-			if( xSequenceGreaterThan( ulSequenceNumber, pxSegment->ulSequenceNumber ) != pdFALSE )
-			{
-				continue;
-			}
-
-			/* Is it ready? */
-			if( ulSequenceNumber != pxSegment->ulSequenceNumber )
-			{
-				/* coverity[break_stmt] : Break statement terminating the loop */
-				break;
-			}
-
-			ulDataLength = ( uint32_t ) pxSegment->lDataLength;
-
-			if( pxSegment->u.bits.bAcked == pdFALSE_UNSIGNED )
-			{
-				if( xSequenceGreaterThan( pxSegment->ulSequenceNumber + ( uint32_t )ulDataLength, ulLast ) != pdFALSE )
-				{
-					/* What happens?  Only part of this segment was accepted,
-					probably due to WND limits
-
-					  AAAAAAA BBBBBBB << acked
-					  aaaaaaa aaaa    << sent */
-					#if( ipconfigHAS_DEBUG_PRINTF != 0 )
-					{
-						uint32_t ulFirstSeq = pxSegment->ulSequenceNumber - pxWindow->tx.ulFirstSequenceNumber;
-						FreeRTOS_debug_printf( ( "prvTCPWindowTxCheckAck[%u.%u]: %lu - %lu Partial sequence number %lu - %lu\n",
-							pxWindow->usPeerPortNumber,
-							pxWindow->usOurPortNumber,
-							ulFirstSeq - pxWindow->tx.ulFirstSequenceNumber,
-							ulLast - pxWindow->tx.ulFirstSequenceNumber,
-							ulFirstSeq, ulFirstSeq + ulDataLength ) );
-					}
-					#endif	/* ipconfigHAS_DEBUG_PRINTF */
-					break;
-				}
-
-				/* This segment is fully ACK'd, set the flag. */
-				pxSegment->u.bits.bAcked = pdTRUE;
-
-				/* Calculate the RTT only if the segment was sent-out for the
-				first time and if this is the last ACK'd segment in a range. */
-				if( ( pxSegment->u.bits.ucTransmitCount == 1U ) && ( ( pxSegment->ulSequenceNumber + ulDataLength ) == ulLast ) )
-				{
-					int32_t mS = ( int32_t ) ulTimerGetAge( &( pxSegment->xTransmitTimer ) );
-
-					if( pxWindow->lSRTT >= mS )
-					{
-						/* RTT becomes smaller: adapt slowly. */
-						pxWindow->lSRTT = ( ( winSRTT_DECREMENT_NEW * mS ) + ( winSRTT_DECREMENT_CURRENT * pxWindow->lSRTT ) ) / ( winSRTT_DECREMENT_NEW + winSRTT_DECREMENT_CURRENT );
-					}
-					else
-					{
-						/* RTT becomes larger: adapt quicker */
-						pxWindow->lSRTT = ( ( winSRTT_INCREMENT_NEW * mS ) + ( winSRTT_INCREMENT_CURRENT * pxWindow->lSRTT ) ) / ( winSRTT_INCREMENT_NEW + winSRTT_INCREMENT_CURRENT );
-					}
-
-					/* Cap to the minimum of 50ms. */
-					if( pxWindow->lSRTT < winSRTT_CAP_mS )
-					{
-						pxWindow->lSRTT = winSRTT_CAP_mS;
-					}
-				}
-
-				/* Unlink it from the 3 queues, but do not destroy it (yet). */
-				xDoUnlink = pdTRUE;
-			}
-
-			/* pxSegment->u.bits.bAcked is now true.  Is it located at the left
-			side of the transmission queue?  If so, it may be freed. */
-			if( ulSequenceNumber == pxWindow->tx.ulCurrentSequenceNumber )
-			{
-				if( ( xTCPWindowLoggingLevel >= 2 ) && ( ipconfigTCP_MAY_LOG_PORT( pxWindow->usOurPortNumber ) ) )
-				{
-					FreeRTOS_debug_printf( ( "prvTCPWindowTxCheckAck: %lu - %lu Ready sequence number %lu\n",
-						ulFirst - pxWindow->tx.ulFirstSequenceNumber,
-						ulLast - pxWindow->tx.ulFirstSequenceNumber,
-						pxSegment->ulSequenceNumber - pxWindow->tx.ulFirstSequenceNumber ) );
-				}
-
-				/* Increase the left-hand value of the transmission window. */
-				pxWindow->tx.ulCurrentSequenceNumber += ulDataLength;
-
-				/* This function will return the number of bytes that the tail
-				of txStream may be advanced. */
-				ulBytesConfirmed += ulDataLength;
-
-				/* All segments below tx.ulCurrentSequenceNumber may be freed. */
-				vTCPWindowFree( pxSegment );
-
-				/* No need to unlink it any more. */
-				xDoUnlink = pdFALSE;
-			}
-
-			if( ( xDoUnlink != pdFALSE ) && ( listLIST_ITEM_CONTAINER( &( pxSegment->xQueueItem ) ) != NULL ) )
-			{
-				/* Remove item from its queues. */
-				( void ) uxListRemove( &pxSegment->xQueueItem );
-			}
-
-			ulSequenceNumber += ulDataLength;
-		}
-
-		return ulBytesConfirmed;
-	}
-#endif /* ipconfigUSE_TCP_WIN == 1 */
-/*-----------------------------------------------------------*/
-
-#if( ipconfigUSE_TCP_WIN == 1 )
-
-	static uint32_t prvTCPWindowFastRetransmit( TCPWindow_t *pxWindow, uint32_t ulFirst )
-	{
-	const ListItem_t * pxIterator;
-	const ListItem_t * pxEnd;
-	TCPSegment_t *pxSegment;
-	uint32_t ulCount = 0UL;
-
-		/* A higher Tx block has been acknowledged.  Now iterate through the
-		 xWaitQueue to find a possible condition for a FAST retransmission. */
-
-		pxEnd = ipPOINTER_CAST( const ListItem_t *, listGET_END_MARKER( &( pxWindow->xWaitQueue ) ) );
-
-		pxIterator  = listGET_NEXT( pxEnd );
-
-		while( pxIterator != pxEnd )
-		{
-			/* Get the owner, which is a TCP segment. */
-			pxSegment = ipPOINTER_CAST( TCPSegment_t *, listGET_LIST_ITEM_OWNER( pxIterator ) );
-
-			/* Hop to the next item before the current gets unlinked. */
-			pxIterator  = listGET_NEXT( pxIterator );
-
-			/* Fast retransmission:
-			When 3 packets with a higher sequence number have been acknowledged
-			by the peer, it is very unlikely a current packet will ever arrive.
-			It will be retransmitted far before the RTO. */
-			if( pxSegment->u.bits.bAcked == pdFALSE_UNSIGNED )
-			{
-				if( xSequenceLessThan( pxSegment->ulSequenceNumber, ulFirst ) != pdFALSE )
-				{
-					pxSegment->u.bits.ucDupAckCount++;
-					if( pxSegment->u.bits.ucDupAckCount == DUPLICATE_ACKS_BEFORE_FAST_RETRANSMIT )
-					{
-						pxSegment->u.bits.ucTransmitCount = ( uint8_t ) pdFALSE;
-
-						/* Not clearing 'ucDupAckCount' yet as more SACK's might come in
-						which might lead to a second fast rexmit. */
-						if( ( xTCPWindowLoggingLevel >= 0 ) && ( ipconfigTCP_MAY_LOG_PORT( pxWindow->usOurPortNumber ) ) )
-						{
-							FreeRTOS_debug_printf( ( "prvTCPWindowFastRetransmit: Requeue sequence number %lu < %lu\n",
-								pxSegment->ulSequenceNumber - pxWindow->tx.ulFirstSequenceNumber,
-								ulFirst - pxWindow->tx.ulFirstSequenceNumber ) );
-							FreeRTOS_flush_logging( );
-						}
-
-						/* Remove it from xWaitQueue. */
-						( void ) uxListRemove( &pxSegment->xQueueItem );
-						/* Add this segment to the priority queue so it gets
-						retransmitted immediately. */
-						vListInsertFifo( &( pxWindow->xPriorityQueue ), &( pxSegment->xQueueItem ) );
-						ulCount++;
-					}
-				}
-			}
-		}
-
-		return ulCount;
-	}
-#endif /* ipconfigUSE_TCP_WIN == 1 */
-/*-----------------------------------------------------------*/
-
-#if( ipconfigUSE_TCP_WIN == 1 )
-
-	uint32_t ulTCPWindowTxAck( TCPWindow_t *pxWindow, uint32_t ulSequenceNumber )
-	{
-	uint32_t ulFirstSequence, ulReturn;
-
-		/* Receive a normal ACK. */
-
-		ulFirstSequence = pxWindow->tx.ulCurrentSequenceNumber;
-
-		if( xSequenceLessThanOrEqual( ulSequenceNumber, ulFirstSequence ) != pdFALSE )
-		{
-			ulReturn = 0UL;
-		}
-		else
-		{
-			ulReturn = prvTCPWindowTxCheckAck( pxWindow, ulFirstSequence, ulSequenceNumber );
-		}
-
-		return ulReturn;
-	}
+        return xHasSpace;
+    }
 
 #endif /* ipconfigUSE_TCP_WIN == 1 */
 /*-----------------------------------------------------------*/
 
-#if( ipconfigUSE_TCP_WIN == 1 )
+#if ( ipconfigUSE_TCP_WIN == 1 )
 
-	uint32_t ulTCPWindowTxSack( TCPWindow_t *pxWindow, uint32_t ulFirst, uint32_t ulLast )
-	{
-	uint32_t ulAckCount;
-	uint32_t ulCurrentSequenceNumber = pxWindow->tx.ulCurrentSequenceNumber;
+    BaseType_t xTCPWindowTxHasData( TCPWindow_t const * pxWindow,
+                                    uint32_t ulWindowSize,
+                                    TickType_t * pulDelay )
+    {
+        TCPSegment_t const * pxSegment;
+        BaseType_t xReturn;
+        TickType_t ulAge, ulMaxAge;
 
-		/* Receive a SACK option. */
-		ulAckCount = prvTCPWindowTxCheckAck( pxWindow, ulFirst, ulLast );
-		( void ) prvTCPWindowFastRetransmit( pxWindow, ulFirst );
+        *pulDelay = 0U;
 
-		if( ( xTCPWindowLoggingLevel >= 1 ) && ( xSequenceGreaterThan( ulFirst, ulCurrentSequenceNumber ) != pdFALSE ) )
-		{
-			FreeRTOS_debug_printf( ( "ulTCPWindowTxSack[%u,%u]: from %lu to %lu (ack = %lu)\n",
-				pxWindow->usPeerPortNumber,
-				pxWindow->usOurPortNumber,
-				ulFirst - pxWindow->tx.ulFirstSequenceNumber,
-				ulLast - pxWindow->tx.ulFirstSequenceNumber,
-				pxWindow->tx.ulCurrentSequenceNumber - pxWindow->tx.ulFirstSequenceNumber ) );
-			FreeRTOS_flush_logging( );
-		}
+        if( listLIST_IS_EMPTY( &pxWindow->xPriorityQueue ) == pdFALSE )
+        {
+            /* No need to look at retransmissions or new transmission as long as
+             * there are priority segments.  *pulDelay equals zero, meaning it must
+             * be sent out immediately. */
+            xReturn = pdTRUE;
+        }
+        else
+        {
+            pxSegment = xTCPWindowPeekHead( &( pxWindow->xWaitQueue ) );
 
-		return ulAckCount;
-	}
+            if( pxSegment != NULL )
+            {
+                /* There is an outstanding segment, see if it is time to resend
+                 * it. */
+                ulAge = ulTimerGetAge( &pxSegment->xTransmitTimer );
+
+                /* After a packet has been sent for the first time, it will wait
+                 * '1 * lSRTT' ms for an ACK. A second time it will wait '2 * lSRTT' ms,
+                 * each time doubling the time-out */
+                ulMaxAge = ( 1UL << pxSegment->u.bits.ucTransmitCount ) * ( ( uint32_t ) pxWindow->lSRTT );
+
+                if( ulMaxAge > ulAge )
+                {
+                    /* A segment must be sent after this amount of msecs */
+                    *pulDelay = ulMaxAge - ulAge;
+                }
+
+                xReturn = pdTRUE;
+            }
+            else
+            {
+                /* No priority segment, no outstanding data, see if there is new
+                 * transmission data. */
+                pxSegment = xTCPWindowPeekHead( &pxWindow->xTxQueue );
+
+                /* See if it fits in the peer's reception window. */
+                if( pxSegment == NULL )
+                {
+                    xReturn = pdFALSE;
+                }
+                else if( prvTCPWindowTxHasSpace( pxWindow, ulWindowSize ) == pdFALSE )
+                {
+                    /* Too many outstanding messages. */
+                    xReturn = pdFALSE;
+                }
+                else if( ( pxWindow->u.bits.bSendFullSize != pdFALSE_UNSIGNED ) && ( pxSegment->lDataLength < pxSegment->lMaxLength ) )
+                {
+                    /* 'bSendFullSize' is a special optimisation.  If true, the
+                     * driver will only sent completely filled packets (of MSS
+                     * bytes). */
+                    xReturn = pdFALSE;
+                }
+                else
+                {
+                    xReturn = pdTRUE;
+                }
+            }
+        }
+
+        return xReturn;
+    }
+
+#endif /* ipconfigUSE_TCP_WIN == 1 */
+/*-----------------------------------------------------------*/
+
+#if ( ipconfigUSE_TCP_WIN == 1 )
+
+    uint32_t ulTCPWindowTxGet( TCPWindow_t * pxWindow,
+                               uint32_t ulWindowSize,
+                               int32_t * plPosition )
+    {
+        TCPSegment_t * pxSegment;
+        uint32_t ulMaxTime;
+        uint32_t ulReturn = ~0UL;
+
+
+        /* Fetches data to be sent-out now.
+         *
+         * Priority messages: segments with a resend need no check current sliding
+         * window size. */
+        pxSegment = xTCPWindowGetHead( &( pxWindow->xPriorityQueue ) );
+        pxWindow->ulOurSequenceNumber = pxWindow->tx.ulHighestSequenceNumber;
+
+        if( pxSegment == NULL )
+        {
+            /* Waiting messages: outstanding messages with a running timer
+             * neither check peer's reception window size because these packets
+             * have been sent earlier. */
+            pxSegment = xTCPWindowPeekHead( &( pxWindow->xWaitQueue ) );
+
+            if( pxSegment != NULL )
+            {
+                /* Do check the timing. */
+                ulMaxTime = ( 1UL << pxSegment->u.bits.ucTransmitCount ) * ( ( uint32_t ) pxWindow->lSRTT );
+
+                if( ulTimerGetAge( &pxSegment->xTransmitTimer ) > ulMaxTime )
+                {
+                    /* A normal (non-fast) retransmission.  Move it from the
+                     * head of the waiting queue. */
+                    pxSegment = xTCPWindowGetHead( &( pxWindow->xWaitQueue ) );
+                    pxSegment->u.bits.ucDupAckCount = ( uint8_t ) pdFALSE_UNSIGNED;
+
+                    /* Some detailed logging. */
+                    if( ( xTCPWindowLoggingLevel != 0 ) && ( ipconfigTCP_MAY_LOG_PORT( pxWindow->usOurPortNumber ) ) )
+                    {
+                        FreeRTOS_debug_printf( ( "ulTCPWindowTxGet[%u,%u]: WaitQueue %ld bytes for sequence number %lu (%lX)\n",
+                                                 pxWindow->usPeerPortNumber,
+                                                 pxWindow->usOurPortNumber,
+                                                 pxSegment->lDataLength,
+                                                 pxSegment->ulSequenceNumber - pxWindow->tx.ulFirstSequenceNumber,
+                                                 pxSegment->ulSequenceNumber ) );
+                        FreeRTOS_flush_logging();
+                    }
+                }
+                else
+                {
+                    pxSegment = NULL;
+                }
+            }
+
+            if( pxSegment == NULL )
+            {
+                /* New messages: sent-out for the first time.  Check current
+                 * sliding window size of peer. */
+                pxSegment = xTCPWindowPeekHead( &( pxWindow->xTxQueue ) );
+
+                if( pxSegment == NULL )
+                {
+                    /* No segments queued. */
+                    ulReturn = 0UL;
+                }
+                else if( ( pxWindow->u.bits.bSendFullSize != pdFALSE_UNSIGNED ) && ( pxSegment->lDataLength < pxSegment->lMaxLength ) )
+                {
+                    /* A segment has been queued but the driver waits until it
+                     * has a full size of MSS. */
+                    ulReturn = 0;
+                }
+                else if( prvTCPWindowTxHasSpace( pxWindow, ulWindowSize ) == pdFALSE )
+                {
+                    /* Peer has no more space at this moment. */
+                    ulReturn = 0;
+                }
+                else
+                {
+                    /* Move it out of the Tx queue. */
+                    pxSegment = xTCPWindowGetHead( &( pxWindow->xTxQueue ) );
+
+                    /* Don't let pxHeadSegment point to this segment any more,
+                     * so no more data will be added. */
+                    if( pxWindow->pxHeadSegment == pxSegment )
+                    {
+                        pxWindow->pxHeadSegment = NULL;
+                    }
+
+                    /* pxWindow->tx.highest registers the highest sequence
+                     * number in our transmission window. */
+                    pxWindow->tx.ulHighestSequenceNumber = pxSegment->ulSequenceNumber + ( ( uint32_t ) pxSegment->lDataLength );
+
+                    /* ...and more detailed logging */
+                    if( ( xTCPWindowLoggingLevel >= 2 ) && ( ipconfigTCP_MAY_LOG_PORT( pxWindow->usOurPortNumber ) ) )
+                    {
+                        FreeRTOS_debug_printf( ( "ulTCPWindowTxGet[%u,%u]: XmitQueue %ld bytes for sequence number %lu (ws %lu)\n",
+                                                 pxWindow->usPeerPortNumber,
+                                                 pxWindow->usOurPortNumber,
+                                                 pxSegment->lDataLength,
+                                                 pxSegment->ulSequenceNumber - pxWindow->tx.ulFirstSequenceNumber,
+                                                 ulWindowSize ) );
+                        FreeRTOS_flush_logging();
+                    }
+                }
+            }
+        }
+        else
+        {
+            /* There is a priority segment. It doesn't need any checking for
+             * space or timeouts. */
+            if( xTCPWindowLoggingLevel != 0 )
+            {
+                FreeRTOS_debug_printf( ( "ulTCPWindowTxGet[%u,%u]: PrioQueue %ld bytes for sequence number %lu (ws %lu)\n",
+                                         pxWindow->usPeerPortNumber,
+                                         pxWindow->usOurPortNumber,
+                                         pxSegment->lDataLength,
+                                         pxSegment->ulSequenceNumber - pxWindow->tx.ulFirstSequenceNumber,
+                                         ulWindowSize ) );
+                FreeRTOS_flush_logging();
+            }
+        }
+
+        /* See if it has already been determined to return 0. */
+        if( ulReturn != 0UL )
+        {
+            /* pxSegment is not NULL when ulReturn != 0UL. */
+            configASSERT( pxSegment != NULL );
+            configASSERT( listLIST_ITEM_CONTAINER( &( pxSegment->xQueueItem ) ) == NULL );
+
+            /* Now that the segment will be transmitted, add it to the tail of
+             * the waiting queue. */
+            vListInsertFifo( &pxWindow->xWaitQueue, &pxSegment->xQueueItem );
+
+            /* And mark it as outstanding. */
+            pxSegment->u.bits.bOutstanding = pdTRUE_UNSIGNED;
+
+            /* Administer the transmit count, needed for fast
+             * retransmissions. */
+            ( pxSegment->u.bits.ucTransmitCount )++;
+
+            /* If there have been several retransmissions (4), decrease the
+             * size of the transmission window to at most 2 times MSS. */
+            if( pxSegment->u.bits.ucTransmitCount == MAX_TRANSMIT_COUNT_USING_LARGE_WINDOW )
+            {
+                if( pxWindow->xSize.ulTxWindowLength > ( 2U * ( ( uint32_t ) pxWindow->usMSS ) ) )
+                {
+                    FreeRTOS_debug_printf( ( "ulTCPWindowTxGet[%u - %d]: Change Tx window: %lu -> %u\n",
+                                             pxWindow->usPeerPortNumber,
+                                             pxWindow->usOurPortNumber,
+                                             pxWindow->xSize.ulTxWindowLength,
+                                             2U * pxWindow->usMSS ) );
+                    pxWindow->xSize.ulTxWindowLength = ( 2UL * pxWindow->usMSS );
+                }
+            }
+
+            /* Clear the transmit timer. */
+            vTCPTimerSet( &( pxSegment->xTransmitTimer ) );
+
+            pxWindow->ulOurSequenceNumber = pxSegment->ulSequenceNumber;
+
+            /* Inform the caller where to find the data within the queue. */
+            *plPosition = pxSegment->lStreamPos;
+
+            /* And return the length of the data segment */
+            ulReturn = ( uint32_t ) pxSegment->lDataLength;
+        }
+
+        return ulReturn;
+    }
+
+#endif /* ipconfigUSE_TCP_WIN == 1 */
+/*-----------------------------------------------------------*/
+
+#if ( ipconfigUSE_TCP_WIN == 1 )
+
+    static uint32_t prvTCPWindowTxCheckAck( TCPWindow_t * pxWindow,
+                                            uint32_t ulFirst,
+                                            uint32_t ulLast )
+    {
+        uint32_t ulBytesConfirmed = 0U;
+        uint32_t ulSequenceNumber = ulFirst, ulDataLength;
+        const ListItem_t * pxIterator;
+        const ListItem_t * pxEnd = ipPOINTER_CAST( const ListItem_t *, listGET_END_MARKER( &pxWindow->xTxSegments ) );
+        BaseType_t xDoUnlink;
+        TCPSegment_t * pxSegment;
+
+        /* An acknowledgement or a selective ACK (SACK) was received.  See if some outstanding data
+         * may be removed from the transmission queue(s).
+         * All TX segments for which
+         * ( ( ulSequenceNumber >= ulFirst ) && ( ulSequenceNumber < ulLast ) in a
+         * contiguous block.  Note that the segments are stored in xTxSegments in a
+         * strict sequential order. */
+
+        /* SRTT[i] = (1-a) * SRTT[i-1] + a * RTT
+         *
+         * 0 < a < 1; usually a = 1/8
+         *
+         * RTO = 2 * SRTT
+         *
+         * where:
+         * RTT is Round Trip Time
+         * SRTT is Smoothed RTT
+         * RTO is Retransmit timeout
+         *
+         * A Smoothed RTT will increase quickly, but it is conservative when
+         * becoming smaller. */
+
+        pxIterator = listGET_NEXT( pxEnd );
+
+        while( ( pxIterator != pxEnd ) && ( xSequenceLessThan( ulSequenceNumber, ulLast ) != 0 ) )
+        {
+            xDoUnlink = pdFALSE;
+            pxSegment = ipPOINTER_CAST( TCPSegment_t *, listGET_LIST_ITEM_OWNER( pxIterator ) );
+
+            /* Move to the next item because the current item might get
+             * removed. */
+            pxIterator = ( const ListItem_t * ) listGET_NEXT( pxIterator );
+
+            /* Continue if this segment does not fall within the ACK'd range. */
+            if( xSequenceGreaterThan( ulSequenceNumber, pxSegment->ulSequenceNumber ) != pdFALSE )
+            {
+                continue;
+            }
+
+            /* Is it ready? */
+            if( ulSequenceNumber != pxSegment->ulSequenceNumber )
+            {
+                /* coverity[break_stmt] : Break statement terminating the loop */
+                break;
+            }
+
+            ulDataLength = ( uint32_t ) pxSegment->lDataLength;
+
+            if( pxSegment->u.bits.bAcked == pdFALSE_UNSIGNED )
+            {
+                if( xSequenceGreaterThan( pxSegment->ulSequenceNumber + ( uint32_t ) ulDataLength, ulLast ) != pdFALSE )
+                {
+                    /* What happens?  Only part of this segment was accepted,
+                     * probably due to WND limits
+                     *
+                     * AAAAAAA BBBBBBB << acked
+                     * aaaaaaa aaaa    << sent */
+                    #if ( ipconfigHAS_DEBUG_PRINTF != 0 )
+                        {
+                            uint32_t ulFirstSeq = pxSegment->ulSequenceNumber - pxWindow->tx.ulFirstSequenceNumber;
+                            FreeRTOS_debug_printf( ( "prvTCPWindowTxCheckAck[%u.%u]: %lu - %lu Partial sequence number %lu - %lu\n",
+                                                     pxWindow->usPeerPortNumber,
+                                                     pxWindow->usOurPortNumber,
+                                                     ulFirstSeq - pxWindow->tx.ulFirstSequenceNumber,
+                                                     ulLast - pxWindow->tx.ulFirstSequenceNumber,
+                                                     ulFirstSeq, ulFirstSeq + ulDataLength ) );
+                        }
+                    #endif /* ipconfigHAS_DEBUG_PRINTF */
+                    break;
+                }
+
+                /* This segment is fully ACK'd, set the flag. */
+                pxSegment->u.bits.bAcked = pdTRUE;
+
+                /* Calculate the RTT only if the segment was sent-out for the
+                 * first time and if this is the last ACK'd segment in a range. */
+                if( ( pxSegment->u.bits.ucTransmitCount == 1U ) && ( ( pxSegment->ulSequenceNumber + ulDataLength ) == ulLast ) )
+                {
+                    int32_t mS = ( int32_t ) ulTimerGetAge( &( pxSegment->xTransmitTimer ) );
+
+                    if( pxWindow->lSRTT >= mS )
+                    {
+                        /* RTT becomes smaller: adapt slowly. */
+                        pxWindow->lSRTT = ( ( winSRTT_DECREMENT_NEW * mS ) + ( winSRTT_DECREMENT_CURRENT * pxWindow->lSRTT ) ) / ( winSRTT_DECREMENT_NEW + winSRTT_DECREMENT_CURRENT );
+                    }
+                    else
+                    {
+                        /* RTT becomes larger: adapt quicker */
+                        pxWindow->lSRTT = ( ( winSRTT_INCREMENT_NEW * mS ) + ( winSRTT_INCREMENT_CURRENT * pxWindow->lSRTT ) ) / ( winSRTT_INCREMENT_NEW + winSRTT_INCREMENT_CURRENT );
+                    }
+
+                    /* Cap to the minimum of 50ms. */
+                    if( pxWindow->lSRTT < winSRTT_CAP_mS )
+                    {
+                        pxWindow->lSRTT = winSRTT_CAP_mS;
+                    }
+                }
+
+                /* Unlink it from the 3 queues, but do not destroy it (yet). */
+                xDoUnlink = pdTRUE;
+            }
+
+            /* pxSegment->u.bits.bAcked is now true.  Is it located at the left
+             * side of the transmission queue?  If so, it may be freed. */
+            if( ulSequenceNumber == pxWindow->tx.ulCurrentSequenceNumber )
+            {
+                if( ( xTCPWindowLoggingLevel >= 2 ) && ( ipconfigTCP_MAY_LOG_PORT( pxWindow->usOurPortNumber ) ) )
+                {
+                    FreeRTOS_debug_printf( ( "prvTCPWindowTxCheckAck: %lu - %lu Ready sequence number %lu\n",
+                                             ulFirst - pxWindow->tx.ulFirstSequenceNumber,
+                                             ulLast - pxWindow->tx.ulFirstSequenceNumber,
+                                             pxSegment->ulSequenceNumber - pxWindow->tx.ulFirstSequenceNumber ) );
+                }
+
+                /* Increase the left-hand value of the transmission window. */
+                pxWindow->tx.ulCurrentSequenceNumber += ulDataLength;
+
+                /* This function will return the number of bytes that the tail
+                 * of txStream may be advanced. */
+                ulBytesConfirmed += ulDataLength;
+
+                /* All segments below tx.ulCurrentSequenceNumber may be freed. */
+                vTCPWindowFree( pxSegment );
+
+                /* No need to unlink it any more. */
+                xDoUnlink = pdFALSE;
+            }
+
+            if( ( xDoUnlink != pdFALSE ) && ( listLIST_ITEM_CONTAINER( &( pxSegment->xQueueItem ) ) != NULL ) )
+            {
+                /* Remove item from its queues. */
+                ( void ) uxListRemove( &pxSegment->xQueueItem );
+            }
+
+            ulSequenceNumber += ulDataLength;
+        }
+
+        return ulBytesConfirmed;
+    }
+#endif /* ipconfigUSE_TCP_WIN == 1 */
+/*-----------------------------------------------------------*/
+
+#if ( ipconfigUSE_TCP_WIN == 1 )
+
+    static uint32_t prvTCPWindowFastRetransmit( TCPWindow_t * pxWindow,
+                                                uint32_t ulFirst )
+    {
+        const ListItem_t * pxIterator;
+        const ListItem_t * pxEnd;
+        TCPSegment_t * pxSegment;
+        uint32_t ulCount = 0UL;
+
+        /* A higher Tx block has been acknowledged.  Now iterate through the
+         * xWaitQueue to find a possible condition for a FAST retransmission. */
+
+        pxEnd = ipPOINTER_CAST( const ListItem_t *, listGET_END_MARKER( &( pxWindow->xWaitQueue ) ) );
+
+        pxIterator = listGET_NEXT( pxEnd );
+
+        while( pxIterator != pxEnd )
+        {
+            /* Get the owner, which is a TCP segment. */
+            pxSegment = ipPOINTER_CAST( TCPSegment_t *, listGET_LIST_ITEM_OWNER( pxIterator ) );
+
+            /* Hop to the next item before the current gets unlinked. */
+            pxIterator = listGET_NEXT( pxIterator );
+
+            /* Fast retransmission:
+             * When 3 packets with a higher sequence number have been acknowledged
+             * by the peer, it is very unlikely a current packet will ever arrive.
+             * It will be retransmitted far before the RTO. */
+            if( pxSegment->u.bits.bAcked == pdFALSE_UNSIGNED )
+            {
+                if( xSequenceLessThan( pxSegment->ulSequenceNumber, ulFirst ) != pdFALSE )
+                {
+                    pxSegment->u.bits.ucDupAckCount++;
+
+                    if( pxSegment->u.bits.ucDupAckCount == DUPLICATE_ACKS_BEFORE_FAST_RETRANSMIT )
+                    {
+                        pxSegment->u.bits.ucTransmitCount = ( uint8_t ) pdFALSE;
+
+                        /* Not clearing 'ucDupAckCount' yet as more SACK's might come in
+                         * which might lead to a second fast rexmit. */
+                        if( ( xTCPWindowLoggingLevel >= 0 ) && ( ipconfigTCP_MAY_LOG_PORT( pxWindow->usOurPortNumber ) ) )
+                        {
+                            FreeRTOS_debug_printf( ( "prvTCPWindowFastRetransmit: Requeue sequence number %lu < %lu\n",
+                                                     pxSegment->ulSequenceNumber - pxWindow->tx.ulFirstSequenceNumber,
+                                                     ulFirst - pxWindow->tx.ulFirstSequenceNumber ) );
+                            FreeRTOS_flush_logging();
+                        }
+
+                        /* Remove it from xWaitQueue. */
+                        ( void ) uxListRemove( &pxSegment->xQueueItem );
+
+                        /* Add this segment to the priority queue so it gets
+                         * retransmitted immediately. */
+                        vListInsertFifo( &( pxWindow->xPriorityQueue ), &( pxSegment->xQueueItem ) );
+                        ulCount++;
+                    }
+                }
+            }
+        }
+
+        return ulCount;
+    }
+#endif /* ipconfigUSE_TCP_WIN == 1 */
+/*-----------------------------------------------------------*/
+
+#if ( ipconfigUSE_TCP_WIN == 1 )
+
+    uint32_t ulTCPWindowTxAck( TCPWindow_t * pxWindow,
+                               uint32_t ulSequenceNumber )
+    {
+        uint32_t ulFirstSequence, ulReturn;
+
+        /* Receive a normal ACK. */
+
+        ulFirstSequence = pxWindow->tx.ulCurrentSequenceNumber;
+
+        if( xSequenceLessThanOrEqual( ulSequenceNumber, ulFirstSequence ) != pdFALSE )
+        {
+            ulReturn = 0UL;
+        }
+        else
+        {
+            ulReturn = prvTCPWindowTxCheckAck( pxWindow, ulFirstSequence, ulSequenceNumber );
+        }
+
+        return ulReturn;
+    }
+
+#endif /* ipconfigUSE_TCP_WIN == 1 */
+/*-----------------------------------------------------------*/
+
+#if ( ipconfigUSE_TCP_WIN == 1 )
+
+    uint32_t ulTCPWindowTxSack( TCPWindow_t * pxWindow,
+                                uint32_t ulFirst,
+                                uint32_t ulLast )
+    {
+        uint32_t ulAckCount;
+        uint32_t ulCurrentSequenceNumber = pxWindow->tx.ulCurrentSequenceNumber;
+
+        /* Receive a SACK option. */
+        ulAckCount = prvTCPWindowTxCheckAck( pxWindow, ulFirst, ulLast );
+        ( void ) prvTCPWindowFastRetransmit( pxWindow, ulFirst );
+
+        if( ( xTCPWindowLoggingLevel >= 1 ) && ( xSequenceGreaterThan( ulFirst, ulCurrentSequenceNumber ) != pdFALSE ) )
+        {
+            FreeRTOS_debug_printf( ( "ulTCPWindowTxSack[%u,%u]: from %lu to %lu (ack = %lu)\n",
+                                     pxWindow->usPeerPortNumber,
+                                     pxWindow->usOurPortNumber,
+                                     ulFirst - pxWindow->tx.ulFirstSequenceNumber,
+                                     ulLast - pxWindow->tx.ulFirstSequenceNumber,
+                                     pxWindow->tx.ulCurrentSequenceNumber - pxWindow->tx.ulFirstSequenceNumber ) );
+            FreeRTOS_flush_logging();
+        }
+
+        return ulAckCount;
+    }
 
 #endif /* ipconfigUSE_TCP_WIN == 1 */
 /*-----------------------------------------------------------*/
 
 /*
-#####   #                      #####   ####  ######
-# # #   #                      # # #  #    #  #    #
-  #                              #   #     #  #    #
-  #   ###   #####  #    #        #   #        #    #
-  #     #   #    # #    #        #   #        #####
-  #     #   #    # #    # ####   #   #        #
-  #     #   #    # #    #        #   #     #  #
-  #     #   #    #  ####         #    #    #  #
+ #####   #                      #####   ####  ######
+ # # #   #                      # # #  #    #  #    #
+ #                              #   #     #  #    #
+ #   ###   #####  #    #        #   #        #    #
+ #     #   #    # #    #        #   #        #####
+ #     #   #    # #    # ####   #   #        #
+ #     #   #    # #    #        #   #     #  #
+ #     #   #    #  ####         #    #    #  #
  #### ##### #    #     #        ####   ####  ####
-                      #
-                   ###
-*/
-#if( ipconfigUSE_TCP_WIN == 0 )
+ #
+ ###
+ */
+#if ( ipconfigUSE_TCP_WIN == 0 )
 
-	int32_t lTCPWindowRxCheck( TCPWindow_t *pxWindow, uint32_t ulSequenceNumber, uint32_t ulLength, uint32_t ulSpace )
-	{
-	int32_t iReturn;
+    int32_t lTCPWindowRxCheck( TCPWindow_t * pxWindow,
+                               uint32_t ulSequenceNumber,
+                               uint32_t ulLength,
+                               uint32_t ulSpace )
+    {
+        int32_t iReturn;
 
-		/* Data was received at 'ulSequenceNumber'.  See if it was expected
-		and if there is enough space to store the new data. */
-		if( ( pxWindow->rx.ulCurrentSequenceNumber != ulSequenceNumber ) || ( ulSpace < ulLength ) )
-		{
-			iReturn = -1;
-		}
-		else
-		{
-			pxWindow->rx.ulCurrentSequenceNumber += ( uint32_t ) ulLength;
-			iReturn = 0;
-		}
+        /* Data was received at 'ulSequenceNumber'.  See if it was expected
+         * and if there is enough space to store the new data. */
+        if( ( pxWindow->rx.ulCurrentSequenceNumber != ulSequenceNumber ) || ( ulSpace < ulLength ) )
+        {
+            iReturn = -1;
+        }
+        else
+        {
+            pxWindow->rx.ulCurrentSequenceNumber += ( uint32_t ) ulLength;
+            iReturn = 0;
+        }
 
-		return iReturn;
-	}
-
-#endif /* ipconfigUSE_TCP_WIN == 0 */
-/*-----------------------------------------------------------*/
-
-#if( ipconfigUSE_TCP_WIN == 0 )
-
-	int32_t lTCPWindowTxAdd( TCPWindow_t *pxWindow, uint32_t ulLength, int32_t lPosition, int32_t lMax )
-	{
-	TCPSegment_t *pxSegment = &( pxWindow->xTxSegment );
-	int32_t lResult;
-
-		/* Data is being scheduled for transmission. */
-
-		/* lMax would indicate the size of the txStream. */
-		( void ) lMax;
-		/* This is tiny TCP: there is only 1 segment for outgoing data.
-		As long as 'lDataLength' is unequal to zero, the segment is still occupied. */
-		if( pxSegment->lDataLength > 0 )
-		{
-			lResult = 0L;
-		}
-		else
-		{
-			if( ulLength > ( uint32_t ) pxSegment->lMaxLength )
-			{
-				if( ( xTCPWindowLoggingLevel != 0 ) && ( ipconfigTCP_MAY_LOG_PORT( pxWindow->usOurPortNumber ) != pdFALSE ) )
-				{
-					FreeRTOS_debug_printf( ( "lTCPWindowTxAdd: can only store %ld / %ld bytes\n", ulLength, pxSegment->lMaxLength ) );
-				}
-
-				ulLength = ( uint32_t ) pxSegment->lMaxLength;
-			}
-
-			if( ( xTCPWindowLoggingLevel != 0 ) && ( ipconfigTCP_MAY_LOG_PORT( pxWindow->usOurPortNumber ) != pdFALSE ) )
-			{
-				FreeRTOS_debug_printf( ( "lTCPWindowTxAdd: SeqNr %ld (%ld) Len %ld\n",
-					pxWindow->ulNextTxSequenceNumber - pxWindow->tx.ulFirstSequenceNumber,
-					pxWindow->tx.ulCurrentSequenceNumber - pxWindow->tx.ulFirstSequenceNumber,
-					ulLength ) );
-			}
-
-			/* The sequence number of the first byte in this packet. */
-			pxSegment->ulSequenceNumber = pxWindow->ulNextTxSequenceNumber;
-			pxSegment->lDataLength = ( int32_t ) ulLength;
-			pxSegment->lStreamPos = lPosition;
-			pxSegment->u.ulFlags = 0UL;
-			vTCPTimerSet( &( pxSegment->xTransmitTimer ) );
-
-			/* Increase the sequence number of the next data to be stored for
-			transmission. */
-			pxWindow->ulNextTxSequenceNumber += ulLength;
-			lResult = ( int32_t )ulLength;
-		}
-
-		return lResult;
-	}
+        return iReturn;
+    }
 
 #endif /* ipconfigUSE_TCP_WIN == 0 */
 /*-----------------------------------------------------------*/
 
-#if( ipconfigUSE_TCP_WIN == 0 )
+#if ( ipconfigUSE_TCP_WIN == 0 )
 
-	uint32_t ulTCPWindowTxGet( TCPWindow_t *pxWindow, uint32_t ulWindowSize, int32_t *plPosition )
-	{
-	TCPSegment_t *pxSegment = &( pxWindow->xTxSegment );
-	uint32_t ulLength = ( uint32_t ) pxSegment->lDataLength;
-	uint32_t ulMaxTime;
+    int32_t lTCPWindowTxAdd( TCPWindow_t * pxWindow,
+                             uint32_t ulLength,
+                             int32_t lPosition,
+                             int32_t lMax )
+    {
+        TCPSegment_t * pxSegment = &( pxWindow->xTxSegment );
+        int32_t lResult;
 
-		if( ulLength != 0UL )
-		{
-			/* _HT_ Still under investigation */
-			( void ) ulWindowSize;
+        /* Data is being scheduled for transmission. */
 
-			if( pxSegment->u.bits.bOutstanding != pdFALSE_UNSIGNED )
-			{
-				/* As 'ucTransmitCount' has a minimum of 1, take 2 * RTT */
-				ulMaxTime = ( ( uint32_t ) 1U << pxSegment->u.bits.ucTransmitCount ) * ( ( uint32_t ) pxWindow->lSRTT );
+        /* lMax would indicate the size of the txStream. */
+        ( void ) lMax;
 
-				if( ulTimerGetAge( &( pxSegment->xTransmitTimer ) ) < ulMaxTime )
-				{
-					ulLength = 0UL;
-				}
-			}
+        /* This is tiny TCP: there is only 1 segment for outgoing data.
+         * As long as 'lDataLength' is unequal to zero, the segment is still occupied. */
+        if( pxSegment->lDataLength > 0 )
+        {
+            lResult = 0L;
+        }
+        else
+        {
+            if( ulLength > ( uint32_t ) pxSegment->lMaxLength )
+            {
+                if( ( xTCPWindowLoggingLevel != 0 ) && ( ipconfigTCP_MAY_LOG_PORT( pxWindow->usOurPortNumber ) != pdFALSE ) )
+                {
+                    FreeRTOS_debug_printf( ( "lTCPWindowTxAdd: can only store %ld / %ld bytes\n", ulLength, pxSegment->lMaxLength ) );
+                }
 
-			if( ulLength != 0UL )
-			{
-				pxSegment->u.bits.bOutstanding = pdTRUE_UNSIGNED;
-				pxSegment->u.bits.ucTransmitCount++;
-				vTCPTimerSet (&pxSegment->xTransmitTimer);
-				pxWindow->ulOurSequenceNumber = pxSegment->ulSequenceNumber;
-				*plPosition = pxSegment->lStreamPos;
-			}
-		}
+                ulLength = ( uint32_t ) pxSegment->lMaxLength;
+            }
 
-		return ulLength;
-	}
+            if( ( xTCPWindowLoggingLevel != 0 ) && ( ipconfigTCP_MAY_LOG_PORT( pxWindow->usOurPortNumber ) != pdFALSE ) )
+            {
+                FreeRTOS_debug_printf( ( "lTCPWindowTxAdd: SeqNr %ld (%ld) Len %ld\n",
+                                         pxWindow->ulNextTxSequenceNumber - pxWindow->tx.ulFirstSequenceNumber,
+                                         pxWindow->tx.ulCurrentSequenceNumber - pxWindow->tx.ulFirstSequenceNumber,
+                                         ulLength ) );
+            }
 
-#endif /* ipconfigUSE_TCP_WIN == 0 */
-/*-----------------------------------------------------------*/
+            /* The sequence number of the first byte in this packet. */
+            pxSegment->ulSequenceNumber = pxWindow->ulNextTxSequenceNumber;
+            pxSegment->lDataLength = ( int32_t ) ulLength;
+            pxSegment->lStreamPos = lPosition;
+            pxSegment->u.ulFlags = 0UL;
+            vTCPTimerSet( &( pxSegment->xTransmitTimer ) );
 
-#if( ipconfigUSE_TCP_WIN == 0 )
+            /* Increase the sequence number of the next data to be stored for
+             * transmission. */
+            pxWindow->ulNextTxSequenceNumber += ulLength;
+            lResult = ( int32_t ) ulLength;
+        }
 
-	BaseType_t xTCPWindowTxDone( const TCPWindow_t *pxWindow )
-	{
-	BaseType_t xReturn;
-
-		/* Has the outstanding data been sent because user wants to shutdown? */
-		if( pxWindow->xTxSegment.lDataLength == 0 )
-		{
-			xReturn = pdTRUE;
-		}
-		else
-		{
-			xReturn = pdFALSE;
-		}
-
-		return xReturn;
-	}
+        return lResult;
+    }
 
 #endif /* ipconfigUSE_TCP_WIN == 0 */
 /*-----------------------------------------------------------*/
 
-#if( ipconfigUSE_TCP_WIN == 0 )
+#if ( ipconfigUSE_TCP_WIN == 0 )
 
-	static BaseType_t prvTCPWindowTxHasSpace( TCPWindow_t *pxWindow, uint32_t ulWindowSize );
-	static BaseType_t prvTCPWindowTxHasSpace( TCPWindow_t *pxWindow, uint32_t ulWindowSize )
-	{
-	BaseType_t xReturn;
+    uint32_t ulTCPWindowTxGet( TCPWindow_t * pxWindow,
+                               uint32_t ulWindowSize,
+                               int32_t * plPosition )
+    {
+        TCPSegment_t * pxSegment = &( pxWindow->xTxSegment );
+        uint32_t ulLength = ( uint32_t ) pxSegment->lDataLength;
+        uint32_t ulMaxTime;
 
-		if( ulWindowSize >= pxWindow->usMSSInit )
-		{
-			xReturn = pdTRUE;
-		}
-		else
-		{
-			xReturn = pdFALSE;
-		}
+        if( ulLength != 0UL )
+        {
+            /* _HT_ Still under investigation */
+            ( void ) ulWindowSize;
 
-		return xReturn;
-	}
+            if( pxSegment->u.bits.bOutstanding != pdFALSE_UNSIGNED )
+            {
+                /* As 'ucTransmitCount' has a minimum of 1, take 2 * RTT */
+                ulMaxTime = ( ( uint32_t ) 1U << pxSegment->u.bits.ucTransmitCount ) * ( ( uint32_t ) pxWindow->lSRTT );
 
-#endif /* ipconfigUSE_TCP_WIN == 0 */
-/*-----------------------------------------------------------*/
+                if( ulTimerGetAge( &( pxSegment->xTransmitTimer ) ) < ulMaxTime )
+                {
+                    ulLength = 0UL;
+                }
+            }
 
-#if( ipconfigUSE_TCP_WIN == 0 )
+            if( ulLength != 0UL )
+            {
+                pxSegment->u.bits.bOutstanding = pdTRUE_UNSIGNED;
+                pxSegment->u.bits.ucTransmitCount++;
+                vTCPTimerSet( &pxSegment->xTransmitTimer );
+                pxWindow->ulOurSequenceNumber = pxSegment->ulSequenceNumber;
+                *plPosition = pxSegment->lStreamPos;
+            }
+        }
 
-	BaseType_t xTCPWindowTxHasData( TCPWindow_t const *pxWindow, uint32_t ulWindowSize, TickType_t *pulDelay )
-	{
-	TCPSegment_t *pxSegment = &( pxWindow->xTxSegment );
-	BaseType_t xReturn;
-	TickType_t ulAge, ulMaxAge;
-
-		/* Check data to be sent. */
-		*pulDelay = ( TickType_t ) 0;
-		if( pxSegment->lDataLength == 0 )
-		{
-			/* Got nothing to send right now. */
-			xReturn = pdFALSE;
-		}
-		else
-		{
-			if( pxSegment->u.bits.bOutstanding != pdFALSE_UNSIGNED )
-			{
-				ulAge = ulTimerGetAge ( &pxSegment->xTransmitTimer );
-				ulMaxAge = ( ( TickType_t ) 1U << pxSegment->u.bits.ucTransmitCount ) * ( ( uint32_t ) pxWindow->lSRTT );
-
-				if( ulMaxAge > ulAge )
-				{
-					*pulDelay = ulMaxAge - ulAge;
-				}
-
-				xReturn = pdTRUE;
-			}
-			else if( prvTCPWindowTxHasSpace( pxWindow, ulWindowSize ) == pdFALSE )
-			{
-				/* Too many outstanding messages. */
-				xReturn = pdFALSE;
-			}
-			else
-			{
-				xReturn = pdTRUE;
-			}
-		}
-
-		return xReturn;
-	}
+        return ulLength;
+    }
 
 #endif /* ipconfigUSE_TCP_WIN == 0 */
 /*-----------------------------------------------------------*/
 
-#if( ipconfigUSE_TCP_WIN == 0 )
+#if ( ipconfigUSE_TCP_WIN == 0 )
 
-	uint32_t ulTCPWindowTxAck( TCPWindow_t *pxWindow, uint32_t ulSequenceNumber )
-	{
-	TCPSegment_t *pxSegment = &( pxWindow->xTxSegment );
-	uint32_t ulDataLength = ( uint32_t ) pxSegment->lDataLength;
+    BaseType_t xTCPWindowTxDone( const TCPWindow_t * pxWindow )
+    {
+        BaseType_t xReturn;
 
-		/* Receive a normal ACK */
+        /* Has the outstanding data been sent because user wants to shutdown? */
+        if( pxWindow->xTxSegment.lDataLength == 0 )
+        {
+            xReturn = pdTRUE;
+        }
+        else
+        {
+            xReturn = pdFALSE;
+        }
 
-		if( ulDataLength != 0UL )
-		{
-			if( ulSequenceNumber < ( pxWindow->tx.ulCurrentSequenceNumber + ulDataLength ) )
-			{
-				if( ipconfigTCP_MAY_LOG_PORT( pxWindow->usOurPortNumber ) != pdFALSE )
-				{
-					FreeRTOS_debug_printf( ( "win_tx_ack: acked %ld expc %ld len %ld\n",
-						ulSequenceNumber - pxWindow->tx.ulFirstSequenceNumber,
-						pxWindow->tx.ulCurrentSequenceNumber - pxWindow->tx.ulFirstSequenceNumber,
-						ulDataLength ) );
-				}
-
-				/* Nothing to send right now. */
-				ulDataLength = 0UL;
-			}
-			else
-			{
-				pxWindow->tx.ulCurrentSequenceNumber += ulDataLength;
-
-				if( ( xTCPWindowLoggingLevel != 0 ) && ( ipconfigTCP_MAY_LOG_PORT( pxWindow->usOurPortNumber ) != pdFALSE ) )
-				{
-					FreeRTOS_debug_printf( ( "win_tx_ack: acked seqnr %ld len %ld\n",
-						ulSequenceNumber - pxWindow->tx.ulFirstSequenceNumber,
-						ulDataLength ) );
-				}
-
-				pxSegment->lDataLength = 0;
-			}
-		}
-
-		return ulDataLength;
-	}
+        return xReturn;
+    }
 
 #endif /* ipconfigUSE_TCP_WIN == 0 */
 /*-----------------------------------------------------------*/
 
-#if( ipconfigUSE_TCP_WIN == 0 )
+#if ( ipconfigUSE_TCP_WIN == 0 )
 
-	BaseType_t xTCPWindowRxEmpty( const TCPWindow_t *pxWindow )
-	{
-		/* Return true if 'ulCurrentSequenceNumber >= ulHighestSequenceNumber'
-		'ulCurrentSequenceNumber' is the highest sequence number stored,
-		'ulHighestSequenceNumber' is the highest sequence number seen. */
-		return xSequenceGreaterThanOrEqual( pxWindow->rx.ulCurrentSequenceNumber, pxWindow->rx.ulHighestSequenceNumber );
-	}
+    static BaseType_t prvTCPWindowTxHasSpace( TCPWindow_t * pxWindow,
+                                              uint32_t ulWindowSize );
+    static BaseType_t prvTCPWindowTxHasSpace( TCPWindow_t * pxWindow,
+                                              uint32_t ulWindowSize )
+    {
+        BaseType_t xReturn;
 
-#endif /* ipconfigUSE_TCP_WIN == 0 */
-/*-----------------------------------------------------------*/
+        if( ulWindowSize >= pxWindow->usMSSInit )
+        {
+            xReturn = pdTRUE;
+        }
+        else
+        {
+            xReturn = pdFALSE;
+        }
 
-#if( ipconfigUSE_TCP_WIN == 0 )
-
-	/* Destroy a window (always returns NULL) */
-	void vTCPWindowDestroy( const TCPWindow_t *pxWindow )
-	{
-		/* As in tiny TCP there are no shared segments descriptors, there is
-		nothing to release. */
-		( void ) pxWindow;
-	}
+        return xReturn;
+    }
 
 #endif /* ipconfigUSE_TCP_WIN == 0 */
 /*-----------------------------------------------------------*/
 
+#if ( ipconfigUSE_TCP_WIN == 0 )
 
+    BaseType_t xTCPWindowTxHasData( TCPWindow_t const * pxWindow,
+                                    uint32_t ulWindowSize,
+                                    TickType_t * pulDelay )
+    {
+        TCPSegment_t * pxSegment = &( pxWindow->xTxSegment );
+        BaseType_t xReturn;
+        TickType_t ulAge, ulMaxAge;
+
+        /* Check data to be sent. */
+        *pulDelay = ( TickType_t ) 0;
+
+        if( pxSegment->lDataLength == 0 )
+        {
+            /* Got nothing to send right now. */
+            xReturn = pdFALSE;
+        }
+        else
+        {
+            if( pxSegment->u.bits.bOutstanding != pdFALSE_UNSIGNED )
+            {
+                ulAge = ulTimerGetAge( &pxSegment->xTransmitTimer );
+                ulMaxAge = ( ( TickType_t ) 1U << pxSegment->u.bits.ucTransmitCount ) * ( ( uint32_t ) pxWindow->lSRTT );
+
+                if( ulMaxAge > ulAge )
+                {
+                    *pulDelay = ulMaxAge - ulAge;
+                }
+
+                xReturn = pdTRUE;
+            }
+            else if( prvTCPWindowTxHasSpace( pxWindow, ulWindowSize ) == pdFALSE )
+            {
+                /* Too many outstanding messages. */
+                xReturn = pdFALSE;
+            }
+            else
+            {
+                xReturn = pdTRUE;
+            }
+        }
+
+        return xReturn;
+    }
+
+#endif /* ipconfigUSE_TCP_WIN == 0 */
+/*-----------------------------------------------------------*/
+
+#if ( ipconfigUSE_TCP_WIN == 0 )
+
+    uint32_t ulTCPWindowTxAck( TCPWindow_t * pxWindow,
+                               uint32_t ulSequenceNumber )
+    {
+        TCPSegment_t * pxSegment = &( pxWindow->xTxSegment );
+        uint32_t ulDataLength = ( uint32_t ) pxSegment->lDataLength;
+
+        /* Receive a normal ACK */
+
+        if( ulDataLength != 0UL )
+        {
+            if( ulSequenceNumber < ( pxWindow->tx.ulCurrentSequenceNumber + ulDataLength ) )
+            {
+                if( ipconfigTCP_MAY_LOG_PORT( pxWindow->usOurPortNumber ) != pdFALSE )
+                {
+                    FreeRTOS_debug_printf( ( "win_tx_ack: acked %ld expc %ld len %ld\n",
+                                             ulSequenceNumber - pxWindow->tx.ulFirstSequenceNumber,
+                                             pxWindow->tx.ulCurrentSequenceNumber - pxWindow->tx.ulFirstSequenceNumber,
+                                             ulDataLength ) );
+                }
+
+                /* Nothing to send right now. */
+                ulDataLength = 0UL;
+            }
+            else
+            {
+                pxWindow->tx.ulCurrentSequenceNumber += ulDataLength;
+
+                if( ( xTCPWindowLoggingLevel != 0 ) && ( ipconfigTCP_MAY_LOG_PORT( pxWindow->usOurPortNumber ) != pdFALSE ) )
+                {
+                    FreeRTOS_debug_printf( ( "win_tx_ack: acked seqnr %ld len %ld\n",
+                                             ulSequenceNumber - pxWindow->tx.ulFirstSequenceNumber,
+                                             ulDataLength ) );
+                }
+
+                pxSegment->lDataLength = 0;
+            }
+        }
+
+        return ulDataLength;
+    }
+
+#endif /* ipconfigUSE_TCP_WIN == 0 */
+/*-----------------------------------------------------------*/
+
+#if ( ipconfigUSE_TCP_WIN == 0 )
+
+    BaseType_t xTCPWindowRxEmpty( const TCPWindow_t * pxWindow )
+    {
+        /* Return true if 'ulCurrentSequenceNumber >= ulHighestSequenceNumber'
+         * 'ulCurrentSequenceNumber' is the highest sequence number stored,
+         * 'ulHighestSequenceNumber' is the highest sequence number seen. */
+        return xSequenceGreaterThanOrEqual( pxWindow->rx.ulCurrentSequenceNumber, pxWindow->rx.ulHighestSequenceNumber );
+    }
+
+#endif /* ipconfigUSE_TCP_WIN == 0 */
+/*-----------------------------------------------------------*/
+
+#if ( ipconfigUSE_TCP_WIN == 0 )
+
+    /* Destroy a window (always returns NULL) */
+    void vTCPWindowDestroy( const TCPWindow_t * pxWindow )
+    {
+        /* As in tiny TCP there are no shared segments descriptors, there is
+         * nothing to release. */
+        ( void ) pxWindow;
+    }
+
+#endif /* ipconfigUSE_TCP_WIN == 0 */
+/*-----------------------------------------------------------*/

--- a/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/FreeRTOS_UDP_IP.c
+++ b/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/FreeRTOS_UDP_IP.c
@@ -43,371 +43,374 @@
 #include "NetworkInterface.h"
 #include "NetworkBufferManagement.h"
 
-#if( ipconfigUSE_DNS == 1 )
-	#include "FreeRTOS_DNS.h"
+#if ( ipconfigUSE_DNS == 1 )
+    #include "FreeRTOS_DNS.h"
 #endif
 
 /* The expected IP version and header length coded into the IP header itself. */
-#define ipIP_VERSION_AND_HEADER_LENGTH_BYTE ( ( uint8_t ) 0x45 )
+#define ipIP_VERSION_AND_HEADER_LENGTH_BYTE    ( ( uint8_t ) 0x45 )
 
 /* Part of the Ethernet and IP headers are always constant when sending an IPv4
-UDP packet.  This array defines the constant parts, allowing this part of the
-packet to be filled in using a simple memcpy() instead of individual writes. */
+ *  UDP packet.  This array defines the constant parts, allowing this part of the
+ *  packet to be filled in using a simple memcpy() instead of individual writes. */
 /*lint -e708 (Info -- union initialization). */
 UDPPacketHeader_t xDefaultPartUDPPacketHeader =
 {
-	/* .ucBytes : */
-	{
-		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 	/* Ethernet source MAC address. */
-		0x08, 0x00, 							/* Ethernet frame type. */
-		ipIP_VERSION_AND_HEADER_LENGTH_BYTE, 	/* ucVersionHeaderLength. */
-		0x00, 									/* ucDifferentiatedServicesCode. */
-		0x00, 0x00, 							/* usLength. */
-		0x00, 0x00, 							/* usIdentification. */
-		0x00, 0x00, 							/* usFragmentOffset. */
-		ipconfigUDP_TIME_TO_LIVE, 				/* ucTimeToLive */
-		ipPROTOCOL_UDP, 						/* ucProtocol. */
-		0x00, 0x00, 							/* usHeaderChecksum. */
-		0x00, 0x00, 0x00, 0x00 					/* Source IP address. */
-	}
+    /* .ucBytes : */
+    {
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00,  /* Ethernet source MAC address. */
+        0x08, 0x00,                          /* Ethernet frame type. */
+        ipIP_VERSION_AND_HEADER_LENGTH_BYTE, /* ucVersionHeaderLength. */
+        0x00,                                /* ucDifferentiatedServicesCode. */
+        0x00, 0x00,                          /* usLength. */
+        0x00, 0x00,                          /* usIdentification. */
+        0x00, 0x00,                          /* usFragmentOffset. */
+        ipconfigUDP_TIME_TO_LIVE,            /* ucTimeToLive */
+        ipPROTOCOL_UDP,                      /* ucProtocol. */
+        0x00, 0x00,                          /* usHeaderChecksum. */
+        0x00, 0x00, 0x00, 0x00               /* Source IP address. */
+    }
 };
 /*-----------------------------------------------------------*/
 
 void vProcessGeneratedUDPPacket( NetworkBufferDescriptor_t * const pxNetworkBuffer )
 {
-UDPPacket_t *pxUDPPacket;
-IPHeader_t *pxIPHeader;
-eARPLookupResult_t eReturned;
-uint32_t ulIPAddress = pxNetworkBuffer->ulIPAddress;
-size_t uxPayloadSize;
+    UDPPacket_t * pxUDPPacket;
+    IPHeader_t * pxIPHeader;
+    eARPLookupResult_t eReturned;
+    uint32_t ulIPAddress = pxNetworkBuffer->ulIPAddress;
+    size_t uxPayloadSize;
 
-	/* Map the UDP packet onto the start of the frame. */
-	pxUDPPacket = ipPOINTER_CAST( UDPPacket_t *, pxNetworkBuffer->pucEthernetBuffer );
+    /* Map the UDP packet onto the start of the frame. */
+    pxUDPPacket = ipPOINTER_CAST( UDPPacket_t *, pxNetworkBuffer->pucEthernetBuffer );
 
-#if ipconfigSUPPORT_OUTGOING_PINGS == 1
-	if( pxNetworkBuffer->usPort == ( uint16_t ) ipPACKET_CONTAINS_ICMP_DATA )
-	{
-		uxPayloadSize = pxNetworkBuffer->xDataLength - sizeof( ICMPPacket_t );
-	}
-	else
-#endif
-	{
-		uxPayloadSize = pxNetworkBuffer->xDataLength - sizeof( UDPPacket_t );
-	}
+    #if ipconfigSUPPORT_OUTGOING_PINGS == 1
+        if( pxNetworkBuffer->usPort == ( uint16_t ) ipPACKET_CONTAINS_ICMP_DATA )
+        {
+            uxPayloadSize = pxNetworkBuffer->xDataLength - sizeof( ICMPPacket_t );
+        }
+        else
+    #endif
+    {
+        uxPayloadSize = pxNetworkBuffer->xDataLength - sizeof( UDPPacket_t );
+    }
 
-	/* Determine the ARP cache status for the requested IP address. */
-	eReturned = eARPGetCacheEntry( &( ulIPAddress ), &( pxUDPPacket->xEthernetHeader.xDestinationAddress ) );
+    /* Determine the ARP cache status for the requested IP address. */
+    eReturned = eARPGetCacheEntry( &( ulIPAddress ), &( pxUDPPacket->xEthernetHeader.xDestinationAddress ) );
 
-	if( eReturned != eCantSendPacket )
-	{
-		if( eReturned == eARPCacheHit )
-		{
-			#if( ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM == 0 )
-				uint8_t ucSocketOptions;
-			#endif
-			iptraceSENDING_UDP_PACKET( pxNetworkBuffer->ulIPAddress );
+    if( eReturned != eCantSendPacket )
+    {
+        if( eReturned == eARPCacheHit )
+        {
+            #if ( ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM == 0 )
+                uint8_t ucSocketOptions;
+            #endif
+            iptraceSENDING_UDP_PACKET( pxNetworkBuffer->ulIPAddress );
 
-			/* Create short cuts to the data within the packet. */
-			pxIPHeader = &( pxUDPPacket->xIPHeader );
+            /* Create short cuts to the data within the packet. */
+            pxIPHeader = &( pxUDPPacket->xIPHeader );
 
-		#if ( ipconfigSUPPORT_OUTGOING_PINGS == 1 )
-			/* Is it possible that the packet is not actually a UDP packet
-			after all, but an ICMP packet. */
-			if( pxNetworkBuffer->usPort != ( uint16_t ) ipPACKET_CONTAINS_ICMP_DATA )
-		#endif /* ipconfigSUPPORT_OUTGOING_PINGS */
-			{
-			UDPHeader_t *pxUDPHeader;
+            #if ( ipconfigSUPPORT_OUTGOING_PINGS == 1 )
+                /* Is it possible that the packet is not actually a UDP packet
+                 * after all, but an ICMP packet. */
+                if( pxNetworkBuffer->usPort != ( uint16_t ) ipPACKET_CONTAINS_ICMP_DATA )
+            #endif /* ipconfigSUPPORT_OUTGOING_PINGS */
+            {
+                UDPHeader_t * pxUDPHeader;
 
-				pxUDPHeader = &( pxUDPPacket->xUDPHeader );
+                pxUDPHeader = &( pxUDPPacket->xUDPHeader );
 
-				pxUDPHeader->usDestinationPort = pxNetworkBuffer->usPort;
-				pxUDPHeader->usSourcePort = pxNetworkBuffer->usBoundPort;
-				pxUDPHeader->usLength = ( uint16_t ) ( uxPayloadSize + sizeof( UDPHeader_t ) );
-				pxUDPHeader->usLength = FreeRTOS_htons( pxUDPHeader->usLength );
-				pxUDPHeader->usChecksum = 0U;
-			}
+                pxUDPHeader->usDestinationPort = pxNetworkBuffer->usPort;
+                pxUDPHeader->usSourcePort = pxNetworkBuffer->usBoundPort;
+                pxUDPHeader->usLength = ( uint16_t ) ( uxPayloadSize + sizeof( UDPHeader_t ) );
+                pxUDPHeader->usLength = FreeRTOS_htons( pxUDPHeader->usLength );
+                pxUDPHeader->usChecksum = 0U;
+            }
 
-			/* memcpy() the constant parts of the header information into
-			the	correct location within the packet.  This fills in:
-				xEthernetHeader.xSourceAddress
-				xEthernetHeader.usFrameType
-				xIPHeader.ucVersionHeaderLength
-				xIPHeader.ucDifferentiatedServicesCode
-				xIPHeader.usLength
-				xIPHeader.usIdentification
-				xIPHeader.usFragmentOffset
-				xIPHeader.ucTimeToLive
-				xIPHeader.ucProtocol
-			and
-				xIPHeader.usHeaderChecksum
-			*/
+            /* memcpy() the constant parts of the header information into
+             * the	correct location within the packet.  This fills in:
+             *  xEthernetHeader.xSourceAddress
+             *  xEthernetHeader.usFrameType
+             *  xIPHeader.ucVersionHeaderLength
+             *  xIPHeader.ucDifferentiatedServicesCode
+             *  xIPHeader.usLength
+             *  xIPHeader.usIdentification
+             *  xIPHeader.usFragmentOffset
+             *  xIPHeader.ucTimeToLive
+             *  xIPHeader.ucProtocol
+             * and
+             *  xIPHeader.usHeaderChecksum
+             */
 
-			/* Save options now, as they will be overwritten by memcpy */
-			#if( ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM == 0 )
-			{
-				ucSocketOptions = pxNetworkBuffer->pucEthernetBuffer[ ipSOCKET_OPTIONS_OFFSET ];
-		}
-			#endif
-			/*
-			 * Offset the memcpy by the size of a MAC address to start at the packet's
-			 * Ethernet header 'source' MAC address; the preceding 'destination' should not be altered.
-			 */
-			/* The Ethernet source address is at offset 6. */
-			char *pxUdpSrcAddrOffset = ( char *) ( &( pxNetworkBuffer->pucEthernetBuffer[ sizeof( MACAddress_t ) ] ) );
-			( void ) memcpy( pxUdpSrcAddrOffset, xDefaultPartUDPPacketHeader.ucBytes, sizeof( xDefaultPartUDPPacketHeader ) );
+            /* Save options now, as they will be overwritten by memcpy */
+            #if ( ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM == 0 )
+                {
+                    ucSocketOptions = pxNetworkBuffer->pucEthernetBuffer[ ipSOCKET_OPTIONS_OFFSET ];
+                }
+            #endif
 
-		#if ipconfigSUPPORT_OUTGOING_PINGS == 1
-			if( pxNetworkBuffer->usPort == ( uint16_t ) ipPACKET_CONTAINS_ICMP_DATA )
-			{
-				pxIPHeader->ucProtocol = ipPROTOCOL_ICMP;
-				pxIPHeader->usLength = ( uint16_t ) ( uxPayloadSize + sizeof( IPHeader_t ) + sizeof( ICMPHeader_t ) );
-			}
-			else
-		#endif /* ipconfigSUPPORT_OUTGOING_PINGS */
-			{
-				pxIPHeader->usLength = ( uint16_t ) ( uxPayloadSize + sizeof( IPHeader_t ) + sizeof( UDPHeader_t ) );
-			}
+            /*
+             * Offset the memcpy by the size of a MAC address to start at the packet's
+             * Ethernet header 'source' MAC address; the preceding 'destination' should not be altered.
+             */
+            /* The Ethernet source address is at offset 6. */
+            char * pxUdpSrcAddrOffset = ( char * ) ( &( pxNetworkBuffer->pucEthernetBuffer[ sizeof( MACAddress_t ) ] ) );
+            ( void ) memcpy( pxUdpSrcAddrOffset, xDefaultPartUDPPacketHeader.ucBytes, sizeof( xDefaultPartUDPPacketHeader ) );
 
-			pxIPHeader->usLength = FreeRTOS_htons( pxIPHeader->usLength );
-			pxIPHeader->ulDestinationIPAddress = pxNetworkBuffer->ulIPAddress;
+            #if ipconfigSUPPORT_OUTGOING_PINGS == 1
+                if( pxNetworkBuffer->usPort == ( uint16_t ) ipPACKET_CONTAINS_ICMP_DATA )
+                {
+                    pxIPHeader->ucProtocol = ipPROTOCOL_ICMP;
+                    pxIPHeader->usLength = ( uint16_t ) ( uxPayloadSize + sizeof( IPHeader_t ) + sizeof( ICMPHeader_t ) );
+                }
+                else
+            #endif /* ipconfigSUPPORT_OUTGOING_PINGS */
+            {
+                pxIPHeader->usLength = ( uint16_t ) ( uxPayloadSize + sizeof( IPHeader_t ) + sizeof( UDPHeader_t ) );
+            }
 
-			#if( ipconfigUSE_LLMNR == 1 )
-			{
-				/* LLMNR messages are typically used on a LAN and they're
-				 * not supposed to cross routers */
-				if( pxNetworkBuffer->ulIPAddress == ipLLMNR_IP_ADDR )
-				{
-					pxIPHeader->ucTimeToLive = 0x01;
-				}
-			}
-			#endif
+            pxIPHeader->usLength = FreeRTOS_htons( pxIPHeader->usLength );
+            pxIPHeader->ulDestinationIPAddress = pxNetworkBuffer->ulIPAddress;
 
-			#if( ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM == 0 )
-			{
-				pxIPHeader->usHeaderChecksum = 0U;
-				pxIPHeader->usHeaderChecksum = usGenerateChecksum( 0U, ( uint8_t * ) &( pxIPHeader->ucVersionHeaderLength ), ipSIZE_OF_IPv4_HEADER );
-				pxIPHeader->usHeaderChecksum = ~FreeRTOS_htons( pxIPHeader->usHeaderChecksum );
+            #if ( ipconfigUSE_LLMNR == 1 )
+                {
+                    /* LLMNR messages are typically used on a LAN and they're
+                     * not supposed to cross routers */
+                    if( pxNetworkBuffer->ulIPAddress == ipLLMNR_IP_ADDR )
+                    {
+                        pxIPHeader->ucTimeToLive = 0x01;
+                    }
+                }
+            #endif
 
-				if( ( ucSocketOptions & ( uint8_t ) FREERTOS_SO_UDPCKSUM_OUT ) != 0U )
-				{
-					( void ) usGenerateProtocolChecksum( ( uint8_t * ) pxUDPPacket, pxNetworkBuffer->xDataLength, pdTRUE );
-				}
-				else
-				{
-					pxUDPPacket->xUDPHeader.usChecksum = 0U;
-				}
-			}
-			#endif
-		}
-		else if( eReturned == eARPCacheMiss )
-		{
-			/* Add an entry to the ARP table with a null hardware address.
-			This allows the ARP timer to know that an ARP reply is
-			outstanding, and perform retransmissions if necessary. */
-			vARPRefreshCacheEntry( NULL, ulIPAddress );
+            #if ( ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM == 0 )
+                {
+                    pxIPHeader->usHeaderChecksum = 0U;
+                    pxIPHeader->usHeaderChecksum = usGenerateChecksum( 0U, ( uint8_t * ) &( pxIPHeader->ucVersionHeaderLength ), ipSIZE_OF_IPv4_HEADER );
+                    pxIPHeader->usHeaderChecksum = ~FreeRTOS_htons( pxIPHeader->usHeaderChecksum );
 
-			/* Generate an ARP for the required IP address. */
-			iptracePACKET_DROPPED_TO_GENERATE_ARP( pxNetworkBuffer->ulIPAddress );
-			pxNetworkBuffer->ulIPAddress = ulIPAddress;
-			vARPGenerateRequestPacket( pxNetworkBuffer );
-		}
-		else
-		{
-			/* The lookup indicated that an ARP request has already been
-			sent out for the queried IP address. */
-			eReturned = eCantSendPacket;
-		}
-	}
+                    if( ( ucSocketOptions & ( uint8_t ) FREERTOS_SO_UDPCKSUM_OUT ) != 0U )
+                    {
+                        ( void ) usGenerateProtocolChecksum( ( uint8_t * ) pxUDPPacket, pxNetworkBuffer->xDataLength, pdTRUE );
+                    }
+                    else
+                    {
+                        pxUDPPacket->xUDPHeader.usChecksum = 0U;
+                    }
+                }
+            #endif /* if ( ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM == 0 ) */
+        }
+        else if( eReturned == eARPCacheMiss )
+        {
+            /* Add an entry to the ARP table with a null hardware address.
+             * This allows the ARP timer to know that an ARP reply is
+             * outstanding, and perform retransmissions if necessary. */
+            vARPRefreshCacheEntry( NULL, ulIPAddress );
 
-	if( eReturned != eCantSendPacket )
-	{
-		/* The network driver is responsible for freeing the network buffer
-		after the packet has been sent. */
+            /* Generate an ARP for the required IP address. */
+            iptracePACKET_DROPPED_TO_GENERATE_ARP( pxNetworkBuffer->ulIPAddress );
+            pxNetworkBuffer->ulIPAddress = ulIPAddress;
+            vARPGenerateRequestPacket( pxNetworkBuffer );
+        }
+        else
+        {
+            /* The lookup indicated that an ARP request has already been
+             * sent out for the queried IP address. */
+            eReturned = eCantSendPacket;
+        }
+    }
 
-		#if defined( ipconfigETHERNET_MINIMUM_PACKET_BYTES )
-		{
-			if( pxNetworkBuffer->xDataLength < ( size_t ) ipconfigETHERNET_MINIMUM_PACKET_BYTES )
-			{
-			BaseType_t xIndex;
+    if( eReturned != eCantSendPacket )
+    {
+        /* The network driver is responsible for freeing the network buffer
+         * after the packet has been sent. */
 
-				for( xIndex = ( BaseType_t ) pxNetworkBuffer->xDataLength; xIndex < ( BaseType_t ) ipconfigETHERNET_MINIMUM_PACKET_BYTES; xIndex++ )
-				{
-					pxNetworkBuffer->pucEthernetBuffer[ xIndex ] = 0U;
-				}
-				pxNetworkBuffer->xDataLength = ( size_t ) ipconfigETHERNET_MINIMUM_PACKET_BYTES;
-			}
-		}
-		#endif
+        #if defined( ipconfigETHERNET_MINIMUM_PACKET_BYTES )
+            {
+                if( pxNetworkBuffer->xDataLength < ( size_t ) ipconfigETHERNET_MINIMUM_PACKET_BYTES )
+                {
+                    BaseType_t xIndex;
 
-		( void ) xNetworkInterfaceOutput( pxNetworkBuffer, pdTRUE );
-	}
-	else
-	{
-		/* The packet can't be sent (DHCP not completed?).  Just drop the
-		packet. */
-		vReleaseNetworkBufferAndDescriptor( pxNetworkBuffer );
-	}
+                    for( xIndex = ( BaseType_t ) pxNetworkBuffer->xDataLength; xIndex < ( BaseType_t ) ipconfigETHERNET_MINIMUM_PACKET_BYTES; xIndex++ )
+                    {
+                        pxNetworkBuffer->pucEthernetBuffer[ xIndex ] = 0U;
+                    }
+
+                    pxNetworkBuffer->xDataLength = ( size_t ) ipconfigETHERNET_MINIMUM_PACKET_BYTES;
+                }
+            }
+        #endif /* if defined( ipconfigETHERNET_MINIMUM_PACKET_BYTES ) */
+
+        ( void ) xNetworkInterfaceOutput( pxNetworkBuffer, pdTRUE );
+    }
+    else
+    {
+        /* The packet can't be sent (DHCP not completed?).  Just drop the
+         * packet. */
+        vReleaseNetworkBufferAndDescriptor( pxNetworkBuffer );
+    }
 }
 /*-----------------------------------------------------------*/
 
-BaseType_t xProcessReceivedUDPPacket( NetworkBufferDescriptor_t *pxNetworkBuffer, uint16_t usPort )
+BaseType_t xProcessReceivedUDPPacket( NetworkBufferDescriptor_t * pxNetworkBuffer,
+                                      uint16_t usPort )
 {
-BaseType_t xReturn = pdPASS;
-FreeRTOS_Socket_t *pxSocket;
-configASSERT( pxNetworkBuffer != NULL );
-configASSERT( pxNetworkBuffer->pucEthernetBuffer != NULL );
+    BaseType_t xReturn = pdPASS;
+    FreeRTOS_Socket_t * pxSocket;
+
+    configASSERT( pxNetworkBuffer != NULL );
+    configASSERT( pxNetworkBuffer->pucEthernetBuffer != NULL );
 
 
-const UDPPacket_t *pxUDPPacket = ipPOINTER_CAST( const UDPPacket_t *, pxNetworkBuffer->pucEthernetBuffer );
+    const UDPPacket_t * pxUDPPacket = ipPOINTER_CAST( const UDPPacket_t *, pxNetworkBuffer->pucEthernetBuffer );
 
-	/* Caller must check for minimum packet size. */
-	pxSocket = pxUDPSocketLookup( usPort );
+    /* Caller must check for minimum packet size. */
+    pxSocket = pxUDPSocketLookup( usPort );
 
-	if( pxSocket != NULL )
-	{
+    if( pxSocket != NULL )
+    {
+        /* When refreshing the ARP cache with received UDP packets we must be
+         * careful;  hundreds of broadcast messages may pass and if we're not
+         * handling them, no use to fill the ARP cache with those IP addresses. */
+        vARPRefreshCacheEntry( &( pxUDPPacket->xEthernetHeader.xSourceAddress ), pxUDPPacket->xIPHeader.ulSourceIPAddress );
 
-		/* When refreshing the ARP cache with received UDP packets we must be
-		careful;  hundreds of broadcast messages may pass and if we're not
-		handling them, no use to fill the ARP cache with those IP addresses. */
-		vARPRefreshCacheEntry( &( pxUDPPacket->xEthernetHeader.xSourceAddress ), pxUDPPacket->xIPHeader.ulSourceIPAddress );
+        #if ( ipconfigUSE_CALLBACKS == 1 )
+            {
+                /* Did the owner of this socket register a reception handler ? */
+                if( ipconfigIS_VALID_PROG_ADDRESS( pxSocket->u.xUDP.pxHandleReceive ) )
+                {
+                    struct freertos_sockaddr xSourceAddress, destinationAddress;
+                    void * pcData = &( pxNetworkBuffer->pucEthernetBuffer[ ipUDP_PAYLOAD_OFFSET_IPv4 ] );
+                    FOnUDPReceive_t xHandler = ( FOnUDPReceive_t ) pxSocket->u.xUDP.pxHandleReceive;
+                    xSourceAddress.sin_port = pxNetworkBuffer->usPort;
+                    xSourceAddress.sin_addr = pxNetworkBuffer->ulIPAddress;
+                    destinationAddress.sin_port = usPort;
+                    destinationAddress.sin_addr = pxUDPPacket->xIPHeader.ulDestinationIPAddress;
 
-		#if( ipconfigUSE_CALLBACKS == 1 )
-		{
-			/* Did the owner of this socket register a reception handler ? */
-			if( ipconfigIS_VALID_PROG_ADDRESS( pxSocket->u.xUDP.pxHandleReceive ) )
-			{
-				struct freertos_sockaddr xSourceAddress, destinationAddress;
-				void *pcData = &( pxNetworkBuffer->pucEthernetBuffer[ ipUDP_PAYLOAD_OFFSET_IPv4 ] );
-				FOnUDPReceive_t xHandler = ( FOnUDPReceive_t ) pxSocket->u.xUDP.pxHandleReceive;
-				xSourceAddress.sin_port = pxNetworkBuffer->usPort;
-				xSourceAddress.sin_addr = pxNetworkBuffer->ulIPAddress;
-				destinationAddress.sin_port = usPort;
-				destinationAddress.sin_addr = pxUDPPacket->xIPHeader.ulDestinationIPAddress;
+                    /* The value of 'xDataLength' was proven to be at least the size of a UDP packet in prvProcessIPPacket(). */
+                    if( xHandler( ( Socket_t ) pxSocket,
+                                  ( void * ) pcData,
+                                  ( size_t ) ( pxNetworkBuffer->xDataLength - ipUDP_PAYLOAD_OFFSET_IPv4 ),
+                                  &( xSourceAddress ),
+                                  &( destinationAddress ) ) != 0 )
+                    {
+                        xReturn = pdFAIL; /* xHandler has consumed the data, do not add it to .xWaitingPacketsList'. */
+                    }
+                }
+            }
+        #endif /* ipconfigUSE_CALLBACKS */
 
-				/* The value of 'xDataLength' was proven to be at least the size of a UDP packet in prvProcessIPPacket(). */
-				if( xHandler( ( Socket_t ) pxSocket,
-							  ( void* ) pcData,
-							  ( size_t ) ( pxNetworkBuffer->xDataLength - ipUDP_PAYLOAD_OFFSET_IPv4 ),
-							  &( xSourceAddress ),
-							  &( destinationAddress ) ) != 0 )
-				{
-					xReturn = pdFAIL; /* xHandler has consumed the data, do not add it to .xWaitingPacketsList'. */
-				}
-			}
-		}
-		#endif /* ipconfigUSE_CALLBACKS */
+        #if ( ipconfigUDP_MAX_RX_PACKETS > 0U )
+            {
+                if( xReturn == pdPASS )
+                {
+                    if( listCURRENT_LIST_LENGTH( &( pxSocket->u.xUDP.xWaitingPacketsList ) ) >= pxSocket->u.xUDP.uxMaxPackets )
+                    {
+                        FreeRTOS_debug_printf( ( "xProcessReceivedUDPPacket: buffer full %ld >= %ld port %u\n",
+                                                 listCURRENT_LIST_LENGTH( &( pxSocket->u.xUDP.xWaitingPacketsList ) ),
+                                                 pxSocket->u.xUDP.uxMaxPackets, pxSocket->usLocalPort ) );
+                        xReturn = pdFAIL; /* we did not consume or release the buffer */
+                    }
+                }
+            }
+        #endif /* if ( ipconfigUDP_MAX_RX_PACKETS > 0U ) */
 
-		#if( ipconfigUDP_MAX_RX_PACKETS > 0U )
-		{
-			if( xReturn == pdPASS )
-			{
-				if ( listCURRENT_LIST_LENGTH( &( pxSocket->u.xUDP.xWaitingPacketsList ) ) >= pxSocket->u.xUDP.uxMaxPackets )
-				{
-					FreeRTOS_debug_printf( ( "xProcessReceivedUDPPacket: buffer full %ld >= %ld port %u\n",
-						listCURRENT_LIST_LENGTH( &( pxSocket->u.xUDP.xWaitingPacketsList ) ),
-						pxSocket->u.xUDP.uxMaxPackets, pxSocket->usLocalPort ) );
-					xReturn = pdFAIL; /* we did not consume or release the buffer */
-				}
-			}
-		}
-		#endif
+        #if ( ipconfigUSE_CALLBACKS == 1 ) || ( ipconfigUDP_MAX_RX_PACKETS > 0U )
+            if( xReturn == pdPASS ) /*lint !e774: Boolean within 'if' always evaluates to True, depending on configuration. [MISRA 2012 Rule 14.3, required. */
+        #else
+            /* xReturn is still pdPASS. */
+        #endif
+        {
+            vTaskSuspendAll();
+            {
+                taskENTER_CRITICAL();
+                {
+                    /* Add the network packet to the list of packets to be
+                     * processed by the socket. */
+                    vListInsertEnd( &( pxSocket->u.xUDP.xWaitingPacketsList ), &( pxNetworkBuffer->xBufferListItem ) );
+                }
+                taskEXIT_CRITICAL();
+            }
+            ( void ) xTaskResumeAll();
 
-		#if( ipconfigUSE_CALLBACKS == 1 ) || ( ipconfigUDP_MAX_RX_PACKETS > 0U )
-		if( xReturn == pdPASS )	/*lint !e774: Boolean within 'if' always evaluates to True, depending on configuration. [MISRA 2012 Rule 14.3, required. */
-		#else
-		/* xReturn is still pdPASS. */
-		#endif
-		{
-			vTaskSuspendAll();
-			{
-				taskENTER_CRITICAL();
-				{
-					/* Add the network packet to the list of packets to be
-					processed by the socket. */
-					vListInsertEnd( &( pxSocket->u.xUDP.xWaitingPacketsList ), &( pxNetworkBuffer->xBufferListItem ) );
-				}
-				taskEXIT_CRITICAL();
-			}
-			( void ) xTaskResumeAll();
+            /* Set the socket's receive event */
+            if( pxSocket->xEventGroup != NULL )
+            {
+                ( void ) xEventGroupSetBits( pxSocket->xEventGroup, ( EventBits_t ) eSOCKET_RECEIVE );
+            }
 
-			/* Set the socket's receive event */
-			if( pxSocket->xEventGroup != NULL )
-			{
-				( void ) xEventGroupSetBits( pxSocket->xEventGroup, ( EventBits_t ) eSOCKET_RECEIVE );
-			}
+            #if ( ipconfigSUPPORT_SELECT_FUNCTION == 1 )
+                {
+                    if( ( pxSocket->pxSocketSet != NULL ) && ( ( pxSocket->xSelectBits & ( ( EventBits_t ) eSELECT_READ ) ) != 0U ) )
+                    {
+                        ( void ) xEventGroupSetBits( pxSocket->pxSocketSet->xSelectGroup, ( EventBits_t ) eSELECT_READ );
+                    }
+                }
+            #endif
 
-			#if( ipconfigSUPPORT_SELECT_FUNCTION == 1 )
-			{
-				if( ( pxSocket->pxSocketSet != NULL ) && ( ( pxSocket->xSelectBits & ( ( EventBits_t ) eSELECT_READ ) ) != 0U ) )
-				{
-					( void ) xEventGroupSetBits( pxSocket->pxSocketSet->xSelectGroup, ( EventBits_t ) eSELECT_READ );
-				}
-			}
-			#endif
+            #if ( ipconfigSOCKET_HAS_USER_SEMAPHORE == 1 )
+                {
+                    if( pxSocket->pxUserSemaphore != NULL )
+                    {
+                        ( void ) xSemaphoreGive( pxSocket->pxUserSemaphore );
+                    }
+                }
+            #endif
 
-			#if( ipconfigSOCKET_HAS_USER_SEMAPHORE == 1 )
-			{
-				if( pxSocket->pxUserSemaphore != NULL )
-				{
-					( void ) xSemaphoreGive( pxSocket->pxUserSemaphore );
-				}
-			}
-			#endif
+            #if ( ipconfigUSE_DHCP == 1 )
+                {
+                    if( xIsDHCPSocket( pxSocket ) != 0 )
+                    {
+                        ( void ) xSendEventToIPTask( eDHCPEvent );
+                    }
+                }
+            #endif
+        }
+    }
+    else
+    {
+        /* There is no socket listening to the target port, but still it might
+         * be for this node. */
 
-			#if( ipconfigUSE_DHCP == 1 )
-			{
-				if( xIsDHCPSocket( pxSocket ) != 0 )
-				{
-					( void ) xSendEventToIPTask( eDHCPEvent );
-				}
-			}
-			#endif
-		}
-	}
-	else
-	{
-		/* There is no socket listening to the target port, but still it might
-		be for this node. */
+        #if ( ipconfigUSE_DNS == 1 ) && ( ipconfigDNS_USE_CALLBACKS == 1 )
+            /* A DNS reply, check for the source port.  Although the DNS client
+             * does open a UDP socket to send a messages, this socket will be
+             * closed after a short timeout.  Messages that come late (after the
+             * socket is closed) will be treated here. */
+            if( FreeRTOS_ntohs( pxUDPPacket->xUDPHeader.usSourcePort ) == ( uint16_t ) ipDNS_PORT )
+            {
+                vARPRefreshCacheEntry( &( pxUDPPacket->xEthernetHeader.xSourceAddress ), pxUDPPacket->xIPHeader.ulSourceIPAddress );
+                xReturn = ( BaseType_t ) ulDNSHandlePacket( pxNetworkBuffer );
+            }
+            else
+        #endif
 
-		#if( ipconfigUSE_DNS == 1 ) && ( ipconfigDNS_USE_CALLBACKS == 1 )
-			/* A DNS reply, check for the source port.  Although the DNS client
-			does open a UDP socket to send a messages, this socket will be
-			closed after a short timeout.  Messages that come late (after the
-			socket is closed) will be treated here. */
-			if( FreeRTOS_ntohs( pxUDPPacket->xUDPHeader.usSourcePort ) == ( uint16_t ) ipDNS_PORT )
-			{
-				vARPRefreshCacheEntry( &( pxUDPPacket->xEthernetHeader.xSourceAddress ), pxUDPPacket->xIPHeader.ulSourceIPAddress );
-				xReturn = ( BaseType_t )ulDNSHandlePacket( pxNetworkBuffer );
-			}
-			else
-		#endif
+        #if ( ipconfigUSE_LLMNR == 1 )
+            /* A LLMNR request, check for the destination port. */
+            if( ( usPort == FreeRTOS_ntohs( ipLLMNR_PORT ) ) ||
+                ( pxUDPPacket->xUDPHeader.usSourcePort == FreeRTOS_ntohs( ipLLMNR_PORT ) ) )
+            {
+                vARPRefreshCacheEntry( &( pxUDPPacket->xEthernetHeader.xSourceAddress ), pxUDPPacket->xIPHeader.ulSourceIPAddress );
+                xReturn = ( BaseType_t ) ulDNSHandlePacket( pxNetworkBuffer );
+            }
+            else
+        #endif /* ipconfigUSE_LLMNR */
 
-		#if( ipconfigUSE_LLMNR == 1 )
-			/* A LLMNR request, check for the destination port. */
-			if( ( usPort == FreeRTOS_ntohs( ipLLMNR_PORT ) ) ||
-				( pxUDPPacket->xUDPHeader.usSourcePort == FreeRTOS_ntohs( ipLLMNR_PORT ) ) )
-			{
-				vARPRefreshCacheEntry( &( pxUDPPacket->xEthernetHeader.xSourceAddress ), pxUDPPacket->xIPHeader.ulSourceIPAddress );
-				xReturn = ( BaseType_t )ulDNSHandlePacket( pxNetworkBuffer );
-			}
-			else
-		#endif /* ipconfigUSE_LLMNR */
+        #if ( ipconfigUSE_NBNS == 1 )
+            /* a NetBIOS request, check for the destination port */
+            if( ( usPort == FreeRTOS_ntohs( ipNBNS_PORT ) ) ||
+                ( pxUDPPacket->xUDPHeader.usSourcePort == FreeRTOS_ntohs( ipNBNS_PORT ) ) )
+            {
+                vARPRefreshCacheEntry( &( pxUDPPacket->xEthernetHeader.xSourceAddress ), pxUDPPacket->xIPHeader.ulSourceIPAddress );
+                xReturn = ( BaseType_t ) ulNBNSHandlePacket( pxNetworkBuffer );
+            }
+            else
+        #endif /* ipconfigUSE_NBNS */
+        {
+            xReturn = pdFAIL;
+        }
+    }
 
-		#if( ipconfigUSE_NBNS == 1 )
-			/* a NetBIOS request, check for the destination port */
-			if( ( usPort == FreeRTOS_ntohs( ipNBNS_PORT ) ) ||
-				( pxUDPPacket->xUDPHeader.usSourcePort == FreeRTOS_ntohs( ipNBNS_PORT ) ) )
-			{
-				vARPRefreshCacheEntry( &( pxUDPPacket->xEthernetHeader.xSourceAddress ), pxUDPPacket->xIPHeader.ulSourceIPAddress );
-				xReturn = ( BaseType_t )ulNBNSHandlePacket( pxNetworkBuffer );
-			}
-			else
-		#endif /* ipconfigUSE_NBNS */
-			{
-				xReturn = pdFAIL;
-			}
-	}
-
-	return xReturn;
+    return xReturn;
 }
 /*-----------------------------------------------------------*/

--- a/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/include/FreeRTOSIPConfigDefaults.h
+++ b/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/include/FreeRTOSIPConfigDefaults.h
@@ -29,126 +29,128 @@
 #define FREERTOS_DEFAULT_IP_CONFIG_H
 
 /* The error numbers defined in this file will be moved to the core FreeRTOS
-code in future versions of FreeRTOS - at which time the following header file
-will be removed. */
+ * code in future versions of FreeRTOS - at which time the following header file
+ * will be removed. */
 #include "FreeRTOS_errno_TCP.h"
 
 /* This file provides default values for configuration options that are missing
-from the FreeRTOSIPConfig.h configuration header file. */
+ * from the FreeRTOSIPConfig.h configuration header file. */
 
 
 /* Ensure defined configuration constants are using the most up to date naming. */
 #ifdef tcpconfigIP_TIME_TO_LIVE
-	#error now called: ipconfigTCP_TIME_TO_LIVE
+    #error now called: ipconfigTCP_TIME_TO_LIVE
 #endif
 
 #ifdef updconfigIP_TIME_TO_LIVE
-	#error now called: ipconfigUDP_TIME_TO_LIVE
+    #error now called: ipconfigUDP_TIME_TO_LIVE
 #endif
 
 #ifdef ipFILLER_SIZE
-	#error now called: ipconfigPACKET_FILLER_SIZE
+    #error now called: ipconfigPACKET_FILLER_SIZE
 #endif
 
 #ifdef dnsMAX_REQUEST_ATTEMPTS
-	#error now called: ipconfigDNS_REQUEST_ATTEMPTS
+    #error now called: ipconfigDNS_REQUEST_ATTEMPTS
 #endif
 
 #ifdef ipconfigUDP_TASK_PRIORITY
-	#error now called: ipconfigIP_TASK_PRIORITY
+    #error now called: ipconfigIP_TASK_PRIORITY
 #endif
 
 #ifdef ipconfigUDP_TASK_STACK_SIZE_WORDS
-	#error now called: ipconfigIP_TASK_STACK_SIZE_WORDS
+    #error now called: ipconfigIP_TASK_STACK_SIZE_WORDS
 #endif
 
 #ifdef ipconfigDRIVER_INCLUDED_RX_IP_FILTERING
-	#error now called: ipconfigETHERNET_DRIVER_FILTERS_PACKETS
+    #error now called: ipconfigETHERNET_DRIVER_FILTERS_PACKETS
 #endif
 
 #ifdef ipconfigMAX_SEND_BLOCK_TIME_TICKS
-	#error now called: ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS
+    #error now called: ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS
 #endif
 
 #ifdef ipconfigUSE_RECEIVE_CONNECT_CALLBACKS
-	#error now called: ipconfigUSE_CALLBACKS
+    #error now called: ipconfigUSE_CALLBACKS
 #endif
 
 #ifdef ipconfigNUM_NETWORK_BUFFERS
-	#error now called: ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS
+    #error now called: ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS
 #endif
 
 #ifdef ipconfigTCP_HANG_PROT
-	#error now called: ipconfigTCP_HANG_PROTECTION
+    #error now called: ipconfigTCP_HANG_PROTECTION
 #endif
 
 #ifdef ipconfigTCP_HANG_PROT_TIME
-	#error now called: ipconfigTCP_HANG_PROTECTION_TIME
+    #error now called: ipconfigTCP_HANG_PROTECTION_TIME
 #endif
 
 #ifdef FreeRTOS_lprintf
-	#error now called: FreeRTOS_debug_printf
+    #error now called: FreeRTOS_debug_printf
 #endif
 
 #if ( ipconfigEVENT_QUEUE_LENGTH < ( ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS + 5 ) )
-	#error The ipconfigEVENT_QUEUE_LENGTH parameter must be at least ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS + 5
+    #error The ipconfigEVENT_QUEUE_LENGTH parameter must be at least ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS + 5
 #endif
 
 #if ( ipconfigNETWORK_MTU < 46 )
-	#error ipconfigNETWORK_MTU must be at least 46.
+    #error ipconfigNETWORK_MTU must be at least 46.
 #endif
 
-#ifdef	ipconfigBUFFER_ALLOC_FIXED_SIZE
-	#error ipconfigBUFFER_ALLOC_FIXED_SIZE was dropped and replaced by a const value, declared in BufferAllocation[12].c
+#ifdef  ipconfigBUFFER_ALLOC_FIXED_SIZE
+    #error ipconfigBUFFER_ALLOC_FIXED_SIZE was dropped and replaced by a const value, declared in BufferAllocation[12].c
 #endif
 
-#ifdef	ipconfigNIC_SEND_PASSES_DMA
-	#error now called: ipconfigZERO_COPY_TX_DRIVER
+#ifdef  ipconfigNIC_SEND_PASSES_DMA
+    #error now called: ipconfigZERO_COPY_TX_DRIVER
 #endif
 
-#ifdef	HAS_TX_CRC_OFFLOADING
-	/* _HT_ As these macro names have changed, throw an error
-	if they're still defined. */
-	#error now called: ipconfigHAS_TX_CRC_OFFLOADING
+#ifdef  HAS_TX_CRC_OFFLOADING
+
+    /* _HT_ As these macro names have changed, throw an error
+     * if they're still defined. */
+    #error now called: ipconfigHAS_TX_CRC_OFFLOADING
 #endif
 
-#ifdef	HAS_RX_CRC_OFFLOADING
-	#error now called: ipconfigHAS_RX_CRC_OFFLOADING
+#ifdef  HAS_RX_CRC_OFFLOADING
+    #error now called: ipconfigHAS_RX_CRC_OFFLOADING
 #endif
 
 #ifdef ipconfigTCP_RX_BUF_LEN
-	#error ipconfigTCP_RX_BUF_LEN is now called ipconfigTCP_RX_BUFFER_LENGTH
+    #error ipconfigTCP_RX_BUF_LEN is now called ipconfigTCP_RX_BUFFER_LENGTH
 #endif
 
 #ifdef ipconfigTCP_TX_BUF_LEN
-	#error ipconfigTCP_TX_BUF_LEN is now called ipconfigTCP_TX_BUFFER_LENGTH
+    #error ipconfigTCP_TX_BUF_LEN is now called ipconfigTCP_TX_BUFFER_LENGTH
 #endif
 
 #ifdef ipconfigDHCP_USES_USER_HOOK
-	#error ipconfigDHCP_USES_USER_HOOK and its associated callback have been superceeded - see http://www.FreeRTOS.org/FreeRTOS-Plus/FreeRTOS_Plus_TCP/TCP_IP_Configuration.html#ipconfigUSE_DHCP_HOOK
+    #error ipconfigDHCP_USES_USER_HOOK and its associated callback have been superceeded - see http: /*www.FreeRTOS.org/FreeRTOS-Plus/FreeRTOS_Plus_TCP/TCP_IP_Configuration.html#ipconfigUSE_DHCP_HOOK */
 #endif
 
 #ifndef ipconfigUSE_TCP
-	#define	ipconfigUSE_TCP						( 1 )
+    #define ipconfigUSE_TCP    ( 1 )
 #endif
 
-#if	ipconfigUSE_TCP
+#if ipconfigUSE_TCP
 
-	/* Include support for TCP scaling windows */
-	#ifndef ipconfigUSE_TCP_WIN
-		#define ipconfigUSE_TCP_WIN				( 1 )
-	#endif
+    /* Include support for TCP scaling windows */
+    #ifndef ipconfigUSE_TCP_WIN
+        #define ipconfigUSE_TCP_WIN    ( 1 )
+    #endif
 
-	#ifndef ipconfigTCP_WIN_SEG_COUNT
-		#define	ipconfigTCP_WIN_SEG_COUNT		( 256 )
-	#endif
+    #ifndef ipconfigTCP_WIN_SEG_COUNT
+        #define ipconfigTCP_WIN_SEG_COUNT    ( 256 )
+    #endif
 
-	#ifndef ipconfigIGNORE_UNKNOWN_PACKETS
-		/* When non-zero, TCP will not send RST packets in reply to
-		TCP packets which are unknown, or out-of-order. */
-		#define ipconfigIGNORE_UNKNOWN_PACKETS	( 0 )
-	#endif
-#endif
+    #ifndef ipconfigIGNORE_UNKNOWN_PACKETS
+
+        /* When non-zero, TCP will not send RST packets in reply to
+         * TCP packets which are unknown, or out-of-order. */
+        #define ipconfigIGNORE_UNKNOWN_PACKETS    ( 0 )
+    #endif
+#endif /* if ipconfigUSE_TCP */
 
 /*
  * For debuging/logging: check if the port number is used for telnet
@@ -157,26 +159,27 @@ from the FreeRTOSIPConfig.h configuration header file. */
  * This macro will only be used if FreeRTOS_debug_printf() is defined for logging
  */
 #ifndef ipconfigTCP_MAY_LOG_PORT
-	#define ipconfigTCP_MAY_LOG_PORT(xPort)			( ( xPort ) != 23U )
+    #define ipconfigTCP_MAY_LOG_PORT( xPort )    ( ( xPort ) != 23U )
 #endif
 
 
-#ifndef	ipconfigSOCK_DEFAULT_RECEIVE_BLOCK_TIME
-	#define	ipconfigSOCK_DEFAULT_RECEIVE_BLOCK_TIME	portMAX_DELAY
+#ifndef ipconfigSOCK_DEFAULT_RECEIVE_BLOCK_TIME
+    #define ipconfigSOCK_DEFAULT_RECEIVE_BLOCK_TIME    portMAX_DELAY
 #endif
 
-#ifndef	ipconfigSOCK_DEFAULT_SEND_BLOCK_TIME
-	#define	ipconfigSOCK_DEFAULT_SEND_BLOCK_TIME	portMAX_DELAY
+#ifndef ipconfigSOCK_DEFAULT_SEND_BLOCK_TIME
+    #define ipconfigSOCK_DEFAULT_SEND_BLOCK_TIME    portMAX_DELAY
 #endif
 
 
-#ifndef	ipconfigDNS_RECEIVE_BLOCK_TIME_TICKS
-	#define	ipconfigDNS_RECEIVE_BLOCK_TIME_TICKS	pdMS_TO_TICKS( 5000U )
+#ifndef ipconfigDNS_RECEIVE_BLOCK_TIME_TICKS
+    #define ipconfigDNS_RECEIVE_BLOCK_TIME_TICKS    pdMS_TO_TICKS( 5000U )
 #endif
 
-#ifndef	ipconfigDNS_SEND_BLOCK_TIME_TICKS
-	#define	ipconfigDNS_SEND_BLOCK_TIME_TICKS		pdMS_TO_TICKS( 500U )
+#ifndef ipconfigDNS_SEND_BLOCK_TIME_TICKS
+    #define ipconfigDNS_SEND_BLOCK_TIME_TICKS    pdMS_TO_TICKS( 500U )
 #endif
+
 /*
  * FreeRTOS debug logging routine (proposal)
  * The macro will be called in the printf() style. Users can define
@@ -188,16 +191,16 @@ from the FreeRTOSIPConfig.h configuration header file. */
  * interrupt-safe.
  */
 #ifdef ipconfigHAS_DEBUG_PRINTF
-	#if( ipconfigHAS_DEBUG_PRINTF == 0 )
-		#ifdef FreeRTOS_debug_printf
-			#error Do not define FreeRTOS_debug_print if ipconfigHAS_DEBUG_PRINTF is set to 0
-		#endif /* ifdef FreeRTOS_debug_printf */
-	#endif /* ( ipconfigHAS_DEBUG_PRINTF == 0 ) */
+    #if ( ipconfigHAS_DEBUG_PRINTF == 0 )
+        #ifdef FreeRTOS_debug_printf
+            #error Do not define FreeRTOS_debug_print if ipconfigHAS_DEBUG_PRINTF is set to 0
+        #endif /* ifdef FreeRTOS_debug_printf */
+    #endif /* ( ipconfigHAS_DEBUG_PRINTF == 0 ) */
 #endif /* ifdef ipconfigHAS_DEBUG_PRINTF */
 
 #ifndef FreeRTOS_debug_printf
-    #define FreeRTOS_debug_printf( MSG )		do{} while( ipFALSE_BOOL )
-	#define ipconfigHAS_DEBUG_PRINTF			0
+    #define FreeRTOS_debug_printf( MSG )    do{} while( ipFALSE_BOOL )
+    #define ipconfigHAS_DEBUG_PRINTF    0
 #endif
 
 /*
@@ -209,16 +212,16 @@ from the FreeRTOSIPConfig.h configuration header file. */
  * The FreeRTOS_printf() must be thread-safe but does not have to be interrupt-safe
  */
 #ifdef ipconfigHAS_PRINTF
-	#if( ipconfigHAS_PRINTF == 0 )
-		#ifdef FreeRTOS_printf
-			#error Do not define FreeRTOS_print if ipconfigHAS_PRINTF is set to 0
-		#endif /* ifdef FreeRTOS_debug_printf */
-	#endif /* ( ipconfigHAS_PRINTF == 0 ) */
+    #if ( ipconfigHAS_PRINTF == 0 )
+        #ifdef FreeRTOS_printf
+            #error Do not define FreeRTOS_print if ipconfigHAS_PRINTF is set to 0
+        #endif /* ifdef FreeRTOS_debug_printf */
+    #endif /* ( ipconfigHAS_PRINTF == 0 ) */
 #endif /* ifdef ipconfigHAS_PRINTF */
 
 #ifndef FreeRTOS_printf
-    #define FreeRTOS_printf( MSG )				do{} while( ipFALSE_BOOL )
-	#define ipconfigHAS_PRINTF					0
+    #define FreeRTOS_printf( MSG )    do{} while( ipFALSE_BOOL )
+    #define ipconfigHAS_PRINTF    0
 #endif
 
 /*
@@ -227,7 +230,7 @@ from the FreeRTOSIPConfig.h configuration header file. */
  * An example of this is the netstat command, which produces many lines of logging
  */
 #ifndef FreeRTOS_flush_logging
-    #define FreeRTOS_flush_logging( )			do{} while( ipFALSE_BOOL )
+    #define FreeRTOS_flush_logging()    do{} while( ipFALSE_BOOL )
 #endif
 
 /* Malloc functions. Within most applications of FreeRTOS, the couple
@@ -238,19 +241,19 @@ from the FreeRTOSIPConfig.h configuration header file. */
  * MallocSocket is used to allocate the space for the sockets
  */
 #ifndef pvPortMallocLarge
-	#define pvPortMallocLarge( x )				pvPortMalloc( x )
+    #define pvPortMallocLarge( x )    pvPortMalloc( x )
 #endif
 
 #ifndef vPortFreeLarge
-	#define vPortFreeLarge(ptr)					vPortFree(ptr)
+    #define vPortFreeLarge( ptr )    vPortFree( ptr )
 #endif
 
 #ifndef pvPortMallocSocket
-	#define pvPortMallocSocket( x )				pvPortMalloc( x )
+    #define pvPortMallocSocket( x )    pvPortMalloc( x )
 #endif
 
 #ifndef vPortFreeSocket
-	#define vPortFreeSocket(ptr)				vPortFree(ptr)
+    #define vPortFreeSocket( ptr )    vPortFree( ptr )
 #endif
 
 /*
@@ -263,107 +266,110 @@ from the FreeRTOSIPConfig.h configuration header file. */
  *            uses a 'random' or anonymous port number
  */
 #ifndef ipconfigRAND32
-	#define ipconfigRAND32() rand()
+    #define ipconfigRAND32()    rand()
 #endif
+
 /* --------------------------------------------------------
  * End of: HT Added some macro defaults for the PLUS-UDP project
  * -------------------------------------------------------- */
 
 #ifndef ipconfigUSE_NETWORK_EVENT_HOOK
-	#define ipconfigUSE_NETWORK_EVENT_HOOK 0
+    #define ipconfigUSE_NETWORK_EVENT_HOOK    0
 #endif
 
 #ifndef ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS
-	#define ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS ( pdMS_TO_TICKS( 20U ) )
+    #define ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS    ( pdMS_TO_TICKS( 20U ) )
 #endif
 
 #ifndef ipconfigARP_CACHE_ENTRIES
-	#define ipconfigARP_CACHE_ENTRIES		10
+    #define ipconfigARP_CACHE_ENTRIES    10
 #endif
 
 #ifndef ipconfigMAX_ARP_RETRANSMISSIONS
-	#define ipconfigMAX_ARP_RETRANSMISSIONS ( 5U )
+    #define ipconfigMAX_ARP_RETRANSMISSIONS    ( 5U )
 #endif
 
 #ifndef ipconfigMAX_ARP_AGE
-	#define ipconfigMAX_ARP_AGE			150U
+    #define ipconfigMAX_ARP_AGE    150U
 #endif
 
 #ifndef ipconfigUSE_ARP_REVERSED_LOOKUP
-	#define ipconfigUSE_ARP_REVERSED_LOOKUP		0
+    #define ipconfigUSE_ARP_REVERSED_LOOKUP    0
 #endif
 
 #ifndef ipconfigUSE_ARP_REMOVE_ENTRY
-	#define	ipconfigUSE_ARP_REMOVE_ENTRY		0
+    #define ipconfigUSE_ARP_REMOVE_ENTRY    0
 #endif
 
 #ifndef ipconfigINCLUDE_FULL_INET_ADDR
-	#define ipconfigINCLUDE_FULL_INET_ADDR	1
+    #define ipconfigINCLUDE_FULL_INET_ADDR    1
 #endif
 
 #ifndef ipconfigUSE_LINKED_RX_MESSAGES
-	#define ipconfigUSE_LINKED_RX_MESSAGES			0
+    #define ipconfigUSE_LINKED_RX_MESSAGES    0
 #endif
 
 #ifndef ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS
-	#define ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS		45
+    #define ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS    45
 #endif
 
 #ifndef ipconfigEVENT_QUEUE_LENGTH
-	#define ipconfigEVENT_QUEUE_LENGTH		( ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS + 5 )
+    #define ipconfigEVENT_QUEUE_LENGTH    ( ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS + 5 )
 #endif
 
 #ifndef ipconfigALLOW_SOCKET_SEND_WITHOUT_BIND
-	#define ipconfigALLOW_SOCKET_SEND_WITHOUT_BIND 1
+    #define ipconfigALLOW_SOCKET_SEND_WITHOUT_BIND    1
 #endif
 
 #ifndef ipconfigUDP_TIME_TO_LIVE
-	#define ipconfigUDP_TIME_TO_LIVE		128
+    #define ipconfigUDP_TIME_TO_LIVE    128
 #endif
 
 #ifndef ipconfigTCP_TIME_TO_LIVE
-	#define ipconfigTCP_TIME_TO_LIVE		128
+    #define ipconfigTCP_TIME_TO_LIVE    128
 #endif
 
 #ifndef ipconfigUDP_MAX_RX_PACKETS
-	/* Make postive to define the maximum number of packets which will be buffered
-	 * for each UDP socket.
-	 * Can be overridden with the socket option FREERTOS_SO_UDP_MAX_RX_PACKETS
-	 */
-	#define ipconfigUDP_MAX_RX_PACKETS		0U
+
+    /* Make postive to define the maximum number of packets which will be buffered
+     * for each UDP socket.
+     * Can be overridden with the socket option FREERTOS_SO_UDP_MAX_RX_PACKETS
+     */
+    #define ipconfigUDP_MAX_RX_PACKETS    0U
 #endif
 
 #ifndef ipconfigUSE_DHCP
-	#define ipconfigUSE_DHCP				1
+    #define ipconfigUSE_DHCP    1
 #endif
 
 #ifndef ipconfigUSE_DHCP_HOOK
-	#define ipconfigUSE_DHCP_HOOK		0
+    #define ipconfigUSE_DHCP_HOOK    0
 #endif
 
 #ifndef ipconfigDHCP_FALL_BACK_AUTO_IP
-	/*
-	 * Only applicable when DHCP is in use:
-	 * If no DHCP server responds, use "Auto-IP" : the
-	 * device will allocate a random LinkLayer IP address.
-	 */
-	#define ipconfigDHCP_FALL_BACK_AUTO_IP		( 0 )
+
+    /*
+     * Only applicable when DHCP is in use:
+     * If no DHCP server responds, use "Auto-IP" : the
+     * device will allocate a random LinkLayer IP address.
+     */
+    #define ipconfigDHCP_FALL_BACK_AUTO_IP    ( 0 )
 #endif
 
-#if( ipconfigDHCP_FALL_BACK_AUTO_IP != 0 )
-	#define ipconfigARP_USE_CLASH_DETECTION		1
+#if ( ipconfigDHCP_FALL_BACK_AUTO_IP != 0 )
+    #define ipconfigARP_USE_CLASH_DETECTION    1
 #endif
 
 #ifndef ipconfigARP_USE_CLASH_DETECTION
-	#define ipconfigARP_USE_CLASH_DETECTION		0
+    #define ipconfigARP_USE_CLASH_DETECTION    0
 #endif
 
 #ifndef ipconfigNETWORK_MTU
-	#define ipconfigNETWORK_MTU		1500
+    #define ipconfigNETWORK_MTU    1500
 #endif
 
 #ifndef ipconfigTCP_MSS
-	#define ipconfigTCP_MSS		( ipconfigNETWORK_MTU - ( ipSIZE_OF_IPv4_HEADER + ipSIZE_OF_TCP_HEADER  ) )
+    #define ipconfigTCP_MSS    ( ipconfigNETWORK_MTU - ( ipSIZE_OF_IPv4_HEADER + ipSIZE_OF_TCP_HEADER ) )
 #endif
 
 /* Each TCP socket has circular stream buffers for Rx and Tx, which
@@ -371,215 +377,221 @@ from the FreeRTOSIPConfig.h configuration header file. */
  * The defaults for these size are defined here, although
  * they can be overridden at runtime by using the setsockopt() call */
 #ifndef ipconfigTCP_RX_BUFFER_LENGTH
-	#define ipconfigTCP_RX_BUFFER_LENGTH			( 4U * ipconfigTCP_MSS )	/* defaults to 5840 bytes */
+    #define ipconfigTCP_RX_BUFFER_LENGTH    ( 4U * ipconfigTCP_MSS )            /* defaults to 5840 bytes */
 #endif
 
 /* Define the size of Tx stream buffer for TCP sockets */
 #ifndef ipconfigTCP_TX_BUFFER_LENGTH
-#	define ipconfigTCP_TX_BUFFER_LENGTH			( 4U * ipconfigTCP_MSS )	/* defaults to 5840 bytes */
+    #define ipconfigTCP_TX_BUFFER_LENGTH    ( 4U * ipconfigTCP_MSS )        /* defaults to 5840 bytes */
 #endif
 
 #ifndef ipconfigMAXIMUM_DISCOVER_TX_PERIOD
-	#ifdef _WINDOWS_
-		#define ipconfigMAXIMUM_DISCOVER_TX_PERIOD		( pdMS_TO_TICKS( 999U ) )
-	#else
-		#define ipconfigMAXIMUM_DISCOVER_TX_PERIOD		( pdMS_TO_TICKS( 30000U ) )
-	#endif /* _WINDOWS_ */
+    #ifdef _WINDOWS_
+        #define ipconfigMAXIMUM_DISCOVER_TX_PERIOD    ( pdMS_TO_TICKS( 999U ) )
+    #else
+        #define ipconfigMAXIMUM_DISCOVER_TX_PERIOD    ( pdMS_TO_TICKS( 30000U ) )
+    #endif /* _WINDOWS_ */
 #endif /* ipconfigMAXIMUM_DISCOVER_TX_PERIOD */
 
-#if( ipconfigUSE_DNS == 0 )
-	/* The DNS module will not be included. */
-	#if( ( ipconfigUSE_LLMNR != 0 ) || ( ipconfigUSE_NBNS != 0 ) )
-		/* LLMNR and NBNS depend on DNS because those protocols share a lot of code. */
-		#error When either LLMNR or NBNS is used, ipconfigUSE_DNS must be defined
-	#endif
+#if ( ipconfigUSE_DNS == 0 )
+    /* The DNS module will not be included. */
+    #if ( ( ipconfigUSE_LLMNR != 0 ) || ( ipconfigUSE_NBNS != 0 ) )
+        /* LLMNR and NBNS depend on DNS because those protocols share a lot of code. */
+        #error When either LLMNR or NBNS is used, ipconfigUSE_DNS must be defined
+    #endif
 #endif
 
 #ifndef ipconfigUSE_DNS
-	#define ipconfigUSE_DNS						1
+    #define ipconfigUSE_DNS    1
 #endif
 
 #ifndef ipconfigDNS_REQUEST_ATTEMPTS
-	#define ipconfigDNS_REQUEST_ATTEMPTS		5
+    #define ipconfigDNS_REQUEST_ATTEMPTS    5
 #endif
 
 #ifndef ipconfigUSE_DNS_CACHE
-	#define ipconfigUSE_DNS_CACHE				0
+    #define ipconfigUSE_DNS_CACHE    0
 #endif
 
-#if( ipconfigUSE_DNS_CACHE != 0 )
-	#ifndef ipconfigDNS_CACHE_NAME_LENGTH
-		/* Per https://tools.ietf.org/html/rfc1035, 253 is the maximum string length
-		of a DNS name. The following default accounts for a null terminator. */
-		#define ipconfigDNS_CACHE_NAME_LENGTH   254
-	#endif
+#if ( ipconfigUSE_DNS_CACHE != 0 )
+    #ifndef ipconfigDNS_CACHE_NAME_LENGTH
 
-	#ifndef ipconfigDNS_CACHE_ENTRIES
-		#define ipconfigDNS_CACHE_ENTRIES			1
-	#endif
+        /* Per https://tools.ietf.org/html/rfc1035, 253 is the maximum string length
+         * of a DNS name. The following default accounts for a null terminator. */
+        #define ipconfigDNS_CACHE_NAME_LENGTH    254
+    #endif
+
+    #ifndef ipconfigDNS_CACHE_ENTRIES
+        #define ipconfigDNS_CACHE_ENTRIES    1
+    #endif
 
 #endif /* ipconfigUSE_DNS_CACHE != 0 */
 
 /* When accessing services which have multiple IP addresses, setting this
-greater than 1 can improve reliability by returning different IP address
-answers on successive calls to FreeRTOS_gethostbyname(). */
-#ifndef ipconfigDNS_CACHE_ADDRESSES_PER_ENTRY 
-	#define ipconfigDNS_CACHE_ADDRESSES_PER_ENTRY 1
+ * greater than 1 can improve reliability by returning different IP address
+ * answers on successive calls to FreeRTOS_gethostbyname(). */
+#ifndef ipconfigDNS_CACHE_ADDRESSES_PER_ENTRY
+    #define ipconfigDNS_CACHE_ADDRESSES_PER_ENTRY    1
 #endif
 
 #ifndef ipconfigCHECK_IP_QUEUE_SPACE
-	#define ipconfigCHECK_IP_QUEUE_SPACE			0
+    #define ipconfigCHECK_IP_QUEUE_SPACE    0
 #endif
 
 #ifndef ipconfigUSE_LLMNR
-	/* Include support for LLMNR: Link-local Multicast Name Resolution (non-Microsoft) */
-	#define ipconfigUSE_LLMNR					( 0 )
+    /* Include support for LLMNR: Link-local Multicast Name Resolution (non-Microsoft) */
+    #define ipconfigUSE_LLMNR    ( 0 )
 #endif
 
 #ifndef ipconfigREPLY_TO_INCOMING_PINGS
-	#define ipconfigREPLY_TO_INCOMING_PINGS		1
+    #define ipconfigREPLY_TO_INCOMING_PINGS    1
 #endif
 
 #ifndef ipconfigSUPPORT_OUTGOING_PINGS
-	#define ipconfigSUPPORT_OUTGOING_PINGS		0
+    #define ipconfigSUPPORT_OUTGOING_PINGS    0
 #endif
 
 #ifndef ipconfigFILTER_OUT_NON_ETHERNET_II_FRAMES
-	#define ipconfigFILTER_OUT_NON_ETHERNET_II_FRAMES 1
+    #define ipconfigFILTER_OUT_NON_ETHERNET_II_FRAMES    1
 #endif
 
 #ifndef ipconfigETHERNET_DRIVER_FILTERS_FRAME_TYPES
-	#define ipconfigETHERNET_DRIVER_FILTERS_FRAME_TYPES	1
+    #define ipconfigETHERNET_DRIVER_FILTERS_FRAME_TYPES    1
 #endif
 
 #ifndef configINCLUDE_TRACE_RELATED_CLI_COMMANDS
-	#define ipconfigINCLUDE_EXAMPLE_FREERTOS_PLUS_TRACE_CALLS 0
+    #define ipconfigINCLUDE_EXAMPLE_FREERTOS_PLUS_TRACE_CALLS    0
 #else
-	#define ipconfigINCLUDE_EXAMPLE_FREERTOS_PLUS_TRACE_CALLS configINCLUDE_TRACE_RELATED_CLI_COMMANDS
+    #define ipconfigINCLUDE_EXAMPLE_FREERTOS_PLUS_TRACE_CALLS    configINCLUDE_TRACE_RELATED_CLI_COMMANDS
 #endif
 
 #ifndef ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM
-	#define	ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM	( 0 )
+    #define ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM    ( 0 )
 #endif
 
 #ifndef ipconfigETHERNET_DRIVER_FILTERS_PACKETS
-	#define	ipconfigETHERNET_DRIVER_FILTERS_PACKETS	( 0 )
+    #define ipconfigETHERNET_DRIVER_FILTERS_PACKETS    ( 0 )
 #endif
 
 #ifndef ipconfigWATCHDOG_TIMER
-	/* This macro will be called in every loop the IP-task makes.  It may be
-	replaced by user-code that triggers a watchdog */
-	#define ipconfigWATCHDOG_TIMER()
+
+    /* This macro will be called in every loop the IP-task makes.  It may be
+     * replaced by user-code that triggers a watchdog */
+    #define ipconfigWATCHDOG_TIMER()
 #endif
 
 #ifndef ipconfigUSE_CALLBACKS
-	#define ipconfigUSE_CALLBACKS			( 0 )
+    #define ipconfigUSE_CALLBACKS    ( 0 )
 #endif
 
-#if( ipconfigUSE_CALLBACKS != 0 )
-	#ifndef ipconfigIS_VALID_PROG_ADDRESS
-		/* Replace this macro with a test returning non-zero if the memory pointer to by x
-		 * is valid memory which can contain executable code
-		 * In fact this is an extra safety measure: if a handler points to invalid memory,
-		 * it will not be called
-		 */
-		#define ipconfigIS_VALID_PROG_ADDRESS(x)		( ( x ) != NULL )
-	#endif
+#if ( ipconfigUSE_CALLBACKS != 0 )
+    #ifndef ipconfigIS_VALID_PROG_ADDRESS
+
+        /* Replace this macro with a test returning non-zero if the memory pointer to by x
+         * is valid memory which can contain executable code
+         * In fact this is an extra safety measure: if a handler points to invalid memory,
+         * it will not be called
+         */
+        #define ipconfigIS_VALID_PROG_ADDRESS( x )    ( ( x ) != NULL )
+    #endif
 #endif
 
 #ifndef ipconfigHAS_INLINE_FUNCTIONS
-	#define	ipconfigHAS_INLINE_FUNCTIONS	( 1 )
+    #define ipconfigHAS_INLINE_FUNCTIONS    ( 1 )
 #endif
 
 #ifndef portINLINE
-	#define portINLINE inline
+    #define portINLINE    inline
 #endif
 
 #ifndef ipconfigZERO_COPY_TX_DRIVER
-	/* When non-zero, the buffers passed to the SEND routine may be passed
-	to DMA. As soon as sending is ready, the buffers must be released by
-	calling vReleaseNetworkBufferAndDescriptor(), */
-	#define ipconfigZERO_COPY_TX_DRIVER		( 0 )
+
+    /* When non-zero, the buffers passed to the SEND routine may be passed
+     * to DMA. As soon as sending is ready, the buffers must be released by
+     * calling vReleaseNetworkBufferAndDescriptor(), */
+    #define ipconfigZERO_COPY_TX_DRIVER    ( 0 )
 #endif
 
 #ifndef ipconfigZERO_COPY_RX_DRIVER
-	/* This define doesn't mean much to the driver, except that it makes
-	sure that pxPacketBuffer_to_NetworkBuffer() will be included. */
-	#define ipconfigZERO_COPY_RX_DRIVER		( 0 )
+
+    /* This define doesn't mean much to the driver, except that it makes
+     * sure that pxPacketBuffer_to_NetworkBuffer() will be included. */
+    #define ipconfigZERO_COPY_RX_DRIVER    ( 0 )
 #endif
 
 #ifndef ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM
-	#define ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM 0
+    #define ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM    0
 #endif
 
 #ifndef ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM
-	#define ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM 0
+    #define ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM    0
 #endif
 
 #ifndef ipconfigDHCP_REGISTER_HOSTNAME
-	#define ipconfigDHCP_REGISTER_HOSTNAME 0
+    #define ipconfigDHCP_REGISTER_HOSTNAME    0
 #endif
 
 #ifndef ipconfigSOCKET_HAS_USER_SEMAPHORE
-	#define ipconfigSOCKET_HAS_USER_SEMAPHORE 0
+    #define ipconfigSOCKET_HAS_USER_SEMAPHORE    0
 #endif
 
 #ifndef ipconfigSOCKET_HAS_USER_WAKE_CALLBACK
-	#define ipconfigSOCKET_HAS_USER_WAKE_CALLBACK 0
+    #define ipconfigSOCKET_HAS_USER_WAKE_CALLBACK    0
 #endif
 
 #ifndef ipconfigSUPPORT_SELECT_FUNCTION
-	#define ipconfigSUPPORT_SELECT_FUNCTION 0
+    #define ipconfigSUPPORT_SELECT_FUNCTION    0
 #endif
 
 #ifndef ipconfigTCP_KEEP_ALIVE
-	#define ipconfigTCP_KEEP_ALIVE 0
+    #define ipconfigTCP_KEEP_ALIVE    0
 #endif
 
 #ifndef ipconfigDNS_USE_CALLBACKS
-	#define ipconfigDNS_USE_CALLBACKS 0
+    #define ipconfigDNS_USE_CALLBACKS    0
 #endif
 
 #ifndef ipconfigSUPPORT_SIGNALS
-	#define ipconfigSUPPORT_SIGNALS				0
+    #define ipconfigSUPPORT_SIGNALS    0
 #endif
 
 #ifndef ipconfigUSE_NBNS
-	#define ipconfigUSE_NBNS 0
+    #define ipconfigUSE_NBNS    0
 #endif
 
-/* As an attack surface reduction for ports that listen for inbound 
-connections, hang protection can help reduce the impact of SYN floods. */
+/* As an attack surface reduction for ports that listen for inbound
+ * connections, hang protection can help reduce the impact of SYN floods. */
 #ifndef ipconfigTCP_HANG_PROTECTION
-	#define ipconfigTCP_HANG_PROTECTION  1
+    #define ipconfigTCP_HANG_PROTECTION    1
 #endif
 
 /* Non-activity timeout is expressed in seconds. */
 #ifndef ipconfigTCP_HANG_PROTECTION_TIME
-	#define ipconfigTCP_HANG_PROTECTION_TIME 30U
+    #define ipconfigTCP_HANG_PROTECTION_TIME    30U
 #endif
 
 #ifndef ipconfigTCP_IP_SANITY
-	#define ipconfigTCP_IP_SANITY 0
+    #define ipconfigTCP_IP_SANITY    0
 #endif
 
 #ifndef ipconfigARP_STORES_REMOTE_ADDRESSES
-	#define ipconfigARP_STORES_REMOTE_ADDRESSES 0
+    #define ipconfigARP_STORES_REMOTE_ADDRESSES    0
 #endif
 
 #ifndef ipconfigBUFFER_PADDING
-	/* Expert option: define a value for 'ipBUFFER_PADDING'.
-	When 'ipconfigBUFFER_PADDING' equals 0,
-	'ipBUFFER_PADDING' will get a default value of 8 + 2 bytes. */
-	#define ipconfigBUFFER_PADDING			0U
+
+    /* Expert option: define a value for 'ipBUFFER_PADDING'.
+     * When 'ipconfigBUFFER_PADDING' equals 0,
+     * 'ipBUFFER_PADDING' will get a default value of 8 + 2 bytes. */
+    #define ipconfigBUFFER_PADDING    0U
 #endif
 
 #ifndef ipconfigPACKET_FILLER_SIZE
-	#define ipconfigPACKET_FILLER_SIZE		2U
+    #define ipconfigPACKET_FILLER_SIZE    2U
 #endif
 
 #ifndef ipconfigSELECT_USES_NOTIFY
-	#define ipconfigSELECT_USES_NOTIFY		0
+    #define ipconfigSELECT_USES_NOTIFY    0
 #endif
 
 #endif /* FREERTOS_DEFAULT_IP_CONFIG_H */

--- a/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/include/FreeRTOS_ARP.h
+++ b/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/include/FreeRTOS_ARP.h
@@ -24,35 +24,35 @@
  */
 
 #ifndef FREERTOS_ARP_H
-#define FREERTOS_ARP_H
+    #define FREERTOS_ARP_H
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+    #ifdef __cplusplus
+        extern "C" {
+    #endif
 
 /* Application level configuration options. */
-#include "FreeRTOSIPConfig.h"
-#include "FreeRTOSIPConfigDefaults.h"
-#include "IPTraceMacroDefaults.h"
+    #include "FreeRTOSIPConfig.h"
+    #include "FreeRTOSIPConfigDefaults.h"
+    #include "IPTraceMacroDefaults.h"
 
 /*-----------------------------------------------------------*/
 /* Miscellaneous structure and definitions. */
 /*-----------------------------------------------------------*/
 
-typedef struct xARP_CACHE_TABLE_ROW
-{
-	uint32_t ulIPAddress;		/* The IP address of an ARP cache entry. */
-	MACAddress_t xMACAddress;	/* The MAC address of an ARP cache entry. */
-	uint8_t ucAge;				/* A value that is periodically decremented but can also be refreshed by active communication.  The ARP cache entry is removed if the value reaches zero. */
-    uint8_t ucValid;			/* pdTRUE: xMACAddress is valid, pdFALSE: waiting for ARP reply */
-} ARPCacheRow_t;
+    typedef struct xARP_CACHE_TABLE_ROW
+    {
+        uint32_t ulIPAddress;     /* The IP address of an ARP cache entry. */
+        MACAddress_t xMACAddress; /* The MAC address of an ARP cache entry. */
+        uint8_t ucAge;            /* A value that is periodically decremented but can also be refreshed by active communication.  The ARP cache entry is removed if the value reaches zero. */
+        uint8_t ucValid;          /* pdTRUE: xMACAddress is valid, pdFALSE: waiting for ARP reply */
+    } ARPCacheRow_t;
 
-typedef enum
-{
-	eARPCacheMiss = 0,			/* 0 An ARP table lookup did not find a valid entry. */
-	eARPCacheHit,				/* 1 An ARP table lookup found a valid entry. */
-	eCantSendPacket				/* 2 There is no IP address, or an ARP is still in progress, so the packet cannot be sent. */
-} eARPLookupResult_t;
+    typedef enum
+    {
+        eARPCacheMiss = 0, /* 0 An ARP table lookup did not find a valid entry. */
+        eARPCacheHit,      /* 1 An ARP table lookup found a valid entry. */
+        eCantSendPacket    /* 2 There is no IP address, or an ARP is still in progress, so the packet cannot be sent. */
+    } eARPLookupResult_t;
 
 /*
  * If ulIPAddress is already in the ARP cache table then reset the age of the
@@ -60,24 +60,25 @@ typedef enum
  * cache table then add it - replacing the oldest current entry if there is not
  * a free space available.
  */
-void vARPRefreshCacheEntry( const MACAddress_t * pxMACAddress, const uint32_t ulIPAddress );
+    void vARPRefreshCacheEntry( const MACAddress_t * pxMACAddress,
+                                const uint32_t ulIPAddress );
 
-#if( ipconfigARP_USE_CLASH_DETECTION != 0 )
-	/* Becomes non-zero if another device responded to a gratuitos ARP message. */
-	extern BaseType_t xARPHadIPClash;
-	/* MAC-address of the other device containing the same IP-address. */
-	extern MACAddress_t xARPClashMacAddress;
-#endif /* ipconfigARP_USE_CLASH_DETECTION */
+    #if ( ipconfigARP_USE_CLASH_DETECTION != 0 )
+        /* Becomes non-zero if another device responded to a gratuitos ARP message. */
+        extern BaseType_t xARPHadIPClash;
+        /* MAC-address of the other device containing the same IP-address. */
+        extern MACAddress_t xARPClashMacAddress;
+    #endif /* ipconfigARP_USE_CLASH_DETECTION */
 
-#if( ipconfigUSE_ARP_REMOVE_ENTRY != 0 )
+    #if ( ipconfigUSE_ARP_REMOVE_ENTRY != 0 )
 
-	/*
-	 * In some rare cases, it might be useful to remove a ARP cache entry of a
-	 * known MAC address to make sure it gets refreshed.
-	 */
-	uint32_t ulARPRemoveCacheEntryByMac( const MACAddress_t * pxMACAddress );
+        /*
+         * In some rare cases, it might be useful to remove a ARP cache entry of a
+         * known MAC address to make sure it gets refreshed.
+         */
+        uint32_t ulARPRemoveCacheEntryByMac( const MACAddress_t * pxMACAddress );
 
-#endif /* ipconfigUSE_ARP_REMOVE_ENTRY != 0 */
+    #endif /* ipconfigUSE_ARP_REMOVE_ENTRY != 0 */
 
 /*
  * Look for ulIPAddress in the ARP cache.  If the IP address exists, copy the
@@ -87,65 +88,56 @@ void vARPRefreshCacheEntry( const MACAddress_t * pxMACAddress, const uint32_t ul
  * (maybe DHCP is still in process, or the addressing needs a gateway but there
  * isn't a gateway defined) then return eCantSendPacket.
  */
-eARPLookupResult_t eARPGetCacheEntry( uint32_t *pulIPAddress, MACAddress_t * const pxMACAddress );
+    eARPLookupResult_t eARPGetCacheEntry( uint32_t * pulIPAddress,
+                                          MACAddress_t * const pxMACAddress );
 
-#if( ipconfigUSE_ARP_REVERSED_LOOKUP != 0 )
+    #if ( ipconfigUSE_ARP_REVERSED_LOOKUP != 0 )
 
-	/* Lookup an IP-address if only the MAC-address is known */
-	eARPLookupResult_t eARPGetCacheEntryByMac( MACAddress_t * const pxMACAddress, uint32_t *pulIPAddress );
+        /* Lookup an IP-address if only the MAC-address is known */
+        eARPLookupResult_t eARPGetCacheEntryByMac( MACAddress_t * const pxMACAddress,
+                                                   uint32_t * pulIPAddress );
 
-#endif
+    #endif
+
 /*
  * Reduce the age count in each entry within the ARP cache.  An entry is no
  * longer considered valid and is deleted if its age reaches zero.
  */
-void vARPAgeCache( void );
+    void vARPAgeCache( void );
 
 /*
  * Send out an ARP request for the IP address contained in pxNetworkBuffer, and
  * add an entry into the ARP table that indicates that an ARP reply is
  * outstanding so re-transmissions can be generated.
  */
-void vARPGenerateRequestPacket( NetworkBufferDescriptor_t * const pxNetworkBuffer );
+    void vARPGenerateRequestPacket( NetworkBufferDescriptor_t * const pxNetworkBuffer );
 
 /*
  * After DHCP is ready and when changing IP address, force a quick send of our new IP
  * address
  */
-void vARPSendGratuitous( void );
+    void vARPSendGratuitous( void );
 
 /* This function will check if the target IP-address belongs to this device.
-If so, the packet will be passed to the IP-stack, who will answer it.
-The function is to be called within the function xNetworkInterfaceOutput()
-in NetworkInterface.c as follows:
+ * If so, the packet will be passed to the IP-stack, who will answer it.
+ * The function is to be called within the function xNetworkInterfaceOutput()
+ * in NetworkInterface.c as follows:
+ *
+ *  if( xCheckLoopback( pxDescriptor, bReleaseAfterSend ) != 0 )
+ *  {
+ *     / * The packet has been sent back to the IP-task.
+ * The IP-task will further handle it.
+ * Do not release the descriptor.
+ * /
+ *      return pdTRUE;
+ *  }
+ *  / * Send the packet as usual. * /
+ */
+    BaseType_t xCheckLoopback( NetworkBufferDescriptor_t * const pxDescriptor,
+                               BaseType_t bReleaseAfterSend );
 
-	if( xCheckLoopback( pxDescriptor, bReleaseAfterSend ) != 0 )
-	{
-	   / * The packet has been sent back to the IP-task.
-		 * The IP-task will further handle it.
-		 * Do not release the descriptor.
-		 * /
-		return pdTRUE;
-	}
-	/ * Send the packet as usual. * /
-*/
-BaseType_t xCheckLoopback( NetworkBufferDescriptor_t * const pxDescriptor, BaseType_t bReleaseAfterSend );
-
-#ifdef __cplusplus
-} // extern "C"
-#endif
+    #ifdef __cplusplus
+        } /* extern "C" */
+    #endif
 
 #endif /* FREERTOS_ARP_H */
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/include/FreeRTOS_DHCP.h
+++ b/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/include/FreeRTOS_DHCP.h
@@ -24,96 +24,85 @@
  */
 
 #ifndef FREERTOS_DHCP_H
-#define FREERTOS_DHCP_H
+    #define FREERTOS_DHCP_H
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+    #ifdef __cplusplus
+        extern "C" {
+    #endif
 
 /* Application level configuration options. */
-#include "FreeRTOSIPConfig.h"
-#include "IPTraceMacroDefaults.h"
+    #include "FreeRTOSIPConfig.h"
+    #include "IPTraceMacroDefaults.h"
 
-#if( ipconfigUSE_DHCP_HOOK != 0 )
-	/* Used in the DHCP callback if ipconfigUSE_DHCP_HOOK is set to 1. */
-	typedef enum eDHCP_PHASE
-	{
-		eDHCPPhasePreDiscover,	/* Driver is about to send a DHCP discovery. */
-		eDHCPPhasePreRequest	/* Driver is about to request DHCP an IP address. */
-	} eDHCPCallbackPhase_t;
+    #if ( ipconfigUSE_DHCP_HOOK != 0 )
+        /* Used in the DHCP callback if ipconfigUSE_DHCP_HOOK is set to 1. */
+        typedef enum eDHCP_PHASE
+        {
+            eDHCPPhasePreDiscover, /* Driver is about to send a DHCP discovery. */
+            eDHCPPhasePreRequest   /* Driver is about to request DHCP an IP address. */
+        } eDHCPCallbackPhase_t;
 
-	/* Used in the DHCP callback if ipconfigUSE_DHCP_HOOK is set to 1. */
-	typedef enum eDHCP_ANSWERS
-	{
-		eDHCPContinue,			/* Continue the DHCP process */
-		eDHCPUseDefaults,		/* Stop DHCP and use the static defaults. */
-		eDHCPStopNoChanges,		/* Stop DHCP and continue with current settings. */
-	} eDHCPCallbackAnswer_t;
-#endif	/* #if( ipconfigUSE_DHCP_HOOK != 0 ) */
+        /* Used in the DHCP callback if ipconfigUSE_DHCP_HOOK is set to 1. */
+        typedef enum eDHCP_ANSWERS
+        {
+            eDHCPContinue,      /* Continue the DHCP process */
+            eDHCPUseDefaults,   /* Stop DHCP and use the static defaults. */
+            eDHCPStopNoChanges, /* Stop DHCP and continue with current settings. */
+        } eDHCPCallbackAnswer_t;
+    #endif /* #if( ipconfigUSE_DHCP_HOOK != 0 ) */
 
 /* DHCP state machine states. */
-typedef enum
-{
-	eWaitingSendFirstDiscover = 0,	/* Initial state.  Send a discover the first time it is called, and reset all timers. */
-	eWaitingOffer,					/* Either resend the discover, or, if the offer is forthcoming, send a request. */
-	eWaitingAcknowledge,			/* Either resend the request. */
-	#if( ipconfigDHCP_FALL_BACK_AUTO_IP != 0 )
-		eGetLinkLayerAddress,		/* When DHCP didn't respond, try to obtain a LinkLayer address 168.254.x.x. */
-	#endif
-	eLeasedAddress,					/* Resend the request at the appropriate time to renew the lease. */
-	eNotUsingLeasedAddress			/* DHCP failed, and a default IP address is being used. */
-} eDHCPState_t;
+    typedef enum
+    {
+        eWaitingSendFirstDiscover = 0, /* Initial state.  Send a discover the first time it is called, and reset all timers. */
+        eWaitingOffer,                 /* Either resend the discover, or, if the offer is forthcoming, send a request. */
+        eWaitingAcknowledge,           /* Either resend the request. */
+        #if ( ipconfigDHCP_FALL_BACK_AUTO_IP != 0 )
+            eGetLinkLayerAddress,      /* When DHCP didn't respond, try to obtain a LinkLayer address 168.254.x.x. */
+        #endif
+        eLeasedAddress,                /* Resend the request at the appropriate time to renew the lease. */
+        eNotUsingLeasedAddress         /* DHCP failed, and a default IP address is being used. */
+    } eDHCPState_t;
 
 /* Hold information in between steps in the DHCP state machine. */
-struct xDHCP_DATA
-{
-	uint32_t ulTransactionId;
-	uint32_t ulOfferedIPAddress;
-	uint32_t ulDHCPServerAddress;
-	uint32_t ulLeaseTime;
-	/* Hold information on the current timer state. */
-	TickType_t xDHCPTxTime;
-	TickType_t xDHCPTxPeriod;
-	/* Try both without and with the broadcast flag */
-	BaseType_t xUseBroadcast;
-	/* Maintains the DHCP state machine state. */
-	eDHCPState_t eDHCPState;
-};
+    struct xDHCP_DATA
+    {
+        uint32_t ulTransactionId;
+        uint32_t ulOfferedIPAddress;
+        uint32_t ulDHCPServerAddress;
+        uint32_t ulLeaseTime;
+        /* Hold information on the current timer state. */
+        TickType_t xDHCPTxTime;
+        TickType_t xDHCPTxPeriod;
+        /* Try both without and with the broadcast flag */
+        BaseType_t xUseBroadcast;
+        /* Maintains the DHCP state machine state. */
+        eDHCPState_t eDHCPState;
+    };
 
-typedef struct xDHCP_DATA DHCPData_t;
+    typedef struct xDHCP_DATA DHCPData_t;
 
 /*
  * NOT A PUBLIC API FUNCTION.
  */
-void vDHCPProcess( BaseType_t xReset );
+    void vDHCPProcess( BaseType_t xReset );
 
 /* Internal call: returns true if socket is the current DHCP socket */
-BaseType_t xIsDHCPSocket( Socket_t xSocket );
+    BaseType_t xIsDHCPSocket( Socket_t xSocket );
 
-#if( ipconfigUSE_DHCP_HOOK != 0 )
-	/* Prototype of the hook (or callback) function that must be provided by the
-	application if ipconfigUSE_DHCP_HOOK is set to 1.  See the following URL for
-	usage information:
-	http://www.FreeRTOS.org/FreeRTOS-Plus/FreeRTOS_Plus_TCP/TCP_IP_Configuration.html#ipconfigUSE_DHCP_HOOK
-	*/
-	eDHCPCallbackAnswer_t xApplicationDHCPHook( eDHCPCallbackPhase_t eDHCPPhase, uint32_t ulIPAddress );
-#endif	/* ( ipconfigUSE_DHCP_HOOK != 0 ) */
+    #if ( ipconfigUSE_DHCP_HOOK != 0 )
 
-#ifdef __cplusplus
-}	/* extern "C" */
-#endif
+        /* Prototype of the hook (or callback) function that must be provided by the
+         * application if ipconfigUSE_DHCP_HOOK is set to 1.  See the following URL for
+         * usage information:
+         * http://www.FreeRTOS.org/FreeRTOS-Plus/FreeRTOS_Plus_TCP/TCP_IP_Configuration.html#ipconfigUSE_DHCP_HOOK
+         */
+        eDHCPCallbackAnswer_t xApplicationDHCPHook( eDHCPCallbackPhase_t eDHCPPhase,
+                                                    uint32_t ulIPAddress );
+    #endif /* ( ipconfigUSE_DHCP_HOOK != 0 ) */
+
+    #ifdef __cplusplus
+        } /* extern "C" */
+    #endif
 
 #endif /* FREERTOS_DHCP_H */
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/include/FreeRTOS_DNS.h
+++ b/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/include/FreeRTOS_DNS.h
@@ -24,15 +24,15 @@
  */
 
 #ifndef FREERTOS_DNS_H
-#define FREERTOS_DNS_H
+    #define FREERTOS_DNS_H
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+    #ifdef __cplusplus
+        extern "C" {
+    #endif
 
 /* Application level configuration options. */
-#include "FreeRTOSIPConfig.h"
-#include "IPTraceMacroDefaults.h"
+    #include "FreeRTOSIPConfig.h"
+    #include "IPTraceMacroDefaults.h"
 
 
 /* The Link-local Multicast Name Resolution (LLMNR)
@@ -42,115 +42,110 @@ extern "C" {
  *
  * The target IP address will be 224.0.0.252
  */
-#if( ipconfigBYTE_ORDER == pdFREERTOS_BIG_ENDIAN )
-	#define	ipLLMNR_IP_ADDR			0xE00000FCUL
-#else
-	#define	ipLLMNR_IP_ADDR			0xFC0000E0UL
-#endif /* ipconfigBYTE_ORDER == pdFREERTOS_BIG_ENDIAN */
+    #if ( ipconfigBYTE_ORDER == pdFREERTOS_BIG_ENDIAN )
+        #define ipLLMNR_IP_ADDR    0xE00000FCUL
+    #else
+        #define ipLLMNR_IP_ADDR    0xFC0000E0UL
+    #endif /* ipconfigBYTE_ORDER == pdFREERTOS_BIG_ENDIAN */
 
-#define	ipLLMNR_PORT	5355 /* Standard LLMNR port. */
-#define	ipDNS_PORT		53	/* Standard DNS port. */
-#define	ipDHCP_CLIENT	67
-#define	ipDHCP_SERVER	68
-#define	ipNBNS_PORT		137	/* NetBIOS Name Service. */
-#define	ipNBDGM_PORT	138 /* Datagram Service, not included. */
+    #define ipLLMNR_PORT           5355 /* Standard LLMNR port. */
+    #define ipDNS_PORT             53   /* Standard DNS port. */
+    #define ipDHCP_CLIENT          67
+    #define ipDHCP_SERVER          68
+    #define ipNBNS_PORT            137 /* NetBIOS Name Service. */
+    #define ipNBDGM_PORT           138 /* Datagram Service, not included. */
 
-#if( ipconfigUSE_LLMNR == 1 ) || ( ipconfigUSE_NBNS == 1 )
-	/*
-	 * The following function should be provided by the user and return true if it
-	 * matches the domain name.
-	 */
-	extern BaseType_t xApplicationDNSQueryHook( const char *pcName );
-#endif	/* ( ipconfigUSE_LLMNR == 1 ) || ( ipconfigUSE_NBNS == 1 ) */
+    #if ( ipconfigUSE_LLMNR == 1 ) || ( ipconfigUSE_NBNS == 1 )
+
+        /*
+         * The following function should be provided by the user and return true if it
+         * matches the domain name.
+         */
+        extern BaseType_t xApplicationDNSQueryHook( const char * pcName );
+    #endif /* ( ipconfigUSE_LLMNR == 1 ) || ( ipconfigUSE_NBNS == 1 ) */
 
 /*
  * LLMNR is very similar to DNS, so is handled by the DNS routines.
  */
-uint32_t ulDNSHandlePacket( const NetworkBufferDescriptor_t *pxNetworkBuffer );
+    uint32_t ulDNSHandlePacket( const NetworkBufferDescriptor_t * pxNetworkBuffer );
 
-#if( ipconfigUSE_LLMNR == 1 )
-	/* The LLMNR MAC address is 01:00:5e:00:00:fc */
-	extern const MACAddress_t xLLMNR_MacAdress;
-#endif /* ipconfigUSE_LLMNR */
+    #if ( ipconfigUSE_LLMNR == 1 )
+        /* The LLMNR MAC address is 01:00:5e:00:00:fc */
+        extern const MACAddress_t xLLMNR_MacAdress;
+    #endif /* ipconfigUSE_LLMNR */
 
-#if( ipconfigUSE_NBNS != 0 )
+    #if ( ipconfigUSE_NBNS != 0 )
 
-	/*
-	 * Inspect a NetBIOS Names-Service message.  If the name matches with ours
-	 * (xApplicationDNSQueryHook returns true) an answer will be sent back.
-	 * Note that LLMNR is a better protocol for name services on a LAN as it is
-	 * less polluted
-	 */
-	uint32_t ulNBNSHandlePacket (NetworkBufferDescriptor_t *pxNetworkBuffer );
+        /*
+         * Inspect a NetBIOS Names-Service message.  If the name matches with ours
+         * (xApplicationDNSQueryHook returns true) an answer will be sent back.
+         * Note that LLMNR is a better protocol for name services on a LAN as it is
+         * less polluted
+         */
+        uint32_t ulNBNSHandlePacket( NetworkBufferDescriptor_t * pxNetworkBuffer );
 
-#endif /* ipconfigUSE_NBNS */
+    #endif /* ipconfigUSE_NBNS */
 
-#if( ipconfigUSE_DNS_CACHE != 0 )
+    #if ( ipconfigUSE_DNS_CACHE != 0 )
 
-	/* Look for the indicated host name in the DNS cache. Returns the IPv4 
-	address if present, or 0x0 otherwise. */
-	uint32_t FreeRTOS_dnslookup( const char *pcHostName );
+        /* Look for the indicated host name in the DNS cache. Returns the IPv4
+         * address if present, or 0x0 otherwise. */
+        uint32_t FreeRTOS_dnslookup( const char * pcHostName );
 
-	/* Remove all entries from the DNS cache. */
-	void FreeRTOS_dnsclear( void );
+        /* Remove all entries from the DNS cache. */
+        void FreeRTOS_dnsclear( void );
 
-#endif /* ipconfigUSE_DNS_CACHE != 0 */
+    #endif /* ipconfigUSE_DNS_CACHE != 0 */
 
-#if( ipconfigDNS_USE_CALLBACKS != 0 )
+    #if ( ipconfigDNS_USE_CALLBACKS != 0 )
 
-	/*
-	 * Users may define this type of function as a callback.
-	 * It will be called when a DNS reply is received or when a timeout has been reached.
-	 */
-	typedef void (* FOnDNSEvent ) ( const char * /* pcName */, void * /* pvSearchID */, uint32_t /* ulIPAddress */ );
+        /*
+         * Users may define this type of function as a callback.
+         * It will be called when a DNS reply is received or when a timeout has been reached.
+         */
+        typedef void (* FOnDNSEvent ) ( const char * /* pcName */,
+                                        void * /* pvSearchID */,
+                                        uint32_t /* ulIPAddress */ );
 
-	/*
-	 * Asynchronous version of gethostbyname()
-	 * xTimeout is in units of ms.
-	 */
-	uint32_t FreeRTOS_gethostbyname_a( const char *pcHostName, FOnDNSEvent pCallback, void *pvSearchID, TickType_t uxTimeout );
-	void FreeRTOS_gethostbyname_cancel( void *pvSearchID );
+        /*
+         * Asynchronous version of gethostbyname()
+         * xTimeout is in units of ms.
+         */
+        uint32_t FreeRTOS_gethostbyname_a( const char * pcHostName,
+                                           FOnDNSEvent pCallback,
+                                           void * pvSearchID,
+                                           TickType_t uxTimeout );
+        void FreeRTOS_gethostbyname_cancel( void * pvSearchID );
 
-#endif
+    #endif /* if ( ipconfigDNS_USE_CALLBACKS != 0 ) */
 
 /*
  * Lookup a IPv4 node in a blocking-way.
  * It returns a 32-bit IP-address, 0 when not found.
  * gethostbyname() is already deprecated.
  */
-uint32_t FreeRTOS_gethostbyname( const char *pcHostName );
+    uint32_t FreeRTOS_gethostbyname( const char * pcHostName );
 
-#if( ipconfigDNS_USE_CALLBACKS == 1 )
-	/*
-	 * The function vDNSInitialise() initialises the DNS module.
-	 * It will be called "internally", by the IP-task.
-	 */
-	void vDNSInitialise( void );
-#endif	/* ( ipconfigDNS_USE_CALLBACKS == 1 ) */
+    #if ( ipconfigDNS_USE_CALLBACKS == 1 )
 
-#if( ipconfigDNS_USE_CALLBACKS == 1 )
-	/*
-	 * A function local to the library.
-	 */
-	extern void vDNSCheckCallBack( void *pvSearchID );
-#endif
+        /*
+         * The function vDNSInitialise() initialises the DNS module.
+         * It will be called "internally", by the IP-task.
+         */
+        void vDNSInitialise( void );
+    #endif /* ( ipconfigDNS_USE_CALLBACKS == 1 ) */
+
+    #if ( ipconfigDNS_USE_CALLBACKS == 1 )
+
+        /*
+         * A function local to the library.
+         */
+        extern void vDNSCheckCallBack( void * pvSearchID );
+    #endif
 
 
-#ifdef __cplusplus
-}	/* extern "C" */
-#endif
+    #ifdef __cplusplus
+        } /* extern "C" */
+    #endif
 
 #endif /* FREERTOS_DNS_H */
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/include/FreeRTOS_IP.h
+++ b/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/include/FreeRTOS_IP.h
@@ -24,47 +24,48 @@
  */
 
 #ifndef FREERTOS_IP_H
-#define FREERTOS_IP_H
+    #define FREERTOS_IP_H
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+    #ifdef __cplusplus
+        extern "C" {
+    #endif
 
-#include "FreeRTOS.h"
-#include "task.h"
+    #include "FreeRTOS.h"
+    #include "task.h"
 
 /* Application level configuration options. */
-#include "FreeRTOSIPConfig.h"
-#include "FreeRTOSIPConfigDefaults.h"
-#include "IPTraceMacroDefaults.h"
+    #include "FreeRTOSIPConfig.h"
+    #include "FreeRTOSIPConfigDefaults.h"
+    #include "IPTraceMacroDefaults.h"
 
-#ifdef __COVERITY__
-	/* Coverity static checks don't like inlined functions.
-	As it is up to the users to allow inlining, don't let
-	let Coverity know about it. */
+    #ifdef __COVERITY__
 
-	#ifdef portINLINE
-		/* coverity[misra_c_2012_rule_20_5_violation] */
-		/* The usage of #undef violates the rule. */
-		#undef portINLINE
+        /* Coverity static checks don't like inlined functions.
+         * As it is up to the users to allow inlining, don't let
+         * let Coverity know about it. */
 
-	#endif
+        #ifdef portINLINE
+            /* coverity[misra_c_2012_rule_20_5_violation] */
+            /* The usage of #undef violates the rule. */
+            #undef portINLINE
 
-	#define	portINLINE
-#endif
+        #endif
+
+        #define portINLINE
+    #endif /* ifdef __COVERITY__ */
 
 /* Some constants defining the sizes of several parts of a packet.
-These defines come before inlucding the configuration header files. */
+ * These defines come before inlucding the configuration header files. */
 /* The size of the Ethernet header is 14, meaning that 802.1Q VLAN tags
-are not ( yet ) supported. */
-#define ipSIZE_OF_ETH_HEADER			14U
-#define ipSIZE_OF_IPv4_HEADER			20U
-#define ipSIZE_OF_IGMP_HEADER			8U
-#define ipSIZE_OF_ICMP_HEADER			8U
-#define ipSIZE_OF_UDP_HEADER			8U
-#define ipSIZE_OF_TCP_HEADER			20U
+ * are not ( yet ) supported. */
+    #define ipSIZE_OF_ETH_HEADER      14U
+    #define ipSIZE_OF_IPv4_HEADER     20U
+    #define ipSIZE_OF_IGMP_HEADER     8U
+    #define ipSIZE_OF_ICMP_HEADER     8U
+    #define ipSIZE_OF_UDP_HEADER      8U
+    #define ipSIZE_OF_TCP_HEADER      20U
 
-#define ipSIZE_OF_IPv4_ADDRESS	4U
+    #define ipSIZE_OF_IPv4_ADDRESS    4U
 
 /*
  * Generate a randomized TCP Initial Sequence Number per RFC.
@@ -72,237 +73,276 @@ are not ( yet ) supported. */
  */
 /* coverity[misra_c_2012_rule_8_6_violation] */
 /* "ulApplicationGetNextSequenceNumber" is declared but never defined. */
-extern uint32_t ulApplicationGetNextSequenceNumber( uint32_t ulSourceAddress,
-													uint16_t usSourcePort,
-													uint32_t ulDestinationAddress,
-													uint16_t usDestinationPort );
+    extern uint32_t ulApplicationGetNextSequenceNumber( uint32_t ulSourceAddress,
+                                                        uint16_t usSourcePort,
+                                                        uint32_t ulDestinationAddress,
+                                                        uint16_t usDestinationPort );
 
 /* The number of octets in the MAC and IP addresses respectively. */
-#define ipMAC_ADDRESS_LENGTH_BYTES ( 6 )
-#define ipIP_ADDRESS_LENGTH_BYTES ( 4 )
+    #define ipMAC_ADDRESS_LENGTH_BYTES                 ( 6 )
+    #define ipIP_ADDRESS_LENGTH_BYTES                  ( 4 )
 
 /* IP protocol definitions. */
-#define ipPROTOCOL_ICMP			( 1U )
-#define ipPROTOCOL_IGMP         ( 2U )
-#define ipPROTOCOL_TCP			( 6U )
-#define ipPROTOCOL_UDP			( 17U )
+    #define ipPROTOCOL_ICMP                            ( 1U )
+    #define ipPROTOCOL_IGMP                            ( 2U )
+    #define ipPROTOCOL_TCP                             ( 6U )
+    #define ipPROTOCOL_UDP                             ( 17U )
 
 /* The character used to fill ICMP echo requests, and therefore also the
-character expected to fill ICMP echo replies. */
-#define ipECHO_DATA_FILL_BYTE						'x'
+ * character expected to fill ICMP echo replies. */
+    #define ipECHO_DATA_FILL_BYTE                      'x'
 
 /* Dimensions the buffers that are filled by received Ethernet frames. */
-#define ipSIZE_OF_ETH_CRC_BYTES					( 4UL )
-#define ipSIZE_OF_ETH_OPTIONAL_802_1Q_TAG_BYTES	( 4UL )
-#define ipTOTAL_ETHERNET_FRAME_SIZE				( ( ( uint32_t ) ipconfigNETWORK_MTU ) + ( ( uint32_t ) ipSIZE_OF_ETH_HEADER ) + ipSIZE_OF_ETH_CRC_BYTES + ipSIZE_OF_ETH_OPTIONAL_802_1Q_TAG_BYTES )
+    #define ipSIZE_OF_ETH_CRC_BYTES                    ( 4UL )
+    #define ipSIZE_OF_ETH_OPTIONAL_802_1Q_TAG_BYTES    ( 4UL )
+    #define ipTOTAL_ETHERNET_FRAME_SIZE                ( ( ( uint32_t ) ipconfigNETWORK_MTU ) + ( ( uint32_t ) ipSIZE_OF_ETH_HEADER ) + ipSIZE_OF_ETH_CRC_BYTES + ipSIZE_OF_ETH_OPTIONAL_802_1Q_TAG_BYTES )
 
 
 /* Space left at the beginning of a network buffer storage area to store a
-pointer back to the network buffer.  Should be a multiple of 8 to ensure 8 byte
-alignment is maintained on architectures that require it.
-
-In order to get a 32-bit alignment of network packets, an offset of 2 bytes
-would be desirable, as defined by ipconfigPACKET_FILLER_SIZE.  So the malloc'd
-buffer will have the following contents:
-	uint32_t pointer;	// word-aligned
-	uchar_8 filler[6];
-	<< ETH-header >>	// half-word-aligned
-	uchar_8 dest[6];    // start of pucEthernetBuffer
-	uchar_8 dest[6];
-	uchar16_t type;
-	<< IP-header >>		// word-aligned
-	uint8_t ucVersionHeaderLength;
-	etc
+ * pointer back to the network buffer.  Should be a multiple of 8 to ensure 8 byte
+ * alignment is maintained on architectures that require it.
+ *
+ * In order to get a 32-bit alignment of network packets, an offset of 2 bytes
+ * would be desirable, as defined by ipconfigPACKET_FILLER_SIZE.  So the malloc'd
+ * buffer will have the following contents:
+ *  uint32_t pointer;	// word-aligned
+ *  uchar_8 filler[6];
+ *  << ETH-header >>	// half-word-aligned
+ *  uchar_8 dest[6];    // start of pucEthernetBuffer
+ *  uchar_8 dest[6];
+ *  uchar16_t type;
+ *  << IP-header >>		// word-aligned
+ *  uint8_t ucVersionHeaderLength;
+ *  etc
  */
 
-#if( ipconfigBUFFER_PADDING != 0 )
-    #define ipBUFFER_PADDING    ipconfigBUFFER_PADDING
-#else
-    #define ipBUFFER_PADDING    ( 8U + ipconfigPACKET_FILLER_SIZE )
-#endif
+    #if ( ipconfigBUFFER_PADDING != 0 )
+        #define ipBUFFER_PADDING    ipconfigBUFFER_PADDING
+    #else
+        #define ipBUFFER_PADDING    ( 8U + ipconfigPACKET_FILLER_SIZE )
+    #endif
 
 /* The structure used to store buffers and pass them around the network stack.
-Buffers can be in use by the stack, in use by the network interface hardware
-driver, or free (not in use). */
-typedef struct xNETWORK_BUFFER
-{
-	ListItem_t xBufferListItem; 	/* Used to reference the buffer form the free buffer list or a socket. */
-	uint32_t ulIPAddress;			/* Source or destination IP address, depending on usage scenario. */
-	uint8_t *pucEthernetBuffer; 	/* Pointer to the start of the Ethernet frame. */
-	size_t xDataLength; 			/* Starts by holding the total Ethernet frame length, then the UDP/TCP payload length. */
-	uint16_t usPort;				/* Source or destination port, depending on usage scenario. */
-	uint16_t usBoundPort;			/* The port to which a transmitting socket is bound. */
-	#if( ipconfigUSE_LINKED_RX_MESSAGES != 0 )
-		struct xNETWORK_BUFFER *pxNextBuffer; /* Possible optimisation for expert users - requires network driver support. */
-	#endif
-} NetworkBufferDescriptor_t;
+ * Buffers can be in use by the stack, in use by the network interface hardware
+ * driver, or free (not in use). */
+    typedef struct xNETWORK_BUFFER
+    {
+        ListItem_t xBufferListItem;                /* Used to reference the buffer form the free buffer list or a socket. */
+        uint32_t ulIPAddress;                      /* Source or destination IP address, depending on usage scenario. */
+        uint8_t * pucEthernetBuffer;               /* Pointer to the start of the Ethernet frame. */
+        size_t xDataLength;                        /* Starts by holding the total Ethernet frame length, then the UDP/TCP payload length. */
+        uint16_t usPort;                           /* Source or destination port, depending on usage scenario. */
+        uint16_t usBoundPort;                      /* The port to which a transmitting socket is bound. */
+        #if ( ipconfigUSE_LINKED_RX_MESSAGES != 0 )
+            struct xNETWORK_BUFFER * pxNextBuffer; /* Possible optimisation for expert users - requires network driver support. */
+        #endif
+    } NetworkBufferDescriptor_t;
 
-#include "pack_struct_start.h"
-struct xMAC_ADDRESS
-{
-	uint8_t ucBytes[ ipMAC_ADDRESS_LENGTH_BYTES ];
-}
-#include "pack_struct_end.h"
+    #include "pack_struct_start.h"
+    struct xMAC_ADDRESS
+    {
+        uint8_t ucBytes[ ipMAC_ADDRESS_LENGTH_BYTES ];
+    }
+    #include "pack_struct_end.h"
 
-typedef struct xMAC_ADDRESS MACAddress_t;
+    typedef struct xMAC_ADDRESS MACAddress_t;
 
-typedef enum eNETWORK_EVENTS
-{
-	eNetworkUp,		/* The network is configured. */
-	eNetworkDown	/* The network connection has been lost. */
-} eIPCallbackEvent_t;
+    typedef enum eNETWORK_EVENTS
+    {
+        eNetworkUp,  /* The network is configured. */
+        eNetworkDown /* The network connection has been lost. */
+    } eIPCallbackEvent_t;
 
 /* MISRA check: some modules refer to this typedef even though
-ipconfigSUPPORT_OUTGOING_PINGS is not enabled. */
-typedef enum ePING_REPLY_STATUS
-{
-	eSuccess = 0,		/* A correct reply has been received for an outgoing ping. */
-	eInvalidChecksum,	/* A reply was received for an outgoing ping but the checksum of the reply was incorrect. */
-	eInvalidData		/* A reply was received to an outgoing ping but the payload of the reply was not correct. */
-} ePingReplyStatus_t;
+ * ipconfigSUPPORT_OUTGOING_PINGS is not enabled. */
+    typedef enum ePING_REPLY_STATUS
+    {
+        eSuccess = 0,     /* A correct reply has been received for an outgoing ping. */
+        eInvalidChecksum, /* A reply was received for an outgoing ping but the checksum of the reply was incorrect. */
+        eInvalidData      /* A reply was received to an outgoing ping but the payload of the reply was not correct. */
+    } ePingReplyStatus_t;
 
-typedef struct xIP_TIMER
-{
-	uint32_t
-		bActive : 1,	/* This timer is running and must be processed. */
-		bExpired : 1;	/* Timer has expired and a task must be processed. */
-	TimeOut_t xTimeOut;
-	TickType_t ulRemainingTime;
-	TickType_t ulReloadTime;
-} IPTimer_t;
+    typedef struct xIP_TIMER
+    {
+        uint32_t
+            bActive : 1,  /* This timer is running and must be processed. */
+            bExpired : 1; /* Timer has expired and a task must be processed. */
+        TimeOut_t xTimeOut;
+        TickType_t ulRemainingTime;
+        TickType_t ulReloadTime;
+    } IPTimer_t;
 
 /* Endian related definitions. */
-#if( ipconfigBYTE_ORDER == pdFREERTOS_LITTLE_ENDIAN )
+    #if ( ipconfigBYTE_ORDER == pdFREERTOS_LITTLE_ENDIAN )
 
-	/* FreeRTOS_htons / FreeRTOS_htonl: some platforms might have built-in versions
-	using a single instruction so allow these versions to be overridden. */
-	#ifndef FreeRTOS_htons
-		#define FreeRTOS_htons( usIn ) ( (uint16_t) ( ( ( usIn ) << 8U ) | ( ( usIn ) >> 8U ) ) )
-	#endif
+        /* FreeRTOS_htons / FreeRTOS_htonl: some platforms might have built-in versions
+         * using a single instruction so allow these versions to be overridden. */
+        #ifndef FreeRTOS_htons
+            #define FreeRTOS_htons( usIn )    ( ( uint16_t ) ( ( ( usIn ) << 8U ) | ( ( usIn ) >> 8U ) ) )
+        #endif
 
-	#ifndef	FreeRTOS_htonl
-		#define FreeRTOS_htonl( ulIn ) 											\
-			(																	\
-				( uint32_t ) 													\
-				( 																\
-					( ( ( ( uint32_t ) ( ulIn ) )                ) << 24  ) | 	\
-					( ( ( ( uint32_t ) ( ulIn ) ) & 0x0000ff00UL ) <<  8  ) | 	\
-					( ( ( ( uint32_t ) ( ulIn ) ) & 0x00ff0000UL ) >>  8  ) | 	\
-					( ( ( ( uint32_t ) ( ulIn ) )                ) >> 24  )  	\
-				) 																\
-			)
-	#endif
+        #ifndef FreeRTOS_htonl
+            #define FreeRTOS_htonl( ulIn )                          \
+    (                                                               \
+        ( uint32_t )                                                \
+        (                                                           \
+            ( ( ( ( uint32_t ) ( ulIn ) ) ) << 24 ) |               \
+            ( ( ( ( uint32_t ) ( ulIn ) ) & 0x0000ff00UL ) << 8 ) | \
+            ( ( ( ( uint32_t ) ( ulIn ) ) & 0x00ff0000UL ) >> 8 ) | \
+            ( ( ( ( uint32_t ) ( ulIn ) ) ) >> 24 )                 \
+        )                                                           \
+    )
+        #endif /* ifndef FreeRTOS_htonl */
 
-#else /* ipconfigBYTE_ORDER */
+    #else /* ipconfigBYTE_ORDER */
 
-	#define FreeRTOS_htons( x ) ( ( uint16_t ) ( x ) )
-	#define FreeRTOS_htonl( x ) ( ( uint32_t ) ( x ) )
+        #define FreeRTOS_htons( x )    ( ( uint16_t ) ( x ) )
+        #define FreeRTOS_htonl( x )    ( ( uint32_t ) ( x ) )
 
-#endif /* ipconfigBYTE_ORDER == pdFREERTOS_LITTLE_ENDIAN */
+    #endif /* ipconfigBYTE_ORDER == pdFREERTOS_LITTLE_ENDIAN */
 
-#define FreeRTOS_ntohs( x ) FreeRTOS_htons( x )
-#define FreeRTOS_ntohl( x ) FreeRTOS_htonl( x )
+    #define FreeRTOS_ntohs( x )    FreeRTOS_htons( x )
+    #define FreeRTOS_ntohl( x )    FreeRTOS_htonl( x )
 
-#if( ipconfigHAS_INLINE_FUNCTIONS == 1 )
+    #if ( ipconfigHAS_INLINE_FUNCTIONS == 1 )
 
-	static portINLINE int32_t  FreeRTOS_max_int32  (int32_t  a, int32_t  b);
-	static portINLINE uint32_t FreeRTOS_max_uint32 (uint32_t a, uint32_t b);
-	static portINLINE int32_t  FreeRTOS_min_int32  (int32_t  a, int32_t  b);
-	static portINLINE uint32_t FreeRTOS_min_uint32 (uint32_t a, uint32_t b);
-	static portINLINE uint32_t FreeRTOS_round_up   (uint32_t a, uint32_t d);
-	static portINLINE uint32_t FreeRTOS_round_down (uint32_t a, uint32_t d);
-	static portINLINE BaseType_t  FreeRTOS_min_BaseType  (BaseType_t  a, BaseType_t  b);
+        static portINLINE int32_t FreeRTOS_max_int32( int32_t a,
+                                                      int32_t b );
+        static portINLINE uint32_t FreeRTOS_max_uint32( uint32_t a,
+                                                        uint32_t b );
+        static portINLINE int32_t FreeRTOS_min_int32( int32_t a,
+                                                      int32_t b );
+        static portINLINE uint32_t FreeRTOS_min_uint32( uint32_t a,
+                                                        uint32_t b );
+        static portINLINE uint32_t FreeRTOS_round_up( uint32_t a,
+                                                      uint32_t d );
+        static portINLINE uint32_t FreeRTOS_round_down( uint32_t a,
+                                                        uint32_t d );
+        static portINLINE BaseType_t FreeRTOS_min_BaseType( BaseType_t a,
+                                                            BaseType_t b );
 
-	static portINLINE int32_t  FreeRTOS_max_int32  (int32_t  a, int32_t  b) { return ( a >= b ) ? a : b; }
-	static portINLINE uint32_t FreeRTOS_max_uint32 (uint32_t a, uint32_t b) { return ( a >= b ) ? a : b; }
-	static portINLINE int32_t  FreeRTOS_min_int32  (int32_t  a, int32_t  b) { return ( a <= b ) ? a : b; }
-	static portINLINE uint32_t FreeRTOS_min_uint32 (uint32_t a, uint32_t b) { return ( a <= b ) ? a : b; }
-	static portINLINE uint32_t FreeRTOS_round_up   (uint32_t a, uint32_t d) { return d * ( ( a + d - 1U ) / d ); }
-	static portINLINE uint32_t FreeRTOS_round_down (uint32_t a, uint32_t d) { return d * ( a / d ); }
+        static portINLINE int32_t FreeRTOS_max_int32( int32_t a,
+                                                      int32_t b )
+        {
+            return ( a >= b ) ? a : b;
+        }
+        static portINLINE uint32_t FreeRTOS_max_uint32( uint32_t a,
+                                                        uint32_t b )
+        {
+            return ( a >= b ) ? a : b;
+        }
+        static portINLINE int32_t FreeRTOS_min_int32( int32_t a,
+                                                      int32_t b )
+        {
+            return ( a <= b ) ? a : b;
+        }
+        static portINLINE uint32_t FreeRTOS_min_uint32( uint32_t a,
+                                                        uint32_t b )
+        {
+            return ( a <= b ) ? a : b;
+        }
+        static portINLINE uint32_t FreeRTOS_round_up( uint32_t a,
+                                                      uint32_t d )
+        {
+            return d * ( ( a + d - 1U ) / d );
+        }
+        static portINLINE uint32_t FreeRTOS_round_down( uint32_t a,
+                                                        uint32_t d )
+        {
+            return d * ( a / d );
+        }
 
-	static portINLINE BaseType_t  FreeRTOS_min_BaseType  (BaseType_t  a, BaseType_t  b) { return ( a <= b ) ? a : b; }
+        static portINLINE BaseType_t FreeRTOS_min_BaseType( BaseType_t a,
+                                                            BaseType_t b )
+        {
+            return ( a <= b ) ? a : b;
+        }
 
-#else
+    #else /* if ( ipconfigHAS_INLINE_FUNCTIONS == 1 ) */
 
-	#define FreeRTOS_max_int32(a,b)  ( ( ( ( int32_t  ) ( a ) ) >= ( ( int32_t  ) ( b ) ) ) ? ( ( int32_t  ) ( a ) ) : ( ( int32_t  ) ( b ) ) )
-	#define FreeRTOS_max_uint32(a,b) ( ( ( ( uint32_t ) ( a ) ) >= ( ( uint32_t ) ( b ) ) ) ? ( ( uint32_t ) ( a ) ) : ( ( uint32_t ) ( b ) ) )
+        #define FreeRTOS_max_int32( a, b )       ( ( ( ( int32_t ) ( a ) ) >= ( ( int32_t ) ( b ) ) ) ? ( ( int32_t ) ( a ) ) : ( ( int32_t ) ( b ) ) )
+        #define FreeRTOS_max_uint32( a, b )      ( ( ( ( uint32_t ) ( a ) ) >= ( ( uint32_t ) ( b ) ) ) ? ( ( uint32_t ) ( a ) ) : ( ( uint32_t ) ( b ) ) )
 
-	#define FreeRTOS_min_int32(a,b)  ( ( ( ( int32_t  ) a ) <= ( ( int32_t  ) b ) ) ? ( ( int32_t  ) a ) : ( ( int32_t  ) b ) )
-	#define FreeRTOS_min_uint32(a,b) ( ( ( ( uint32_t ) a ) <= ( ( uint32_t ) b ) ) ? ( ( uint32_t ) a ) : ( ( uint32_t ) b ) )
+        #define FreeRTOS_min_int32( a, b )       ( ( ( ( int32_t ) a ) <= ( ( int32_t ) b ) ) ? ( ( int32_t ) a ) : ( ( int32_t ) b ) )
+        #define FreeRTOS_min_uint32( a, b )      ( ( ( ( uint32_t ) a ) <= ( ( uint32_t ) b ) ) ? ( ( uint32_t ) a ) : ( ( uint32_t ) b ) )
 
-	/*  Round-up: divide a by d and round=up the result. */
-	#define FreeRTOS_round_up(a,d)   ( ( ( uint32_t ) ( d ) ) * ( ( ( ( uint32_t ) ( a ) ) + ( ( uint32_t ) ( d ) ) - 1UL ) / ( ( uint32_t ) ( d ) ) ) )
-	#define FreeRTOS_round_down(a,d) ( ( ( uint32_t ) ( d ) ) * ( ( ( uint32_t ) ( a ) ) / ( ( uint32_t ) ( d ) ) ) )
+        /*  Round-up: divide a by d and round=up the result. */
+        #define FreeRTOS_round_up( a, d )        ( ( ( uint32_t ) ( d ) ) * ( ( ( ( uint32_t ) ( a ) ) + ( ( uint32_t ) ( d ) ) - 1UL ) / ( ( uint32_t ) ( d ) ) ) )
+        #define FreeRTOS_round_down( a, d )      ( ( ( uint32_t ) ( d ) ) * ( ( ( uint32_t ) ( a ) ) / ( ( uint32_t ) ( d ) ) ) )
 
-	#define FreeRTOS_min_BaseType(a, b)  ( ( ( BaseType_t  ) ( a ) ) <= ( ( BaseType_t  ) ( b ) ) ? ( ( BaseType_t  ) ( a ) ) : ( ( BaseType_t  ) ( b ) ) )
+        #define FreeRTOS_min_BaseType( a, b )    ( ( ( BaseType_t ) ( a ) ) <= ( ( BaseType_t ) ( b ) ) ? ( ( BaseType_t ) ( a ) ) : ( ( BaseType_t ) ( b ) ) )
 
-#endif /* ipconfigHAS_INLINE_FUNCTIONS */
+    #endif /* ipconfigHAS_INLINE_FUNCTIONS */
 
-#define ipMS_TO_MIN_TICKS( xTimeInMs ) ( ( pdMS_TO_TICKS( ( xTimeInMs ) ) < ( ( TickType_t ) 1U ) ) ? ( ( TickType_t ) 1U ) : pdMS_TO_TICKS( ( xTimeInMs ) ) )
+    #define ipMS_TO_MIN_TICKS( xTimeInMs )    ( ( pdMS_TO_TICKS( ( xTimeInMs ) ) < ( ( TickType_t ) 1U ) ) ? ( ( TickType_t ) 1U ) : pdMS_TO_TICKS( ( xTimeInMs ) ) )
 
 /* For backward compatibility. */
-#define pdMS_TO_MIN_TICKS( xTimeInMs )	ipMS_TO_MIN_TICKS( xTimeInMs )
+    #define pdMS_TO_MIN_TICKS( xTimeInMs )    ipMS_TO_MIN_TICKS( xTimeInMs )
 
-#ifndef pdTRUE_SIGNED
-	/* Temporary solution: eventually the defines below will appear in 'Source\include\projdefs.h' */
-	#define pdTRUE_SIGNED		pdTRUE
-	#define pdFALSE_SIGNED		pdFALSE
-	#define pdTRUE_UNSIGNED		( 1U )
-	#define pdFALSE_UNSIGNED	( 0U )
-	#define ipTRUE_BOOL			( 1 == 1 )
-	#define ipFALSE_BOOL		( 1 == 2 )
-#endif
+    #ifndef pdTRUE_SIGNED
+        /* Temporary solution: eventually the defines below will appear in 'Source\include\projdefs.h' */
+        #define pdTRUE_SIGNED       pdTRUE
+        #define pdFALSE_SIGNED      pdFALSE
+        #define pdTRUE_UNSIGNED     ( 1U )
+        #define pdFALSE_UNSIGNED    ( 0U )
+        #define ipTRUE_BOOL         ( 1 == 1 )
+        #define ipFALSE_BOOL        ( 1 == 2 )
+    #endif
 
 /*
  * FULL, UP-TO-DATE AND MAINTAINED REFERENCE DOCUMENTATION FOR ALL THESE
  * FUNCTIONS IS AVAILABLE ON THE FOLLOWING URL:
  * http://www.FreeRTOS.org/FreeRTOS-Plus/FreeRTOS_Plus_TCP/FreeRTOS_TCP_API_Functions.html
  */
-BaseType_t FreeRTOS_IPInit( const uint8_t ucIPAddress[ ipIP_ADDRESS_LENGTH_BYTES ],
-	const uint8_t ucNetMask[ ipIP_ADDRESS_LENGTH_BYTES ],
-	const uint8_t ucGatewayAddress[ ipIP_ADDRESS_LENGTH_BYTES ],
-	const uint8_t ucDNSServerAddress[ ipIP_ADDRESS_LENGTH_BYTES ],
-	const uint8_t ucMACAddress[ ipMAC_ADDRESS_LENGTH_BYTES ] );
+    BaseType_t FreeRTOS_IPInit( const uint8_t ucIPAddress[ ipIP_ADDRESS_LENGTH_BYTES ],
+                                const uint8_t ucNetMask[ ipIP_ADDRESS_LENGTH_BYTES ],
+                                const uint8_t ucGatewayAddress[ ipIP_ADDRESS_LENGTH_BYTES ],
+                                const uint8_t ucDNSServerAddress[ ipIP_ADDRESS_LENGTH_BYTES ],
+                                const uint8_t ucMACAddress[ ipMAC_ADDRESS_LENGTH_BYTES ] );
 
-void * FreeRTOS_GetUDPPayloadBuffer( size_t uxRequestedSizeBytes, TickType_t uxBlockTimeTicks );
-void FreeRTOS_GetAddressConfiguration( uint32_t *pulIPAddress,
-									   uint32_t *pulNetMask,
-									   uint32_t *pulGatewayAddress,
-									   uint32_t *pulDNSServerAddress );
+    void * FreeRTOS_GetUDPPayloadBuffer( size_t uxRequestedSizeBytes,
+                                         TickType_t uxBlockTimeTicks );
+    void FreeRTOS_GetAddressConfiguration( uint32_t * pulIPAddress,
+                                           uint32_t * pulNetMask,
+                                           uint32_t * pulGatewayAddress,
+                                           uint32_t * pulDNSServerAddress );
 
-void FreeRTOS_SetAddressConfiguration( const uint32_t *pulIPAddress,
-									   const uint32_t *pulNetMask,
-									   const uint32_t *pulGatewayAddress,
-									   const uint32_t *pulDNSServerAddress );
+    void FreeRTOS_SetAddressConfiguration( const uint32_t * pulIPAddress,
+                                           const uint32_t * pulNetMask,
+                                           const uint32_t * pulGatewayAddress,
+                                           const uint32_t * pulDNSServerAddress );
 
 /* MISRA defining 'FreeRTOS_SendPingRequest' should be dependent on 'ipconfigSUPPORT_OUTGOING_PINGS'.
-In order not to break some existing project, define it unconditionally. */
-BaseType_t FreeRTOS_SendPingRequest( uint32_t ulIPAddress, size_t uxNumberOfBytesToSend, TickType_t uxBlockTimeTicks );
+ * In order not to break some existing project, define it unconditionally. */
+    BaseType_t FreeRTOS_SendPingRequest( uint32_t ulIPAddress,
+                                         size_t uxNumberOfBytesToSend,
+                                         TickType_t uxBlockTimeTicks );
 
-void FreeRTOS_ReleaseUDPPayloadBuffer( void const * pvBuffer );
-const uint8_t * FreeRTOS_GetMACAddress( void );
-void FreeRTOS_UpdateMACAddress( const uint8_t ucMACAddress[ipMAC_ADDRESS_LENGTH_BYTES] );
-#if( ipconfigUSE_NETWORK_EVENT_HOOK == 1 )
-	/* coverity[misra_c_2012_rule_8_6_violation] */
-	/* This function shall be defined by the application. */
-	void vApplicationIPNetworkEventHook( eIPCallbackEvent_t eNetworkEvent );
-#endif
-#if ( ipconfigSUPPORT_OUTGOING_PINGS == 1 )
-	void vApplicationPingReplyHook( ePingReplyStatus_t eStatus, uint16_t usIdentifier );
-#endif
-uint32_t FreeRTOS_GetIPAddress( void );
-void FreeRTOS_SetIPAddress( uint32_t ulIPAddress );
-void FreeRTOS_SetNetmask( uint32_t ulNetmask );
-void FreeRTOS_SetGatewayAddress( uint32_t ulGatewayAddress );
-uint32_t FreeRTOS_GetGatewayAddress( void );
-uint32_t FreeRTOS_GetDNSServerAddress( void );
-uint32_t FreeRTOS_GetNetmask( void );
-void FreeRTOS_OutputARPRequest( uint32_t ulIPAddress );
-BaseType_t FreeRTOS_IsNetworkUp( void );
+    void FreeRTOS_ReleaseUDPPayloadBuffer( void const * pvBuffer );
+    const uint8_t * FreeRTOS_GetMACAddress( void );
+    void FreeRTOS_UpdateMACAddress( const uint8_t ucMACAddress[ ipMAC_ADDRESS_LENGTH_BYTES ] );
+    #if ( ipconfigUSE_NETWORK_EVENT_HOOK == 1 )
+        /* coverity[misra_c_2012_rule_8_6_violation] */
+        /* This function shall be defined by the application. */
+        void vApplicationIPNetworkEventHook( eIPCallbackEvent_t eNetworkEvent );
+    #endif
+    #if ( ipconfigSUPPORT_OUTGOING_PINGS == 1 )
+        void vApplicationPingReplyHook( ePingReplyStatus_t eStatus,
+                                        uint16_t usIdentifier );
+    #endif
+    uint32_t FreeRTOS_GetIPAddress( void );
+    void FreeRTOS_SetIPAddress( uint32_t ulIPAddress );
+    void FreeRTOS_SetNetmask( uint32_t ulNetmask );
+    void FreeRTOS_SetGatewayAddress( uint32_t ulGatewayAddress );
+    uint32_t FreeRTOS_GetGatewayAddress( void );
+    uint32_t FreeRTOS_GetDNSServerAddress( void );
+    uint32_t FreeRTOS_GetNetmask( void );
+    void FreeRTOS_OutputARPRequest( uint32_t ulIPAddress );
+    BaseType_t FreeRTOS_IsNetworkUp( void );
 
-#if( ipconfigCHECK_IP_QUEUE_SPACE != 0 )
-	UBaseType_t uxGetMinimumIPQueueSpace( void );
-#endif
+    #if ( ipconfigCHECK_IP_QUEUE_SPACE != 0 )
+        UBaseType_t uxGetMinimumIPQueueSpace( void );
+    #endif
 
 /*
  * Defined in FreeRTOS_Sockets.c
@@ -310,91 +350,79 @@ BaseType_t FreeRTOS_IsNetworkUp( void );
  * Socket has had activity, reset the timer so it will not be closed
  * because of inactivity
  */
-const char *FreeRTOS_GetTCPStateName( UBaseType_t ulState);
+    const char * FreeRTOS_GetTCPStateName( UBaseType_t ulState );
 
 /* _HT_ Temporary: show all valid ARP entries
  */
-void FreeRTOS_PrintARPCache( void );
-void FreeRTOS_ClearARP( void );
+    void FreeRTOS_PrintARPCache( void );
+    void FreeRTOS_ClearARP( void );
 
 /* Return pdTRUE if the IPv4 address is a multicast address. */
-BaseType_t xIsIPv4Multicast( uint32_t ulIPAddress );
+    BaseType_t xIsIPv4Multicast( uint32_t ulIPAddress );
 
 /* Set the MAC-address that belongs to a given IPv4 multi-cast address. */
-void vSetMultiCastIPv4MacAddress( uint32_t ulIPAddress, MACAddress_t *pxMACAddress );
+    void vSetMultiCastIPv4MacAddress( uint32_t ulIPAddress,
+                                      MACAddress_t * pxMACAddress );
 
-#if( ipconfigDHCP_REGISTER_HOSTNAME == 1 )
+    #if ( ipconfigDHCP_REGISTER_HOSTNAME == 1 )
 
-	/* DHCP has an option for clients to register their hostname.  It doesn't
-	have much use, except that a device can be found in a router along with its
-	name. If this option is used the callback below must be provided by the
-	application	writer to return a const string, denoting the device's name. */
-	/* coverity[misra_c_2012_rule_8_6_violation], typically defined in a user module. */
-	const char *pcApplicationHostnameHook( void );
+        /* DHCP has an option for clients to register their hostname.  It doesn't
+         * have much use, except that a device can be found in a router along with its
+         * name. If this option is used the callback below must be provided by the
+         * application	writer to return a const string, denoting the device's name. */
+        /* coverity[misra_c_2012_rule_8_6_violation], typically defined in a user module. */
+        const char * pcApplicationHostnameHook( void );
 
-#endif /* ipconfigDHCP_REGISTER_HOSTNAME */
+    #endif /* ipconfigDHCP_REGISTER_HOSTNAME */
 
 
 /* This xApplicationGetRandomNumber() will set *pulNumber to a random number,
-and return pdTRUE. When the random number generator is broken, it shall return
-pdFALSE.
-The function is defined in 'iot_secure_sockets.c'.
-If that module is not included in the project, the application must provide an
-implementation of it.
-The macro's ipconfigRAND32() and configRAND32() are not in use anymore. */
+ * and return pdTRUE. When the random number generator is broken, it shall return
+ * pdFALSE.
+ * The function is defined in 'iot_secure_sockets.c'.
+ * If that module is not included in the project, the application must provide an
+ * implementation of it.
+ * The macro's ipconfigRAND32() and configRAND32() are not in use anymore. */
 /* "xApplicationGetRandomNumber" is declared but never defined, because it may
-be defined in a user module. */
+ * be defined in a user module. */
 /* coverity[misra_c_2012_rule_8_6_violation] */
-extern BaseType_t xApplicationGetRandomNumber( uint32_t *pulNumber );
+    extern BaseType_t xApplicationGetRandomNumber( uint32_t * pulNumber );
 
 /* For backward compatibility define old structure names to the newer equivalent
-structure name. */
-#ifndef ipconfigENABLE_BACKWARD_COMPATIBILITY
-	#define ipconfigENABLE_BACKWARD_COMPATIBILITY	1
-#endif
+ * structure name. */
+    #ifndef ipconfigENABLE_BACKWARD_COMPATIBILITY
+        #define ipconfigENABLE_BACKWARD_COMPATIBILITY    1
+    #endif
 
-#if( ipconfigENABLE_BACKWARD_COMPATIBILITY == 1 )
-	#define xIPStackEvent_t 			IPStackEvent_t
-	#define xNetworkBufferDescriptor_t 	NetworkBufferDescriptor_t
-	#define xMACAddress_t 				MACAddress_t
-	#define xWinProperties_t 			WinProperties_t
-	#define xSocket_t 					Socket_t
-	#define xSocketSet_t 				SocketSet_t
-	#define ipSIZE_OF_IP_HEADER			ipSIZE_OF_IPv4_HEADER
+    #if ( ipconfigENABLE_BACKWARD_COMPATIBILITY == 1 )
+        #define xIPStackEvent_t               IPStackEvent_t
+        #define xNetworkBufferDescriptor_t    NetworkBufferDescriptor_t
+        #define xMACAddress_t                 MACAddress_t
+        #define xWinProperties_t              WinProperties_t
+        #define xSocket_t                     Socket_t
+        #define xSocketSet_t                  SocketSet_t
+        #define ipSIZE_OF_IP_HEADER           ipSIZE_OF_IPv4_HEADER
 
-	/* Since August 2016, the public types and fields below have changed name:
-	abbreviations TCP/UDP are now written in capitals, and type names now end with "_t". */
-	#define FOnConnected				FOnConnected_t
-	#define FOnTcpReceive				FOnTCPReceive_t
-	#define FOnTcpSent					FOnTCPSent_t
-	#define FOnUdpReceive				FOnUDPReceive_t
-	#define FOnUdpSent					FOnUDPSent_t
+        /* Since August 2016, the public types and fields below have changed name:
+         * abbreviations TCP/UDP are now written in capitals, and type names now end with "_t". */
+        #define FOnConnected                  FOnConnected_t
+        #define FOnTcpReceive                 FOnTCPReceive_t
+        #define FOnTcpSent                    FOnTCPSent_t
+        #define FOnUdpReceive                 FOnUDPReceive_t
+        #define FOnUdpSent                    FOnUDPSent_t
 
-	#define pOnTcpConnected				pxOnTCPConnected
-	#define pOnTcpReceive				pxOnTCPReceive
-	#define pOnTcpSent					pxOnTCPSent
-	#define pOnUdpReceive				pxOnUDPReceive
-	#define pOnUdpSent					pxOnUDPSent
+        #define pOnTcpConnected               pxOnTCPConnected
+        #define pOnTcpReceive                 pxOnTCPReceive
+        #define pOnTcpSent                    pxOnTCPSent
+        #define pOnUdpReceive                 pxOnUDPReceive
+        #define pOnUdpSent                    pxOnUDPSent
 
-	#define FOnUdpSent					FOnUDPSent_t
-	#define FOnTcpSent					FOnTCPSent_t
-#endif /* ipconfigENABLE_BACKWARD_COMPATIBILITY */
+        #define FOnUdpSent                    FOnUDPSent_t
+        #define FOnTcpSent                    FOnTCPSent_t
+    #endif /* ipconfigENABLE_BACKWARD_COMPATIBILITY */
 
-#ifdef __cplusplus
-} /* extern "C" */
-#endif
+    #ifdef __cplusplus
+        } /* extern "C" */
+    #endif
 
 #endif /* FREERTOS_IP_H */
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/include/FreeRTOS_IP_Private.h
+++ b/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/include/FreeRTOS_IP_Private.h
@@ -24,314 +24,314 @@
  */
 
 #ifndef FREERTOS_IP_PRIVATE_H
-#define FREERTOS_IP_PRIVATE_H
+    #define FREERTOS_IP_PRIVATE_H
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+    #ifdef __cplusplus
+        extern "C" {
+    #endif
 
 /* Application level configuration options. */
-#include "FreeRTOSIPConfig.h"
-#include "FreeRTOSIPConfigDefaults.h"
-#include "FreeRTOS_Sockets.h"
-#include "IPTraceMacroDefaults.h"
-#include "FreeRTOS_Stream_Buffer.h"
-#if( ipconfigUSE_TCP == 1 )
-	#include "FreeRTOS_TCP_WIN.h"
-	#include "FreeRTOS_TCP_IP.h"
-#endif
+    #include "FreeRTOSIPConfig.h"
+    #include "FreeRTOSIPConfigDefaults.h"
+    #include "FreeRTOS_Sockets.h"
+    #include "IPTraceMacroDefaults.h"
+    #include "FreeRTOS_Stream_Buffer.h"
+    #if ( ipconfigUSE_TCP == 1 )
+        #include "FreeRTOS_TCP_WIN.h"
+        #include "FreeRTOS_TCP_IP.h"
+    #endif
 
-#include "semphr.h"
+    #include "semphr.h"
 
-#include "event_groups.h"
+    #include "event_groups.h"
 
-typedef struct xNetworkAddressingParameters
-{
-	uint32_t ulDefaultIPAddress;
-	uint32_t ulNetMask;
-	uint32_t ulGatewayAddress;
-	uint32_t ulDNSServerAddress;
-	uint32_t ulBroadcastAddress;
-} NetworkAddressingParameters_t;
+    typedef struct xNetworkAddressingParameters
+    {
+        uint32_t ulDefaultIPAddress;
+        uint32_t ulNetMask;
+        uint32_t ulGatewayAddress;
+        uint32_t ulDNSServerAddress;
+        uint32_t ulBroadcastAddress;
+    } NetworkAddressingParameters_t;
 
-extern BaseType_t xTCPWindowLoggingLevel;
-extern QueueHandle_t xNetworkEventQueue;
+    extern BaseType_t xTCPWindowLoggingLevel;
+    extern QueueHandle_t xNetworkEventQueue;
 
 /*-----------------------------------------------------------*/
 /* Protocol headers.                                         */
 /*-----------------------------------------------------------*/
 
-#include "pack_struct_start.h"
-struct xETH_HEADER
-{
-	MACAddress_t xDestinationAddress; /*  0 + 6 = 6  */
-	MACAddress_t xSourceAddress;      /*  6 + 6 = 12 */
-	uint16_t usFrameType;              /* 12 + 2 = 14 */
-}
-#include "pack_struct_end.h"
-typedef struct xETH_HEADER EthernetHeader_t;
+    #include "pack_struct_start.h"
+    struct xETH_HEADER
+    {
+        MACAddress_t xDestinationAddress; /*  0 + 6 = 6  */
+        MACAddress_t xSourceAddress;      /*  6 + 6 = 12 */
+        uint16_t usFrameType;             /* 12 + 2 = 14 */
+    }
+    #include "pack_struct_end.h"
+    typedef struct xETH_HEADER EthernetHeader_t;
 
-#include "pack_struct_start.h"
-struct xARP_HEADER
-{
-	uint16_t usHardwareType;				/*  0 +  2 =  2 */
-	uint16_t usProtocolType;				/*  2 +  2 =  4 */
-	uint8_t ucHardwareAddressLength;		/*  4 +  1 =  5 */
-	uint8_t ucProtocolAddressLength;		/*  5 +  1 =  6 */
-	uint16_t usOperation;					/*  6 +  2 =  8 */
-	MACAddress_t xSenderHardwareAddress;	/*  8 +  6 = 14 */
-	uint8_t ucSenderProtocolAddress[ 4 ];	/* 14 +  4 = 18  */
-	MACAddress_t xTargetHardwareAddress;	/* 18 +  6 = 24  */
-	uint32_t ulTargetProtocolAddress;		/* 24 +  4 = 28  */
-}
-#include "pack_struct_end.h"
-typedef struct xARP_HEADER ARPHeader_t;
+    #include "pack_struct_start.h"
+    struct xARP_HEADER
+    {
+        uint16_t usHardwareType;              /*  0 +  2 =  2 */
+        uint16_t usProtocolType;              /*  2 +  2 =  4 */
+        uint8_t ucHardwareAddressLength;      /*  4 +  1 =  5 */
+        uint8_t ucProtocolAddressLength;      /*  5 +  1 =  6 */
+        uint16_t usOperation;                 /*  6 +  2 =  8 */
+        MACAddress_t xSenderHardwareAddress;  /*  8 +  6 = 14 */
+        uint8_t ucSenderProtocolAddress[ 4 ]; /* 14 +  4 = 18  */
+        MACAddress_t xTargetHardwareAddress;  /* 18 +  6 = 24  */
+        uint32_t ulTargetProtocolAddress;     /* 24 +  4 = 28  */
+    }
+    #include "pack_struct_end.h"
+    typedef struct xARP_HEADER ARPHeader_t;
 
-#include "pack_struct_start.h"
-struct xIP_HEADER
-{
-	uint8_t ucVersionHeaderLength;        /*  0 + 1 =  1 */
-	uint8_t ucDifferentiatedServicesCode; /*  1 + 1 =  2 */
-	uint16_t usLength;                    /*  2 + 2 =  4 */
-	uint16_t usIdentification;            /*  4 + 2 =  6 */
-	uint16_t usFragmentOffset;            /*  6 + 2 =  8 */
-	uint8_t ucTimeToLive;                 /*  8 + 1 =  9 */
-	uint8_t ucProtocol;                   /*  9 + 1 = 10 */
-	uint16_t usHeaderChecksum;            /* 10 + 2 = 12 */
-	uint32_t ulSourceIPAddress;           /* 12 + 4 = 16 */
-	uint32_t ulDestinationIPAddress;      /* 16 + 4 = 20 */
-}
-#include "pack_struct_end.h"
-typedef struct xIP_HEADER IPHeader_t;
+    #include "pack_struct_start.h"
+    struct xIP_HEADER
+    {
+        uint8_t ucVersionHeaderLength;        /*  0 + 1 =  1 */
+        uint8_t ucDifferentiatedServicesCode; /*  1 + 1 =  2 */
+        uint16_t usLength;                    /*  2 + 2 =  4 */
+        uint16_t usIdentification;            /*  4 + 2 =  6 */
+        uint16_t usFragmentOffset;            /*  6 + 2 =  8 */
+        uint8_t ucTimeToLive;                 /*  8 + 1 =  9 */
+        uint8_t ucProtocol;                   /*  9 + 1 = 10 */
+        uint16_t usHeaderChecksum;            /* 10 + 2 = 12 */
+        uint32_t ulSourceIPAddress;           /* 12 + 4 = 16 */
+        uint32_t ulDestinationIPAddress;      /* 16 + 4 = 20 */
+    }
+    #include "pack_struct_end.h"
+    typedef struct xIP_HEADER IPHeader_t;
 
-#include "pack_struct_start.h"
-struct xICMP_HEADER
-{
-	uint8_t ucTypeOfMessage;   /* 0 + 1 = 1 */
-	uint8_t ucTypeOfService;   /* 1 + 1 = 2 */
-	uint16_t usChecksum;       /* 2 + 2 = 4 */
-	uint16_t usIdentifier;     /* 4 + 2 = 6 */
-	uint16_t usSequenceNumber; /* 6 + 2 = 8 */
-}
-#include "pack_struct_end.h"
-typedef struct xICMP_HEADER ICMPHeader_t;
+    #include "pack_struct_start.h"
+    struct xICMP_HEADER
+    {
+        uint8_t ucTypeOfMessage;   /* 0 + 1 = 1 */
+        uint8_t ucTypeOfService;   /* 1 + 1 = 2 */
+        uint16_t usChecksum;       /* 2 + 2 = 4 */
+        uint16_t usIdentifier;     /* 4 + 2 = 6 */
+        uint16_t usSequenceNumber; /* 6 + 2 = 8 */
+    }
+    #include "pack_struct_end.h"
+    typedef struct xICMP_HEADER ICMPHeader_t;
 
-#include "pack_struct_start.h"
-struct xUDP_HEADER
-{
-	uint16_t usSourcePort;      /* 0 + 2 = 2 */
-	uint16_t usDestinationPort; /* 2 + 2 = 4 */
-	uint16_t usLength;          /* 4 + 2 = 6 */
-	uint16_t usChecksum;        /* 6 + 2 = 8 */
-}
-#include "pack_struct_end.h"
-typedef struct xUDP_HEADER UDPHeader_t;
+    #include "pack_struct_start.h"
+    struct xUDP_HEADER
+    {
+        uint16_t usSourcePort;      /* 0 + 2 = 2 */
+        uint16_t usDestinationPort; /* 2 + 2 = 4 */
+        uint16_t usLength;          /* 4 + 2 = 6 */
+        uint16_t usChecksum;        /* 6 + 2 = 8 */
+    }
+    #include "pack_struct_end.h"
+    typedef struct xUDP_HEADER UDPHeader_t;
 
-#include "pack_struct_start.h"
-struct xTCP_HEADER
-{
-	uint16_t usSourcePort;		/* +  2 =  2 */
-	uint16_t usDestinationPort;	/* +  2 =  4 */
-	uint32_t ulSequenceNumber;	/* +  4 =  8 */
-	uint32_t ulAckNr;   	 	/* +  4 = 12 */
-	uint8_t  ucTCPOffset;		/* +  1 = 13 */
-	uint8_t  ucTCPFlags;		/* +  1 = 14 */
-	uint16_t usWindow;			/* +  2 = 15 */
-	uint16_t usChecksum;		/* +  2 = 18 */
-	uint16_t usUrgent;			/* +  2 = 20 */
-#if ipconfigUSE_TCP == 1
-	/* the option data is not a part of the TCP header */
-	uint8_t  ucOptdata[ipSIZE_TCP_OPTIONS];		/* + 12 = 32 */
-#endif
-}
-#include "pack_struct_end.h"
-typedef struct xTCP_HEADER TCPHeader_t;
+    #include "pack_struct_start.h"
+    struct xTCP_HEADER
+    {
+        uint16_t usSourcePort;      /* +  2 =  2 */
+        uint16_t usDestinationPort; /* +  2 =  4 */
+        uint32_t ulSequenceNumber;  /* +  4 =  8 */
+        uint32_t ulAckNr;           /* +  4 = 12 */
+        uint8_t ucTCPOffset;        /* +  1 = 13 */
+        uint8_t ucTCPFlags;         /* +  1 = 14 */
+        uint16_t usWindow;          /* +  2 = 15 */
+        uint16_t usChecksum;        /* +  2 = 18 */
+        uint16_t usUrgent;          /* +  2 = 20 */
+        #if ipconfigUSE_TCP == 1
+            /* the option data is not a part of the TCP header */
+            uint8_t ucOptdata[ ipSIZE_TCP_OPTIONS ]; /* + 12 = 32 */
+        #endif
+    }
+    #include "pack_struct_end.h"
+    typedef struct xTCP_HEADER TCPHeader_t;
 
 /*-----------------------------------------------------------*/
 /* Nested protocol packets.                                  */
 /*-----------------------------------------------------------*/
 
-#include "pack_struct_start.h"
-struct xARP_PACKET
-{
-	EthernetHeader_t xEthernetHeader;	/*  0 + 14 = 14 */
-	ARPHeader_t xARPHeader;			/* 14 + 28 = 42 */
-}
-#include "pack_struct_end.h"
-typedef struct xARP_PACKET ARPPacket_t;
+    #include "pack_struct_start.h"
+    struct xARP_PACKET
+    {
+        EthernetHeader_t xEthernetHeader; /*  0 + 14 = 14 */
+        ARPHeader_t xARPHeader;           /* 14 + 28 = 42 */
+    }
+    #include "pack_struct_end.h"
+    typedef struct xARP_PACKET ARPPacket_t;
 
-#include "pack_struct_start.h"
-struct xIP_PACKET
-{
-	EthernetHeader_t xEthernetHeader;
-	IPHeader_t xIPHeader;
-}
-#include "pack_struct_end.h"
-typedef struct xIP_PACKET IPPacket_t;
+    #include "pack_struct_start.h"
+    struct xIP_PACKET
+    {
+        EthernetHeader_t xEthernetHeader;
+        IPHeader_t xIPHeader;
+    }
+    #include "pack_struct_end.h"
+    typedef struct xIP_PACKET IPPacket_t;
 
-#include "pack_struct_start.h"
-struct xICMP_PACKET
-{
-	EthernetHeader_t xEthernetHeader;
-	IPHeader_t xIPHeader;
-	ICMPHeader_t xICMPHeader;
-}
-#include "pack_struct_end.h"
-typedef struct xICMP_PACKET ICMPPacket_t;
+    #include "pack_struct_start.h"
+    struct xICMP_PACKET
+    {
+        EthernetHeader_t xEthernetHeader;
+        IPHeader_t xIPHeader;
+        ICMPHeader_t xICMPHeader;
+    }
+    #include "pack_struct_end.h"
+    typedef struct xICMP_PACKET ICMPPacket_t;
 
-#include "pack_struct_start.h"
-struct xUDP_PACKET
-{
-	EthernetHeader_t xEthernetHeader; /*  0 + 14 = 14 */
-	IPHeader_t xIPHeader;             /* 14 + 20 = 34 */
-	UDPHeader_t xUDPHeader;           /* 34 +  8 = 42 */
-}
-#include "pack_struct_end.h"
-typedef struct xUDP_PACKET UDPPacket_t;
+    #include "pack_struct_start.h"
+    struct xUDP_PACKET
+    {
+        EthernetHeader_t xEthernetHeader; /*  0 + 14 = 14 */
+        IPHeader_t xIPHeader;             /* 14 + 20 = 34 */
+        UDPHeader_t xUDPHeader;           /* 34 +  8 = 42 */
+    }
+    #include "pack_struct_end.h"
+    typedef struct xUDP_PACKET UDPPacket_t;
 
-#include "pack_struct_start.h"
-struct xTCP_PACKET
-{
-	EthernetHeader_t xEthernetHeader; /*  0 + 14 = 14 */
-	IPHeader_t xIPHeader;             /* 14 + 20 = 34 */
-	TCPHeader_t xTCPHeader;           /* 34 + 32 = 66 */
-}
-#include "pack_struct_end.h"
-typedef struct xTCP_PACKET TCPPacket_t;
+    #include "pack_struct_start.h"
+    struct xTCP_PACKET
+    {
+        EthernetHeader_t xEthernetHeader; /*  0 + 14 = 14 */
+        IPHeader_t xIPHeader;             /* 14 + 20 = 34 */
+        TCPHeader_t xTCPHeader;           /* 34 + 32 = 66 */
+    }
+    #include "pack_struct_end.h"
+    typedef struct xTCP_PACKET TCPPacket_t;
 
-typedef union XPROT_PACKET
-{
-	ARPPacket_t xARPPacket;
-	TCPPacket_t xTCPPacket;
-	UDPPacket_t xUDPPacket;
-	ICMPPacket_t xICMPPacket;
-} ProtocolPacket_t;
+    typedef union XPROT_PACKET
+    {
+        ARPPacket_t xARPPacket;
+        TCPPacket_t xTCPPacket;
+        UDPPacket_t xUDPPacket;
+        ICMPPacket_t xICMPPacket;
+    } ProtocolPacket_t;
 
-typedef union xPROT_HEADERS
-{
-	ICMPHeader_t xICMPHeader;
-	UDPHeader_t xUDPHeader;
-	TCPHeader_t xTCPHeader;
-} ProtocolHeaders_t;
+    typedef union xPROT_HEADERS
+    {
+        ICMPHeader_t xICMPHeader;
+        UDPHeader_t xUDPHeader;
+        TCPHeader_t xTCPHeader;
+    } ProtocolHeaders_t;
 
 
 /* The maximum UDP payload length. */
-#define ipMAX_UDP_PAYLOAD_LENGTH ( ( ipconfigNETWORK_MTU - ipSIZE_OF_IPv4_HEADER ) - ipSIZE_OF_UDP_HEADER )
+    #define ipMAX_UDP_PAYLOAD_LENGTH    ( ( ipconfigNETWORK_MTU - ipSIZE_OF_IPv4_HEADER ) - ipSIZE_OF_UDP_HEADER )
 
-typedef enum
-{
-	eReleaseBuffer = 0,		/* Processing the frame did not find anything to do - just release the buffer. */
-	eProcessBuffer,			/* An Ethernet frame has a valid address - continue process its contents. */
-	eReturnEthernetFrame,	/* The Ethernet frame contains an ARP or ICMP packet that can be returned to its source. */
-	eFrameConsumed			/* Processing the Ethernet packet contents resulted in the payload being sent to the stack. */
-} eFrameProcessingResult_t;
+    typedef enum
+    {
+        eReleaseBuffer = 0,   /* Processing the frame did not find anything to do - just release the buffer. */
+        eProcessBuffer,       /* An Ethernet frame has a valid address - continue process its contents. */
+        eReturnEthernetFrame, /* The Ethernet frame contains an ARP or ICMP packet that can be returned to its source. */
+        eFrameConsumed        /* Processing the Ethernet packet contents resulted in the payload being sent to the stack. */
+    } eFrameProcessingResult_t;
 
-typedef enum
-{
-	eNoEvent = -1,
-	eNetworkDownEvent,		/* 0: The network interface has been lost and/or needs [re]connecting. */
-	eNetworkRxEvent,		/* 1: The network interface has queued a received Ethernet frame. */
-	eNetworkTxEvent,		/* 2: Let the IP-task send a network packet. */
-	eARPTimerEvent,			/* 3: The ARP timer expired. */
-	eStackTxEvent,			/* 4: The software stack has queued a packet to transmit. */
-	eDHCPEvent,				/* 5: Process the DHCP state machine. */
-	eTCPTimerEvent,			/* 6: See if any TCP socket needs attention. */
-	eTCPAcceptEvent,		/* 7: Client API FreeRTOS_accept() waiting for client connections. */
-	eTCPNetStat,			/* 8: IP-task is asked to produce a netstat listing. */
-	eSocketBindEvent,		/* 9: Send a message to the IP-task to bind a socket to a port. */
-	eSocketCloseEvent,		/*10: Send a message to the IP-task to close a socket. */
-	eSocketSelectEvent,		/*11: Send a message to the IP-task for select(). */
-	eSocketSignalEvent,		/*12: A socket must be signalled. */
-} eIPEvent_t;
+    typedef enum
+    {
+        eNoEvent = -1,
+        eNetworkDownEvent,  /* 0: The network interface has been lost and/or needs [re]connecting. */
+        eNetworkRxEvent,    /* 1: The network interface has queued a received Ethernet frame. */
+        eNetworkTxEvent,    /* 2: Let the IP-task send a network packet. */
+        eARPTimerEvent,     /* 3: The ARP timer expired. */
+        eStackTxEvent,      /* 4: The software stack has queued a packet to transmit. */
+        eDHCPEvent,         /* 5: Process the DHCP state machine. */
+        eTCPTimerEvent,     /* 6: See if any TCP socket needs attention. */
+        eTCPAcceptEvent,    /* 7: Client API FreeRTOS_accept() waiting for client connections. */
+        eTCPNetStat,        /* 8: IP-task is asked to produce a netstat listing. */
+        eSocketBindEvent,   /* 9: Send a message to the IP-task to bind a socket to a port. */
+        eSocketCloseEvent,  /*10: Send a message to the IP-task to close a socket. */
+        eSocketSelectEvent, /*11: Send a message to the IP-task for select(). */
+        eSocketSignalEvent, /*12: A socket must be signalled. */
+    } eIPEvent_t;
 
-typedef struct IP_TASK_COMMANDS
-{
-	eIPEvent_t eEventType;
-	void *pvData;
-} IPStackEvent_t;
+    typedef struct IP_TASK_COMMANDS
+    {
+        eIPEvent_t eEventType;
+        void * pvData;
+    } IPStackEvent_t;
 
-#define ipBROADCAST_IP_ADDRESS 0xffffffffUL
+    #define ipBROADCAST_IP_ADDRESS               0xffffffffUL
 
 /* Offset into the Ethernet frame that is used to temporarily store information
-on the fragmentation status of the packet being sent.  The value is important,
-as it is past the location into which the destination address will get placed. */
-#define ipFRAGMENTATION_PARAMETERS_OFFSET		( 6 )
-#define ipSOCKET_OPTIONS_OFFSET					( 6 )
+ * on the fragmentation status of the packet being sent.  The value is important,
+ * as it is past the location into which the destination address will get placed. */
+    #define ipFRAGMENTATION_PARAMETERS_OFFSET    ( 6 )
+    #define ipSOCKET_OPTIONS_OFFSET              ( 6 )
 
 /* Only used when outgoing fragmentation is being used (FreeRTOSIPConfig.h
-setting. */
-#define ipGET_UDP_PAYLOAD_OFFSET_FOR_FRAGMENT( usFragmentOffset ) ( ( ( usFragmentOffset ) == 0 ) ? ipUDP_PAYLOAD_OFFSET_IPv4 : ipIP_PAYLOAD_OFFSET )
+ * setting. */
+    #define ipGET_UDP_PAYLOAD_OFFSET_FOR_FRAGMENT( usFragmentOffset )    ( ( ( usFragmentOffset ) == 0 ) ? ipUDP_PAYLOAD_OFFSET_IPv4 : ipIP_PAYLOAD_OFFSET )
 
 /* The offset into a UDP packet at which the UDP data (payload) starts. */
-#define ipUDP_PAYLOAD_OFFSET_IPv4	( sizeof( UDPPacket_t ) )
+    #define ipUDP_PAYLOAD_OFFSET_IPv4    ( sizeof( UDPPacket_t ) )
 
 /* The offset into an IP packet into which the IP data (payload) starts. */
-#define ipIP_PAYLOAD_OFFSET		( sizeof( IPPacket_t ) )
+    #define ipIP_PAYLOAD_OFFSET          ( sizeof( IPPacket_t ) )
 
-#if( ipconfigBYTE_ORDER == pdFREERTOS_LITTLE_ENDIAN )
+    #if ( ipconfigBYTE_ORDER == pdFREERTOS_LITTLE_ENDIAN )
 
-	/* Ethernet frame types. */
-	#define ipARP_FRAME_TYPE	( 0x0608U )
-	#define ipIPv4_FRAME_TYPE	( 0x0008U )
+        /* Ethernet frame types. */
+        #define ipARP_FRAME_TYPE                ( 0x0608U )
+        #define ipIPv4_FRAME_TYPE               ( 0x0008U )
 
-	/* ARP related definitions. */
-	#define ipARP_PROTOCOL_TYPE				( 0x0008U )
-	#define ipARP_HARDWARE_TYPE_ETHERNET	( 0x0100U )
-	#define ipARP_REQUEST					( 0x0100U )
-	#define ipARP_REPLY						( 0x0200U )
+        /* ARP related definitions. */
+        #define ipARP_PROTOCOL_TYPE             ( 0x0008U )
+        #define ipARP_HARDWARE_TYPE_ETHERNET    ( 0x0100U )
+        #define ipARP_REQUEST                   ( 0x0100U )
+        #define ipARP_REPLY                     ( 0x0200U )
 
-#else
+    #else /* if ( ipconfigBYTE_ORDER == pdFREERTOS_LITTLE_ENDIAN ) */
 
-	/* Ethernet frame types. */
-	#define ipARP_FRAME_TYPE	( 0x0806U )
-	#define ipIPv4_FRAME_TYPE	( 0x0800U )
+        /* Ethernet frame types. */
+        #define ipARP_FRAME_TYPE                ( 0x0806U )
+        #define ipIPv4_FRAME_TYPE               ( 0x0800U )
 
-	/* ARP related definitions. */
-	#define ipARP_PROTOCOL_TYPE ( 0x0800U )
-	#define ipARP_HARDWARE_TYPE_ETHERNET ( 0x0001U )
-	#define ipARP_REQUEST ( 0x0001 )
-	#define ipARP_REPLY ( 0x0002 )
+        /* ARP related definitions. */
+        #define ipARP_PROTOCOL_TYPE             ( 0x0800U )
+        #define ipARP_HARDWARE_TYPE_ETHERNET    ( 0x0001U )
+        #define ipARP_REQUEST                   ( 0x0001 )
+        #define ipARP_REPLY                     ( 0x0002 )
 
-#endif /* ipconfigBYTE_ORDER == pdFREERTOS_LITTLE_ENDIAN */
+    #endif /* ipconfigBYTE_ORDER == pdFREERTOS_LITTLE_ENDIAN */
 
 
 /* For convenience, a MAC address of all zeros and another of all 0xffs are
-defined const for quick reference. */
-extern const MACAddress_t xBroadcastMACAddress; /* all 0xff's */
-extern uint16_t usPacketIdentifier;
+ * defined const for quick reference. */
+    extern const MACAddress_t xBroadcastMACAddress; /* all 0xff's */
+    extern uint16_t usPacketIdentifier;
 
 /* Define a default UDP packet header (declared in FreeRTOS_UDP_IP.c) */
-typedef union xUDPPacketHeader
-{
-	uint8_t ucBytes[24];
-	uint32_t ulWords[6];
-} UDPPacketHeader_t;
-extern UDPPacketHeader_t xDefaultPartUDPPacketHeader;
+    typedef union xUDPPacketHeader
+    {
+        uint8_t ucBytes[ 24 ];
+        uint32_t ulWords[ 6 ];
+    } UDPPacketHeader_t;
+    extern UDPPacketHeader_t xDefaultPartUDPPacketHeader;
 
 /* Structure that stores the netmask, gateway address and DNS server addresses. */
-extern NetworkAddressingParameters_t xNetworkAddressing;
+    extern NetworkAddressingParameters_t xNetworkAddressing;
 
 /* Structure that stores the defaults for netmask, gateway address and DNS.
-These values will be copied to 'xNetworkAddressing' in case DHCP is not used,
-and also in case DHCP does not lead to a confirmed request. */
+ * These values will be copied to 'xNetworkAddressing' in case DHCP is not used,
+ * and also in case DHCP does not lead to a confirmed request. */
 /*lint -e9003*/
-extern NetworkAddressingParameters_t xDefaultAddressing;	/*lint !e9003 could define variable 'xDefaultAddressing' at block scope [MISRA 2012 Rule 8.9, advisory]. */
+    extern NetworkAddressingParameters_t xDefaultAddressing; /*lint !e9003 could define variable 'xDefaultAddressing' at block scope [MISRA 2012 Rule 8.9, advisory]. */
 
 /* True when BufferAllocation_1.c was included, false for BufferAllocation_2.c */
-extern const BaseType_t xBufferAllocFixedSize;
+    extern const BaseType_t xBufferAllocFixedSize;
 
 /* Defined in FreeRTOS_Sockets.c */
-#if ( ipconfigUSE_TCP == 1 )
-	extern List_t xBoundTCPSocketsList;
-#endif
+    #if ( ipconfigUSE_TCP == 1 )
+        extern List_t xBoundTCPSocketsList;
+    #endif
 
 /* The local IP address is accessed from within xDefaultPartUDPPacketHeader,
-rather than duplicated in its own variable. */
-#define ipLOCAL_IP_ADDRESS_POINTER ( ( uint32_t * ) &( xDefaultPartUDPPacketHeader.ulWords[ 20U / sizeof(uint32_t) ] ) )
+ * rather than duplicated in its own variable. */
+    #define ipLOCAL_IP_ADDRESS_POINTER    ( ( uint32_t * ) &( xDefaultPartUDPPacketHeader.ulWords[ 20U / sizeof( uint32_t ) ] ) )
 
 /* The local MAC address is accessed from within xDefaultPartUDPPacketHeader,
-rather than duplicated in its own variable. */
-#define ipLOCAL_MAC_ADDRESS ( xDefaultPartUDPPacketHeader.ucBytes )
+ * rather than duplicated in its own variable. */
+    #define ipLOCAL_MAC_ADDRESS           ( xDefaultPartUDPPacketHeader.ucBytes )
 
 /* In this library, there is often a cast from a character pointer
  * to a pointer to a struct.
@@ -346,11 +346,11 @@ rather than duplicated in its own variable. */
  * 2 advisory by MISRA:
  * -emacro(9079,ipPOINTER_CAST)   // 9079: conversion from pointer to void to pointer to other type [MISRA 2012 Rule 11.5, advisory])
  * --emacro((826),ipPOINTER_CAST) // 826:  Suspicious pointer-to-pointer conversion (area too small)
- * 
+ *
  * The MISRA warnings can safely be suppressed because all casts are planned with care.
  */
 
-#define ipPOINTER_CAST( TYPE, pointer  ) ( ( TYPE ) ( pointer ) )
+    #define ipPOINTER_CAST( TYPE, pointer )    ( ( TYPE ) ( pointer ) )
 
 /* Sequence and ACK numbers are essentially unsigned (uint32_t). But when
  * a distance is calculated, it is useful to use signed numbers:
@@ -363,54 +363,54 @@ rather than duplicated in its own variable. */
  * -emacro(9030,ipNUMERIC_CAST) // 9030: Impermissible cast; cannot cast from 'essentially Boolean' to 'essentially signed' [MISRA 2012 Rule 10.5, advisory])
  */
 
-#define ipNUMERIC_CAST( TYPE, expression  ) ( ( TYPE ) ( expression ) )
+    #define ipNUMERIC_CAST( TYPE, expression )    ( ( TYPE ) ( expression ) )
 
 /* ICMP packets are sent using the same function as UDP packets.  The port
-number is used to distinguish between the two, as 0 is an invalid UDP port. */
-#define ipPACKET_CONTAINS_ICMP_DATA					( 0 )
+ * number is used to distinguish between the two, as 0 is an invalid UDP port. */
+    #define ipPACKET_CONTAINS_ICMP_DATA    ( 0 )
 
 /* For now, the lower 8 bits in 'xEventBits' will be reserved for the above
-socket events. */
-#define SOCKET_EVENT_BIT_COUNT   8
+ * socket events. */
+    #define SOCKET_EVENT_BIT_COUNT         8
 
-#define vSetField16( pxBase, xType, xField, usValue ) \
-{ \
-	( ( uint8_t* )( pxBase ) ) [ offsetof( xType, xField ) + 0 ] = ( uint8_t ) ( ( usValue ) >> 8 ); \
-	( ( uint8_t* )( pxBase ) ) [ offsetof( xType, xField ) + 1 ] = ( uint8_t ) ( ( usValue ) & 0xffU ); \
-}
+    #define vSetField16( pxBase, xType, xField, usValue )                                                    \
+    {                                                                                                        \
+        ( ( uint8_t * ) ( pxBase ) )[ offsetof( xType, xField ) + 0 ] = ( uint8_t ) ( ( usValue ) >> 8 );    \
+        ( ( uint8_t * ) ( pxBase ) )[ offsetof( xType, xField ) + 1 ] = ( uint8_t ) ( ( usValue ) & 0xffU ); \
+    }
 
-#define vSetField32( pxBase, xType, xField, ulValue ) \
-{ \
-	( (uint8_t*)( pxBase ) ) [ offsetof( xType, xField ) + 0 ] = ( uint8_t )   ( ( ulValue ) >> 24 ); \
-	( (uint8_t*)( pxBase ) ) [ offsetof( xType, xField ) + 1 ] = ( uint8_t ) ( ( ( ulValue ) >> 16 ) & 0xffU ); \
-	( (uint8_t*)( pxBase ) ) [ offsetof( xType, xField ) + 2 ] = ( uint8_t ) ( ( ( ulValue ) >> 8 ) & 0xffU ); \
-	( (uint8_t*)( pxBase ) ) [ offsetof( xType, xField ) + 3 ] = ( uint8_t )   ( ( ulValue ) & 0xffU ); \
-}
+    #define vSetField32( pxBase, xType, xField, ulValue )                                                              \
+    {                                                                                                                  \
+        ( ( uint8_t * ) ( pxBase ) )[ offsetof( xType, xField ) + 0 ] = ( uint8_t ) ( ( ulValue ) >> 24 );             \
+        ( ( uint8_t * ) ( pxBase ) )[ offsetof( xType, xField ) + 1 ] = ( uint8_t ) ( ( ( ulValue ) >> 16 ) & 0xffU ); \
+        ( ( uint8_t * ) ( pxBase ) )[ offsetof( xType, xField ) + 2 ] = ( uint8_t ) ( ( ( ulValue ) >> 8 ) & 0xffU );  \
+        ( ( uint8_t * ) ( pxBase ) )[ offsetof( xType, xField ) + 3 ] = ( uint8_t ) ( ( ulValue ) & 0xffU );           \
+    }
 
-#define vFlip_16( left, right ) \
-	do { \
-		uint16_t tmp = (left); \
-		(left) = (right); \
-		(right) = tmp; \
-	} while ( ipFALSE_BOOL )
+    #define vFlip_16( left, right ) \
+    do {                            \
+        uint16_t tmp = ( left );    \
+        ( left ) = ( right );       \
+        ( right ) = tmp;            \
+    } while ( ipFALSE_BOOL )
 
-#define vFlip_32( left, right ) \
-	do { \
-		uint32_t tmp = (left); \
-		(left) = (right); \
-		(right) = tmp; \
-	} while ( ipFALSE_BOOL )
+    #define vFlip_32( left, right ) \
+    do {                            \
+        uint32_t tmp = ( left );    \
+        ( left ) = ( right );       \
+        ( right ) = tmp;            \
+    } while ( ipFALSE_BOOL )
 
-#ifndef ARRAY_SIZE
-	#define ARRAY_SIZE(x)	( ( BaseType_t ) ( sizeof( x ) / sizeof( ( x )[ 0 ] ) ) )
-#endif
+    #ifndef ARRAY_SIZE
+        #define ARRAY_SIZE( x )    ( ( BaseType_t ) ( sizeof( x ) / sizeof( ( x )[ 0 ] ) ) )
+    #endif
 
 /*
  * A version of FreeRTOS_GetReleaseNetworkBuffer() that can be called from an
  * interrupt.  If a non zero value is returned, then the calling ISR should
  * perform a context switch before exiting the ISR.
  */
-BaseType_t FreeRTOS_ReleaseFreeNetworkBufferFromISR( void );
+    BaseType_t FreeRTOS_ReleaseFreeNetworkBufferFromISR( void );
 
 /*
  * Create a message that contains a command to initialise the network interface.
@@ -424,264 +424,275 @@ BaseType_t FreeRTOS_ReleaseFreeNetworkBufferFromISR( void );
  * returns a non-zero value then a context switch should be performed ebfore
  * the interrupt is exited.
  */
-void FreeRTOS_NetworkDown( void );
-BaseType_t FreeRTOS_NetworkDownFromISR( void );
+    void FreeRTOS_NetworkDown( void );
+    BaseType_t FreeRTOS_NetworkDownFromISR( void );
 
 /*
  * Processes incoming ARP packets.
  */
-eFrameProcessingResult_t eARPProcessPacket( ARPPacket_t * const pxARPFrame );
+    eFrameProcessingResult_t eARPProcessPacket( ARPPacket_t * const pxARPFrame );
 
 /*
  * Inspect an Ethernet frame to see if it contains data that the stack needs to
  * process.  eProcessBuffer is returned if the frame should be processed by the
  * stack.  eReleaseBuffer is returned if the frame should be discarded.
  */
-eFrameProcessingResult_t eConsiderFrameForProcessing( const uint8_t * const pucEthernetBuffer );
+    eFrameProcessingResult_t eConsiderFrameForProcessing( const uint8_t * const pucEthernetBuffer );
 
 /*
  * Return the checksum generated over xDataLengthBytes from pucNextData.
  */
-uint16_t usGenerateChecksum( uint16_t usSum, const uint8_t * pucNextData, size_t uxByteCount );
+    uint16_t usGenerateChecksum( uint16_t usSum,
+                                 const uint8_t * pucNextData,
+                                 size_t uxByteCount );
 
 /* Socket related private functions. */
 
 /*
- * The caller must ensure that pxNetworkBuffer->xDataLength is the UDP packet 
- * payload size (excluding packet headers) and that the packet in pucEthernetBuffer 
- * is at least the size of UDPPacket_t. 
+ * The caller must ensure that pxNetworkBuffer->xDataLength is the UDP packet
+ * payload size (excluding packet headers) and that the packet in pucEthernetBuffer
+ * is at least the size of UDPPacket_t.
  */
-BaseType_t xProcessReceivedUDPPacket( NetworkBufferDescriptor_t *pxNetworkBuffer, uint16_t usPort );
+    BaseType_t xProcessReceivedUDPPacket( NetworkBufferDescriptor_t * pxNetworkBuffer,
+                                          uint16_t usPort );
 
 /*
- * Initialize the socket list data structures for TCP and UDP. 
+ * Initialize the socket list data structures for TCP and UDP.
  */
-void vNetworkSocketsInit( void );
+    void vNetworkSocketsInit( void );
 
 /*
  * Returns pdTRUE if the IP task has been created and is initialised.  Otherwise
  * returns pdFALSE.
  */
-BaseType_t xIPIsNetworkTaskReady( void );
+    BaseType_t xIPIsNetworkTaskReady( void );
 
-#if( ipconfigSOCKET_HAS_USER_WAKE_CALLBACK == 1 )
-	struct xSOCKET;
-	typedef void (*SocketWakeupCallback_t)( struct xSOCKET * pxSocket );
-#endif
+    #if ( ipconfigSOCKET_HAS_USER_WAKE_CALLBACK == 1 )
+        struct xSOCKET;
+        typedef void (* SocketWakeupCallback_t)( struct xSOCKET * pxSocket );
+    #endif
 
-#if( ipconfigUSE_TCP == 1 )
+    #if ( ipconfigUSE_TCP == 1 )
 
-	/*
-	 * Actually a user thing, but because xBoundTCPSocketsList, let it do by the
-	 * IP-task
-	 */
-	void vTCPNetStat( void );
+        /*
+         * Actually a user thing, but because xBoundTCPSocketsList, let it do by the
+         * IP-task
+         */
+        void vTCPNetStat( void );
 
-	/*
-	 * At least one socket needs to check for timeouts
-	 */
-	TickType_t xTCPTimerCheck( BaseType_t xWillSleep );
+        /*
+         * At least one socket needs to check for timeouts
+         */
+        TickType_t xTCPTimerCheck( BaseType_t xWillSleep );
 
-	/* Every TCP socket has a buffer space just big enough to store
-	the last TCP header received.
-	As a reference of this field may be passed to DMA, force the
-	alignment to 8 bytes. */
-	typedef union
-	{
-		struct
-		{
-			/* Increase the alignment of this union by adding a 64-bit variable. */
-			uint64_t ullAlignmentWord;
-		} a;
-		struct
-		{
-			/* The next field only serves to give 'ucLastPacket' a correct
-			alignment of 8 + 2.  See comments in FreeRTOS_IP.h */
-			uint8_t ucFillPacket[ ipconfigPACKET_FILLER_SIZE ];
-			uint8_t ucLastPacket[ sizeof( TCPPacket_t ) ];
-		} u;
-	} LastTCPPacket_t;
+        /* Every TCP socket has a buffer space just big enough to store
+         * the last TCP header received.
+         * As a reference of this field may be passed to DMA, force the
+         * alignment to 8 bytes. */
+        typedef union
+        {
+            struct
+            {
+                /* Increase the alignment of this union by adding a 64-bit variable. */
+                uint64_t ullAlignmentWord;
+            } a;
+            struct
+            {
+                /* The next field only serves to give 'ucLastPacket' a correct
+                 * alignment of 8 + 2.  See comments in FreeRTOS_IP.h */
+                uint8_t ucFillPacket[ ipconfigPACKET_FILLER_SIZE ];
+                uint8_t ucLastPacket[ sizeof( TCPPacket_t ) ];
+            } u;
+        } LastTCPPacket_t;
 
-	/*
-	 * Note that the values of all short and long integers in these structs
-	 * are being stored in the native-endian way
-	 * Translation should take place when accessing any structure which defines
-	 * network packets, such as IPHeader_t and TCPHeader_t
-	 */
-	typedef struct TCPSOCKET
-	{
-		uint32_t ulRemoteIP;		/* IP address of remote machine */
-		uint16_t usRemotePort;		/* Port on remote machine */
-		struct {
-			/* Most compilers do like bit-flags */
-			uint32_t
-				bMssChange : 1,		/* This socket has seen a change in MSS */
-				bPassAccept : 1,	/* when true, this socket may be returned in a call to accept() */
-				bPassQueued : 1,	/* when true, this socket is an orphan until it gets connected
-									 * Why an orphan? Because it may not be returned in a accept() call until it
-									 * gets the state eESTABLISHED */
-				bReuseSocket : 1,	/* When a listening socket gets a connection, do not create a new instance but keep on using it */
-				bCloseAfterSend : 1,/* As soon as the last byte has been transmitted, finalise the connection
-									 * Useful in e.g. FTP connections, where the last data bytes are sent along with the FIN flag */
-				bUserShutdown : 1,	/* User requesting a graceful shutdown */
-				bCloseRequested : 1,/* Request to finalise the connection */
-				bLowWater : 1,		/* high-water level has been reached. Cleared as soon as 'rx-count < lo-water' */
-				bWinChange : 1,		/* The value of bLowWater has changed, must send a window update */
-				bSendKeepAlive : 1,	/* When this flag is true, a TCP keep-alive message must be send */
-				bWaitKeepAlive : 1,	/* When this flag is true, a TCP keep-alive reply is expected */
-				bConnPrepared : 1,	/* Connecting socket: Message has been prepared */
-				#if( ipconfigSUPPORT_SELECT_FUNCTION == 1 )
-					bConnPassed : 1,	/* Connecting socket: Socket has been passed in a successful select()  */
-				#endif /* ipconfigSUPPORT_SELECT_FUNCTION */
-				bFinAccepted : 1,	/* This socket has received (or sent) a FIN and accepted it */
-				bFinSent : 1,		/* We've sent out a FIN */
-				bFinRecv : 1,		/* We've received a FIN from our peer */
-				bFinAcked : 1,		/* Our FIN packet has been acked */
-				bFinLast : 1,		/* The last ACK (after FIN and FIN+ACK) has been sent or will be sent by the peer */
-				bRxStopped : 1,		/* Application asked to temporarily stop reception */
-				bMallocError : 1,	/* There was an error allocating a stream */
-				bWinScaling : 1;	/* A TCP-Window Scaling option was offered and accepted in the SYN phase. */
-		} bits;
-		uint32_t ulHighestRxAllowed;
-								/* The highest sequence number that we can receive at any moment */
-		uint16_t usTimeout;		/* Time (in ticks) after which this socket needs attention */
-		uint16_t usCurMSS;		/* Current Maximum Segment Size */
-		uint16_t usInitMSS;		/* Initial maximum segment Size */
-		uint16_t usChildCount;	/* In case of a listening socket: number of connections on this port number */
-		uint16_t usBacklog;		/* In case of a listening socket: maximum number of concurrent connections on this port number */
-		uint8_t ucRepCount;		/* Send repeat count, for retransmissions
-								 * This counter is separate from the xmitCount in the
-								 * TCP win segments */
-		uint8_t ucTCPState;		/* TCP state: see eTCP_STATE */
-		struct xSOCKET *pxPeerSocket;	/* for server socket: child, for child socket: parent */
-		#if( ipconfigTCP_KEEP_ALIVE == 1 )
-			uint8_t ucKeepRepCount;
-			TickType_t xLastAliveTime;
-		#endif /* ipconfigTCP_KEEP_ALIVE */
-		#if( ipconfigTCP_HANG_PROTECTION == 1 )
-			TickType_t xLastActTime;
-		#endif /* ipconfigTCP_HANG_PROTECTION */
-		size_t uxLittleSpace;
-		size_t uxEnoughSpace;
-		size_t uxRxStreamSize;
-		size_t uxTxStreamSize;
-		StreamBuffer_t *rxStream;
-		StreamBuffer_t *txStream;
-		#if( ipconfigUSE_TCP_WIN == 1 )
-			NetworkBufferDescriptor_t *pxAckMessage;
-		#endif /* ipconfigUSE_TCP_WIN */
-		/* Buffer space to store the last TCP header received. */
-		LastTCPPacket_t xPacket;
-		uint8_t tcpflags;		/* TCP flags */
-		#if( ipconfigUSE_TCP_WIN != 0 )
-			uint8_t ucMyWinScaleFactor;
-			uint8_t ucPeerWinScaleFactor;
-		#endif
-		#if( ipconfigUSE_CALLBACKS == 1 )
-			FOnTCPReceive_t pxHandleReceive;	/*
-										 		 * In case of a TCP socket:
-										 		 * typedef void (* FOnTCPReceive_t) (Socket_t xSocket, void *pData, size_t xLength );
-										 		 */
-			FOnTCPSent_t pxHandleSent;
-			FOnConnected_t pxHandleConnected;	/* Actually type: typedef void (* FOnConnected_t) (Socket_t xSocket, BaseType_t ulConnected ); */
-		#endif /* ipconfigUSE_CALLBACKS */
-		uint32_t ulWindowSize;		/* Current Window size advertised by peer */
-		size_t uxRxWinSize;	/* Fixed value: size of the TCP reception window */
-		size_t uxTxWinSize;	/* Fixed value: size of the TCP transmit window */
+        /*
+         * Note that the values of all short and long integers in these structs
+         * are being stored in the native-endian way
+         * Translation should take place when accessing any structure which defines
+         * network packets, such as IPHeader_t and TCPHeader_t
+         */
+        typedef struct TCPSOCKET
+        {
+            uint32_t ulRemoteIP;   /* IP address of remote machine */
+            uint16_t usRemotePort; /* Port on remote machine */
+            struct
+            {
+                /* Most compilers do like bit-flags */
+                uint32_t
+                    bMssChange : 1,      /* This socket has seen a change in MSS */
+                    bPassAccept : 1,     /* when true, this socket may be returned in a call to accept() */
+                    bPassQueued : 1,     /* when true, this socket is an orphan until it gets connected
+                                          * Why an orphan? Because it may not be returned in a accept() call until it
+                                          * gets the state eESTABLISHED */
+                    bReuseSocket : 1,    /* When a listening socket gets a connection, do not create a new instance but keep on using it */
+                    bCloseAfterSend : 1, /* As soon as the last byte has been transmitted, finalise the connection
+                                          * Useful in e.g. FTP connections, where the last data bytes are sent along with the FIN flag */
+                    bUserShutdown : 1,   /* User requesting a graceful shutdown */
+                    bCloseRequested : 1, /* Request to finalise the connection */
+                    bLowWater : 1,       /* high-water level has been reached. Cleared as soon as 'rx-count < lo-water' */
+                    bWinChange : 1,      /* The value of bLowWater has changed, must send a window update */
+                    bSendKeepAlive : 1,  /* When this flag is true, a TCP keep-alive message must be send */
+                    bWaitKeepAlive : 1,  /* When this flag is true, a TCP keep-alive reply is expected */
+                    bConnPrepared : 1,   /* Connecting socket: Message has been prepared */
+                #if ( ipconfigSUPPORT_SELECT_FUNCTION == 1 )
+                    bConnPassed : 1,     /* Connecting socket: Socket has been passed in a successful select()  */
+                #endif /* ipconfigSUPPORT_SELECT_FUNCTION */
+                bFinAccepted : 1,        /* This socket has received (or sent) a FIN and accepted it */
+                    bFinSent : 1,        /* We've sent out a FIN */
+                    bFinRecv : 1,        /* We've received a FIN from our peer */
+                    bFinAcked : 1,       /* Our FIN packet has been acked */
+                    bFinLast : 1,        /* The last ACK (after FIN and FIN+ACK) has been sent or will be sent by the peer */
+                    bRxStopped : 1,      /* Application asked to temporarily stop reception */
+                    bMallocError : 1,    /* There was an error allocating a stream */
+                    bWinScaling : 1;     /* A TCP-Window Scaling option was offered and accepted in the SYN phase. */
+            } bits;
+            uint32_t ulHighestRxAllowed;
+            /* The highest sequence number that we can receive at any moment */
+            uint16_t usTimeout;            /* Time (in ticks) after which this socket needs attention */
+            uint16_t usCurMSS;             /* Current Maximum Segment Size */
+            uint16_t usInitMSS;            /* Initial maximum segment Size */
+            uint16_t usChildCount;         /* In case of a listening socket: number of connections on this port number */
+            uint16_t usBacklog;            /* In case of a listening socket: maximum number of concurrent connections on this port number */
+            uint8_t ucRepCount;            /* Send repeat count, for retransmissions
+                                            * This counter is separate from the xmitCount in the
+                                            * TCP win segments */
+            uint8_t ucTCPState;            /* TCP state: see eTCP_STATE */
+            struct xSOCKET * pxPeerSocket; /* for server socket: child, for child socket: parent */
+            #if ( ipconfigTCP_KEEP_ALIVE == 1 )
+                uint8_t ucKeepRepCount;
+                TickType_t xLastAliveTime;
+            #endif /* ipconfigTCP_KEEP_ALIVE */
+            #if ( ipconfigTCP_HANG_PROTECTION == 1 )
+                TickType_t xLastActTime;
+            #endif /* ipconfigTCP_HANG_PROTECTION */
+            size_t uxLittleSpace;
+            size_t uxEnoughSpace;
+            size_t uxRxStreamSize;
+            size_t uxTxStreamSize;
+            StreamBuffer_t * rxStream;
+            StreamBuffer_t * txStream;
+            #if ( ipconfigUSE_TCP_WIN == 1 )
+                NetworkBufferDescriptor_t * pxAckMessage;
+            #endif /* ipconfigUSE_TCP_WIN */
+            /* Buffer space to store the last TCP header received. */
+            LastTCPPacket_t xPacket;
+            uint8_t tcpflags; /* TCP flags */
+            #if ( ipconfigUSE_TCP_WIN != 0 )
+                uint8_t ucMyWinScaleFactor;
+                uint8_t ucPeerWinScaleFactor;
+            #endif
+            #if ( ipconfigUSE_CALLBACKS == 1 )
+                FOnTCPReceive_t pxHandleReceive;  /*
+                                                   * In case of a TCP socket:
+                                                   * typedef void (* FOnTCPReceive_t) (Socket_t xSocket, void *pData, size_t xLength );
+                                                   */
+                FOnTCPSent_t pxHandleSent;
+                FOnConnected_t pxHandleConnected; /* Actually type: typedef void (* FOnConnected_t) (Socket_t xSocket, BaseType_t ulConnected ); */
+            #endif /* ipconfigUSE_CALLBACKS */
+            uint32_t ulWindowSize;                /* Current Window size advertised by peer */
+            size_t uxRxWinSize;                   /* Fixed value: size of the TCP reception window */
+            size_t uxTxWinSize;                   /* Fixed value: size of the TCP transmit window */
 
-		TCPWindow_t xTCPWindow;
-	} IPTCPSocket_t;
+            TCPWindow_t xTCPWindow;
+        } IPTCPSocket_t;
 
-#endif /* ipconfigUSE_TCP */
+    #endif /* ipconfigUSE_TCP */
 
-typedef struct UDPSOCKET
-{
-	List_t xWaitingPacketsList;	/* Incoming packets */
-	#if( ipconfigUDP_MAX_RX_PACKETS > 0 )
-		UBaseType_t uxMaxPackets; /* Protection: limits the number of packets buffered per socket */
-	#endif /* ipconfigUDP_MAX_RX_PACKETS */
-	#if( ipconfigUSE_CALLBACKS == 1 )
-		FOnUDPReceive_t pxHandleReceive;	/*
-											 * In case of a UDP socket:
-											 * typedef void (* FOnUDPReceive_t) (Socket_t xSocket, void *pData, size_t xLength, struct freertos_sockaddr *pxAddr );
-											 */
-		FOnUDPSent_t pxHandleSent;
-	#endif /* ipconfigUSE_CALLBACKS */
-} IPUDPSocket_t;
+    typedef struct UDPSOCKET
+    {
+        List_t xWaitingPacketsList;   /* Incoming packets */
+        #if ( ipconfigUDP_MAX_RX_PACKETS > 0 )
+            UBaseType_t uxMaxPackets; /* Protection: limits the number of packets buffered per socket */
+        #endif /* ipconfigUDP_MAX_RX_PACKETS */
+        #if ( ipconfigUSE_CALLBACKS == 1 )
+            FOnUDPReceive_t pxHandleReceive; /*
+                                              * In case of a UDP socket:
+                                              * typedef void (* FOnUDPReceive_t) (Socket_t xSocket, void *pData, size_t xLength, struct freertos_sockaddr *pxAddr );
+                                              */
+            FOnUDPSent_t pxHandleSent;
+        #endif /* ipconfigUSE_CALLBACKS */
+    } IPUDPSocket_t;
 
 /* Formally typedef'd as eSocketEvent_t. */
-enum eSOCKET_EVENT {
-	eSOCKET_RECEIVE = 0x0001,
-	eSOCKET_SEND    = 0x0002,
-	eSOCKET_ACCEPT  = 0x0004,
-	eSOCKET_CONNECT = 0x0008,
-	eSOCKET_BOUND   = 0x0010,
-	eSOCKET_CLOSED	= 0x0020,
-	eSOCKET_INTR	= 0x0040,
-	eSOCKET_ALL		= 0x007F,
-};
+    enum eSOCKET_EVENT
+    {
+        eSOCKET_RECEIVE = 0x0001,
+        eSOCKET_SEND = 0x0002,
+        eSOCKET_ACCEPT = 0x0004,
+        eSOCKET_CONNECT = 0x0008,
+        eSOCKET_BOUND = 0x0010,
+        eSOCKET_CLOSED = 0x0020,
+        eSOCKET_INTR = 0x0040,
+        eSOCKET_ALL = 0x007F,
+    };
 
-typedef struct xSOCKET
-{
-	EventBits_t xEventBits;
-	EventGroupHandle_t xEventGroup;
+    typedef struct xSOCKET
+    {
+        EventBits_t xEventBits;
+        EventGroupHandle_t xEventGroup;
 
-	ListItem_t xBoundSocketListItem; /* Used to reference the socket from a bound sockets list. */
-	TickType_t xReceiveBlockTime; /* if recv[to] is called while no data is available, wait this amount of time. Unit in clock-ticks */
-	TickType_t xSendBlockTime; /* if send[to] is called while there is not enough space to send, wait this amount of time. Unit in clock-ticks */
+        ListItem_t xBoundSocketListItem; /* Used to reference the socket from a bound sockets list. */
+        TickType_t xReceiveBlockTime;    /* if recv[to] is called while no data is available, wait this amount of time. Unit in clock-ticks */
+        TickType_t xSendBlockTime;       /* if send[to] is called while there is not enough space to send, wait this amount of time. Unit in clock-ticks */
 
-	uint16_t usLocalPort;		/* Local port on this machine */
-	uint8_t ucSocketOptions;
-	uint8_t ucProtocol; /* choice of FREERTOS_IPPROTO_UDP/TCP */
-	#if( ipconfigSOCKET_HAS_USER_SEMAPHORE == 1 )
-		SemaphoreHandle_t pxUserSemaphore;
-	#endif /* ipconfigSOCKET_HAS_USER_SEMAPHORE */
-	#if( ipconfigSOCKET_HAS_USER_WAKE_CALLBACK == 1 )
-		SocketWakeupCallback_t pxUserWakeCallback;
-	#endif /* ipconfigSOCKET_HAS_USER_WAKE_CALLBACK */
+        uint16_t usLocalPort;            /* Local port on this machine */
+        uint8_t ucSocketOptions;
+        uint8_t ucProtocol;              /* choice of FREERTOS_IPPROTO_UDP/TCP */
+        #if ( ipconfigSOCKET_HAS_USER_SEMAPHORE == 1 )
+            SemaphoreHandle_t pxUserSemaphore;
+        #endif /* ipconfigSOCKET_HAS_USER_SEMAPHORE */
+        #if ( ipconfigSOCKET_HAS_USER_WAKE_CALLBACK == 1 )
+            SocketWakeupCallback_t pxUserWakeCallback;
+        #endif /* ipconfigSOCKET_HAS_USER_WAKE_CALLBACK */
 
-	#if( ipconfigSUPPORT_SELECT_FUNCTION == 1 )
-		struct xSOCKET_SET *pxSocketSet;
-		/* User may indicate which bits are interesting for this socket. */
-		EventBits_t xSelectBits;
-		/* These bits indicate the events which have actually occurred.
-		They are maintained by the IP-task */
-		EventBits_t xSocketBits;
-	#endif /* ipconfigSUPPORT_SELECT_FUNCTION */
-	/* TCP/UDP specific fields: */
-	/* Before accessing any member of this structure, it should be confirmed */
-	/* that the protocol corresponds with the type of structure */
+        #if ( ipconfigSUPPORT_SELECT_FUNCTION == 1 )
+            struct xSOCKET_SET * pxSocketSet;
+            /* User may indicate which bits are interesting for this socket. */
+            EventBits_t xSelectBits;
 
-	union
-	{
-		IPUDPSocket_t xUDP;
-		#if( ipconfigUSE_TCP == 1 )
-			IPTCPSocket_t xTCP;
-			/* Make sure that xTCP is 8-bytes aligned by
-			declaring a 64-bit variable in the same union */
-			uint64_t ullTCPAlignment;
-		#endif /* ipconfigUSE_TCP */
-	} u;
-} FreeRTOS_Socket_t;
+            /* These bits indicate the events which have actually occurred.
+             * They are maintained by the IP-task */
+            EventBits_t xSocketBits;
+        #endif /* ipconfigSUPPORT_SELECT_FUNCTION */
+        /* TCP/UDP specific fields: */
+        /* Before accessing any member of this structure, it should be confirmed */
+        /* that the protocol corresponds with the type of structure */
 
-#if( ipconfigUSE_TCP == 1 )
-	/*
-	 * Lookup a TCP socket, using a multiple matching: both port numbers and
-	 * return IP address.
-	 */
-	FreeRTOS_Socket_t *pxTCPSocketLookup( uint32_t ulLocalIP, UBaseType_t uxLocalPort, uint32_t ulRemoteIP, UBaseType_t uxRemotePort );
+        union
+        {
+            IPUDPSocket_t xUDP;
+            #if ( ipconfigUSE_TCP == 1 )
+                IPTCPSocket_t xTCP;
 
-#endif /* ipconfigUSE_TCP */
+                /* Make sure that xTCP is 8-bytes aligned by
+                 * declaring a 64-bit variable in the same union */
+                uint64_t ullTCPAlignment;
+            #endif /* ipconfigUSE_TCP */
+        } u;
+    } FreeRTOS_Socket_t;
+
+    #if ( ipconfigUSE_TCP == 1 )
+
+        /*
+         * Lookup a TCP socket, using a multiple matching: both port numbers and
+         * return IP address.
+         */
+        FreeRTOS_Socket_t * pxTCPSocketLookup( uint32_t ulLocalIP,
+                                               UBaseType_t uxLocalPort,
+                                               uint32_t ulRemoteIP,
+                                               UBaseType_t uxRemotePort );
+
+    #endif /* ipconfigUSE_TCP */
 
 /*
  * Look up a local socket by finding a match with the local port.
  */
-FreeRTOS_Socket_t *pxUDPSocketLookup( UBaseType_t uxLocalPort );
+    FreeRTOS_Socket_t * pxUDPSocketLookup( UBaseType_t uxLocalPort );
 
 /*
  * Called when the application has generated a UDP packet to send.
  */
-void vProcessGeneratedUDPPacket( NetworkBufferDescriptor_t * const pxNetworkBuffer );
+    void vProcessGeneratedUDPPacket( NetworkBufferDescriptor_t * const pxNetworkBuffer );
 
 /*
  * Calculate the upper-layer checksum
@@ -690,13 +701,16 @@ void vProcessGeneratedUDPPacket( NetworkBufferDescriptor_t * const pxNetworkBuff
  * bOut = false: checksum will be calculated for incoming packets
  *     returning 0xffff means: checksum was correct
  */
-uint16_t usGenerateProtocolChecksum( const uint8_t * const pucEthernetBuffer, size_t uxBufferLength, BaseType_t xOutgoingPacket );
+    uint16_t usGenerateProtocolChecksum( const uint8_t * const pucEthernetBuffer,
+                                         size_t uxBufferLength,
+                                         BaseType_t xOutgoingPacket );
 
 /*
  * An Ethernet frame has been updated (maybe it was an ARP request or a PING
  * request?) and is to be sent back to its source.
  */
-void vReturnEthernetFrame( NetworkBufferDescriptor_t * pxNetworkBuffer, BaseType_t xReleaseAfterSend );
+    void vReturnEthernetFrame( NetworkBufferDescriptor_t * pxNetworkBuffer,
+                               BaseType_t xReleaseAfterSend );
 
 /*
  * The internal version of bind()
@@ -704,7 +718,10 @@ void vReturnEthernetFrame( NetworkBufferDescriptor_t * pxNetworkBuffer, BaseType
  * The TCP driver needs to bind a socket at the moment a listening socket
  * creates a new connected socket
  */
-BaseType_t vSocketBind( FreeRTOS_Socket_t *pxSocket, struct freertos_sockaddr * pxBindAddress, size_t uxAddressLength, BaseType_t xInternal );
+    BaseType_t vSocketBind( FreeRTOS_Socket_t * pxSocket,
+                            struct freertos_sockaddr * pxBindAddress,
+                            size_t uxAddressLength,
+                            BaseType_t xInternal );
 
 /*
  * Internal function to add streaming data to a TCP socket. If ulIn == true,
@@ -713,127 +730,120 @@ BaseType_t vSocketBind( FreeRTOS_Socket_t *pxSocket, struct freertos_sockaddr * 
  * packet come in out-of-order, an offset will be used to put it in front and
  * the head will not change yet.
  */
-int32_t lTCPAddRxdata(FreeRTOS_Socket_t *pxSocket, size_t uxOffset, const uint8_t *pcData, uint32_t ulByteCount);
+    int32_t lTCPAddRxdata( FreeRTOS_Socket_t * pxSocket,
+                           size_t uxOffset,
+                           const uint8_t * pcData,
+                           uint32_t ulByteCount );
 
 /*
  * Currently called for any important event.
  */
-void vSocketWakeUpUser( FreeRTOS_Socket_t *pxSocket );
+    void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket );
 
 /*
  * Some helping function, their meaning should be clear
  */
- /* coverity[misra_c_2012_rule_2_2_violation] */
-static portINLINE uint32_t ulChar2u32 (const uint8_t *apChr);
-static portINLINE uint32_t ulChar2u32 (const uint8_t *apChr)
-{
-	return  ( ( ( uint32_t )apChr[0] ) << 24) |
-			( ( ( uint32_t )apChr[1] ) << 16) |
-			( ( ( uint32_t )apChr[2] ) << 8) |
-			( ( ( uint32_t )apChr[3] ) );
-}
+/* coverity[misra_c_2012_rule_2_2_violation] */
+    static portINLINE uint32_t ulChar2u32( const uint8_t * apChr );
+    static portINLINE uint32_t ulChar2u32( const uint8_t * apChr )
+    {
+        return ( ( ( uint32_t ) apChr[ 0 ] ) << 24 ) |
+               ( ( ( uint32_t ) apChr[ 1 ] ) << 16 ) |
+               ( ( ( uint32_t ) apChr[ 2 ] ) << 8 ) |
+               ( ( ( uint32_t ) apChr[ 3 ] ) );
+    }
 
-static portINLINE uint16_t usChar2u16 (const uint8_t *apChr);
-static portINLINE uint16_t usChar2u16 (const uint8_t *apChr)
-{
-	return ( uint16_t )
-			( ( ( ( uint32_t )apChr[0] ) << 8) |
-			  ( ( ( uint32_t )apChr[1] ) ) );
-}
+    static portINLINE uint16_t usChar2u16( const uint8_t * apChr );
+    static portINLINE uint16_t usChar2u16( const uint8_t * apChr )
+    {
+        return ( uint16_t )
+               ( ( ( ( uint32_t ) apChr[ 0 ] ) << 8 ) |
+                 ( ( ( uint32_t ) apChr[ 1 ] ) ) );
+    }
 
 /* Check a single socket for retransmissions and timeouts */
-BaseType_t xTCPSocketCheck( FreeRTOS_Socket_t *pxSocket );
+    BaseType_t xTCPSocketCheck( FreeRTOS_Socket_t * pxSocket );
 
-BaseType_t xTCPCheckNewClient( FreeRTOS_Socket_t *pxSocket );
+    BaseType_t xTCPCheckNewClient( FreeRTOS_Socket_t * pxSocket );
 
 /* Defined in FreeRTOS_Sockets.c
  * Close a socket
  */
-void *vSocketClose( FreeRTOS_Socket_t *pxSocket );
+    void * vSocketClose( FreeRTOS_Socket_t * pxSocket );
 
 /*
  * Send the event eEvent to the IP task event queue, using a block time of
  * zero.  Return pdPASS if the message was sent successfully, otherwise return
  * pdFALSE.
-*/
-BaseType_t xSendEventToIPTask( eIPEvent_t eEvent );
+ */
+    BaseType_t xSendEventToIPTask( eIPEvent_t eEvent );
 
 /*
  * The same as above, but a struct as a parameter, containing:
- * 		eIPEvent_t eEventType;
+ *      eIPEvent_t eEventType;
  *		void *pvData;
  */
-BaseType_t xSendEventStructToIPTask( const IPStackEvent_t *pxEvent, TickType_t uxTimeout );
+    BaseType_t xSendEventStructToIPTask( const IPStackEvent_t * pxEvent,
+                                         TickType_t uxTimeout );
 
 /*
  * Returns a pointer to the original NetworkBuffer from a pointer to a UDP
  * payload buffer.
  */
-NetworkBufferDescriptor_t *pxUDPPayloadBuffer_to_NetworkBuffer( const void * pvBuffer );
+    NetworkBufferDescriptor_t * pxUDPPayloadBuffer_to_NetworkBuffer( const void * pvBuffer );
 
-#if( ipconfigZERO_COPY_TX_DRIVER != 0 )
-	/*
-	 * For the case where the network driver passes a buffer directly to a DMA
-	 * descriptor, this function can be used to translate a 'network buffer' to
-	 * a 'network buffer descriptor'.
-	 */
-	NetworkBufferDescriptor_t *pxPacketBuffer_to_NetworkBuffer( const void *pvBuffer );
-#endif
+    #if ( ipconfigZERO_COPY_TX_DRIVER != 0 )
+
+        /*
+         * For the case where the network driver passes a buffer directly to a DMA
+         * descriptor, this function can be used to translate a 'network buffer' to
+         * a 'network buffer descriptor'.
+         */
+        NetworkBufferDescriptor_t * pxPacketBuffer_to_NetworkBuffer( const void * pvBuffer );
+    #endif
 
 /*
  * Internal: Sets a new state for a TCP socket and performs the necessary
  * actions like calling a OnConnected handler to notify the socket owner.
  */
-#if( ipconfigUSE_TCP == 1 )
-	void vTCPStateChange( FreeRTOS_Socket_t *pxSocket, enum eTCP_STATE eTCPState );
-#endif /* ipconfigUSE_TCP */
+    #if ( ipconfigUSE_TCP == 1 )
+        void vTCPStateChange( FreeRTOS_Socket_t * pxSocket,
+                              enum eTCP_STATE eTCPState );
+    #endif /* ipconfigUSE_TCP */
 
 /* Returns pdTRUE is this function is called from the IP-task */
-BaseType_t xIsCallingFromIPTask( void );
+    BaseType_t xIsCallingFromIPTask( void );
 
-#if( ipconfigSUPPORT_SELECT_FUNCTION == 1 )
+    #if ( ipconfigSUPPORT_SELECT_FUNCTION == 1 )
 
-typedef struct xSOCKET_SET
-{
-	EventGroupHandle_t xSelectGroup;
-} SocketSelect_t;
+        typedef struct xSOCKET_SET
+        {
+            EventGroupHandle_t xSelectGroup;
+        } SocketSelect_t;
 
-extern void vSocketSelect( SocketSelect_t *pxSocketSet );
+        extern void vSocketSelect( SocketSelect_t * pxSocketSet );
 
 /* Define the data that must be passed for a 'eSocketSelectEvent'. */
-typedef struct xSocketSelectMessage
-{
-	TaskHandle_t xTaskhandle;
-	SocketSelect_t *pxSocketSet;
-} SocketSelectMessage_t;
+        typedef struct xSocketSelectMessage
+        {
+            TaskHandle_t xTaskhandle;
+            SocketSelect_t * pxSocketSet;
+        } SocketSelectMessage_t;
 
-#endif /* ipconfigSUPPORT_SELECT_FUNCTION */
+    #endif /* ipconfigSUPPORT_SELECT_FUNCTION */
 
-void vIPSetDHCPTimerEnableState( BaseType_t xEnableState );
-void vIPReloadDHCPTimer( uint32_t ulLeaseTime );
-#if( ipconfigDNS_USE_CALLBACKS != 0 )
-	void vIPReloadDNSTimer( uint32_t ulCheckTime );
-	void vIPSetDnsTimerEnableState( BaseType_t xEnableState );
-#endif
+    void vIPSetDHCPTimerEnableState( BaseType_t xEnableState );
+    void vIPReloadDHCPTimer( uint32_t ulLeaseTime );
+    #if ( ipconfigDNS_USE_CALLBACKS != 0 )
+        void vIPReloadDNSTimer( uint32_t ulCheckTime );
+        void vIPSetDnsTimerEnableState( BaseType_t xEnableState );
+    #endif
 
 /* Send the network-up event and start the ARP timer. */
-void vIPNetworkUpCalls( void );
+    void vIPNetworkUpCalls( void );
 
-#ifdef __cplusplus
-} /* extern "C" */
-#endif
+    #ifdef __cplusplus
+        } /* extern "C" */
+    #endif
 
 #endif /* FREERTOS_IP_PRIVATE_H */
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/include/FreeRTOS_Sockets.h
+++ b/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/include/FreeRTOS_Sockets.h
@@ -24,407 +24,467 @@
  */
 
 #ifndef FREERTOS_SOCKETS_H
-#define FREERTOS_SOCKETS_H
+    #define FREERTOS_SOCKETS_H
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+    #ifdef __cplusplus
+        extern "C" {
+    #endif
 
 /* Standard includes. */
-#include <string.h>
+    #include <string.h>
 
 /* Application level configuration options. */
-#include "FreeRTOSIPConfig.h"
+    #include "FreeRTOSIPConfig.h"
 
-#ifndef FREERTOS_IP_CONFIG_H
-	#error FreeRTOSIPConfig.h has not been included yet
-#endif
+    #ifndef FREERTOS_IP_CONFIG_H
+        #error FreeRTOSIPConfig.h has not been included yet
+    #endif
 
 /* Event bit definitions are required by the select functions. */
-#include "event_groups.h"
+    #include "event_groups.h"
 
-#ifndef INC_FREERTOS_H
-	#error FreeRTOS.h must be included before FreeRTOS_Sockets.h.
-#endif
+    #ifndef INC_FREERTOS_H
+        #error FreeRTOS.h must be included before FreeRTOS_Sockets.h.
+    #endif
 
-#ifndef INC_TASK_H
-	#ifndef TASK_H /* For compatibility with older FreeRTOS versions. */
-		#error The FreeRTOS header file task.h must be included before FreeRTOS_Sockets.h.
-	#endif
-#endif
+    #ifndef INC_TASK_H
+        #ifndef TASK_H /* For compatibility with older FreeRTOS versions. */
+            #error The FreeRTOS header file task.h must be included before FreeRTOS_Sockets.h.
+        #endif
+    #endif
 
 /* Assigned to an Socket_t variable when the socket is not valid, probably
-because it could not be created. */
-#define FREERTOS_INVALID_SOCKET	( ( Socket_t ) ~0U )
+ * because it could not be created. */
+    #define FREERTOS_INVALID_SOCKET    ( ( Socket_t ) ~0U )
 
 /* API function error values.  As errno is supported, the FreeRTOS sockets
-functions return error codes rather than just a pass or fail indication. */
+ * functions return error codes rather than just a pass or fail indication. */
 /* HT: Extended the number of error codes, gave them positive values and if possible
-the corresponding found in errno.h
-In case of an error, API's will still return negative numbers, e.g.
-  return -pdFREERTOS_ERRNO_EWOULDBLOCK;
-in case an operation would block */
+ * the corresponding found in errno.h
+ * In case of an error, API's will still return negative numbers, e.g.
+ * return -pdFREERTOS_ERRNO_EWOULDBLOCK;
+ * in case an operation would block */
 
 /* The following defines are obsolete, please use -pdFREERTOS_ERRNO_Exxx */
 
-#define FREERTOS_SOCKET_ERROR	( -1 )
-#define FREERTOS_EWOULDBLOCK	( - pdFREERTOS_ERRNO_EWOULDBLOCK )
-#define FREERTOS_EINVAL			( - pdFREERTOS_ERRNO_EINVAL )
-#define FREERTOS_EADDRNOTAVAIL	( - pdFREERTOS_ERRNO_EADDRNOTAVAIL )
-#define FREERTOS_EADDRINUSE		( - pdFREERTOS_ERRNO_EADDRINUSE )
-#define FREERTOS_ENOBUFS		( - pdFREERTOS_ERRNO_ENOBUFS )
-#define FREERTOS_ENOPROTOOPT	( - pdFREERTOS_ERRNO_ENOPROTOOPT )
-#define FREERTOS_ECLOSED		( - pdFREERTOS_ERRNO_ENOTCONN )
+    #define FREERTOS_SOCKET_ERROR                 ( -1 )
+    #define FREERTOS_EWOULDBLOCK                  ( -pdFREERTOS_ERRNO_EWOULDBLOCK )
+    #define FREERTOS_EINVAL                       ( -pdFREERTOS_ERRNO_EINVAL )
+    #define FREERTOS_EADDRNOTAVAIL                ( -pdFREERTOS_ERRNO_EADDRNOTAVAIL )
+    #define FREERTOS_EADDRINUSE                   ( -pdFREERTOS_ERRNO_EADDRINUSE )
+    #define FREERTOS_ENOBUFS                      ( -pdFREERTOS_ERRNO_ENOBUFS )
+    #define FREERTOS_ENOPROTOOPT                  ( -pdFREERTOS_ERRNO_ENOPROTOOPT )
+    #define FREERTOS_ECLOSED                      ( -pdFREERTOS_ERRNO_ENOTCONN )
 
 /* Values for the parameters to FreeRTOS_socket(), inline with the Berkeley
-standard.  See the documentation of FreeRTOS_socket() for more information. */
-#define FREERTOS_AF_INET		( 2 )
-#define FREERTOS_AF_INET6		( 10 )
-#define FREERTOS_SOCK_DGRAM		( 2 )
-#define FREERTOS_IPPROTO_UDP	( 17 )
+ * standard.  See the documentation of FreeRTOS_socket() for more information. */
+    #define FREERTOS_AF_INET                      ( 2 )
+    #define FREERTOS_AF_INET6                     ( 10 )
+    #define FREERTOS_SOCK_DGRAM                   ( 2 )
+    #define FREERTOS_IPPROTO_UDP                  ( 17 )
 
-#define FREERTOS_SOCK_STREAM	( 1 )
-#define FREERTOS_IPPROTO_TCP	( 6 )
+    #define FREERTOS_SOCK_STREAM                  ( 1 )
+    #define FREERTOS_IPPROTO_TCP                  ( 6 )
+
 /* IP packet of type "Any local network"
  * can be used in stead of TCP for testing with sockets in raw mode
  */
-#define FREERTOS_IPPROTO_USR_LAN  ( 63 )
+    #define FREERTOS_IPPROTO_USR_LAN              ( 63 )
 
 /* A bit value that can be passed into the FreeRTOS_sendto() function as part of
-the flags parameter.  Setting the FREERTOS_ZERO_COPY in the flags parameter
-indicates that the zero copy interface is being used.  See the documentation for
-FreeRTOS_sockets() for more information. */
-#define FREERTOS_ZERO_COPY		( 1 )
+ * the flags parameter.  Setting the FREERTOS_ZERO_COPY in the flags parameter
+ * indicates that the zero copy interface is being used.  See the documentation for
+ * FreeRTOS_sockets() for more information. */
+    #define FREERTOS_ZERO_COPY                    ( 1 )
 
 /* Values that can be passed in the option name parameter of calls to
-FreeRTOS_setsockopt(). */
-#define FREERTOS_SO_RCVTIMEO			( 0 )		/* Used to set the receive time out. */
-#define FREERTOS_SO_SNDTIMEO			( 1 )		/* Used to set the send time out. */
-#define FREERTOS_SO_UDPCKSUM_OUT		( 2 )	 	/* Used to turn the use of the UDP checksum by a socket on or off.  This also doubles as part of an 8-bit bitwise socket option. */
-#if( ipconfigSOCKET_HAS_USER_SEMAPHORE == 1 )
-	#define FREERTOS_SO_SET_SEMAPHORE	( 3 )		/* Used to set a user's semaphore */
-#endif
-#define FREERTOS_SO_SNDBUF				( 4 )		/* Set the size of the send buffer (TCP only) */
-#define FREERTOS_SO_RCVBUF				( 5 )		/* Set the size of the receive buffer (TCP only) */
+ * FreeRTOS_setsockopt(). */
+    #define FREERTOS_SO_RCVTIMEO                  ( 0 ) /* Used to set the receive time out. */
+    #define FREERTOS_SO_SNDTIMEO                  ( 1 ) /* Used to set the send time out. */
+    #define FREERTOS_SO_UDPCKSUM_OUT              ( 2 ) /* Used to turn the use of the UDP checksum by a socket on or off.  This also doubles as part of an 8-bit bitwise socket option. */
+    #if ( ipconfigSOCKET_HAS_USER_SEMAPHORE == 1 )
+        #define FREERTOS_SO_SET_SEMAPHORE         ( 3 ) /* Used to set a user's semaphore */
+    #endif
+    #define FREERTOS_SO_SNDBUF                    ( 4 ) /* Set the size of the send buffer (TCP only) */
+    #define FREERTOS_SO_RCVBUF                    ( 5 ) /* Set the size of the receive buffer (TCP only) */
 
-#if ipconfigUSE_CALLBACKS == 1
-	#define FREERTOS_SO_TCP_CONN_HANDLER	( 6 )		/* Install a callback for (dis) connection events. Supply pointer to 'F_TCP_UDP_Handler_t' (see below) */
-	#define FREERTOS_SO_TCP_RECV_HANDLER	( 7 )		/* Install a callback for receiving TCP data. Supply pointer to 'F_TCP_UDP_Handler_t' (see below) */
-	#define FREERTOS_SO_TCP_SENT_HANDLER	( 8 )		/* Install a callback for sending TCP data. Supply pointer to 'F_TCP_UDP_Handler_t' (see below) */
-	#define FREERTOS_SO_UDP_RECV_HANDLER	( 9 )		/* Install a callback for receiving UDP data. Supply pointer to 'F_TCP_UDP_Handler_t' (see below) */
-	#define FREERTOS_SO_UDP_SENT_HANDLER	( 10 )		/* Install a callback for sending UDP data. Supply pointer to 'F_TCP_UDP_Handler_t' (see below) */
-#endif /* ipconfigUSE_CALLBACKS */
+    #if ipconfigUSE_CALLBACKS == 1
+        #define FREERTOS_SO_TCP_CONN_HANDLER      ( 6 )  /* Install a callback for (dis) connection events. Supply pointer to 'F_TCP_UDP_Handler_t' (see below) */
+        #define FREERTOS_SO_TCP_RECV_HANDLER      ( 7 )  /* Install a callback for receiving TCP data. Supply pointer to 'F_TCP_UDP_Handler_t' (see below) */
+        #define FREERTOS_SO_TCP_SENT_HANDLER      ( 8 )  /* Install a callback for sending TCP data. Supply pointer to 'F_TCP_UDP_Handler_t' (see below) */
+        #define FREERTOS_SO_UDP_RECV_HANDLER      ( 9 )  /* Install a callback for receiving UDP data. Supply pointer to 'F_TCP_UDP_Handler_t' (see below) */
+        #define FREERTOS_SO_UDP_SENT_HANDLER      ( 10 ) /* Install a callback for sending UDP data. Supply pointer to 'F_TCP_UDP_Handler_t' (see below) */
+    #endif /* ipconfigUSE_CALLBACKS */
 
-#define FREERTOS_SO_REUSE_LISTEN_SOCKET	( 11 )		/* When a listening socket gets connected, do not create a new one but re-use it */
-#define FREERTOS_SO_CLOSE_AFTER_SEND	( 12 )		/* As soon as the last byte has been transmitted, finalise the connection */
-#define FREERTOS_SO_WIN_PROPERTIES		( 13 )		/* Set all buffer and window properties in one call, parameter is pointer to WinProperties_t */
-#define FREERTOS_SO_SET_FULL_SIZE		( 14 )		/* Refuse to send packets smaller than MSS  */
+    #define FREERTOS_SO_REUSE_LISTEN_SOCKET       ( 11 ) /* When a listening socket gets connected, do not create a new one but re-use it */
+    #define FREERTOS_SO_CLOSE_AFTER_SEND          ( 12 ) /* As soon as the last byte has been transmitted, finalise the connection */
+    #define FREERTOS_SO_WIN_PROPERTIES            ( 13 ) /* Set all buffer and window properties in one call, parameter is pointer to WinProperties_t */
+    #define FREERTOS_SO_SET_FULL_SIZE             ( 14 ) /* Refuse to send packets smaller than MSS  */
 
-#define FREERTOS_SO_STOP_RX				( 15 )		/* Temporarily hold up reception, used by streaming client */
+    #define FREERTOS_SO_STOP_RX                   ( 15 ) /* Temporarily hold up reception, used by streaming client */
 
-#if( ipconfigUDP_MAX_RX_PACKETS > 0 )
-	#define FREERTOS_SO_UDP_MAX_RX_PACKETS	( 16 )		/* This option helps to limit the maximum number of packets a UDP socket will buffer */
-#endif
+    #if ( ipconfigUDP_MAX_RX_PACKETS > 0 )
+        #define FREERTOS_SO_UDP_MAX_RX_PACKETS    ( 16 ) /* This option helps to limit the maximum number of packets a UDP socket will buffer */
+    #endif
 
-#if( ipconfigSOCKET_HAS_USER_WAKE_CALLBACK == 1 )
-	#define FREERTOS_SO_WAKEUP_CALLBACK	( 17 )
-#endif
+    #if ( ipconfigSOCKET_HAS_USER_WAKE_CALLBACK == 1 )
+        #define FREERTOS_SO_WAKEUP_CALLBACK           ( 17 )
+    #endif
 
-#define FREERTOS_SO_SET_LOW_HIGH_WATER	( 18 )
+    #define FREERTOS_SO_SET_LOW_HIGH_WATER            ( 18 )
 
-#define FREERTOS_NOT_LAST_IN_FRAGMENTED_PACKET 	( 0x80 )  /* For internal use only, but also part of an 8-bit bitwise value. */
-#define FREERTOS_FRAGMENTED_PACKET				( 0x40 )  /* For internal use only, but also part of an 8-bit bitwise value. */
+    #define FREERTOS_NOT_LAST_IN_FRAGMENTED_PACKET    ( 0x80 ) /* For internal use only, but also part of an 8-bit bitwise value. */
+    #define FREERTOS_FRAGMENTED_PACKET                ( 0x40 ) /* For internal use only, but also part of an 8-bit bitwise value. */
 
 /* Values for flag for FreeRTOS_shutdown(). */
-#define FREERTOS_SHUT_RD				( 0 )		/* Not really at this moment, just for compatibility of the interface */
-#define FREERTOS_SHUT_WR				( 1 )
-#define FREERTOS_SHUT_RDWR				( 2 )
+    #define FREERTOS_SHUT_RD                          ( 0 ) /* Not really at this moment, just for compatibility of the interface */
+    #define FREERTOS_SHUT_WR                          ( 1 )
+    #define FREERTOS_SHUT_RDWR                        ( 2 )
 
 /* Values for flag for FreeRTOS_recv(). */
-#define FREERTOS_MSG_OOB				( 2 )		/* process out-of-band data */
-#define FREERTOS_MSG_PEEK				( 4 )		/* peek at incoming message */
-#define FREERTOS_MSG_DONTROUTE			( 8 )		/* send without using routing tables */
-#define FREERTOS_MSG_DONTWAIT			( 16 )		/* Can be used with recvfrom(), sendto(), recv(), and send(). */
+    #define FREERTOS_MSG_OOB                          ( 2 )  /* process out-of-band data */
+    #define FREERTOS_MSG_PEEK                         ( 4 )  /* peek at incoming message */
+    #define FREERTOS_MSG_DONTROUTE                    ( 8 )  /* send without using routing tables */
+    #define FREERTOS_MSG_DONTWAIT                     ( 16 ) /* Can be used with recvfrom(), sendto(), recv(), and send(). */
 
-typedef struct xWIN_PROPS {
-	/* Properties of the Tx buffer and Tx window */
-	int32_t lTxBufSize;	/* Unit: bytes */
-	int32_t lTxWinSize;	/* Unit: MSS */
+    typedef struct xWIN_PROPS
+    {
+        /* Properties of the Tx buffer and Tx window */
+        int32_t lTxBufSize; /* Unit: bytes */
+        int32_t lTxWinSize; /* Unit: MSS */
 
-	/* Properties of the Rx buffer and Rx window */
-	int32_t lRxBufSize;	/* Unit: bytes */
-	int32_t lRxWinSize;	/* Unit: MSS */
-} WinProperties_t;
+        /* Properties of the Rx buffer and Rx window */
+        int32_t lRxBufSize; /* Unit: bytes */
+        int32_t lRxWinSize; /* Unit: MSS */
+    } WinProperties_t;
 
-typedef struct xLOW_HIGH_WATER {
-	/* Structure to pass for the 'FREERTOS_SO_SET_LOW_HIGH_WATER' option */
-	size_t uxLittleSpace;	/* Send a STOP when buffer space drops below X bytes */
-	size_t uxEnoughSpace;	/* Send a GO when buffer space grows above X bytes */
-} LowHighWater_t;
+    typedef struct xLOW_HIGH_WATER
+    {
+        /* Structure to pass for the 'FREERTOS_SO_SET_LOW_HIGH_WATER' option */
+        size_t uxLittleSpace; /* Send a STOP when buffer space drops below X bytes */
+        size_t uxEnoughSpace; /* Send a GO when buffer space grows above X bytes */
+    } LowHighWater_t;
 
 /* For compatibility with the expected Berkeley sockets naming. */
-#define socklen_t uint32_t
+    #define socklen_t    uint32_t
 
 /* For this limited implementation, only two members are required in the
-Berkeley style sockaddr structure. */
-struct freertos_sockaddr
-{
-	/* _HT_ On 32- and 64-bit architectures, the addition of the two uint8_t
-	fields doesn't make the structure bigger, due to alignment.
-	The fields are inserted as a preparation for IPv6. */
+ * Berkeley style sockaddr structure. */
+    struct freertos_sockaddr
+    {
+        /* _HT_ On 32- and 64-bit architectures, the addition of the two uint8_t
+         * fields doesn't make the structure bigger, due to alignment.
+         * The fields are inserted as a preparation for IPv6. */
 
-	/* sin_len and sin_family not used in the IPv4-only release. */
-	uint8_t sin_len;		/* length of this structure. */
-	uint8_t sin_family;		/* FREERTOS_AF_INET. */
-	uint16_t sin_port;
-	uint32_t sin_addr;
-};
+        /* sin_len and sin_family not used in the IPv4-only release. */
+        uint8_t sin_len;    /* length of this structure. */
+        uint8_t sin_family; /* FREERTOS_AF_INET. */
+        uint16_t sin_port;
+        uint32_t sin_addr;
+    };
 
-extern const char *FreeRTOS_inet_ntoa( uint32_t ulIPAddress, char *pcBuffer );
+    extern const char * FreeRTOS_inet_ntoa( uint32_t ulIPAddress,
+                                            char * pcBuffer );
 
-#if ipconfigBYTE_ORDER == pdFREERTOS_LITTLE_ENDIAN
+    #if ipconfigBYTE_ORDER == pdFREERTOS_LITTLE_ENDIAN
 
-	#define FreeRTOS_inet_addr_quick( ucOctet0, ucOctet1, ucOctet2, ucOctet3 )				\
-										( ( ( ( uint32_t ) ( ucOctet3 ) ) << 24UL ) |		\
-										( ( ( uint32_t ) ( ucOctet2 ) ) << 16UL ) |			\
-										( ( ( uint32_t ) ( ucOctet1 ) ) <<  8UL ) |			\
-										( ( uint32_t ) ( ucOctet0 ) ) )
+        #define FreeRTOS_inet_addr_quick( ucOctet0, ucOctet1, ucOctet2, ucOctet3 ) \
+    ( ( ( ( uint32_t ) ( ucOctet3 ) ) << 24UL ) |                                  \
+      ( ( ( uint32_t ) ( ucOctet2 ) ) << 16UL ) |                                  \
+      ( ( ( uint32_t ) ( ucOctet1 ) ) << 8UL ) |                                   \
+      ( ( uint32_t ) ( ucOctet0 ) ) )
 
-#else /* ipconfigBYTE_ORDER */
+    #else /* ipconfigBYTE_ORDER */
 
-	#define FreeRTOS_inet_addr_quick( ucOctet0, ucOctet1, ucOctet2, ucOctet3 )				\
-										( ( ( ( uint32_t ) ( ucOctet0 ) ) << 24UL ) |		\
-										( ( ( uint32_t ) ( ucOctet1 ) ) << 16UL ) |			\
-										( ( ( uint32_t ) ( ucOctet2 ) ) <<  8UL ) |			\
-										( ( uint32_t ) ( ucOctet3 ) ) )
+        #define FreeRTOS_inet_addr_quick( ucOctet0, ucOctet1, ucOctet2, ucOctet3 ) \
+    ( ( ( ( uint32_t ) ( ucOctet0 ) ) << 24UL ) |                                  \
+      ( ( ( uint32_t ) ( ucOctet1 ) ) << 16UL ) |                                  \
+      ( ( ( uint32_t ) ( ucOctet2 ) ) << 8UL ) |                                   \
+      ( ( uint32_t ) ( ucOctet3 ) ) )
 
-#endif /* ipconfigBYTE_ORDER */
+    #endif /* ipconfigBYTE_ORDER */
 
 /* The socket type itself. */
-struct xSOCKET;
-typedef struct xSOCKET *Socket_t;
+    struct xSOCKET;
+    typedef struct xSOCKET * Socket_t;
 
-#if( ipconfigSUPPORT_SELECT_FUNCTION == 1 )
-	/* The SocketSet_t type is the equivalent to the fd_set type used by the
-	Berkeley API. */
-	struct xSOCKET_SET;
-	typedef struct xSOCKET_SET *SocketSet_t;
-#endif	/* ( ipconfigSUPPORT_SELECT_FUNCTION == 1 ) */
+    #if ( ipconfigSUPPORT_SELECT_FUNCTION == 1 )
+
+        /* The SocketSet_t type is the equivalent to the fd_set type used by the
+         * Berkeley API. */
+        struct xSOCKET_SET;
+        typedef struct xSOCKET_SET * SocketSet_t;
+    #endif /* ( ipconfigSUPPORT_SELECT_FUNCTION == 1 ) */
 
 /**
  * FULL, UP-TO-DATE AND MAINTAINED REFERENCE DOCUMENTATION FOR ALL THESE
  * FUNCTIONS IS AVAILABLE ON THE FOLLOWING URL:
  * http://www.FreeRTOS.org/FreeRTOS-Plus/FreeRTOS_Plus_TCP/FreeRTOS_TCP_API_Functions.html
  */
-Socket_t FreeRTOS_socket( BaseType_t xDomain, BaseType_t xType, BaseType_t xProtocol );
-int32_t FreeRTOS_recvfrom( Socket_t xSocket, void *pvBuffer, size_t uxBufferLength, BaseType_t xFlags, struct freertos_sockaddr *pxSourceAddress, socklen_t *pxSourceAddressLength );
-int32_t FreeRTOS_sendto( Socket_t xSocket, const void *pvBuffer, size_t uxTotalDataLength, BaseType_t xFlags, const struct freertos_sockaddr *pxDestinationAddress, socklen_t xDestinationAddressLength );
-BaseType_t FreeRTOS_bind( Socket_t xSocket, struct freertos_sockaddr const * pxAddress, socklen_t xAddressLength );
+    Socket_t FreeRTOS_socket( BaseType_t xDomain,
+                              BaseType_t xType,
+                              BaseType_t xProtocol );
+    int32_t FreeRTOS_recvfrom( Socket_t xSocket,
+                               void * pvBuffer,
+                               size_t uxBufferLength,
+                               BaseType_t xFlags,
+                               struct freertos_sockaddr * pxSourceAddress,
+                               socklen_t * pxSourceAddressLength );
+    int32_t FreeRTOS_sendto( Socket_t xSocket,
+                             const void * pvBuffer,
+                             size_t uxTotalDataLength,
+                             BaseType_t xFlags,
+                             const struct freertos_sockaddr * pxDestinationAddress,
+                             socklen_t xDestinationAddressLength );
+    BaseType_t FreeRTOS_bind( Socket_t xSocket,
+                              struct freertos_sockaddr const * pxAddress,
+                              socklen_t xAddressLength );
 
 /* function to get the local address and IP port */
-size_t FreeRTOS_GetLocalAddress( Socket_t xSocket, struct freertos_sockaddr *pxAddress );
+    size_t FreeRTOS_GetLocalAddress( Socket_t xSocket,
+                                     struct freertos_sockaddr * pxAddress );
 
-#if( ipconfigETHERNET_DRIVER_FILTERS_PACKETS == 1 )
-	/* Returns true if an UDP socket exists bound to mentioned port number. */
-	BaseType_t xPortHasUDPSocket( uint16_t usPortNr );
-#endif
+    #if ( ipconfigETHERNET_DRIVER_FILTERS_PACKETS == 1 )
+        /* Returns true if an UDP socket exists bound to mentioned port number. */
+        BaseType_t xPortHasUDPSocket( uint16_t usPortNr );
+    #endif
 
-#if ipconfigUSE_TCP == 1
+    #if ipconfigUSE_TCP == 1
 
-BaseType_t FreeRTOS_connect( Socket_t xClientSocket, struct freertos_sockaddr *pxAddress, socklen_t xAddressLength );
-BaseType_t FreeRTOS_listen( Socket_t xSocket, BaseType_t xBacklog );
-BaseType_t FreeRTOS_recv( Socket_t xSocket, void *pvBuffer, size_t uxBufferLength, BaseType_t xFlags );
-BaseType_t FreeRTOS_send( Socket_t xSocket, const void *pvBuffer, size_t uxDataLength, BaseType_t xFlags );
-Socket_t FreeRTOS_accept( Socket_t xServerSocket, struct freertos_sockaddr *pxAddress, socklen_t *pxAddressLength );
-BaseType_t FreeRTOS_shutdown (Socket_t xSocket, BaseType_t xHow);
+        BaseType_t FreeRTOS_connect( Socket_t xClientSocket,
+                                     struct freertos_sockaddr * pxAddress,
+                                     socklen_t xAddressLength );
+        BaseType_t FreeRTOS_listen( Socket_t xSocket,
+                                    BaseType_t xBacklog );
+        BaseType_t FreeRTOS_recv( Socket_t xSocket,
+                                  void * pvBuffer,
+                                  size_t uxBufferLength,
+                                  BaseType_t xFlags );
+        BaseType_t FreeRTOS_send( Socket_t xSocket,
+                                  const void * pvBuffer,
+                                  size_t uxDataLength,
+                                  BaseType_t xFlags );
+        Socket_t FreeRTOS_accept( Socket_t xServerSocket,
+                                  struct freertos_sockaddr * pxAddress,
+                                  socklen_t * pxAddressLength );
+        BaseType_t FreeRTOS_shutdown( Socket_t xSocket,
+                                      BaseType_t xHow );
 
-#if( ipconfigSUPPORT_SIGNALS != 0 )
-	/* Send a signal to the task which is waiting for a given socket. */
-	BaseType_t FreeRTOS_SignalSocket( Socket_t xSocket );
+        #if ( ipconfigSUPPORT_SIGNALS != 0 )
+            /* Send a signal to the task which is waiting for a given socket. */
+            BaseType_t FreeRTOS_SignalSocket( Socket_t xSocket );
 
-	/* Send a signal to the task which reads from this socket (FromISR
-	version). */
-	BaseType_t FreeRTOS_SignalSocketFromISR( Socket_t xSocket, BaseType_t *pxHigherPriorityTaskWoken );
-#endif /* ipconfigSUPPORT_SIGNALS */
+            /* Send a signal to the task which reads from this socket (FromISR
+             * version). */
+            BaseType_t FreeRTOS_SignalSocketFromISR( Socket_t xSocket,
+                                                     BaseType_t * pxHigherPriorityTaskWoken );
+        #endif /* ipconfigSUPPORT_SIGNALS */
 
 /* Return the remote address and IP port. */
-BaseType_t FreeRTOS_GetRemoteAddress( Socket_t xSocket, struct freertos_sockaddr *pxAddress );
+        BaseType_t FreeRTOS_GetRemoteAddress( Socket_t xSocket,
+                                              struct freertos_sockaddr * pxAddress );
 
-#if( ipconfigUSE_TCP == 1 )
+        #if ( ipconfigUSE_TCP == 1 )
 
-	/* returns pdTRUE if TCP socket is connected */
-	BaseType_t FreeRTOS_issocketconnected( Socket_t xSocket );
+            /* returns pdTRUE if TCP socket is connected */
+            BaseType_t FreeRTOS_issocketconnected( Socket_t xSocket );
 
-	/* returns the actual size of MSS being used */
-	BaseType_t FreeRTOS_mss( Socket_t xSocket );
+            /* returns the actual size of MSS being used */
+            BaseType_t FreeRTOS_mss( Socket_t xSocket );
 
-#endif
+        #endif
 
 /* for internal use only: return the connection status */
-BaseType_t FreeRTOS_connstatus( Socket_t xSocket );
+        BaseType_t FreeRTOS_connstatus( Socket_t xSocket );
 
 /* Returns the number of bytes that may be added to txStream */
-BaseType_t FreeRTOS_maywrite( Socket_t xSocket );
+        BaseType_t FreeRTOS_maywrite( Socket_t xSocket );
 
 /*
  * Two helper functions, mostly for testing
  * rx_size returns the number of bytes available in the Rx buffer
  * tx_space returns the free space in the Tx buffer
  */
-#if( ipconfigUSE_TCP == 1 )
-	BaseType_t FreeRTOS_rx_size( Socket_t xSocket );
-	BaseType_t FreeRTOS_tx_space( Socket_t xSocket );
-	BaseType_t FreeRTOS_tx_size( Socket_t xSocket );
-#endif
+        #if ( ipconfigUSE_TCP == 1 )
+            BaseType_t FreeRTOS_rx_size( Socket_t xSocket );
+            BaseType_t FreeRTOS_tx_space( Socket_t xSocket );
+            BaseType_t FreeRTOS_tx_size( Socket_t xSocket );
+        #endif
 
 /* Returns the number of outstanding bytes in txStream. */
+
 /* The function FreeRTOS_outstanding() was already implemented
-FreeRTOS_tx_size(). */
-#define FreeRTOS_outstanding( xSocket )	FreeRTOS_tx_size( xSocket )
+ * FreeRTOS_tx_size(). */
+        #define FreeRTOS_outstanding( xSocket )    FreeRTOS_tx_size( xSocket )
 
 /* Returns the number of bytes in the socket's rxStream. */
+
 /* The function FreeRTOS_recvcount() was already implemented
-FreeRTOS_rx_size(). */
-#define FreeRTOS_recvcount( xSocket )	FreeRTOS_rx_size( xSocket )
+ * FreeRTOS_rx_size(). */
+        #define FreeRTOS_recvcount( xSocket )    FreeRTOS_rx_size( xSocket )
 
 /*
  * For advanced applications only:
  * Get a direct pointer to the circular transmit buffer.
  * '*pxLength' will contain the number of bytes that may be written.
  */
-uint8_t *FreeRTOS_get_tx_head( Socket_t xSocket, BaseType_t *pxLength );
+        uint8_t * FreeRTOS_get_tx_head( Socket_t xSocket,
+                                        BaseType_t * pxLength );
 
-#endif /* ipconfigUSE_TCP */
+    #endif /* ipconfigUSE_TCP */
 
-#if( ipconfigUSE_CALLBACKS != 0 )
-	/*
-	 * Connect / disconnect handler for a TCP socket
-	 * For example:
-	 *		static void vMyConnectHandler (Socket_t xSocket, BaseType_t ulConnected)
-	 *		{
-	 *		}
-	 * 		F_TCP_UDP_Handler_t xHnd = { vMyConnectHandler };
-	 * 		FreeRTOS_setsockopt( sock, 0, FREERTOS_SO_TCP_CONN_HANDLER, ( void * ) &xHnd, sizeof( xHnd ) );
-	 */
-	
-	#ifdef __COVERITY__
-		typedef void (* FOnConnected_t )( Socket_t xSocket, BaseType_t ulConnected );
-	#else
-		typedef void (* FOnConnected_t )( Socket_t, BaseType_t );
-	#endif
+    #if ( ipconfigUSE_CALLBACKS != 0 )
 
-	/*
-	 * Reception handler for a TCP socket
-	 * A user-proved function will be called on reception of a message
-	 * If the handler returns a positive number, the messages will not be stored
-	 * For example:
-	 *		static BaseType_t xOnTCPReceive( Socket_t xSocket, void * pData, size_t uxLength )
-	 *		{
-	 *			// handle the message
-	 *			return 1;
-	 *		}
-	 *		F_TCP_UDP_Handler_t xHand = { xOnTCPReceive };
-	 *		FreeRTOS_setsockopt( sock, 0, FREERTOS_SO_TCP_RECV_HANDLER, ( void * ) &xHand, sizeof( xHand ) );
-	 */
-	#ifdef __COVERITY__
-		typedef BaseType_t (* FOnTCPReceive_t )( Socket_t xSocket, void * pData, size_t xLength );
-		typedef void (* FOnTCPSent_t )( Socket_t xSocket, size_t xLength );
-	#else
-		typedef BaseType_t (* FOnTCPReceive_t )( Socket_t, void *, size_t );
-		typedef void (* FOnTCPSent_t )( Socket_t, size_t );
-	#endif
-	
-	/*
-	 * Reception handler for a UDP socket
-	 * A user-proved function will be called on reception of a message
-	 * If the handler returns a positive number, the messages will not be stored
-	 */
-	#ifdef __COVERITY__
-		typedef BaseType_t (* FOnUDPReceive_t ) (Socket_t xSocket, void * pData, size_t xLength,
-			const struct freertos_sockaddr * pxFrom, const struct freertos_sockaddr * pxDest );
-		typedef void (* FOnUDPSent_t )( Socket_t xSocket, size_t xLength );
-	#else
-		typedef BaseType_t (* FOnUDPReceive_t ) (Socket_t, void *, size_t,
-			const struct freertos_sockaddr *, const struct freertos_sockaddr *);
-		typedef void (* FOnUDPSent_t )( Socket_t, size_t);
-	#endif
+        /*
+         * Connect / disconnect handler for a TCP socket
+         * For example:
+         *		static void vMyConnectHandler (Socket_t xSocket, BaseType_t ulConnected)
+         *		{
+         *		}
+         *      F_TCP_UDP_Handler_t xHnd = { vMyConnectHandler };
+         *      FreeRTOS_setsockopt( sock, 0, FREERTOS_SO_TCP_CONN_HANDLER, ( void * ) &xHnd, sizeof( xHnd ) );
+         */
 
-	typedef union xTCP_UDP_HANDLER
-	{
-		FOnConnected_t	pxOnTCPConnected;	/* FREERTOS_SO_TCP_CONN_HANDLER */
-		FOnTCPReceive_t	pxOnTCPReceive;		/* FREERTOS_SO_TCP_RECV_HANDLER */
-		FOnTCPSent_t	pxOnTCPSent;		/* FREERTOS_SO_TCP_SENT_HANDLER */
-		FOnUDPReceive_t	pxOnUDPReceive;		/* FREERTOS_SO_UDP_RECV_HANDLER */
-		FOnUDPSent_t	pxOnUDPSent;		/* FREERTOS_SO_UDP_SENT_HANDLER */
-	} F_TCP_UDP_Handler_t;
-#endif	/* ( ipconfigUSE_CALLBACKS != 0 ) */
+        #ifdef __COVERITY__
+            typedef void (* FOnConnected_t )( Socket_t xSocket,
+                                              BaseType_t ulConnected );
+        #else
+            typedef void (* FOnConnected_t )( Socket_t,
+                                              BaseType_t );
+        #endif
 
-BaseType_t FreeRTOS_setsockopt( Socket_t xSocket, int32_t lLevel, int32_t lOptionName, const void *pvOptionValue, size_t uxOptionLength );
-BaseType_t FreeRTOS_closesocket( Socket_t xSocket );
+        /*
+         * Reception handler for a TCP socket
+         * A user-proved function will be called on reception of a message
+         * If the handler returns a positive number, the messages will not be stored
+         * For example:
+         *		static BaseType_t xOnTCPReceive( Socket_t xSocket, void * pData, size_t uxLength )
+         *		{
+         *			// handle the message
+         *			return 1;
+         *		}
+         *		F_TCP_UDP_Handler_t xHand = { xOnTCPReceive };
+         *		FreeRTOS_setsockopt( sock, 0, FREERTOS_SO_TCP_RECV_HANDLER, ( void * ) &xHand, sizeof( xHand ) );
+         */
+        #ifdef __COVERITY__
+            typedef BaseType_t (* FOnTCPReceive_t )( Socket_t xSocket,
+                                                     void * pData,
+                                                     size_t xLength );
+            typedef void (* FOnTCPSent_t )( Socket_t xSocket,
+                                            size_t xLength );
+        #else
+            typedef BaseType_t (* FOnTCPReceive_t )( Socket_t,
+                                                     void *,
+                                                     size_t );
+            typedef void (* FOnTCPSent_t )( Socket_t,
+                                            size_t );
+        #endif /* ifdef __COVERITY__ */
+
+        /*
+         * Reception handler for a UDP socket
+         * A user-proved function will be called on reception of a message
+         * If the handler returns a positive number, the messages will not be stored
+         */
+        #ifdef __COVERITY__
+            typedef BaseType_t (* FOnUDPReceive_t ) ( Socket_t xSocket,
+                                                      void * pData,
+                                                      size_t xLength,
+                                                      const struct freertos_sockaddr * pxFrom,
+                                                      const struct freertos_sockaddr * pxDest );
+            typedef void (* FOnUDPSent_t )( Socket_t xSocket,
+                                            size_t xLength );
+        #else
+            typedef BaseType_t (* FOnUDPReceive_t ) ( Socket_t,
+                                                      void *,
+                                                      size_t,
+                                                      const struct freertos_sockaddr *,
+                                                      const struct freertos_sockaddr * );
+            typedef void (* FOnUDPSent_t )( Socket_t,
+                                            size_t );
+        #endif /* ifdef __COVERITY__ */
+
+        typedef union xTCP_UDP_HANDLER
+        {
+            FOnConnected_t pxOnTCPConnected; /* FREERTOS_SO_TCP_CONN_HANDLER */
+            FOnTCPReceive_t pxOnTCPReceive;  /* FREERTOS_SO_TCP_RECV_HANDLER */
+            FOnTCPSent_t pxOnTCPSent;        /* FREERTOS_SO_TCP_SENT_HANDLER */
+            FOnUDPReceive_t pxOnUDPReceive;  /* FREERTOS_SO_UDP_RECV_HANDLER */
+            FOnUDPSent_t pxOnUDPSent;        /* FREERTOS_SO_UDP_SENT_HANDLER */
+        } F_TCP_UDP_Handler_t;
+    #endif /* ( ipconfigUSE_CALLBACKS != 0 ) */
+
+    BaseType_t FreeRTOS_setsockopt( Socket_t xSocket,
+                                    int32_t lLevel,
+                                    int32_t lOptionName,
+                                    const void * pvOptionValue,
+                                    size_t uxOptionLength );
+    BaseType_t FreeRTOS_closesocket( Socket_t xSocket );
 
 /* The following function header should be placed in FreeRTOS_DNS.h.
-It is kept here because some applications  expect it in FreeRTOS_Sockets.h.*/
-#ifndef __COVERITY__
-	uint32_t FreeRTOS_gethostbyname( const char *pcHostName );
-#endif
+ * It is kept here because some applications  expect it in FreeRTOS_Sockets.h.*/
+    #ifndef __COVERITY__
+        uint32_t FreeRTOS_gethostbyname( const char * pcHostName );
+    #endif
 
-BaseType_t FreeRTOS_inet_pton( BaseType_t xAddressFamily, const char *pcSource, void *pvDestination );
-const char *FreeRTOS_inet_ntop( BaseType_t xAddressFamily, const void *pvSource, char *pcDestination, socklen_t uxSize );
+    BaseType_t FreeRTOS_inet_pton( BaseType_t xAddressFamily,
+                                   const char * pcSource,
+                                   void * pvDestination );
+    const char * FreeRTOS_inet_ntop( BaseType_t xAddressFamily,
+                                     const void * pvSource,
+                                     char * pcDestination,
+                                     socklen_t uxSize );
 
 /* Convert a null-terminated string in dot-decimal-notation (d.d.d.d) to a 32-bit unsigned integer. */
-uint32_t FreeRTOS_inet_addr( const char * pcIPAddress );
+    uint32_t FreeRTOS_inet_addr( const char * pcIPAddress );
 
-BaseType_t FreeRTOS_inet_pton4( const char *pcSource, void *pvDestination );
-const char *FreeRTOS_inet_ntop4( const void *pvSource, char *pcDestination, socklen_t uxSize );
+    BaseType_t FreeRTOS_inet_pton4( const char * pcSource,
+                                    void * pvDestination );
+    const char * FreeRTOS_inet_ntop4( const void * pvSource,
+                                      char * pcDestination,
+                                      socklen_t uxSize );
 
 
 /*
  * For the web server: borrow the circular Rx buffer for inspection
  * HTML driver wants to see if a sequence of 13/10/13/10 is available
  */
-const struct xSTREAM_BUFFER *FreeRTOS_get_rx_buf( Socket_t xSocket );
+    const struct xSTREAM_BUFFER * FreeRTOS_get_rx_buf( Socket_t xSocket );
 
-void FreeRTOS_netstat( void );
+    void FreeRTOS_netstat( void );
 
-#if ipconfigSUPPORT_SELECT_FUNCTION == 1
+    #if ipconfigSUPPORT_SELECT_FUNCTION == 1
 
-	/* For FD_SET and FD_CLR, a combination of the following bits can be used: */
+        /* For FD_SET and FD_CLR, a combination of the following bits can be used: */
 
-	typedef enum eSELECT_EVENT {
-		eSELECT_READ    = 0x0001,
-		eSELECT_WRITE   = 0x0002,
-		eSELECT_EXCEPT  = 0x0004,
-		eSELECT_INTR    = 0x0008,
-		eSELECT_ALL		= 0x000F,
-		/* Reserved for internal use: */
-		eSELECT_CALL_IP	= 0x0010,
-		/* end */
-	} eSelectEvent_t;
+        typedef enum eSELECT_EVENT
+        {
+            eSELECT_READ = 0x0001,
+            eSELECT_WRITE = 0x0002,
+            eSELECT_EXCEPT = 0x0004,
+            eSELECT_INTR = 0x0008,
+            eSELECT_ALL = 0x000F,
+            /* Reserved for internal use: */
+            eSELECT_CALL_IP = 0x0010,
+            /* end */
+        } eSelectEvent_t;
 
-	SocketSet_t FreeRTOS_CreateSocketSet( void );
-	void FreeRTOS_DeleteSocketSet( SocketSet_t xSocketSet );
-	void FreeRTOS_FD_SET( Socket_t xSocket, SocketSet_t xSocketSet, EventBits_t xBitsToSet );
-	void FreeRTOS_FD_CLR( Socket_t xSocket, SocketSet_t xSocketSet, EventBits_t xBitsToClear );
-	EventBits_t FreeRTOS_FD_ISSET( Socket_t xSocket, SocketSet_t xSocketSet );
-	BaseType_t FreeRTOS_select( SocketSet_t xSocketSet, TickType_t xBlockTimeTicks );
+        SocketSet_t FreeRTOS_CreateSocketSet( void );
+        void FreeRTOS_DeleteSocketSet( SocketSet_t xSocketSet );
+        void FreeRTOS_FD_SET( Socket_t xSocket,
+                              SocketSet_t xSocketSet,
+                              EventBits_t xBitsToSet );
+        void FreeRTOS_FD_CLR( Socket_t xSocket,
+                              SocketSet_t xSocketSet,
+                              EventBits_t xBitsToClear );
+        EventBits_t FreeRTOS_FD_ISSET( Socket_t xSocket,
+                                       SocketSet_t xSocketSet );
+        BaseType_t FreeRTOS_select( SocketSet_t xSocketSet,
+                                    TickType_t xBlockTimeTicks );
 
-#endif /* ipconfigSUPPORT_SELECT_FUNCTION */
+    #endif /* ipconfigSUPPORT_SELECT_FUNCTION */
 
-#ifdef __cplusplus
-} // extern "C"
-#endif
+    #ifdef __cplusplus
+        } /* extern "C" */
+    #endif
 
 #endif /* FREERTOS_SOCKETS_H */
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/include/FreeRTOS_Stream_Buffer.h
+++ b/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/include/FreeRTOS_Stream_Buffer.h
@@ -33,175 +33,197 @@
  */
 
 #ifndef FREERTOS_STREAM_BUFFER_H
-#define	FREERTOS_STREAM_BUFFER_H
+    #define FREERTOS_STREAM_BUFFER_H
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+    #ifdef __cplusplus
+        extern "C" {
+    #endif
 
-typedef struct xSTREAM_BUFFER {
-	volatile size_t uxTail;		/* next item to read */
-	volatile size_t uxMid;		/* iterator within the valid items */
-	volatile size_t uxHead;		/* next position store a new item */
-	volatile size_t uxFront;	/* iterator within the free space */
-	size_t LENGTH;				/* const value: number of reserved elements */
-	uint8_t ucArray[ sizeof( size_t ) ];
-} StreamBuffer_t;
+    typedef struct xSTREAM_BUFFER
+    {
+        volatile size_t uxTail;  /* next item to read */
+        volatile size_t uxMid;   /* iterator within the valid items */
+        volatile size_t uxHead;  /* next position store a new item */
+        volatile size_t uxFront; /* iterator within the free space */
+        size_t LENGTH;           /* const value: number of reserved elements */
+        uint8_t ucArray[ sizeof( size_t ) ];
+    } StreamBuffer_t;
 
-static portINLINE void vStreamBufferClear( StreamBuffer_t *pxBuffer );
-static portINLINE void vStreamBufferClear( StreamBuffer_t *pxBuffer )
-{
-	/* Make the circular buffer empty */
-	pxBuffer->uxHead = 0U;
-	pxBuffer->uxTail = 0U;
-	pxBuffer->uxFront = 0U;
-	pxBuffer->uxMid = 0U;
-}
+    static portINLINE void vStreamBufferClear( StreamBuffer_t * pxBuffer );
+    static portINLINE void vStreamBufferClear( StreamBuffer_t * pxBuffer )
+    {
+        /* Make the circular buffer empty */
+        pxBuffer->uxHead = 0U;
+        pxBuffer->uxTail = 0U;
+        pxBuffer->uxFront = 0U;
+        pxBuffer->uxMid = 0U;
+    }
 /*-----------------------------------------------------------*/
 
-static portINLINE size_t uxStreamBufferSpace( const StreamBuffer_t *pxBuffer, const size_t uxLower, const size_t uxUpper );
-static portINLINE size_t uxStreamBufferSpace( const StreamBuffer_t *pxBuffer, const size_t uxLower, const size_t uxUpper )
-{
+    static portINLINE size_t uxStreamBufferSpace( const StreamBuffer_t * pxBuffer,
+                                                  const size_t uxLower,
+                                                  const size_t uxUpper );
+    static portINLINE size_t uxStreamBufferSpace( const StreamBuffer_t * pxBuffer,
+                                                  const size_t uxLower,
+                                                  const size_t uxUpper )
+    {
 /* Returns the space between uxLower and uxUpper, which equals to the distance minus 1 */
-size_t uxCount;
+        size_t uxCount;
 
-	uxCount = pxBuffer->LENGTH + uxUpper - uxLower - 1U;
-	if( uxCount >= pxBuffer->LENGTH )
-	{
-		uxCount -= pxBuffer->LENGTH;
-	}
+        uxCount = pxBuffer->LENGTH + uxUpper - uxLower - 1U;
 
-	return uxCount;
-}
+        if( uxCount >= pxBuffer->LENGTH )
+        {
+            uxCount -= pxBuffer->LENGTH;
+        }
+
+        return uxCount;
+    }
 /*-----------------------------------------------------------*/
 
-static portINLINE size_t uxStreamBufferDistance( const StreamBuffer_t *pxBuffer, const size_t uxLower, const size_t uxUpper );
-static portINLINE size_t uxStreamBufferDistance( const StreamBuffer_t *pxBuffer, const size_t uxLower, const size_t uxUpper )
-{
+    static portINLINE size_t uxStreamBufferDistance( const StreamBuffer_t * pxBuffer,
+                                                     const size_t uxLower,
+                                                     const size_t uxUpper );
+    static portINLINE size_t uxStreamBufferDistance( const StreamBuffer_t * pxBuffer,
+                                                     const size_t uxLower,
+                                                     const size_t uxUpper )
+    {
 /* Returns the distance between uxLower and uxUpper */
-size_t uxCount;
+        size_t uxCount;
 
-	uxCount = pxBuffer->LENGTH + uxUpper - uxLower;
-	if ( uxCount >= pxBuffer->LENGTH )
-	{
-		uxCount -= pxBuffer->LENGTH;
-	}
+        uxCount = pxBuffer->LENGTH + uxUpper - uxLower;
 
-	return uxCount;
-}
+        if( uxCount >= pxBuffer->LENGTH )
+        {
+            uxCount -= pxBuffer->LENGTH;
+        }
+
+        return uxCount;
+    }
 /*-----------------------------------------------------------*/
 
-static portINLINE size_t uxStreamBufferGetSpace( const StreamBuffer_t *pxBuffer );
-static portINLINE size_t uxStreamBufferGetSpace( const StreamBuffer_t *pxBuffer )
-{
+    static portINLINE size_t uxStreamBufferGetSpace( const StreamBuffer_t * pxBuffer );
+    static portINLINE size_t uxStreamBufferGetSpace( const StreamBuffer_t * pxBuffer )
+    {
 /* Returns the number of items which can still be added to uxHead
-before hitting on uxTail */
-size_t uxHead = pxBuffer->uxHead;
-size_t uxTail = pxBuffer->uxTail;
+ * before hitting on uxTail */
+        size_t uxHead = pxBuffer->uxHead;
+        size_t uxTail = pxBuffer->uxTail;
 
-	return uxStreamBufferSpace( pxBuffer, uxHead, uxTail );
-}
+        return uxStreamBufferSpace( pxBuffer, uxHead, uxTail );
+    }
 /*-----------------------------------------------------------*/
 
-static portINLINE size_t uxStreamBufferFrontSpace( const StreamBuffer_t *pxBuffer );
-static portINLINE size_t uxStreamBufferFrontSpace( const StreamBuffer_t *pxBuffer )
-{
+    static portINLINE size_t uxStreamBufferFrontSpace( const StreamBuffer_t * pxBuffer );
+    static portINLINE size_t uxStreamBufferFrontSpace( const StreamBuffer_t * pxBuffer )
+    {
 /* Distance between uxFront and uxTail
-or the number of items which can still be added to uxFront,
-before hitting on uxTail */
+ * or the number of items which can still be added to uxFront,
+ * before hitting on uxTail */
 
-size_t uxFront = pxBuffer->uxFront;
-size_t uxTail = pxBuffer->uxTail;
+        size_t uxFront = pxBuffer->uxFront;
+        size_t uxTail = pxBuffer->uxTail;
 
-	return uxStreamBufferSpace( pxBuffer, uxFront, uxTail );
-}
+        return uxStreamBufferSpace( pxBuffer, uxFront, uxTail );
+    }
 /*-----------------------------------------------------------*/
 
-static portINLINE size_t uxStreamBufferGetSize( const StreamBuffer_t *pxBuffer );
-static portINLINE size_t uxStreamBufferGetSize( const StreamBuffer_t *pxBuffer )
-{
+    static portINLINE size_t uxStreamBufferGetSize( const StreamBuffer_t * pxBuffer );
+    static portINLINE size_t uxStreamBufferGetSize( const StreamBuffer_t * pxBuffer )
+    {
 /* Returns the number of items which can be read from uxTail
-before reaching uxHead */
-size_t uxHead = pxBuffer->uxHead;
-size_t uxTail = pxBuffer->uxTail;
+ * before reaching uxHead */
+        size_t uxHead = pxBuffer->uxHead;
+        size_t uxTail = pxBuffer->uxTail;
 
-	return uxStreamBufferDistance( pxBuffer, uxTail, uxHead );
-}
+        return uxStreamBufferDistance( pxBuffer, uxTail, uxHead );
+    }
 /*-----------------------------------------------------------*/
 
-static portINLINE size_t uxStreamBufferMidSpace( const StreamBuffer_t *pxBuffer );
-static portINLINE size_t uxStreamBufferMidSpace( const StreamBuffer_t *pxBuffer )
-{
+    static portINLINE size_t uxStreamBufferMidSpace( const StreamBuffer_t * pxBuffer );
+    static portINLINE size_t uxStreamBufferMidSpace( const StreamBuffer_t * pxBuffer )
+    {
 /* Returns the distance between uxHead and uxMid */
-size_t uxHead = pxBuffer->uxHead;
-size_t uxMid = pxBuffer->uxMid;
+        size_t uxHead = pxBuffer->uxHead;
+        size_t uxMid = pxBuffer->uxMid;
 
-	return uxStreamBufferDistance( pxBuffer, uxMid, uxHead );
-}
+        return uxStreamBufferDistance( pxBuffer, uxMid, uxHead );
+    }
 /*-----------------------------------------------------------*/
 
-static portINLINE void vStreamBufferMoveMid( StreamBuffer_t *pxBuffer, size_t uxCount );
-static portINLINE void vStreamBufferMoveMid( StreamBuffer_t *pxBuffer, size_t uxCount )
-{
+    static portINLINE void vStreamBufferMoveMid( StreamBuffer_t * pxBuffer,
+                                                 size_t uxCount );
+    static portINLINE void vStreamBufferMoveMid( StreamBuffer_t * pxBuffer,
+                                                 size_t uxCount )
+    {
 /* Increment uxMid, but no further than uxHead */
-size_t uxSize = uxStreamBufferMidSpace( pxBuffer );
-size_t uxMoveCount = uxCount;
+        size_t uxSize = uxStreamBufferMidSpace( pxBuffer );
+        size_t uxMoveCount = uxCount;
 
-	if( uxMoveCount > uxSize )
-	{
-		uxMoveCount = uxSize;
-	}
-	pxBuffer->uxMid += uxMoveCount;
-	if( pxBuffer->uxMid >= pxBuffer->LENGTH )
-	{
-		pxBuffer->uxMid -= pxBuffer->LENGTH;
-	}
-}
+        if( uxMoveCount > uxSize )
+        {
+            uxMoveCount = uxSize;
+        }
+
+        pxBuffer->uxMid += uxMoveCount;
+
+        if( pxBuffer->uxMid >= pxBuffer->LENGTH )
+        {
+            pxBuffer->uxMid -= pxBuffer->LENGTH;
+        }
+    }
 /*-----------------------------------------------------------*/
 
-static portINLINE BaseType_t xStreamBufferLessThenEqual( const StreamBuffer_t *pxBuffer, const size_t uxLeft, const size_t uxRight );
-static portINLINE BaseType_t xStreamBufferLessThenEqual( const StreamBuffer_t *pxBuffer, const size_t uxLeft, const size_t uxRight )
-{
-BaseType_t xReturn;
-size_t uxTail = pxBuffer->uxTail;
+    static portINLINE BaseType_t xStreamBufferLessThenEqual( const StreamBuffer_t * pxBuffer,
+                                                             const size_t uxLeft,
+                                                             const size_t uxRight );
+    static portINLINE BaseType_t xStreamBufferLessThenEqual( const StreamBuffer_t * pxBuffer,
+                                                             const size_t uxLeft,
+                                                             const size_t uxRight )
+    {
+        BaseType_t xReturn;
+        size_t uxTail = pxBuffer->uxTail;
 
-	/* Returns true if ( uxLeft < uxRight ) */
-	if( ( ( ( uxLeft < uxTail ) ? 1U : 0U ) ^ ( ( uxRight < uxTail ) ? 1U : 0U )  ) != 0U )
-	{
-		if( uxRight < uxTail )
-		{
-			xReturn = pdTRUE;
-		}
-		else
-		{
-			xReturn = pdFALSE;
-		}
-	}
-	else
-	{
-		if( uxLeft <= uxRight )
-		{
-			xReturn = pdTRUE;
-		}
-		else
-		{
-			xReturn = pdFALSE;
-		}
-	}
-	return xReturn;
-}
+        /* Returns true if ( uxLeft < uxRight ) */
+        if( ( ( ( uxLeft < uxTail ) ? 1U : 0U ) ^ ( ( uxRight < uxTail ) ? 1U : 0U ) ) != 0U )
+        {
+            if( uxRight < uxTail )
+            {
+                xReturn = pdTRUE;
+            }
+            else
+            {
+                xReturn = pdFALSE;
+            }
+        }
+        else
+        {
+            if( uxLeft <= uxRight )
+            {
+                xReturn = pdTRUE;
+            }
+            else
+            {
+                xReturn = pdFALSE;
+            }
+        }
+
+        return xReturn;
+    }
 /*-----------------------------------------------------------*/
 
-static portINLINE size_t uxStreamBufferGetPtr( StreamBuffer_t *pxBuffer, uint8_t **ppucData );
-static portINLINE size_t uxStreamBufferGetPtr( StreamBuffer_t *pxBuffer, uint8_t **ppucData )
-{
-size_t uxNextTail = pxBuffer->uxTail;
-size_t uxSize = uxStreamBufferGetSize( pxBuffer );
+    static portINLINE size_t uxStreamBufferGetPtr( StreamBuffer_t * pxBuffer,
+                                                   uint8_t ** ppucData );
+    static portINLINE size_t uxStreamBufferGetPtr( StreamBuffer_t * pxBuffer,
+                                                   uint8_t ** ppucData )
+    {
+        size_t uxNextTail = pxBuffer->uxTail;
+        size_t uxSize = uxStreamBufferGetSize( pxBuffer );
 
-	*ppucData = pxBuffer->ucArray + uxNextTail;
+        *ppucData = pxBuffer->ucArray + uxNextTail;
 
-	return FreeRTOS_min_uint32( uxSize, pxBuffer->LENGTH - uxNextTail );
-}
+        return FreeRTOS_min_uint32( uxSize, pxBuffer->LENGTH - uxNextTail );
+    }
 
 /*
  * Add bytes to a stream buffer.
@@ -212,7 +234,10 @@ size_t uxSize = uxStreamBufferGetSize( pxBuffer );
  * pucData -	A pointer to the data to be added.
  * uxCount -	The number of bytes to add.
  */
-size_t uxStreamBufferAdd( StreamBuffer_t *pxBuffer, size_t uxOffset, const uint8_t *pucData, size_t uxByteCount );
+    size_t uxStreamBufferAdd( StreamBuffer_t * pxBuffer,
+                              size_t uxOffset,
+                              const uint8_t * pucData,
+                              size_t uxByteCount );
 
 /*
  * Read bytes from a stream buffer.
@@ -223,10 +248,14 @@ size_t uxStreamBufferAdd( StreamBuffer_t *pxBuffer, size_t uxOffset, const uint8
  * uxMaxCount -	The number of bytes to read.
  * xPeek -		If set to pdTRUE the data will remain in the buffer.
  */
-size_t uxStreamBufferGet( StreamBuffer_t *pxBuffer, size_t uxOffset, uint8_t *pucData, size_t uxMaxCount, BaseType_t xPeek );
+    size_t uxStreamBufferGet( StreamBuffer_t * pxBuffer,
+                              size_t uxOffset,
+                              uint8_t * pucData,
+                              size_t uxMaxCount,
+                              BaseType_t xPeek );
 
-#ifdef __cplusplus
-} /* extern "C" */
-#endif
+    #ifdef __cplusplus
+        } /* extern "C" */
+    #endif
 
-#endif	/* !defined( FREERTOS_STREAM_BUFFER_H ) */
+#endif /* !defined( FREERTOS_STREAM_BUFFER_H ) */

--- a/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/include/FreeRTOS_TCP_IP.h
+++ b/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/include/FreeRTOS_TCP_IP.h
@@ -24,57 +24,45 @@
  */
 
 #ifndef FREERTOS_TCP_IP_H
-#define FREERTOS_TCP_IP_H
+    #define FREERTOS_TCP_IP_H
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+    #ifdef __cplusplus
+        extern "C" {
+    #endif
 
-BaseType_t xProcessReceivedTCPPacket( NetworkBufferDescriptor_t *pxDescriptor );
+    BaseType_t xProcessReceivedTCPPacket( NetworkBufferDescriptor_t * pxDescriptor );
 
-typedef enum eTCP_STATE {
-	/* Comments about the TCP states are borrowed from the very useful
-	 * Wiki page:
-	 * http://en.wikipedia.org/wiki/Transmission_Control_Protocol */
-	eCLOSED = 0U,	/* 0 (server + client) no connection state at all. */
-	eTCP_LISTEN,	/* 1 (server) waiting for a connection request
-						 from any remote TCP and port. */
-	eCONNECT_SYN,	/* 2 (client) internal state: socket wants to send
-						 a connect */
-	eSYN_FIRST,		/* 3 (server) Just created, must ACK the SYN request. */
-	eSYN_RECEIVED,	/* 4 (server) waiting for a confirming connection request
-						 acknowledgement after having both received and sent a connection request. */
-	eESTABLISHED,	/* 5 (server + client) an open connection, data received can be
-						 delivered to the user. The normal state for the data transfer phase of the connection. */
-	eFIN_WAIT_1,	/* 6 (server + client) waiting for a connection termination request from the remote TCP,
-						 or an acknowledgement of the connection termination request previously sent. */
-	eFIN_WAIT_2,	/* 7 (server + client) waiting for a connection termination request from the remote TCP. */
-	eCLOSE_WAIT,	/* 8 (server + client) waiting for a connection termination request from the local user. */
-	eCLOSING,		/* 9 (server + client) waiting for a connection termination request acknowledgement from the remote TCP. */
-	eLAST_ACK,		/*10 (server + client) waiting for an acknowledgement of the connection termination request
-						 previously sent to the remote TCP
-						 (which includes an acknowledgement of its connection termination request). */
-	eTIME_WAIT,		/*11 (either server or client) waiting for enough time to pass to be sure the remote TCP received the
-						 acknowledgement of its connection termination request. [According to RFC 793 a connection can
-						 stay in TIME-WAIT for a maximum of four minutes known as a MSL (maximum segment lifetime).] */
-} eIPTCPState_t;
+    typedef enum eTCP_STATE
+    {
+        /* Comments about the TCP states are borrowed from the very useful
+         * Wiki page:
+         * http://en.wikipedia.org/wiki/Transmission_Control_Protocol */
+        eCLOSED = 0U,  /* 0 (server + client) no connection state at all. */
+        eTCP_LISTEN,   /* 1 (server) waiting for a connection request
+                        *   from any remote TCP and port. */
+        eCONNECT_SYN,  /* 2 (client) internal state: socket wants to send
+                        *   a connect */
+        eSYN_FIRST,    /* 3 (server) Just created, must ACK the SYN request. */
+        eSYN_RECEIVED, /* 4 (server) waiting for a confirming connection request
+                        *   acknowledgement after having both received and sent a connection request. */
+        eESTABLISHED,  /* 5 (server + client) an open connection, data received can be
+                        *   delivered to the user. The normal state for the data transfer phase of the connection. */
+        eFIN_WAIT_1,   /* 6 (server + client) waiting for a connection termination request from the remote TCP,
+                        *   or an acknowledgement of the connection termination request previously sent. */
+        eFIN_WAIT_2,   /* 7 (server + client) waiting for a connection termination request from the remote TCP. */
+        eCLOSE_WAIT,   /* 8 (server + client) waiting for a connection termination request from the local user. */
+        eCLOSING,      /* 9 (server + client) waiting for a connection termination request acknowledgement from the remote TCP. */
+        eLAST_ACK,     /*10 (server + client) waiting for an acknowledgement of the connection termination request
+                        *   previously sent to the remote TCP
+                        *   (which includes an acknowledgement of its connection termination request). */
+        eTIME_WAIT,    /*11 (either server or client) waiting for enough time to pass to be sure the remote TCP received the
+                        *   acknowledgement of its connection termination request. [According to RFC 793 a connection can
+                        *   stay in TIME-WAIT for a maximum of four minutes known as a MSL (maximum segment lifetime).] */
+    } eIPTCPState_t;
 
 
-#ifdef __cplusplus
-} // extern "C"
-#endif
+    #ifdef __cplusplus
+        } /* extern "C" */
+    #endif
 
 #endif /* FREERTOS_TCP_IP_H */
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/include/FreeRTOS_TCP_WIN.h
+++ b/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/include/FreeRTOS_TCP_WIN.h
@@ -28,112 +28,112 @@
  *  Module which handles the TCP windowing schemes for FreeRTOS-PLUS-TCP
  */
 
-#ifndef	FREERTOS_TCP_WIN_H
-#define	FREERTOS_TCP_WIN_H
+#ifndef FREERTOS_TCP_WIN_H
+    #define FREERTOS_TCP_WIN_H
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+    #ifdef __cplusplus
+        extern "C" {
+    #endif
 
 /* The name xTCPTimer was already use as the name of an IP-timer. */
-typedef struct xTCPTimerStruct
-{
-	uint32_t ulBorn;
-} TCPTimer_t;
+    typedef struct xTCPTimerStruct
+    {
+        uint32_t ulBorn;
+    } TCPTimer_t;
 
-typedef struct xTCP_SEGMENT
-{
-	uint32_t ulSequenceNumber;		/* The sequence number of the first byte in this packet */
-	int32_t lMaxLength;				/* Maximum space, number of bytes which can be stored in this segment */
-	int32_t lDataLength;			/* Actual number of bytes */
-	int32_t lStreamPos;				/* reference to the [t|r]xStream of the socket */
-	TCPTimer_t xTransmitTimer;		/* saves a timestamp at the moment this segment gets transmitted (TX only) */
-	union
-	{
-		struct
-		{
-			uint32_t
-				ucTransmitCount : 8,/* Number of times the segment has been transmitted, used to calculate the RTT */
-				ucDupAckCount : 8,	/* Counts the number of times that a higher segment was ACK'd. After 3 times a Fast Retransmission takes place */
-				bOutstanding : 1,	/* It the peer's turn, we're just waiting for an ACK */
-				bAcked : 1,			/* This segment has been acknowledged */
-				bIsForRx : 1;		/* pdTRUE if segment is used for reception */
-		} bits;
-		uint32_t ulFlags;
-	} u;
-#if( ipconfigUSE_TCP_WIN != 0 )
-	struct xLIST_ITEM xQueueItem;	/* TX only: segments can be linked in one of three queues: xPriorityQueue, xTxQueue, and xWaitQueue */
-	struct xLIST_ITEM xSegmentItem;	/* With this item the segment can be connected to a list, depending on who is owning it */
-#endif
-} TCPSegment_t;
+    typedef struct xTCP_SEGMENT
+    {
+        uint32_t ulSequenceNumber; /* The sequence number of the first byte in this packet */
+        int32_t lMaxLength;        /* Maximum space, number of bytes which can be stored in this segment */
+        int32_t lDataLength;       /* Actual number of bytes */
+        int32_t lStreamPos;        /* reference to the [t|r]xStream of the socket */
+        TCPTimer_t xTransmitTimer; /* saves a timestamp at the moment this segment gets transmitted (TX only) */
+        union
+        {
+            struct
+            {
+                uint32_t
+                    ucTransmitCount : 8, /* Number of times the segment has been transmitted, used to calculate the RTT */
+                    ucDupAckCount : 8,   /* Counts the number of times that a higher segment was ACK'd. After 3 times a Fast Retransmission takes place */
+                    bOutstanding : 1,    /* It the peer's turn, we're just waiting for an ACK */
+                    bAcked : 1,          /* This segment has been acknowledged */
+                    bIsForRx : 1;        /* pdTRUE if segment is used for reception */
+            } bits;
+            uint32_t ulFlags;
+        } u;
+        #if ( ipconfigUSE_TCP_WIN != 0 )
+            struct xLIST_ITEM xQueueItem;   /* TX only: segments can be linked in one of three queues: xPriorityQueue, xTxQueue, and xWaitQueue */
+            struct xLIST_ITEM xSegmentItem; /* With this item the segment can be connected to a list, depending on who is owning it */
+        #endif
+    } TCPSegment_t;
 
-typedef struct xTCP_WINSIZE
-{
-	uint32_t ulRxWindowLength;
-	uint32_t ulTxWindowLength;
-} TCPWinSize_t;
+    typedef struct xTCP_WINSIZE
+    {
+        uint32_t ulRxWindowLength;
+        uint32_t ulTxWindowLength;
+    } TCPWinSize_t;
 
 /*
  * If TCP time-stamps are being used, they will occupy 12 bytes in
  * each packet, and thus the message space will become smaller
  */
 /* Keep this as a multiple of 4 */
-#if( ipconfigUSE_TCP_WIN == 1 )
-	#define ipSIZE_TCP_OPTIONS	16U
-#else
-	#define ipSIZE_TCP_OPTIONS	12U
-#endif
+    #if ( ipconfigUSE_TCP_WIN == 1 )
+        #define ipSIZE_TCP_OPTIONS    16U
+    #else
+        #define ipSIZE_TCP_OPTIONS    12U
+    #endif
 
 /*
  *	Every TCP connection owns a TCP window for the administration of all packets
  *	It owns two sets of segment descriptors, incoming and outgoing
  */
-typedef struct xTCP_WINDOW
-{
-	union
-	{
-		struct
-		{
-			uint32_t
-				bHasInit : 1,		/* The window structure has been initialised */
-				bSendFullSize : 1,	/* May only send packets with a size equal to MSS (for optimisation) */
-				bTimeStamps : 1;	/* Socket is supposed to use TCP time-stamps. This depends on the */
-		} bits;						/* party which opens the connection */
-		uint32_t ulFlags;
-	} u;
-	TCPWinSize_t xSize;
-	struct
-	{
-		uint32_t ulFirstSequenceNumber;	 /* Logging & debug: the first segment received/sent in this connection
-										  * for Tx: initial send sequence number (ISS)
-										  * for Rx: initial receive sequence number (IRS) */
-		uint32_t ulCurrentSequenceNumber;/* Tx/Rx: the oldest sequence number not yet confirmed, also SND.UNA / RCV.NXT
-										  * In other words: the sequence number of the left side of the sliding window */
-		uint32_t ulFINSequenceNumber;	 /* The sequence number which carried the FIN flag */
-		uint32_t ulHighestSequenceNumber;/* Sequence number of the right-most byte + 1 */
-	} rx, tx;
-	uint32_t ulOurSequenceNumber;		/* The SEQ number we're sending out */
-	uint32_t ulUserDataLength;			/* Number of bytes in Rx buffer which may be passed to the user, after having received a 'missing packet' */
-	uint32_t ulNextTxSequenceNumber;	/* The sequence number given to the next byte to be added for transmission */
-	int32_t lSRTT;						/* Smoothed Round Trip Time, it may increment quickly and it decrements slower */
-	uint8_t ucOptionLength;				/* Number of valid bytes in ulOptionsData[] */
-#if( ipconfigUSE_TCP_WIN == 1 )
-	List_t xPriorityQueue;				/* Priority queue: segments which must be sent immediately */
-	List_t xTxQueue;					/* Transmit queue: segments queued for transmission */
-	List_t xWaitQueue;					/* Waiting queue:  outstanding segments */
-	TCPSegment_t *pxHeadSegment;		/* points to a segment which has not been transmitted and it's size is still growing (user data being added) */
-	uint32_t ulOptionsData[ipSIZE_TCP_OPTIONS/sizeof(uint32_t)];	/* Contains the options we send out */
-	List_t xTxSegments;					/* A linked list of all transmission segments, sorted on sequence number */
-	List_t xRxSegments;					/* A linked list of reception segments, order depends on sequence of arrival */
-#else
-	/* For tiny TCP, there is only 1 outstanding TX segment */
-	TCPSegment_t xTxSegment;			/* Priority queue */
-#endif
-	uint16_t usOurPortNumber;			/* Mostly for debugging/logging: our TCP port number */
-	uint16_t usPeerPortNumber;			/* debugging/logging: the peer's TCP port number */
-	uint16_t usMSS;						/* Current accepted MSS */
-	uint16_t usMSSInit;					/* MSS as configured by the socket owner */
-} TCPWindow_t;
+    typedef struct xTCP_WINDOW
+    {
+        union
+        {
+            struct
+            {
+                uint32_t
+                    bHasInit : 1,      /* The window structure has been initialised */
+                    bSendFullSize : 1, /* May only send packets with a size equal to MSS (for optimisation) */
+                    bTimeStamps : 1;   /* Socket is supposed to use TCP time-stamps. This depends on the */
+            } bits;                    /* party which opens the connection */
+            uint32_t ulFlags;
+        } u;
+        TCPWinSize_t xSize;
+        struct
+        {
+            uint32_t ulFirstSequenceNumber;                                    /* Logging & debug: the first segment received/sent in this connection
+                                                                                * for Tx: initial send sequence number (ISS)
+                                                                                * for Rx: initial receive sequence number (IRS) */
+            uint32_t ulCurrentSequenceNumber;                                  /* Tx/Rx: the oldest sequence number not yet confirmed, also SND.UNA / RCV.NXT
+                                                                                * In other words: the sequence number of the left side of the sliding window */
+            uint32_t ulFINSequenceNumber;                                      /* The sequence number which carried the FIN flag */
+            uint32_t ulHighestSequenceNumber;                                  /* Sequence number of the right-most byte + 1 */
+        } rx, tx;
+        uint32_t ulOurSequenceNumber;                                          /* The SEQ number we're sending out */
+        uint32_t ulUserDataLength;                                             /* Number of bytes in Rx buffer which may be passed to the user, after having received a 'missing packet' */
+        uint32_t ulNextTxSequenceNumber;                                       /* The sequence number given to the next byte to be added for transmission */
+        int32_t lSRTT;                                                         /* Smoothed Round Trip Time, it may increment quickly and it decrements slower */
+        uint8_t ucOptionLength;                                                /* Number of valid bytes in ulOptionsData[] */
+        #if ( ipconfigUSE_TCP_WIN == 1 )
+            List_t xPriorityQueue;                                             /* Priority queue: segments which must be sent immediately */
+            List_t xTxQueue;                                                   /* Transmit queue: segments queued for transmission */
+            List_t xWaitQueue;                                                 /* Waiting queue:  outstanding segments */
+            TCPSegment_t * pxHeadSegment;                                      /* points to a segment which has not been transmitted and it's size is still growing (user data being added) */
+            uint32_t ulOptionsData[ ipSIZE_TCP_OPTIONS / sizeof( uint32_t ) ]; /* Contains the options we send out */
+            List_t xTxSegments;                                                /* A linked list of all transmission segments, sorted on sequence number */
+            List_t xRxSegments;                                                /* A linked list of reception segments, order depends on sequence of arrival */
+        #else
+            /* For tiny TCP, there is only 1 outstanding TX segment */
+            TCPSegment_t xTxSegment; /* Priority queue */
+        #endif
+        uint16_t usOurPortNumber;    /* Mostly for debugging/logging: our TCP port number */
+        uint16_t usPeerPortNumber;   /* debugging/logging: the peer's TCP port number */
+        uint16_t usMSS;              /* Current accepted MSS */
+        uint16_t usMSSInit;          /* MSS as configured by the socket owner */
+    } TCPWindow_t;
 
 
 /*=============================================================================
@@ -143,18 +143,25 @@ typedef struct xTCP_WINDOW
  *=============================================================================*/
 
 /* Create and initialize a window */
-void vTCPWindowCreate( TCPWindow_t *pxWindow, uint32_t ulRxWindowLength,
-	uint32_t ulTxWindowLength, uint32_t ulAckNumber, uint32_t ulSequenceNumber, uint32_t ulMSS );
+    void vTCPWindowCreate( TCPWindow_t * pxWindow,
+                           uint32_t ulRxWindowLength,
+                           uint32_t ulTxWindowLength,
+                           uint32_t ulAckNumber,
+                           uint32_t ulSequenceNumber,
+                           uint32_t ulMSS );
 
 /* Destroy a window (always returns NULL)
  * It will free some resources: a collection of segments */
-void vTCPWindowDestroy( TCPWindow_t const * pxWindow );
+    void vTCPWindowDestroy( TCPWindow_t const * pxWindow );
 
 /* Initialize a window */
-void vTCPWindowInit( TCPWindow_t *pxWindow, uint32_t ulAckNumber, uint32_t ulSequenceNumber, uint32_t ulMSS );
+    void vTCPWindowInit( TCPWindow_t * pxWindow,
+                         uint32_t ulAckNumber,
+                         uint32_t ulSequenceNumber,
+                         uint32_t ulMSS );
 
 /* Clean up allocated segments. Should only be called when FreeRTOS+TCP will no longer be used. */
-void vTCPSegmentCleanup( void );
+    void vTCPSegmentCleanup( void );
 
 /*=============================================================================
  *
@@ -164,11 +171,14 @@ void vTCPSegmentCleanup( void );
 
 /* if true may be passed directly to user (segment expected and window is empty)
  * But pxWindow->ackno should always be used to set "BUF->ackno" */
-int32_t lTCPWindowRxCheck( TCPWindow_t *pxWindow, uint32_t ulSequenceNumber, uint32_t ulLength, uint32_t ulSpace );
+    int32_t lTCPWindowRxCheck( TCPWindow_t * pxWindow,
+                               uint32_t ulSequenceNumber,
+                               uint32_t ulLength,
+                               uint32_t ulSpace );
 
 /* This function will be called as soon as a FIN is received. It will return true
  * if there are no 'open' reception segments */
-BaseType_t xTCPWindowRxEmpty( const TCPWindow_t *pxWindow );
+    BaseType_t xTCPWindowRxEmpty( const TCPWindow_t * pxWindow );
 
 /*=============================================================================
  *
@@ -177,29 +187,39 @@ BaseType_t xTCPWindowRxEmpty( const TCPWindow_t *pxWindow );
  *=============================================================================*/
 
 /* Adds data to the Tx-window */
-int32_t lTCPWindowTxAdd( TCPWindow_t *pxWindow, uint32_t ulLength, int32_t lPosition, int32_t lMax );
+    int32_t lTCPWindowTxAdd( TCPWindow_t * pxWindow,
+                             uint32_t ulLength,
+                             int32_t lPosition,
+                             int32_t lMax );
 
 /* Check data to be sent and calculate the time period we may sleep */
-BaseType_t xTCPWindowTxHasData( TCPWindow_t const * pxWindow, uint32_t ulWindowSize, TickType_t *pulDelay );
+    BaseType_t xTCPWindowTxHasData( TCPWindow_t const * pxWindow,
+                                    uint32_t ulWindowSize,
+                                    TickType_t * pulDelay );
 
 /* See if anything is left to be sent
  * Function will be called when a FIN has been received. Only when the TX window is clean,
  * it will return pdTRUE */
-BaseType_t xTCPWindowTxDone( const TCPWindow_t *pxWindow );
+    BaseType_t xTCPWindowTxDone( const TCPWindow_t * pxWindow );
 
 /* Fetches data to be sent.
  * apPos will point to a location with the circular data buffer: txStream */
-uint32_t ulTCPWindowTxGet( TCPWindow_t *pxWindow, uint32_t ulWindowSize, int32_t *plPosition );
+    uint32_t ulTCPWindowTxGet( TCPWindow_t * pxWindow,
+                               uint32_t ulWindowSize,
+                               int32_t * plPosition );
 
 /* Receive a normal ACK */
-uint32_t ulTCPWindowTxAck( TCPWindow_t *pxWindow, uint32_t ulSequenceNumber );
+    uint32_t ulTCPWindowTxAck( TCPWindow_t * pxWindow,
+                               uint32_t ulSequenceNumber );
 
 /* Receive a SACK option */
-uint32_t ulTCPWindowTxSack( TCPWindow_t *pxWindow, uint32_t ulFirst, uint32_t ulLast );
+    uint32_t ulTCPWindowTxSack( TCPWindow_t * pxWindow,
+                                uint32_t ulFirst,
+                                uint32_t ulLast );
 
 
-#ifdef __cplusplus
-}	/* extern "C" */
-#endif
+    #ifdef __cplusplus
+        } /* extern "C" */
+    #endif
 
 #endif /* FREERTOS_TCP_WIN_H */

--- a/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/include/FreeRTOS_UDP_IP.h
+++ b/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/include/FreeRTOS_UDP_IP.h
@@ -24,33 +24,20 @@
  */
 
 #ifndef FREERTOS_UDP_IP_H
-#define FREERTOS_UDP_IP_H
+    #define FREERTOS_UDP_IP_H
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+    #ifdef __cplusplus
+        extern "C" {
+    #endif
 
 /* Application level configuration options. */
-#include "FreeRTOSIPConfig.h"
-#include "FreeRTOSIPConfigDefaults.h"
-#include "IPTraceMacroDefaults.h"
+    #include "FreeRTOSIPConfig.h"
+    #include "FreeRTOSIPConfigDefaults.h"
+    #include "IPTraceMacroDefaults.h"
 
 
-#ifdef __cplusplus
-} // extern "C"
-#endif
+    #ifdef __cplusplus
+        } /* extern "C" */
+    #endif
 
 #endif /* FREERTOS_UDP_IP_H */
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/include/FreeRTOS_errno_TCP.h
+++ b/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/include/FreeRTOS_errno_TCP.h
@@ -27,71 +27,70 @@
 #define FREERTOS_ERRNO_TCP
 
 /* The following definitions will be included in the core FreeRTOS code in
-future versions of FreeRTOS - hence the 'pd' (ProjDefs) prefix - at which time
-this file will be removed. */
+ * future versions of FreeRTOS - hence the 'pd' (ProjDefs) prefix - at which time
+ * this file will be removed. */
 
 /* The following errno values are used by FreeRTOS+ components, not FreeRTOS
-itself. */
+ * itself. */
 
 /* For future compatibility (see comment above), check the definitions have not
-already been made. */
+ * already been made. */
 #ifndef pdFREERTOS_ERRNO_NONE
-	#define pdFREERTOS_ERRNO_NONE			0	/* No errors */
-	#define	pdFREERTOS_ERRNO_ENOENT			2	/* No such file or directory */
-	#define	pdFREERTOS_ERRNO_EINTR			4	/* Interrupted system call */
-	#define	pdFREERTOS_ERRNO_EIO			5	/* I/O error */
-	#define	pdFREERTOS_ERRNO_ENXIO			6	/* No such device or address */
-	#define	pdFREERTOS_ERRNO_EBADF			9	/* Bad file number */
-	#define	pdFREERTOS_ERRNO_EAGAIN			11	/* No more processes */
-	#define	pdFREERTOS_ERRNO_EWOULDBLOCK	11	/* Operation would block */
-	#define	pdFREERTOS_ERRNO_ENOMEM			12	/* Not enough memory */
-	#define	pdFREERTOS_ERRNO_EACCES			13	/* Permission denied */
-	#define	pdFREERTOS_ERRNO_EFAULT			14	/* Bad address */
-	#define	pdFREERTOS_ERRNO_EBUSY			16	/* Mount device busy */
-	#define	pdFREERTOS_ERRNO_EEXIST			17	/* File exists */
-	#define	pdFREERTOS_ERRNO_EXDEV			18	/* Cross-device link */
-	#define	pdFREERTOS_ERRNO_ENODEV			19	/* No such device */
-	#define	pdFREERTOS_ERRNO_ENOTDIR		20	/* Not a directory */
-	#define	pdFREERTOS_ERRNO_EISDIR			21	/* Is a directory */
-	#define	pdFREERTOS_ERRNO_EINVAL			22	/* Invalid argument */
-	#define	pdFREERTOS_ERRNO_ENOSPC			28	/* No space left on device */
-	#define	pdFREERTOS_ERRNO_ESPIPE			29	/* Illegal seek */
-	#define	pdFREERTOS_ERRNO_EROFS			30	/* Read only file system */
-	#define	pdFREERTOS_ERRNO_EUNATCH		42	/* Protocol driver not attached */
-	#define	pdFREERTOS_ERRNO_EBADE			50	/* Invalid exchange */
-	#define	pdFREERTOS_ERRNO_EFTYPE			79	/* Inappropriate file type or format */
-	#define	pdFREERTOS_ERRNO_ENMFILE		89	/* No more files */
-	#define	pdFREERTOS_ERRNO_ENOTEMPTY		90	/* Directory not empty */
-	#define	pdFREERTOS_ERRNO_ENAMETOOLONG 	91	/* File or path name too long */
-	#define	pdFREERTOS_ERRNO_EOPNOTSUPP		95	/* Operation not supported on transport endpoint */
-	#define	pdFREERTOS_ERRNO_EAFNOSUPPORT	97	/* Address family not supported by protocol */
-	#define	pdFREERTOS_ERRNO_ENOBUFS		105	/* No buffer space available */
-	#define	pdFREERTOS_ERRNO_ENOPROTOOPT	109	/* Protocol not available */
-	#define	pdFREERTOS_ERRNO_EADDRINUSE		112	/* Address already in use */
-	#define	pdFREERTOS_ERRNO_ETIMEDOUT		116	/* Connection timed out */
-	#define	pdFREERTOS_ERRNO_EINPROGRESS	119	/* Connection already in progress */
-	#define	pdFREERTOS_ERRNO_EALREADY		120	/* Socket already connected */
-	#define	pdFREERTOS_ERRNO_EADDRNOTAVAIL 	125	/* Address not available */
-	#define	pdFREERTOS_ERRNO_EISCONN		127	/* Socket is already connected */
-	#define	pdFREERTOS_ERRNO_ENOTCONN		128	/* Socket is not connected */
-	#define	pdFREERTOS_ERRNO_ENOMEDIUM		135	/* No medium inserted */
-	#define	pdFREERTOS_ERRNO_EILSEQ			138	/* An invalid UTF-16 sequence was encountered. */
-	#define	pdFREERTOS_ERRNO_ECANCELED		140	/* Operation canceled. */
+    #define pdFREERTOS_ERRNO_NONE                0   /* No errors */
+    #define pdFREERTOS_ERRNO_ENOENT              2   /* No such file or directory */
+    #define pdFREERTOS_ERRNO_EINTR               4   /* Interrupted system call */
+    #define pdFREERTOS_ERRNO_EIO                 5   /* I/O error */
+    #define pdFREERTOS_ERRNO_ENXIO               6   /* No such device or address */
+    #define pdFREERTOS_ERRNO_EBADF               9   /* Bad file number */
+    #define pdFREERTOS_ERRNO_EAGAIN              11  /* No more processes */
+    #define pdFREERTOS_ERRNO_EWOULDBLOCK         11  /* Operation would block */
+    #define pdFREERTOS_ERRNO_ENOMEM              12  /* Not enough memory */
+    #define pdFREERTOS_ERRNO_EACCES              13  /* Permission denied */
+    #define pdFREERTOS_ERRNO_EFAULT              14  /* Bad address */
+    #define pdFREERTOS_ERRNO_EBUSY               16  /* Mount device busy */
+    #define pdFREERTOS_ERRNO_EEXIST              17  /* File exists */
+    #define pdFREERTOS_ERRNO_EXDEV               18  /* Cross-device link */
+    #define pdFREERTOS_ERRNO_ENODEV              19  /* No such device */
+    #define pdFREERTOS_ERRNO_ENOTDIR             20  /* Not a directory */
+    #define pdFREERTOS_ERRNO_EISDIR              21  /* Is a directory */
+    #define pdFREERTOS_ERRNO_EINVAL              22  /* Invalid argument */
+    #define pdFREERTOS_ERRNO_ENOSPC              28  /* No space left on device */
+    #define pdFREERTOS_ERRNO_ESPIPE              29  /* Illegal seek */
+    #define pdFREERTOS_ERRNO_EROFS               30  /* Read only file system */
+    #define pdFREERTOS_ERRNO_EUNATCH             42  /* Protocol driver not attached */
+    #define pdFREERTOS_ERRNO_EBADE               50  /* Invalid exchange */
+    #define pdFREERTOS_ERRNO_EFTYPE              79  /* Inappropriate file type or format */
+    #define pdFREERTOS_ERRNO_ENMFILE             89  /* No more files */
+    #define pdFREERTOS_ERRNO_ENOTEMPTY           90  /* Directory not empty */
+    #define pdFREERTOS_ERRNO_ENAMETOOLONG        91  /* File or path name too long */
+    #define pdFREERTOS_ERRNO_EOPNOTSUPP          95  /* Operation not supported on transport endpoint */
+    #define pdFREERTOS_ERRNO_EAFNOSUPPORT        97  /* Address family not supported by protocol */
+    #define pdFREERTOS_ERRNO_ENOBUFS             105 /* No buffer space available */
+    #define pdFREERTOS_ERRNO_ENOPROTOOPT         109 /* Protocol not available */
+    #define pdFREERTOS_ERRNO_EADDRINUSE          112 /* Address already in use */
+    #define pdFREERTOS_ERRNO_ETIMEDOUT           116 /* Connection timed out */
+    #define pdFREERTOS_ERRNO_EINPROGRESS         119 /* Connection already in progress */
+    #define pdFREERTOS_ERRNO_EALREADY            120 /* Socket already connected */
+    #define pdFREERTOS_ERRNO_EADDRNOTAVAIL       125 /* Address not available */
+    #define pdFREERTOS_ERRNO_EISCONN             127 /* Socket is already connected */
+    #define pdFREERTOS_ERRNO_ENOTCONN            128 /* Socket is not connected */
+    #define pdFREERTOS_ERRNO_ENOMEDIUM           135 /* No medium inserted */
+    #define pdFREERTOS_ERRNO_EILSEQ              138 /* An invalid UTF-16 sequence was encountered. */
+    #define pdFREERTOS_ERRNO_ECANCELED           140 /* Operation canceled. */
 
-	/* The following endian values are used by FreeRTOS+ components, not FreeRTOS
-	itself. */
-	#define pdFREERTOS_LITTLE_ENDIAN	0
-	#define pdFREERTOS_BIG_ENDIAN		1
-#else
-	#ifndef	pdFREERTOS_ERRNO_EAFNOSUPPORT
-		#define	pdFREERTOS_ERRNO_EAFNOSUPPORT	97	/* Address family not supported by protocol */
-	#endif /* pdFREERTOS_ERRNO_EAFNOSUPPORT */
+    /* The following endian values are used by FreeRTOS+ components, not FreeRTOS
+     * itself. */
+    #define pdFREERTOS_LITTLE_ENDIAN             0
+    #define pdFREERTOS_BIG_ENDIAN                1
+#else /* ifndef pdFREERTOS_ERRNO_NONE */
+    #ifndef pdFREERTOS_ERRNO_EAFNOSUPPORT
+        #define pdFREERTOS_ERRNO_EAFNOSUPPORT    97 /* Address family not supported by protocol */
+    #endif /* pdFREERTOS_ERRNO_EAFNOSUPPORT */
 #endif /* pdFREERTOS_ERRNO_NONE */
 
 /* Translate a pdFREERTOS_ERRNO code to a human readable string. */
-const char *FreeRTOS_strerror_r( BaseType_t xErrnum, char *pcBuffer, size_t uxLength );
+const char * FreeRTOS_strerror_r( BaseType_t xErrnum,
+                                  char * pcBuffer,
+                                  size_t uxLength );
 
 #endif /* FREERTOS_ERRNO_TCP */
-
-
-

--- a/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/include/IPTraceMacroDefaults.h
+++ b/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/include/IPTraceMacroDefaults.h
@@ -24,210 +24,210 @@
  */
 
 /* This file provides default (empty) implementations for any IP trace macros
-that are not defined by the user.  See
-http://www.FreeRTOS.org/FreeRTOS-Plus/FreeRTOS_Plus_TCP/TCP_IP_Trace.html */
+ * that are not defined by the user.  See
+ * http://www.FreeRTOS.org/FreeRTOS-Plus/FreeRTOS_Plus_TCP/TCP_IP_Trace.html */
 
 #ifndef UDP_TRACE_MACRO_DEFAULTS_H
 #define UDP_TRACE_MACRO_DEFAULTS_H
 
 #ifndef iptraceNETWORK_DOWN
-	#define iptraceNETWORK_DOWN()
+    #define iptraceNETWORK_DOWN()
 #endif
 
 #ifndef iptraceNETWORK_BUFFER_RELEASED
-	#define iptraceNETWORK_BUFFER_RELEASED( pxBufferAddress )
+    #define iptraceNETWORK_BUFFER_RELEASED( pxBufferAddress )
 #endif
 
 #ifndef iptraceNETWORK_BUFFER_OBTAINED
-	#define iptraceNETWORK_BUFFER_OBTAINED( pxBufferAddress )
+    #define iptraceNETWORK_BUFFER_OBTAINED( pxBufferAddress )
 #endif
 
 #ifndef iptraceNETWORK_BUFFER_OBTAINED_FROM_ISR
-	#define iptraceNETWORK_BUFFER_OBTAINED_FROM_ISR( pxBufferAddress )
+    #define iptraceNETWORK_BUFFER_OBTAINED_FROM_ISR( pxBufferAddress )
 #endif
 
 #ifndef iptraceFAILED_TO_OBTAIN_NETWORK_BUFFER
-	#define iptraceFAILED_TO_OBTAIN_NETWORK_BUFFER()
+    #define iptraceFAILED_TO_OBTAIN_NETWORK_BUFFER()
 #endif
 
 #ifndef iptraceFAILED_TO_OBTAIN_NETWORK_BUFFER_FROM_ISR
-	#define iptraceFAILED_TO_OBTAIN_NETWORK_BUFFER_FROM_ISR()
+    #define iptraceFAILED_TO_OBTAIN_NETWORK_BUFFER_FROM_ISR()
 #endif
 
 #ifndef iptraceCREATING_ARP_REQUEST
-	#define iptraceCREATING_ARP_REQUEST( ulIPAddress )
+    #define iptraceCREATING_ARP_REQUEST( ulIPAddress )
 #endif
 
 #ifndef iptraceARP_TABLE_ENTRY_WILL_EXPIRE
-	#define iptraceARP_TABLE_ENTRY_WILL_EXPIRE( ulIPAddress )
+    #define iptraceARP_TABLE_ENTRY_WILL_EXPIRE( ulIPAddress )
 #endif
 
 #ifndef iptraceARP_TABLE_ENTRY_EXPIRED
-	#define iptraceARP_TABLE_ENTRY_EXPIRED( ulIPAddress )
+    #define iptraceARP_TABLE_ENTRY_EXPIRED( ulIPAddress )
 #endif
 
 #ifndef iptraceARP_TABLE_ENTRY_CREATED
-	#define iptraceARP_TABLE_ENTRY_CREATED( ulIPAddress, ucMACAddress )
+    #define iptraceARP_TABLE_ENTRY_CREATED( ulIPAddress, ucMACAddress )
 #endif
 
 #ifndef iptraceSENDING_UDP_PACKET
-	#define iptraceSENDING_UDP_PACKET( ulIPAddress )
+    #define iptraceSENDING_UDP_PACKET( ulIPAddress )
 #endif
 
 #ifndef iptracePACKET_DROPPED_TO_GENERATE_ARP
-	#define iptracePACKET_DROPPED_TO_GENERATE_ARP( ulIPAddress )
+    #define iptracePACKET_DROPPED_TO_GENERATE_ARP( ulIPAddress )
 #endif
 
 #ifndef iptraceICMP_PACKET_RECEIVED
-	#define iptraceICMP_PACKET_RECEIVED()
+    #define iptraceICMP_PACKET_RECEIVED()
 #endif
 
 #ifndef iptraceSENDING_PING_REPLY
-	#define iptraceSENDING_PING_REPLY( ulIPAddress )
+    #define iptraceSENDING_PING_REPLY( ulIPAddress )
 #endif
 
 #ifndef traceARP_PACKET_RECEIVED
-	#define traceARP_PACKET_RECEIVED()
+    #define traceARP_PACKET_RECEIVED()
 #endif
 
 #ifndef iptracePROCESSING_RECEIVED_ARP_REPLY
-	#define iptracePROCESSING_RECEIVED_ARP_REPLY( ulIPAddress )
+    #define iptracePROCESSING_RECEIVED_ARP_REPLY( ulIPAddress )
 #endif
 
 #ifndef iptraceSENDING_ARP_REPLY
-	#define iptraceSENDING_ARP_REPLY( ulIPAddress )
+    #define iptraceSENDING_ARP_REPLY( ulIPAddress )
 #endif
 
 #ifndef iptraceFAILED_TO_CREATE_SOCKET
-	#define iptraceFAILED_TO_CREATE_SOCKET()
+    #define iptraceFAILED_TO_CREATE_SOCKET()
 #endif
 
 #ifndef iptraceFAILED_TO_CREATE_EVENT_GROUP
-	#define iptraceFAILED_TO_CREATE_EVENT_GROUP()
+    #define iptraceFAILED_TO_CREATE_EVENT_GROUP()
 #endif
 
 #ifndef iptraceRECVFROM_DISCARDING_BYTES
-	#define iptraceRECVFROM_DISCARDING_BYTES( xNumberOfBytesDiscarded )
+    #define iptraceRECVFROM_DISCARDING_BYTES( xNumberOfBytesDiscarded )
 #endif
 
 #ifndef iptraceETHERNET_RX_EVENT_LOST
-	#define iptraceETHERNET_RX_EVENT_LOST()
+    #define iptraceETHERNET_RX_EVENT_LOST()
 #endif
 
 #ifndef iptraceSTACK_TX_EVENT_LOST
-	#define iptraceSTACK_TX_EVENT_LOST( xEvent )
+    #define iptraceSTACK_TX_EVENT_LOST( xEvent )
 #endif
 
 #ifndef iptraceNETWORK_EVENT_RECEIVED
-	#define iptraceNETWORK_EVENT_RECEIVED( eEvent )
+    #define iptraceNETWORK_EVENT_RECEIVED( eEvent )
 #endif
 
 #ifndef iptraceBIND_FAILED
-	#define iptraceBIND_FAILED( xSocket, usPort )
+    #define iptraceBIND_FAILED( xSocket, usPort )
 #endif
 
 #ifndef iptraceDHCP_REQUESTS_FAILED_USING_DEFAULT_IP_ADDRESS
-	#define iptraceDHCP_REQUESTS_FAILED_USING_DEFAULT_IP_ADDRESS( ulIPAddress )
+    #define iptraceDHCP_REQUESTS_FAILED_USING_DEFAULT_IP_ADDRESS( ulIPAddress )
 #endif
 
 #ifndef iptraceSENDING_DHCP_DISCOVER
-	#define iptraceSENDING_DHCP_DISCOVER()
+    #define iptraceSENDING_DHCP_DISCOVER()
 #endif
 
 #ifndef iptraceSENDING_DHCP_REQUEST
-	#define iptraceSENDING_DHCP_REQUEST()
+    #define iptraceSENDING_DHCP_REQUEST()
 #endif
 
 #ifndef iptraceDHCP_SUCCEDEED
-	#define iptraceDHCP_SUCCEDEED( address )
+    #define iptraceDHCP_SUCCEDEED( address )
 #endif
 
 #ifndef iptraceNETWORK_INTERFACE_TRANSMIT
-	#define iptraceNETWORK_INTERFACE_TRANSMIT()
+    #define iptraceNETWORK_INTERFACE_TRANSMIT()
 #endif
 
 #ifndef iptraceNETWORK_INTERFACE_RECEIVE
-	#define iptraceNETWORK_INTERFACE_RECEIVE()
+    #define iptraceNETWORK_INTERFACE_RECEIVE()
 #endif
 
 #ifndef iptraceSENDING_DNS_REQUEST
-	#define iptraceSENDING_DNS_REQUEST()
+    #define iptraceSENDING_DNS_REQUEST()
 #endif
 
-#ifndef	iptraceWAITING_FOR_TX_DMA_DESCRIPTOR
-	#define iptraceWAITING_FOR_TX_DMA_DESCRIPTOR()
+#ifndef iptraceWAITING_FOR_TX_DMA_DESCRIPTOR
+    #define iptraceWAITING_FOR_TX_DMA_DESCRIPTOR()
 #endif
 
 #ifndef ipconfigINCLUDE_EXAMPLE_FREERTOS_PLUS_TRACE_CALLS
-	#define ipconfigINCLUDE_EXAMPLE_FREERTOS_PLUS_TRACE_CALLS 0
+    #define ipconfigINCLUDE_EXAMPLE_FREERTOS_PLUS_TRACE_CALLS    0
 #endif
 
 #ifndef iptraceFAILED_TO_NOTIFY_SELECT_GROUP
-	#define iptraceFAILED_TO_NOTIFY_SELECT_GROUP( xSocket )
+    #define iptraceFAILED_TO_NOTIFY_SELECT_GROUP( xSocket )
 #endif
 
 #ifndef pvPortMallocSocket
-	#define pvPortMallocSocket(xSize) pvPortMalloc( ( xSize ) )
+    #define pvPortMallocSocket( xSize )    pvPortMalloc( ( xSize ) )
 #endif
 
 #ifndef iptraceRECVFROM_TIMEOUT
-	#define iptraceRECVFROM_TIMEOUT()
+    #define iptraceRECVFROM_TIMEOUT()
 #endif
 
 #ifndef iptraceRECVFROM_INTERRUPTED
-	#define iptraceRECVFROM_INTERRUPTED()
+    #define iptraceRECVFROM_INTERRUPTED()
 #endif
 
 #ifndef iptraceNO_BUFFER_FOR_SENDTO
-	#define iptraceNO_BUFFER_FOR_SENDTO()
+    #define iptraceNO_BUFFER_FOR_SENDTO()
 #endif
 
 #ifndef iptraceSENDTO_SOCKET_NOT_BOUND
-	#define iptraceSENDTO_SOCKET_NOT_BOUND()
+    #define iptraceSENDTO_SOCKET_NOT_BOUND()
 #endif
 
 #ifndef iptraceSENDTO_DATA_TOO_LONG
-	#define iptraceSENDTO_DATA_TOO_LONG()
+    #define iptraceSENDTO_DATA_TOO_LONG()
 #endif
 
 #ifndef ipconfigUSE_TCP_MEM_STATS
-	#define ipconfigUSE_TCP_MEM_STATS	0
+    #define ipconfigUSE_TCP_MEM_STATS    0
 #endif
 
-#if( ipconfigUSE_TCP_MEM_STATS == 0 )
+#if ( ipconfigUSE_TCP_MEM_STATS == 0 )
 
-	/* See tools/tcp_mem_stat.c */
+    /* See tools/tcp_mem_stat.c */
 
-	#ifndef iptraceMEM_STATS_CREATE
-		#define iptraceMEM_STATS_CREATE( xMemType, pxObject, uxSize )
-	#endif
+    #ifndef iptraceMEM_STATS_CREATE
+        #define iptraceMEM_STATS_CREATE( xMemType, pxObject, uxSize )
+    #endif
 
-	#ifndef iptraceMEM_STATS_DELETE
-		#define iptraceMEM_STATS_DELETE( pxObject )
-	#endif
+    #ifndef iptraceMEM_STATS_DELETE
+        #define iptraceMEM_STATS_DELETE( pxObject )
+    #endif
 
-	#ifndef iptraceMEM_STATS_CLOSE
-		#define iptraceMEM_STATS_CLOSE()
-	#endif
+    #ifndef iptraceMEM_STATS_CLOSE
+        #define iptraceMEM_STATS_CLOSE()
+    #endif
 
-#endif	/* ( ipconfigUSE_TCP_MEM_STATS != 0 ) */
+#endif /* ( ipconfigUSE_TCP_MEM_STATS != 0 ) */
 
 #ifndef ipconfigUSE_DUMP_PACKETS
-	#define ipconfigUSE_DUMP_PACKETS	0
+    #define ipconfigUSE_DUMP_PACKETS    0
 #endif
 
-#if( ipconfigUSE_DUMP_PACKETS == 0 )
+#if ( ipconfigUSE_DUMP_PACKETS == 0 )
 
-	/* See tools/tcp_dump_packets.c */
+    /* See tools/tcp_dump_packets.c */
 
-	#ifndef iptraceDUMP_INIT
-		#define iptraceDUMP_INIT( pcFileName, pxEntries )
-	#endif
+    #ifndef iptraceDUMP_INIT
+        #define iptraceDUMP_INIT( pcFileName, pxEntries )
+    #endif
 
-	#ifndef iptraceDUMP_PACKET
-		#define iptraceDUMP_PACKET( pucBuffer, uxLength, xIncoming )
-	#endif
+    #ifndef iptraceDUMP_PACKET
+        #define iptraceDUMP_PACKET( pucBuffer, uxLength, xIncoming )
+    #endif
 
-#endif	/* ( ipconfigUSE_DUMP_PACKETS != 0 ) */
+#endif /* ( ipconfigUSE_DUMP_PACKETS != 0 ) */
 
 #endif /* UDP_TRACE_MACRO_DEFAULTS_H */

--- a/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/include/NetworkBufferManagement.h
+++ b/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/include/NetworkBufferManagement.h
@@ -24,47 +24,49 @@
  */
 
 #ifndef NETWORK_BUFFER_MANAGEMENT_H
-#define NETWORK_BUFFER_MANAGEMENT_H
+    #define NETWORK_BUFFER_MANAGEMENT_H
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+    #ifdef __cplusplus
+        extern "C" {
+    #endif
 
 /* NOTE PUBLIC API FUNCTIONS. */
-BaseType_t xNetworkBuffersInitialise( void );
-NetworkBufferDescriptor_t *pxGetNetworkBufferWithDescriptor( size_t xRequestedSizeBytes, TickType_t xBlockTimeTicks );
-NetworkBufferDescriptor_t *pxNetworkBufferGetFromISR( size_t xRequestedSizeBytes );
-void vReleaseNetworkBufferAndDescriptor( NetworkBufferDescriptor_t * const pxNetworkBuffer );
-BaseType_t vNetworkBufferReleaseFromISR( NetworkBufferDescriptor_t * const pxNetworkBuffer );
-uint8_t *pucGetNetworkBuffer( size_t *pxRequestedSizeBytes );
-void vReleaseNetworkBuffer( uint8_t *pucEthernetBuffer );
+    BaseType_t xNetworkBuffersInitialise( void );
+    NetworkBufferDescriptor_t * pxGetNetworkBufferWithDescriptor( size_t xRequestedSizeBytes,
+                                                                  TickType_t xBlockTimeTicks );
+    NetworkBufferDescriptor_t * pxNetworkBufferGetFromISR( size_t xRequestedSizeBytes );
+    void vReleaseNetworkBufferAndDescriptor( NetworkBufferDescriptor_t * const pxNetworkBuffer );
+    BaseType_t vNetworkBufferReleaseFromISR( NetworkBufferDescriptor_t * const pxNetworkBuffer );
+    uint8_t * pucGetNetworkBuffer( size_t * pxRequestedSizeBytes );
+    void vReleaseNetworkBuffer( uint8_t * pucEthernetBuffer );
 
 /* Get the current number of free network buffers. */
-UBaseType_t uxGetNumberOfFreeNetworkBuffers( void );
+    UBaseType_t uxGetNumberOfFreeNetworkBuffers( void );
 
 /* Get the lowest number of free network buffers. */
-UBaseType_t uxGetMinimumFreeNetworkBuffers( void );
+    UBaseType_t uxGetMinimumFreeNetworkBuffers( void );
 
 /* Copy a network buffer into a bigger buffer. */
-NetworkBufferDescriptor_t *pxDuplicateNetworkBufferWithDescriptor( const NetworkBufferDescriptor_t * const pxNetworkBuffer,
-	size_t uxNewLength);
+    NetworkBufferDescriptor_t * pxDuplicateNetworkBufferWithDescriptor( const NetworkBufferDescriptor_t * const pxNetworkBuffer,
+                                                                        size_t uxNewLength );
 
 /* Increase the size of a Network Buffer.
-In case BufferAllocation_2.c is used, the new space must be allocated. */
-NetworkBufferDescriptor_t *pxResizeNetworkBufferWithDescriptor( NetworkBufferDescriptor_t * pxNetworkBuffer,
-	size_t xNewSizeBytes );
+ * In case BufferAllocation_2.c is used, the new space must be allocated. */
+    NetworkBufferDescriptor_t * pxResizeNetworkBufferWithDescriptor( NetworkBufferDescriptor_t * pxNetworkBuffer,
+                                                                     size_t xNewSizeBytes );
 
-#if ipconfigTCP_IP_SANITY
-	/*
-	 * Check if an address is a valid pointer to a network descriptor
-	 * by looking it up in the array of network descriptors
-	 */
-	UBaseType_t bIsValidNetworkDescriptor (const NetworkBufferDescriptor_t * pxDesc);
-	BaseType_t prvIsFreeBuffer( const NetworkBufferDescriptor_t *pxDescr );
-#endif
+    #if ipconfigTCP_IP_SANITY
 
-#ifdef __cplusplus
-} // extern "C"
-#endif
+        /*
+         * Check if an address is a valid pointer to a network descriptor
+         * by looking it up in the array of network descriptors
+         */
+        UBaseType_t bIsValidNetworkDescriptor( const NetworkBufferDescriptor_t * pxDesc );
+        BaseType_t prvIsFreeBuffer( const NetworkBufferDescriptor_t * pxDescr );
+    #endif
+
+    #ifdef __cplusplus
+        } /* extern "C" */
+    #endif
 
 #endif /* NETWORK_BUFFER_MANAGEMENT_H */

--- a/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/include/NetworkInterface.h
+++ b/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/include/NetworkInterface.h
@@ -24,27 +24,28 @@
  */
 
 #ifndef NETWORK_INTERFACE_H
-#define NETWORK_INTERFACE_H
+    #define NETWORK_INTERFACE_H
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+    #ifdef __cplusplus
+        extern "C" {
+    #endif
 
 /* INTERNAL API FUNCTIONS. */
-BaseType_t xNetworkInterfaceInitialise( void );
-BaseType_t xNetworkInterfaceOutput( NetworkBufferDescriptor_t * const pxNetworkBuffer, BaseType_t xReleaseAfterSend );
+    BaseType_t xNetworkInterfaceInitialise( void );
+    BaseType_t xNetworkInterfaceOutput( NetworkBufferDescriptor_t * const pxNetworkBuffer,
+                                        BaseType_t xReleaseAfterSend );
 /* coverity[misra_c_2012_rule_8_6_violation] */
+
 /* "vNetworkInterfaceAllocateRAMToBuffers" is declared but never defined.
-The following function is only used when BufferAllocation_1.c is linked in the project. */
-void vNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] );
+ * The following function is only used when BufferAllocation_1.c is linked in the project. */
+    void vNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] );
 
 /* "xGetPhyLinkStatus" is provided by the network driver. */
 /* coverity[misra_c_2012_rule_8_6_violation] */
-BaseType_t xGetPhyLinkStatus( void );
+    BaseType_t xGetPhyLinkStatus( void );
 
-#ifdef __cplusplus
-} // extern "C"
-#endif
+    #ifdef __cplusplus
+        } /* extern "C" */
+    #endif
 
 #endif /* NETWORK_INTERFACE_H */
-

--- a/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/include/tcp_dump_packets.h
+++ b/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/include/tcp_dump_packets.h
@@ -9,56 +9,59 @@
 #define DUMP_PACKETS_H
 
 #ifndef dumpMAX_DUMP_ENTRIES
-	#define	dumpMAX_DUMP_ENTRIES	16
+    #define dumpMAX_DUMP_ENTRIES    16
 #endif
 
-#define flag_ICMP4            0x00000001UL
-#define flag_ICMP6            0x00000002UL
-#define flag_UDP              0x00000004UL
-#define flag_TCP              0x00000008UL
-#define flag_DNS              0x00000010UL
-#define flag_REPLY            0x00000020UL
-#define flag_REQUEST          0x00000040UL
-#define flag_SYN              0x00000080UL
-#define flag_FIN              0x00000100UL
-#define flag_RST              0x00000200UL
-#define flag_ACK              0x00000400UL
-#define flag_IN               0x00000800UL
-#define flag_OUT              0x00001000UL
-#define flag_FRAME_ARP        0x00002000UL
-#define flag_ARP              0x00004000UL
-#define flag_UNKNOWN          0x00008000UL
-#define flag_FRAME_4          0x00010000UL
-#define flag_FRAME_6          0x00020000UL
-#define flag_Unknown_FRAME    0x00040000UL
+#define flag_ICMP4                  0x00000001UL
+#define flag_ICMP6                  0x00000002UL
+#define flag_UDP                    0x00000004UL
+#define flag_TCP                    0x00000008UL
+#define flag_DNS                    0x00000010UL
+#define flag_REPLY                  0x00000020UL
+#define flag_REQUEST                0x00000040UL
+#define flag_SYN                    0x00000080UL
+#define flag_FIN                    0x00000100UL
+#define flag_RST                    0x00000200UL
+#define flag_ACK                    0x00000400UL
+#define flag_IN                     0x00000800UL
+#define flag_OUT                    0x00001000UL
+#define flag_FRAME_ARP              0x00002000UL
+#define flag_ARP                    0x00004000UL
+#define flag_UNKNOWN                0x00008000UL
+#define flag_FRAME_4                0x00010000UL
+#define flag_FRAME_6                0x00020000UL
+#define flag_Unknown_FRAME          0x00040000UL
 
 typedef struct xDumpEntry
 {
-	uint32_t ulMask;
-	size_t uxMax;
-	size_t uxCount;
+    uint32_t ulMask;
+    size_t uxMax;
+    size_t uxCount;
 } DumpEntry_t;
 
 typedef struct xDumpEntries
 {
-	size_t uxEntryCount;
-	DumpEntry_t xEntries[ dumpMAX_DUMP_ENTRIES ];
+    size_t uxEntryCount;
+    DumpEntry_t xEntries[ dumpMAX_DUMP_ENTRIES ];
 } DumpEntries_t;
 
 /*
-
+ *
  */
 
-#if( ipconfigUSE_DUMP_PACKETS != 0 )
+#if ( ipconfigUSE_DUMP_PACKETS != 0 )
 
-	extern void dump_packet_init( const char *pcFileName, DumpEntries_t *pxEntries );
-	#define iptraceDUMP_INIT( pcFileName, pxEntries ) \
-		dump_packet_init( pcFileName, pxEntries )
+    extern void dump_packet_init( const char * pcFileName,
+                                  DumpEntries_t * pxEntries );
+    #define iptraceDUMP_INIT( pcFileName, pxEntries ) \
+    dump_packet_init( pcFileName, pxEntries )
 
-	extern void dump_packet( const uint8_t *pucBuffer, size_t uxLength, BaseType_t xIncoming );
-	#define iptraceDUMP_PACKET( pucBuffer, uxLength, xIncoming ) \
-		dump_packet( pucBuffer, uxLength, xIncoming )
+    extern void dump_packet( const uint8_t * pucBuffer,
+                             size_t uxLength,
+                             BaseType_t xIncoming );
+    #define iptraceDUMP_PACKET( pucBuffer, uxLength, xIncoming ) \
+    dump_packet( pucBuffer, uxLength, xIncoming )
 
-#endif
+#endif /* if ( ipconfigUSE_DUMP_PACKETS != 0 ) */
 
-#endif
+#endif /* ifndef DUMP_PACKETS_H */

--- a/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/include/tcp_mem_stats.h
+++ b/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/include/tcp_mem_stats.h
@@ -1,52 +1,53 @@
 /*
  * tcp_mem_stats.h
  */
- 
- 
+
+
 #ifndef TCP_MEM_STATS_H
 
-#define TCP_MEM_STATS_H
+    #define TCP_MEM_STATS_H
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+    #ifdef __cplusplus
+        extern "C" {
+    #endif
 
-typedef enum xTCP_MEMORY
-{
-	tcpSOCKET_TCP,
-	tcpSOCKET_UDP,
-	tcpSOCKET_SET,
-	tcpSEMAPHORE,
-	tcpRX_STREAM_BUFFER,
-	tcpTX_STREAM_BUFFER,
-	tcpNETWORK_BUFFER,
-} TCP_MEMORY_t;
+    typedef enum xTCP_MEMORY
+    {
+        tcpSOCKET_TCP,
+        tcpSOCKET_UDP,
+        tcpSOCKET_SET,
+        tcpSEMAPHORE,
+        tcpRX_STREAM_BUFFER,
+        tcpTX_STREAM_BUFFER,
+        tcpNETWORK_BUFFER,
+    } TCP_MEMORY_t;
 
-#if( ipconfigUSE_TCP_MEM_STATS != 0 )
+    #if ( ipconfigUSE_TCP_MEM_STATS != 0 )
 
-	void vTCPMemStatCreate( TCP_MEMORY_t xMemType, void *pxObject, size_t uxSize );
+        void vTCPMemStatCreate( TCP_MEMORY_t xMemType,
+                                void * pxObject,
+                                size_t uxSize );
 
-	void vTCPMemStatDelete( void *pxObject );
+        void vTCPMemStatDelete( void * pxObject );
 
-	void vTCPMemStatClose( void );
+        void vTCPMemStatClose( void );
 
-	#define iptraceMEM_STATS_CREATE( xMemType, pxObject, uxSize ) \
-		vTCPMemStatCreate( xMemType, pxObject, uxSize )
+        #define iptraceMEM_STATS_CREATE( xMemType, pxObject, uxSize ) \
+    vTCPMemStatCreate( xMemType, pxObject, uxSize )
 
-	#define iptraceMEM_STATS_DELETE( pxObject ) \
-		vTCPMemStatDelete( pxObject )
+        #define iptraceMEM_STATS_DELETE( pxObject ) \
+    vTCPMemStatDelete( pxObject )
 
-	#define iptraceMEM_STATS_CLOSE() \
-		vTCPMemStatClose()
-#else
+        #define iptraceMEM_STATS_CLOSE() \
+    vTCPMemStatClose()
+    #else /* if ( ipconfigUSE_TCP_MEM_STATS != 0 ) */
 
-	/* The header file 'IPTraceMacroDefaults.h' will define the default empty macro's. */
+        /* The header file 'IPTraceMacroDefaults.h' will define the default empty macro's. */
 
-#endif /* ipconfigUSE_TCP_MEM_STATS != 0 */
+    #endif /* ipconfigUSE_TCP_MEM_STATS != 0 */
 
-#ifdef __cplusplus
-} /* extern "C" */
-#endif
+    #ifdef __cplusplus
+        } /* extern "C" */
+    #endif
 
-#endif	/* TCP_MEM_STATS_H */
-
+#endif /* TCP_MEM_STATS_H */

--- a/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/portable/BufferManagement/BufferAllocation_1.c
+++ b/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/portable/BufferManagement/BufferAllocation_1.c
@@ -1,35 +1,35 @@
 /*
-FreeRTOS+TCP V2.2.1
-Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of
-this software and associated documentation files (the "Software"), to deal in
-the Software without restriction, including without limitation the rights to
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
-the Software, and to permit persons to whom the Software is furnished to do so,
-subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
-COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
-IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
- http://aws.amazon.com/freertos
- http://www.FreeRTOS.org
-*/
+ * FreeRTOS+TCP V2.2.1
+ * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
 
 /******************************************************************************
- *
- * See the following web page for essential buffer allocation scheme usage and
- * configuration details:
- * http://www.FreeRTOS.org/FreeRTOS-Plus/FreeRTOS_Plus_TCP/Embedded_Ethernet_Buffer_Management.html
- *
- ******************************************************************************/
+*
+* See the following web page for essential buffer allocation scheme usage and
+* configuration details:
+* http://www.FreeRTOS.org/FreeRTOS-Plus/FreeRTOS_Plus_TCP/Embedded_Ethernet_Buffer_Management.html
+*
+******************************************************************************/
 
 /* Standard includes. */
 #include <stdint.h>
@@ -47,8 +47,8 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "NetworkBufferManagement.h"
 
 /* For an Ethernet interrupt to be able to obtain a network buffer there must
-be at least this number of buffers available. */
-#define baINTERRUPT_BUFFER_GET_THRESHOLD	( 3 )
+ * be at least this number of buffers available. */
+#define baINTERRUPT_BUFFER_GET_THRESHOLD    ( 3 )
 
 /* A list of free (available) NetworkBufferDescriptor_t structures. */
 static List_t xFreeBuffersList;
@@ -57,358 +57,367 @@ static List_t xFreeBuffersList;
 static UBaseType_t uxMinimumFreeNetworkBuffers = 0U;
 
 /* Declares the pool of NetworkBufferDescriptor_t structures that are available
-to the system.  All the network buffers referenced from xFreeBuffersList exist
-in this array.  The array is not accessed directly except during initialisation,
-when the xFreeBuffersList is filled (as all the buffers are free when the system
-is booted). */
+ * to the system.  All the network buffers referenced from xFreeBuffersList exist
+ * in this array.  The array is not accessed directly except during initialisation,
+ * when the xFreeBuffersList is filled (as all the buffers are free when the system
+ * is booted). */
 static NetworkBufferDescriptor_t xNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ];
 
 /* This constant is defined as true to let FreeRTOS_TCP_IP.c know that the
-network buffers have constant size, large enough to hold the biggest Ethernet
-packet. No resizing will be done. */
+ * network buffers have constant size, large enough to hold the biggest Ethernet
+ * packet. No resizing will be done. */
 const BaseType_t xBufferAllocFixedSize = pdTRUE;
 
 /* The semaphore used to obtain network buffers. */
 static SemaphoreHandle_t xNetworkBufferSemaphore = NULL;
 
-#if( ipconfigTCP_IP_SANITY != 0 )
-	static char cIsLow = pdFALSE;
-	UBaseType_t bIsValidNetworkDescriptor( const NetworkBufferDescriptor_t * pxDesc );
+#if ( ipconfigTCP_IP_SANITY != 0 )
+    static char cIsLow = pdFALSE;
+    UBaseType_t bIsValidNetworkDescriptor( const NetworkBufferDescriptor_t * pxDesc );
 #else
-	static UBaseType_t bIsValidNetworkDescriptor( const NetworkBufferDescriptor_t * pxDesc );
+    static UBaseType_t bIsValidNetworkDescriptor( const NetworkBufferDescriptor_t * pxDesc );
 #endif /* ipconfigTCP_IP_SANITY */
 
 static void prvShowWarnings( void );
 
 /* The user can define their own ipconfigBUFFER_ALLOC_LOCK() and
-ipconfigBUFFER_ALLOC_UNLOCK() macros, especially for use form an ISR.  If these
-are not defined then default them to call the normal enter/exit critical
-section macros. */
+ * ipconfigBUFFER_ALLOC_UNLOCK() macros, especially for use form an ISR.  If these
+ * are not defined then default them to call the normal enter/exit critical
+ * section macros. */
 #if !defined( ipconfigBUFFER_ALLOC_LOCK )
 
-	#define ipconfigBUFFER_ALLOC_INIT( ) do {} while ( ipFALSE_BOOL )
-	#define ipconfigBUFFER_ALLOC_LOCK_FROM_ISR()		\
-		UBaseType_t uxSavedInterruptStatus = ( UBaseType_t ) portSET_INTERRUPT_MASK_FROM_ISR(); \
-		{
+    #define ipconfigBUFFER_ALLOC_INIT()    do {} while ( ipFALSE_BOOL )
+    #define ipconfigBUFFER_ALLOC_LOCK_FROM_ISR()                                            \
+    UBaseType_t uxSavedInterruptStatus = ( UBaseType_t ) portSET_INTERRUPT_MASK_FROM_ISR(); \
+    {
+    #define ipconfigBUFFER_ALLOC_UNLOCK_FROM_ISR()               \
+    portCLEAR_INTERRUPT_MASK_FROM_ISR( uxSavedInterruptStatus ); \
+}
 
-	#define ipconfigBUFFER_ALLOC_UNLOCK_FROM_ISR()		\
-			portCLEAR_INTERRUPT_MASK_FROM_ISR( uxSavedInterruptStatus ); \
-		}
-
-	#define ipconfigBUFFER_ALLOC_LOCK()					taskENTER_CRITICAL()
-	#define ipconfigBUFFER_ALLOC_UNLOCK()				taskEXIT_CRITICAL()
+    #define ipconfigBUFFER_ALLOC_LOCK()      taskENTER_CRITICAL()
+    #define ipconfigBUFFER_ALLOC_UNLOCK()    taskEXIT_CRITICAL()
 
 #endif /* ipconfigBUFFER_ALLOC_LOCK */
 
 /*-----------------------------------------------------------*/
 
-#if( ipconfigTCP_IP_SANITY != 0 )
+#if ( ipconfigTCP_IP_SANITY != 0 )
 
-	/* HT: SANITY code will be removed as soon as the library is stable
-	 * and and ready to become public
-	 * Function below gives information about the use of buffers */
-	#define WARN_LOW		( 2 )
-	#define WARN_HIGH		( ( 5 * ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ) / 10 )
+    /* HT: SANITY code will be removed as soon as the library is stable
+     * and and ready to become public
+     * Function below gives information about the use of buffers */
+    #define WARN_LOW     ( 2 )
+    #define WARN_HIGH    ( ( 5 * ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ) / 10 )
 
 #endif /* ipconfigTCP_IP_SANITY */
 
 /*-----------------------------------------------------------*/
 
-#if( ipconfigTCP_IP_SANITY != 0 )
+#if ( ipconfigTCP_IP_SANITY != 0 )
 
-	BaseType_t prvIsFreeBuffer( const NetworkBufferDescriptor_t *pxDescr )
-	{
-		return ( bIsValidNetworkDescriptor( pxDescr ) != 0 ) &&
-			( listIS_CONTAINED_WITHIN( &xFreeBuffersList, &( pxDescr->xBufferListItem ) ) != 0 );
-	}
-	/*-----------------------------------------------------------*/
+    BaseType_t prvIsFreeBuffer( const NetworkBufferDescriptor_t * pxDescr )
+    {
+        return ( bIsValidNetworkDescriptor( pxDescr ) != 0 ) &&
+               ( listIS_CONTAINED_WITHIN( &xFreeBuffersList, &( pxDescr->xBufferListItem ) ) != 0 );
+    }
+    /*-----------------------------------------------------------*/
 
-	static void prvShowWarnings( void )
-	{
-		UBaseType_t uxCount = uxGetNumberOfFreeNetworkBuffers( );
-		if( ( ( cIsLow == 0 ) && ( uxCount <= WARN_LOW ) ) || ( ( cIsLow != 0 ) && ( uxCount >= WARN_HIGH ) ) )
-		{
-			cIsLow = !cIsLow;
-			FreeRTOS_debug_printf( ( "*** Warning *** %s %lu buffers left\n", cIsLow ? "only" : "now", uxCount ) );
-		}
-	}
-	/*-----------------------------------------------------------*/
+    static void prvShowWarnings( void )
+    {
+        UBaseType_t uxCount = uxGetNumberOfFreeNetworkBuffers();
 
-	UBaseType_t bIsValidNetworkDescriptor( const NetworkBufferDescriptor_t * pxDesc )
-	{
-		uint32_t offset = ( uint32_t ) ( ((const char *)pxDesc) - ((const char *)xNetworkBuffers) );
-		if( ( offset >= sizeof( xNetworkBuffers ) ) ||
-			( ( offset % sizeof( xNetworkBuffers[0] ) ) != 0 ) )
-			return pdFALSE;
-		return (UBaseType_t) (pxDesc - xNetworkBuffers) + 1;
-	}
-	/*-----------------------------------------------------------*/
+        if( ( ( cIsLow == 0 ) && ( uxCount <= WARN_LOW ) ) || ( ( cIsLow != 0 ) && ( uxCount >= WARN_HIGH ) ) )
+        {
+            cIsLow = !cIsLow;
+            FreeRTOS_debug_printf( ( "*** Warning *** %s %lu buffers left\n", cIsLow ? "only" : "now", uxCount ) );
+        }
+    }
+    /*-----------------------------------------------------------*/
 
-#else
-	static UBaseType_t bIsValidNetworkDescriptor (const NetworkBufferDescriptor_t * pxDesc)
-	{
-		( void ) pxDesc;
-		return ( UBaseType_t ) pdTRUE;
-	}
-	/*-----------------------------------------------------------*/
+    UBaseType_t bIsValidNetworkDescriptor( const NetworkBufferDescriptor_t * pxDesc )
+    {
+        uint32_t offset = ( uint32_t ) ( ( ( const char * ) pxDesc ) - ( ( const char * ) xNetworkBuffers ) );
 
-	static void prvShowWarnings( void )
-	{
-	}
-	/*-----------------------------------------------------------*/
+        if( ( offset >= sizeof( xNetworkBuffers ) ) ||
+            ( ( offset % sizeof( xNetworkBuffers[ 0 ] ) ) != 0 ) )
+        {
+            return pdFALSE;
+        }
+
+        return ( UBaseType_t ) ( pxDesc - xNetworkBuffers ) + 1;
+    }
+    /*-----------------------------------------------------------*/
+
+#else /* if ( ipconfigTCP_IP_SANITY != 0 ) */
+    static UBaseType_t bIsValidNetworkDescriptor( const NetworkBufferDescriptor_t * pxDesc )
+    {
+        ( void ) pxDesc;
+        return ( UBaseType_t ) pdTRUE;
+    }
+    /*-----------------------------------------------------------*/
+
+    static void prvShowWarnings( void )
+    {
+    }
+    /*-----------------------------------------------------------*/
 
 #endif /* ipconfigTCP_IP_SANITY */
 
 BaseType_t xNetworkBuffersInitialise( void )
 {
-BaseType_t xReturn, x;
+    BaseType_t xReturn, x;
 
-	/* Only initialise the buffers and their associated kernel objects if they
-	have not been initialised before. */
-	if( xNetworkBufferSemaphore == NULL )
-	{
-		/* In case alternative locking is used, the mutexes can be initialised
-		here */
-		ipconfigBUFFER_ALLOC_INIT();
+    /* Only initialise the buffers and their associated kernel objects if they
+     * have not been initialised before. */
+    if( xNetworkBufferSemaphore == NULL )
+    {
+        /* In case alternative locking is used, the mutexes can be initialised
+         * here */
+        ipconfigBUFFER_ALLOC_INIT();
 
-		xNetworkBufferSemaphore = xSemaphoreCreateCounting( ( UBaseType_t ) ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS, ( UBaseType_t ) ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS );
-		configASSERT( xNetworkBufferSemaphore != NULL );
+        xNetworkBufferSemaphore = xSemaphoreCreateCounting( ( UBaseType_t ) ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS, ( UBaseType_t ) ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS );
+        configASSERT( xNetworkBufferSemaphore != NULL );
 
-		if( xNetworkBufferSemaphore != NULL )
-		{
-			vListInitialise( &xFreeBuffersList );
+        if( xNetworkBufferSemaphore != NULL )
+        {
+            vListInitialise( &xFreeBuffersList );
 
-			/* Initialise all the network buffers.  The buffer storage comes
-			from the network interface, and different hardware has different
-			requirements. */
-			vNetworkInterfaceAllocateRAMToBuffers( xNetworkBuffers );
-			for( x = 0; x < ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS; x++ )
-			{
-				/* Initialise and set the owner of the buffer list items. */
-				vListInitialiseItem( &( xNetworkBuffers[ x ].xBufferListItem ) );
-				listSET_LIST_ITEM_OWNER( &( xNetworkBuffers[ x ].xBufferListItem ), &xNetworkBuffers[ x ] );
+            /* Initialise all the network buffers.  The buffer storage comes
+             * from the network interface, and different hardware has different
+             * requirements. */
+            vNetworkInterfaceAllocateRAMToBuffers( xNetworkBuffers );
 
-				/* Currently, all buffers are available for use. */
-				vListInsert( &xFreeBuffersList, &( xNetworkBuffers[ x ].xBufferListItem ) );
-			}
+            for( x = 0; x < ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS; x++ )
+            {
+                /* Initialise and set the owner of the buffer list items. */
+                vListInitialiseItem( &( xNetworkBuffers[ x ].xBufferListItem ) );
+                listSET_LIST_ITEM_OWNER( &( xNetworkBuffers[ x ].xBufferListItem ), &xNetworkBuffers[ x ] );
 
-			uxMinimumFreeNetworkBuffers = ( UBaseType_t ) ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS;
-		}
-	}
+                /* Currently, all buffers are available for use. */
+                vListInsert( &xFreeBuffersList, &( xNetworkBuffers[ x ].xBufferListItem ) );
+            }
 
-	if( xNetworkBufferSemaphore == NULL )
-	{
-		xReturn = pdFAIL;
-	}
-	else
-	{
-		xReturn = pdPASS;
-	}
+            uxMinimumFreeNetworkBuffers = ( UBaseType_t ) ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS;
+        }
+    }
 
-	return xReturn;
+    if( xNetworkBufferSemaphore == NULL )
+    {
+        xReturn = pdFAIL;
+    }
+    else
+    {
+        xReturn = pdPASS;
+    }
+
+    return xReturn;
 }
 /*-----------------------------------------------------------*/
 
-NetworkBufferDescriptor_t *pxGetNetworkBufferWithDescriptor( size_t xRequestedSizeBytes, TickType_t xBlockTimeTicks )
+NetworkBufferDescriptor_t * pxGetNetworkBufferWithDescriptor( size_t xRequestedSizeBytes,
+                                                              TickType_t xBlockTimeTicks )
 {
-NetworkBufferDescriptor_t *pxReturn = NULL;
-BaseType_t xInvalid = pdFALSE;
-UBaseType_t uxCount;
+    NetworkBufferDescriptor_t * pxReturn = NULL;
+    BaseType_t xInvalid = pdFALSE;
+    UBaseType_t uxCount;
 
-	/* The current implementation only has a single size memory block, so
-	the requested size parameter is not used (yet). */
-	( void ) xRequestedSizeBytes;
+    /* The current implementation only has a single size memory block, so
+     * the requested size parameter is not used (yet). */
+    ( void ) xRequestedSizeBytes;
 
-	if( xNetworkBufferSemaphore != NULL )
-	{
-		/* If there is a semaphore available, there is a network buffer
-		available. */
-		if( xSemaphoreTake( xNetworkBufferSemaphore, xBlockTimeTicks ) == pdPASS )
-		{
-			/* Protect the structure as it is accessed from tasks and
-			interrupts. */
-			ipconfigBUFFER_ALLOC_LOCK();
-			{
-				pxReturn = ( NetworkBufferDescriptor_t * ) listGET_OWNER_OF_HEAD_ENTRY( &xFreeBuffersList );
+    if( xNetworkBufferSemaphore != NULL )
+    {
+        /* If there is a semaphore available, there is a network buffer
+         * available. */
+        if( xSemaphoreTake( xNetworkBufferSemaphore, xBlockTimeTicks ) == pdPASS )
+        {
+            /* Protect the structure as it is accessed from tasks and
+             * interrupts. */
+            ipconfigBUFFER_ALLOC_LOCK();
+            {
+                pxReturn = ( NetworkBufferDescriptor_t * ) listGET_OWNER_OF_HEAD_ENTRY( &xFreeBuffersList );
 
-				if( ( bIsValidNetworkDescriptor( pxReturn ) != pdFALSE_UNSIGNED ) &&
-					listIS_CONTAINED_WITHIN( &xFreeBuffersList, &( pxReturn->xBufferListItem ) ) )
-				{
-					( void ) uxListRemove( &( pxReturn->xBufferListItem ) );
-				}
-				else
-				{
-					xInvalid = pdTRUE;
-				}
-			}
-			ipconfigBUFFER_ALLOC_UNLOCK();
+                if( ( bIsValidNetworkDescriptor( pxReturn ) != pdFALSE_UNSIGNED ) &&
+                    listIS_CONTAINED_WITHIN( &xFreeBuffersList, &( pxReturn->xBufferListItem ) ) )
+                {
+                    ( void ) uxListRemove( &( pxReturn->xBufferListItem ) );
+                }
+                else
+                {
+                    xInvalid = pdTRUE;
+                }
+            }
+            ipconfigBUFFER_ALLOC_UNLOCK();
 
-			if( xInvalid == pdTRUE )
-			{
-				/* _RB_ Can printf() be called from an interrupt?  (comment
-				above says this can be called from an interrupt too) */
-				/* _HT_ The function shall not be called from an ISR. Comment
-				was indeed misleading. Hopefully clear now?
-				So the printf()is OK here. */
-				FreeRTOS_debug_printf( ( "pxGetNetworkBufferWithDescriptor: INVALID BUFFER: %p (valid %lu)\n",
-					pxReturn, bIsValidNetworkDescriptor( pxReturn ) ) );
-				pxReturn = NULL;
-			}
-			else
-			{
-				/* Reading UBaseType_t, no critical section needed. */
-				uxCount = listCURRENT_LIST_LENGTH( &xFreeBuffersList );
+            if( xInvalid == pdTRUE )
+            {
+                /* _RB_ Can printf() be called from an interrupt?  (comment
+                 * above says this can be called from an interrupt too) */
+                /* _HT_ The function shall not be called from an ISR. Comment
+                 * was indeed misleading. Hopefully clear now?
+                 * So the printf()is OK here. */
+                FreeRTOS_debug_printf( ( "pxGetNetworkBufferWithDescriptor: INVALID BUFFER: %p (valid %lu)\n",
+                                         pxReturn, bIsValidNetworkDescriptor( pxReturn ) ) );
+                pxReturn = NULL;
+            }
+            else
+            {
+                /* Reading UBaseType_t, no critical section needed. */
+                uxCount = listCURRENT_LIST_LENGTH( &xFreeBuffersList );
 
-				/* For stats, latch the lowest number of network buffers since
-				booting. */
-				if( uxMinimumFreeNetworkBuffers > uxCount )
-				{
-					uxMinimumFreeNetworkBuffers = uxCount;
-				}
+                /* For stats, latch the lowest number of network buffers since
+                 * booting. */
+                if( uxMinimumFreeNetworkBuffers > uxCount )
+                {
+                    uxMinimumFreeNetworkBuffers = uxCount;
+                }
 
-				pxReturn->xDataLength = xRequestedSizeBytes;
+                pxReturn->xDataLength = xRequestedSizeBytes;
 
-				#if( ipconfigTCP_IP_SANITY != 0 )
-				{
-					prvShowWarnings();
-				}
-				#endif /* ipconfigTCP_IP_SANITY */
+                #if ( ipconfigTCP_IP_SANITY != 0 )
+                    {
+                        prvShowWarnings();
+                    }
+                #endif /* ipconfigTCP_IP_SANITY */
 
-				#if( ipconfigUSE_LINKED_RX_MESSAGES != 0 )
-				{
-					/* make sure the buffer is not linked */
-					pxReturn->pxNextBuffer = NULL;
-				}
-				#endif /* ipconfigUSE_LINKED_RX_MESSAGES */
-			}
-			iptraceNETWORK_BUFFER_OBTAINED( pxReturn );
-		}
-		else
-		{
-			/* lint wants to see at least a comment. */
-			iptraceFAILED_TO_OBTAIN_NETWORK_BUFFER();
-		}
-	}
+                #if ( ipconfigUSE_LINKED_RX_MESSAGES != 0 )
+                    {
+                        /* make sure the buffer is not linked */
+                        pxReturn->pxNextBuffer = NULL;
+                    }
+                #endif /* ipconfigUSE_LINKED_RX_MESSAGES */
+            }
 
-	return pxReturn;
+            iptraceNETWORK_BUFFER_OBTAINED( pxReturn );
+        }
+        else
+        {
+            /* lint wants to see at least a comment. */
+            iptraceFAILED_TO_OBTAIN_NETWORK_BUFFER();
+        }
+    }
+
+    return pxReturn;
 }
 /*-----------------------------------------------------------*/
 
-NetworkBufferDescriptor_t *pxNetworkBufferGetFromISR( size_t xRequestedSizeBytes )
+NetworkBufferDescriptor_t * pxNetworkBufferGetFromISR( size_t xRequestedSizeBytes )
 {
-NetworkBufferDescriptor_t *pxReturn = NULL;
+    NetworkBufferDescriptor_t * pxReturn = NULL;
 
-	/* The current implementation only has a single size memory block, so
-	the requested size parameter is not used (yet). */
-	( void ) xRequestedSizeBytes;
+    /* The current implementation only has a single size memory block, so
+     * the requested size parameter is not used (yet). */
+    ( void ) xRequestedSizeBytes;
 
-	/* If there is a semaphore available then there is a buffer available, but,
-	as this is called from an interrupt, only take a buffer if there are at
-	least baINTERRUPT_BUFFER_GET_THRESHOLD buffers remaining.  This prevents,
-	to a certain degree at least, a rapidly executing interrupt exhausting
-	buffer and in so doing preventing tasks from continuing. */
-	if( uxQueueMessagesWaitingFromISR( ( QueueHandle_t ) xNetworkBufferSemaphore ) > ( UBaseType_t ) baINTERRUPT_BUFFER_GET_THRESHOLD )
-	{
-		if( xSemaphoreTakeFromISR( xNetworkBufferSemaphore, NULL ) == pdPASS )
-		{
-			/* Protect the structure as it is accessed from tasks and interrupts. */
-			ipconfigBUFFER_ALLOC_LOCK_FROM_ISR();
-			{
-				pxReturn = ( NetworkBufferDescriptor_t * ) listGET_OWNER_OF_HEAD_ENTRY( &xFreeBuffersList );
-				uxListRemove( &( pxReturn->xBufferListItem ) );
-			}
-			ipconfigBUFFER_ALLOC_UNLOCK_FROM_ISR();
+    /* If there is a semaphore available then there is a buffer available, but,
+     * as this is called from an interrupt, only take a buffer if there are at
+     * least baINTERRUPT_BUFFER_GET_THRESHOLD buffers remaining.  This prevents,
+     * to a certain degree at least, a rapidly executing interrupt exhausting
+     * buffer and in so doing preventing tasks from continuing. */
+    if( uxQueueMessagesWaitingFromISR( ( QueueHandle_t ) xNetworkBufferSemaphore ) > ( UBaseType_t ) baINTERRUPT_BUFFER_GET_THRESHOLD )
+    {
+        if( xSemaphoreTakeFromISR( xNetworkBufferSemaphore, NULL ) == pdPASS )
+        {
+            /* Protect the structure as it is accessed from tasks and interrupts. */
+            ipconfigBUFFER_ALLOC_LOCK_FROM_ISR();
+            {
+                pxReturn = ( NetworkBufferDescriptor_t * ) listGET_OWNER_OF_HEAD_ENTRY( &xFreeBuffersList );
+                uxListRemove( &( pxReturn->xBufferListItem ) );
+            }
+            ipconfigBUFFER_ALLOC_UNLOCK_FROM_ISR();
 
-			iptraceNETWORK_BUFFER_OBTAINED_FROM_ISR( pxReturn );
-		}
-	}
+            iptraceNETWORK_BUFFER_OBTAINED_FROM_ISR( pxReturn );
+        }
+    }
 
-	if( pxReturn == NULL )
-	{
-		iptraceFAILED_TO_OBTAIN_NETWORK_BUFFER_FROM_ISR();
-	}
+    if( pxReturn == NULL )
+    {
+        iptraceFAILED_TO_OBTAIN_NETWORK_BUFFER_FROM_ISR();
+    }
 
-	return pxReturn;
+    return pxReturn;
 }
 /*-----------------------------------------------------------*/
 
 BaseType_t vNetworkBufferReleaseFromISR( NetworkBufferDescriptor_t * const pxNetworkBuffer )
 {
-BaseType_t xHigherPriorityTaskWoken = pdFALSE;
+    BaseType_t xHigherPriorityTaskWoken = pdFALSE;
 
-	/* Ensure the buffer is returned to the list of free buffers before the
-	counting semaphore is 'given' to say a buffer is available. */
-	ipconfigBUFFER_ALLOC_LOCK_FROM_ISR();
-	{
-		vListInsertEnd( &xFreeBuffersList, &( pxNetworkBuffer->xBufferListItem ) );
-	}
-	ipconfigBUFFER_ALLOC_UNLOCK_FROM_ISR();
+    /* Ensure the buffer is returned to the list of free buffers before the
+     * counting semaphore is 'given' to say a buffer is available. */
+    ipconfigBUFFER_ALLOC_LOCK_FROM_ISR();
+    {
+        vListInsertEnd( &xFreeBuffersList, &( pxNetworkBuffer->xBufferListItem ) );
+    }
+    ipconfigBUFFER_ALLOC_UNLOCK_FROM_ISR();
 
-	( void ) xSemaphoreGiveFromISR( xNetworkBufferSemaphore, &xHigherPriorityTaskWoken );
-	iptraceNETWORK_BUFFER_RELEASED( pxNetworkBuffer );
+    ( void ) xSemaphoreGiveFromISR( xNetworkBufferSemaphore, &xHigherPriorityTaskWoken );
+    iptraceNETWORK_BUFFER_RELEASED( pxNetworkBuffer );
 
-	return xHigherPriorityTaskWoken;
+    return xHigherPriorityTaskWoken;
 }
 /*-----------------------------------------------------------*/
 
 void vReleaseNetworkBufferAndDescriptor( NetworkBufferDescriptor_t * const pxNetworkBuffer )
 {
-BaseType_t xListItemAlreadyInFreeList;
+    BaseType_t xListItemAlreadyInFreeList;
 
-	if( bIsValidNetworkDescriptor( pxNetworkBuffer ) == pdFALSE_UNSIGNED )
-	{
-		FreeRTOS_debug_printf( ( "vReleaseNetworkBufferAndDescriptor: Invalid buffer %p\n", pxNetworkBuffer ) );
-	}
-	else
-	{
-		/* Ensure the buffer is returned to the list of free buffers before the
-		counting semaphore is 'given' to say a buffer is available. */
-		ipconfigBUFFER_ALLOC_LOCK();
-		{
-			{
-				xListItemAlreadyInFreeList = listIS_CONTAINED_WITHIN( &xFreeBuffersList, &( pxNetworkBuffer->xBufferListItem ) );
+    if( bIsValidNetworkDescriptor( pxNetworkBuffer ) == pdFALSE_UNSIGNED )
+    {
+        FreeRTOS_debug_printf( ( "vReleaseNetworkBufferAndDescriptor: Invalid buffer %p\n", pxNetworkBuffer ) );
+    }
+    else
+    {
+        /* Ensure the buffer is returned to the list of free buffers before the
+         * counting semaphore is 'given' to say a buffer is available. */
+        ipconfigBUFFER_ALLOC_LOCK();
+        {
+            {
+                xListItemAlreadyInFreeList = listIS_CONTAINED_WITHIN( &xFreeBuffersList, &( pxNetworkBuffer->xBufferListItem ) );
 
-				if( xListItemAlreadyInFreeList == pdFALSE )
-				{
-					vListInsertEnd( &xFreeBuffersList, &( pxNetworkBuffer->xBufferListItem ) );
-				}
-			}
-		}
-		ipconfigBUFFER_ALLOC_UNLOCK();
+                if( xListItemAlreadyInFreeList == pdFALSE )
+                {
+                    vListInsertEnd( &xFreeBuffersList, &( pxNetworkBuffer->xBufferListItem ) );
+                }
+            }
+        }
+        ipconfigBUFFER_ALLOC_UNLOCK();
 
-		if( xListItemAlreadyInFreeList )
-		{
-			FreeRTOS_debug_printf( ( "vReleaseNetworkBufferAndDescriptor: %p ALREADY RELEASED (now %lu)\n",
-				pxNetworkBuffer, uxGetNumberOfFreeNetworkBuffers( ) ) );
-		}
-		else
-		{
-			( void ) xSemaphoreGive( xNetworkBufferSemaphore );
-			prvShowWarnings();
-		}
-		iptraceNETWORK_BUFFER_RELEASED( pxNetworkBuffer );
-	}
+        if( xListItemAlreadyInFreeList )
+        {
+            FreeRTOS_debug_printf( ( "vReleaseNetworkBufferAndDescriptor: %p ALREADY RELEASED (now %lu)\n",
+                                     pxNetworkBuffer, uxGetNumberOfFreeNetworkBuffers() ) );
+        }
+        else
+        {
+            ( void ) xSemaphoreGive( xNetworkBufferSemaphore );
+            prvShowWarnings();
+        }
+
+        iptraceNETWORK_BUFFER_RELEASED( pxNetworkBuffer );
+    }
 }
 /*-----------------------------------------------------------*/
 
 UBaseType_t uxGetMinimumFreeNetworkBuffers( void )
 {
-	return uxMinimumFreeNetworkBuffers;
+    return uxMinimumFreeNetworkBuffers;
 }
 /*-----------------------------------------------------------*/
 
 UBaseType_t uxGetNumberOfFreeNetworkBuffers( void )
 {
-	return listCURRENT_LIST_LENGTH( &xFreeBuffersList );
+    return listCURRENT_LIST_LENGTH( &xFreeBuffersList );
 }
 
-NetworkBufferDescriptor_t *pxResizeNetworkBufferWithDescriptor( NetworkBufferDescriptor_t * pxNetworkBuffer, size_t xNewSizeBytes )
+NetworkBufferDescriptor_t * pxResizeNetworkBufferWithDescriptor( NetworkBufferDescriptor_t * pxNetworkBuffer,
+                                                                 size_t xNewSizeBytes )
 {
-	/* In BufferAllocation_1.c all network buffer are allocated with a
-	maximum size of 'ipTOTAL_ETHERNET_FRAME_SIZE'.No need to resize the
-	network buffer. */
-	pxNetworkBuffer->xDataLength = xNewSizeBytes;
-	return pxNetworkBuffer;
+    /* In BufferAllocation_1.c all network buffer are allocated with a
+     * maximum size of 'ipTOTAL_ETHERNET_FRAME_SIZE'.No need to resize the
+     * network buffer. */
+    pxNetworkBuffer->xDataLength = xNewSizeBytes;
+    return pxNetworkBuffer;
 }
 
 /*#endif */ /* ipconfigINCLUDE_TEST_CODE */

--- a/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/portable/BufferManagement/BufferAllocation_2.c
+++ b/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/portable/BufferManagement/BufferAllocation_2.c
@@ -26,16 +26,16 @@
  */
 
 /******************************************************************************
- *
- * See the following web page for essential buffer allocation scheme usage and
- * configuration details:
- * http://www.FreeRTOS.org/FreeRTOS-Plus/FreeRTOS_Plus_TCP/Embedded_Ethernet_Buffer_Management.html
- *
- ******************************************************************************/
+*
+* See the following web page for essential buffer allocation scheme usage and
+* configuration details:
+* http://www.FreeRTOS.org/FreeRTOS-Plus/FreeRTOS_Plus_TCP/Embedded_Ethernet_Buffer_Management.html
+*
+******************************************************************************/
 
 /* THIS FILE SHOULD NOT BE USED IF THE PROJECT INCLUDES A MEMORY ALLOCATOR
-THAT WILL FRAGMENT THE HEAP MEMORY.  For example, heap_2 must not be used,
-heap_4 can be used. */
+ * THAT WILL FRAGMENT THE HEAP MEMORY.  For example, heap_2 must not be used,
+ * heap_4 can be used. */
 
 
 /* Standard includes. */
@@ -54,21 +54,21 @@ heap_4 can be used. */
 #include "NetworkBufferManagement.h"
 
 /* The obtained network buffer must be large enough to hold a packet that might
-replace the packet that was requested to be sent. */
+ * replace the packet that was requested to be sent. */
 #if ipconfigUSE_TCP == 1
-	#define baMINIMAL_BUFFER_SIZE		sizeof( TCPPacket_t )
+    #define baMINIMAL_BUFFER_SIZE    sizeof( TCPPacket_t )
 #else
-	#define baMINIMAL_BUFFER_SIZE		sizeof( ARPPacket_t )
+    #define baMINIMAL_BUFFER_SIZE    sizeof( ARPPacket_t )
 #endif /* ipconfigUSE_TCP == 1 */
 
 /*_RB_ This is too complex not to have an explanation. */
 #if defined( ipconfigETHERNET_MINIMUM_PACKET_BYTES )
-	#define ASSERT_CONCAT_(a, b) a##b
-	#define ASSERT_CONCAT(a, b) ASSERT_CONCAT_(a, b)
-	#define STATIC_ASSERT(e) \
-		;enum { ASSERT_CONCAT(assert_line_, __LINE__) = 1/(!!(e)) }
+    #define ASSERT_CONCAT_( a, b )    a ## b
+    #define ASSERT_CONCAT( a, b )     ASSERT_CONCAT_( a, b )
+    #define STATIC_ASSERT( e ) \
+    ; enum { ASSERT_CONCAT( assert_line_, __LINE__ ) = 1 / ( !!( e ) ) }
 
-	STATIC_ASSERT( ipconfigETHERNET_MINIMUM_PACKET_BYTES <= baMINIMAL_BUFFER_SIZE );
+    STATIC_ASSERT( ipconfigETHERNET_MINIMUM_PACKET_BYTES <= baMINIMAL_BUFFER_SIZE );
 #endif
 
 /* A list of free (available) NetworkBufferDescriptor_t structures. */
@@ -78,14 +78,14 @@ static List_t xFreeBuffersList;
 static size_t uxMinimumFreeNetworkBuffers;
 
 /* Declares the pool of NetworkBufferDescriptor_t structures that are available
-to the system.  All the network buffers referenced from xFreeBuffersList exist
-in this array.  The array is not accessed directly except during initialisation,
-when the xFreeBuffersList is filled (as all the buffers are free when the system
-is booted). */
+ * to the system.  All the network buffers referenced from xFreeBuffersList exist
+ * in this array.  The array is not accessed directly except during initialisation,
+ * when the xFreeBuffersList is filled (as all the buffers are free when the system
+ * is booted). */
 static NetworkBufferDescriptor_t xNetworkBufferDescriptors[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ];
 
 /* This constant is defined as false to let FreeRTOS_TCP_IP.c know that the
-network buffers have a variable size: resizing may be necessary */
+ * network buffers have a variable size: resizing may be necessary */
 const BaseType_t xBufferAllocFixedSize = pdFALSE;
 
 /* The semaphore used to obtain network buffers. */
@@ -95,255 +95,259 @@ static SemaphoreHandle_t xNetworkBufferSemaphore = NULL;
 
 BaseType_t xNetworkBuffersInitialise( void )
 {
-BaseType_t xReturn, x;
+    BaseType_t xReturn, x;
 
-	/* Only initialise the buffers and their associated kernel objects if they
-	have not been initialised before. */
-	if( xNetworkBufferSemaphore == NULL )
-	{
-		xNetworkBufferSemaphore = xSemaphoreCreateCounting( ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS, ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS );
-		configASSERT( xNetworkBufferSemaphore != NULL );
+    /* Only initialise the buffers and their associated kernel objects if they
+     * have not been initialised before. */
+    if( xNetworkBufferSemaphore == NULL )
+    {
+        xNetworkBufferSemaphore = xSemaphoreCreateCounting( ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS, ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS );
+        configASSERT( xNetworkBufferSemaphore != NULL );
 
-		if( xNetworkBufferSemaphore != NULL )
-		{
-			#if ( configQUEUE_REGISTRY_SIZE > 0 )
-			{
-				vQueueAddToRegistry( xNetworkBufferSemaphore, "NetBufSem" );
-			}
-			#endif /* configQUEUE_REGISTRY_SIZE */
+        if( xNetworkBufferSemaphore != NULL )
+        {
+            #if ( configQUEUE_REGISTRY_SIZE > 0 )
+                {
+                    vQueueAddToRegistry( xNetworkBufferSemaphore, "NetBufSem" );
+                }
+            #endif /* configQUEUE_REGISTRY_SIZE */
 
-			/* If the trace recorder code is included name the semaphore for viewing
-			in FreeRTOS+Trace.  */
-			#if( ipconfigINCLUDE_EXAMPLE_FREERTOS_PLUS_TRACE_CALLS == 1 )
-			{
-				extern QueueHandle_t xNetworkEventQueue;
-				vTraceSetQueueName( xNetworkEventQueue, "IPStackEvent" );
-				vTraceSetQueueName( xNetworkBufferSemaphore, "NetworkBufferCount" );
-			}
-			#endif /*  ipconfigINCLUDE_EXAMPLE_FREERTOS_PLUS_TRACE_CALLS == 1 */
+            /* If the trace recorder code is included name the semaphore for viewing
+             * in FreeRTOS+Trace.  */
+            #if ( ipconfigINCLUDE_EXAMPLE_FREERTOS_PLUS_TRACE_CALLS == 1 )
+                {
+                    extern QueueHandle_t xNetworkEventQueue;
+                    vTraceSetQueueName( xNetworkEventQueue, "IPStackEvent" );
+                    vTraceSetQueueName( xNetworkBufferSemaphore, "NetworkBufferCount" );
+                }
+            #endif /*  ipconfigINCLUDE_EXAMPLE_FREERTOS_PLUS_TRACE_CALLS == 1 */
 
-			vListInitialise( &xFreeBuffersList );
+            vListInitialise( &xFreeBuffersList );
 
-			/* Initialise all the network buffers.  No storage is allocated to
-			the buffers yet. */
-			for( x = 0; x < ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS; x++ )
-			{
-				/* Initialise and set the owner of the buffer list items. */
-				xNetworkBufferDescriptors[ x ].pucEthernetBuffer = NULL;
-				vListInitialiseItem( &( xNetworkBufferDescriptors[ x ].xBufferListItem ) );
-				listSET_LIST_ITEM_OWNER( &( xNetworkBufferDescriptors[ x ].xBufferListItem ), &xNetworkBufferDescriptors[ x ] );
+            /* Initialise all the network buffers.  No storage is allocated to
+             * the buffers yet. */
+            for( x = 0; x < ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS; x++ )
+            {
+                /* Initialise and set the owner of the buffer list items. */
+                xNetworkBufferDescriptors[ x ].pucEthernetBuffer = NULL;
+                vListInitialiseItem( &( xNetworkBufferDescriptors[ x ].xBufferListItem ) );
+                listSET_LIST_ITEM_OWNER( &( xNetworkBufferDescriptors[ x ].xBufferListItem ), &xNetworkBufferDescriptors[ x ] );
 
-				/* Currently, all buffers are available for use. */
-				vListInsert( &xFreeBuffersList, &( xNetworkBufferDescriptors[ x ].xBufferListItem ) );
-			}
+                /* Currently, all buffers are available for use. */
+                vListInsert( &xFreeBuffersList, &( xNetworkBufferDescriptors[ x ].xBufferListItem ) );
+            }
 
-			uxMinimumFreeNetworkBuffers = ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS;
-		}
-	}
+            uxMinimumFreeNetworkBuffers = ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS;
+        }
+    }
 
-	if( xNetworkBufferSemaphore == NULL )
-	{
-		xReturn = pdFAIL;
-	}
-	else
-	{
-		xReturn = pdPASS;
-	}
+    if( xNetworkBufferSemaphore == NULL )
+    {
+        xReturn = pdFAIL;
+    }
+    else
+    {
+        xReturn = pdPASS;
+    }
 
-	return xReturn;
+    return xReturn;
 }
 /*-----------------------------------------------------------*/
 
-uint8_t *pucGetNetworkBuffer( size_t *pxRequestedSizeBytes )
+uint8_t * pucGetNetworkBuffer( size_t * pxRequestedSizeBytes )
 {
-uint8_t *pucEthernetBuffer;
-size_t xSize = *pxRequestedSizeBytes;
+    uint8_t * pucEthernetBuffer;
+    size_t xSize = *pxRequestedSizeBytes;
 
-	if( xSize < baMINIMAL_BUFFER_SIZE )
-	{
-		/* Buffers must be at least large enough to hold a TCP-packet with
-		headers, or an ARP packet, in case TCP is not included. */
-		xSize = baMINIMAL_BUFFER_SIZE;
-	}
+    if( xSize < baMINIMAL_BUFFER_SIZE )
+    {
+        /* Buffers must be at least large enough to hold a TCP-packet with
+         * headers, or an ARP packet, in case TCP is not included. */
+        xSize = baMINIMAL_BUFFER_SIZE;
+    }
 
-	/* Round up xSize to the nearest multiple of N bytes,
-	where N equals 'sizeof( size_t )'. */
-	if( ( xSize & ( sizeof( size_t ) - 1U ) ) != 0U )
-	{
-		xSize = ( xSize | ( sizeof( size_t ) - 1U ) ) + 1U;
-	}
-	*pxRequestedSizeBytes = xSize;
+    /* Round up xSize to the nearest multiple of N bytes,
+     * where N equals 'sizeof( size_t )'. */
+    if( ( xSize & ( sizeof( size_t ) - 1U ) ) != 0U )
+    {
+        xSize = ( xSize | ( sizeof( size_t ) - 1U ) ) + 1U;
+    }
 
-	/* Allocate a buffer large enough to store the requested Ethernet frame size
-	and a pointer to a network buffer structure (hence the addition of
-	ipBUFFER_PADDING bytes). */
-	pucEthernetBuffer = ( uint8_t * ) pvPortMalloc( xSize + ipBUFFER_PADDING );
-	configASSERT( pucEthernetBuffer != NULL );
+    *pxRequestedSizeBytes = xSize;
 
-	if( pucEthernetBuffer != NULL )
-	{
-		/* Enough space is left at the start of the buffer to place a pointer to
-		the network buffer structure that references this Ethernet buffer.
-		Return a pointer to the start of the Ethernet buffer itself. */
-		pucEthernetBuffer += ipBUFFER_PADDING;
-	}
+    /* Allocate a buffer large enough to store the requested Ethernet frame size
+     * and a pointer to a network buffer structure (hence the addition of
+     * ipBUFFER_PADDING bytes). */
+    pucEthernetBuffer = ( uint8_t * ) pvPortMalloc( xSize + ipBUFFER_PADDING );
+    configASSERT( pucEthernetBuffer != NULL );
 
-	return pucEthernetBuffer;
+    if( pucEthernetBuffer != NULL )
+    {
+        /* Enough space is left at the start of the buffer to place a pointer to
+         * the network buffer structure that references this Ethernet buffer.
+         * Return a pointer to the start of the Ethernet buffer itself. */
+        pucEthernetBuffer += ipBUFFER_PADDING;
+    }
+
+    return pucEthernetBuffer;
 }
 /*-----------------------------------------------------------*/
 
-void vReleaseNetworkBuffer( uint8_t *pucEthernetBuffer )
+void vReleaseNetworkBuffer( uint8_t * pucEthernetBuffer )
 {
-	/* There is space before the Ethernet buffer in which a pointer to the
-	network buffer that references this Ethernet buffer is stored.  Remove the
-	space before freeing the buffer. */
-	if( pucEthernetBuffer != NULL )
-	{
-		pucEthernetBuffer -= ipBUFFER_PADDING;
-		vPortFree( ( void * ) pucEthernetBuffer );
-	}
+    /* There is space before the Ethernet buffer in which a pointer to the
+     * network buffer that references this Ethernet buffer is stored.  Remove the
+     * space before freeing the buffer. */
+    if( pucEthernetBuffer != NULL )
+    {
+        pucEthernetBuffer -= ipBUFFER_PADDING;
+        vPortFree( ( void * ) pucEthernetBuffer );
+    }
 }
 /*-----------------------------------------------------------*/
 
-NetworkBufferDescriptor_t *pxGetNetworkBufferWithDescriptor( size_t xRequestedSizeBytes, TickType_t xBlockTimeTicks )
+NetworkBufferDescriptor_t * pxGetNetworkBufferWithDescriptor( size_t xRequestedSizeBytes,
+                                                              TickType_t xBlockTimeTicks )
 {
-NetworkBufferDescriptor_t *pxReturn = NULL;
-size_t uxCount;
+    NetworkBufferDescriptor_t * pxReturn = NULL;
+    size_t uxCount;
 
-	if( xNetworkBufferSemaphore != NULL )
-	{
-		if( ( xRequestedSizeBytes != 0U ) && ( xRequestedSizeBytes < ( size_t ) baMINIMAL_BUFFER_SIZE ) )
-		{
-			/* ARP packets can replace application packets, so the storage must be
-			at least large enough to hold an ARP. */
-			xRequestedSizeBytes = baMINIMAL_BUFFER_SIZE;
-		}
+    if( xNetworkBufferSemaphore != NULL )
+    {
+        if( ( xRequestedSizeBytes != 0U ) && ( xRequestedSizeBytes < ( size_t ) baMINIMAL_BUFFER_SIZE ) )
+        {
+            /* ARP packets can replace application packets, so the storage must be
+             * at least large enough to hold an ARP. */
+            xRequestedSizeBytes = baMINIMAL_BUFFER_SIZE;
+        }
 
-		/* Add 2 bytes to xRequestedSizeBytes and round up xRequestedSizeBytes
-		to the nearest multiple of N bytes, where N equals 'sizeof( size_t )'. */
-		xRequestedSizeBytes += 2U;
-		if( ( xRequestedSizeBytes & ( sizeof( size_t ) - 1U ) ) != 0U )
-		{
-			xRequestedSizeBytes = ( xRequestedSizeBytes | ( sizeof( size_t ) - 1U ) ) + 1U;
-		}
+        /* Add 2 bytes to xRequestedSizeBytes and round up xRequestedSizeBytes
+         * to the nearest multiple of N bytes, where N equals 'sizeof( size_t )'. */
+        xRequestedSizeBytes += 2U;
 
-		/* If there is a semaphore available, there is a network buffer available. */
-		if( xSemaphoreTake( xNetworkBufferSemaphore, xBlockTimeTicks ) == pdPASS )
-		{
-			/* Protect the structure as it is accessed from tasks and interrupts. */
-			taskENTER_CRITICAL();
-			{
-				pxReturn = ( NetworkBufferDescriptor_t * ) listGET_OWNER_OF_HEAD_ENTRY( &xFreeBuffersList );
-				( void ) uxListRemove( &( pxReturn->xBufferListItem ) );
-			}
-			taskEXIT_CRITICAL();
+        if( ( xRequestedSizeBytes & ( sizeof( size_t ) - 1U ) ) != 0U )
+        {
+            xRequestedSizeBytes = ( xRequestedSizeBytes | ( sizeof( size_t ) - 1U ) ) + 1U;
+        }
 
-			/* Reading UBaseType_t, no critical section needed. */
-			uxCount = listCURRENT_LIST_LENGTH( &xFreeBuffersList );
+        /* If there is a semaphore available, there is a network buffer available. */
+        if( xSemaphoreTake( xNetworkBufferSemaphore, xBlockTimeTicks ) == pdPASS )
+        {
+            /* Protect the structure as it is accessed from tasks and interrupts. */
+            taskENTER_CRITICAL();
+            {
+                pxReturn = ( NetworkBufferDescriptor_t * ) listGET_OWNER_OF_HEAD_ENTRY( &xFreeBuffersList );
+                ( void ) uxListRemove( &( pxReturn->xBufferListItem ) );
+            }
+            taskEXIT_CRITICAL();
 
-			if( uxMinimumFreeNetworkBuffers > uxCount )
-			{
-				uxMinimumFreeNetworkBuffers = uxCount;
-			}
+            /* Reading UBaseType_t, no critical section needed. */
+            uxCount = listCURRENT_LIST_LENGTH( &xFreeBuffersList );
 
-			/* Allocate storage of exactly the requested size to the buffer. */
-			configASSERT( pxReturn->pucEthernetBuffer == NULL );
-			if( xRequestedSizeBytes > 0 )
-			{
-				/* Extra space is obtained so a pointer to the network buffer can
-				be stored at the beginning of the buffer. */
-				pxReturn->pucEthernetBuffer = ( uint8_t * ) pvPortMalloc( xRequestedSizeBytes + ipBUFFER_PADDING );
+            if( uxMinimumFreeNetworkBuffers > uxCount )
+            {
+                uxMinimumFreeNetworkBuffers = uxCount;
+            }
 
-				if( pxReturn->pucEthernetBuffer == NULL )
-				{
-					/* The attempt to allocate storage for the buffer payload failed,
-					so the network buffer structure cannot be used and must be
-					released. */
-					vReleaseNetworkBufferAndDescriptor( pxReturn );
-					pxReturn = NULL;
-				}
-				else
-				{
-					/* Store a pointer to the network buffer structure in the
-					buffer storage area, then move the buffer pointer on past the
-					stored pointer so the pointer value is not overwritten by the
-					application when the buffer is used. */
-					*( ( NetworkBufferDescriptor_t ** ) ( pxReturn->pucEthernetBuffer ) ) = pxReturn;
-					pxReturn->pucEthernetBuffer += ipBUFFER_PADDING;
+            /* Allocate storage of exactly the requested size to the buffer. */
+            configASSERT( pxReturn->pucEthernetBuffer == NULL );
 
-					/* Store the actual size of the allocated buffer, which may be
-					greater than the original requested size. */
-					pxReturn->xDataLength = xRequestedSizeBytes;
+            if( xRequestedSizeBytes > 0 )
+            {
+                /* Extra space is obtained so a pointer to the network buffer can
+                 * be stored at the beginning of the buffer. */
+                pxReturn->pucEthernetBuffer = ( uint8_t * ) pvPortMalloc( xRequestedSizeBytes + ipBUFFER_PADDING );
 
-					#if( ipconfigUSE_LINKED_RX_MESSAGES != 0 )
-					{
-						/* make sure the buffer is not linked */
-						pxReturn->pxNextBuffer = NULL;
-					}
-					#endif /* ipconfigUSE_LINKED_RX_MESSAGES */
-				}
-			}
-			else
-			{
-				/* A descriptor is being returned without an associated buffer being
-				allocated. */
-			}
-		}
-	}
+                if( pxReturn->pucEthernetBuffer == NULL )
+                {
+                    /* The attempt to allocate storage for the buffer payload failed,
+                     * so the network buffer structure cannot be used and must be
+                     * released. */
+                    vReleaseNetworkBufferAndDescriptor( pxReturn );
+                    pxReturn = NULL;
+                }
+                else
+                {
+                    /* Store a pointer to the network buffer structure in the
+                     * buffer storage area, then move the buffer pointer on past the
+                     * stored pointer so the pointer value is not overwritten by the
+                     * application when the buffer is used. */
+                    *( ( NetworkBufferDescriptor_t ** ) ( pxReturn->pucEthernetBuffer ) ) = pxReturn;
+                    pxReturn->pucEthernetBuffer += ipBUFFER_PADDING;
 
-	if( pxReturn == NULL )
-	{
-		iptraceFAILED_TO_OBTAIN_NETWORK_BUFFER();
-	}
-	else
-	{
-		/* No action. */
-		iptraceNETWORK_BUFFER_OBTAINED( pxReturn );
-	}
+                    /* Store the actual size of the allocated buffer, which may be
+                     * greater than the original requested size. */
+                    pxReturn->xDataLength = xRequestedSizeBytes;
 
-	return pxReturn;
+                    #if ( ipconfigUSE_LINKED_RX_MESSAGES != 0 )
+                        {
+                            /* make sure the buffer is not linked */
+                            pxReturn->pxNextBuffer = NULL;
+                        }
+                    #endif /* ipconfigUSE_LINKED_RX_MESSAGES */
+                }
+            }
+            else
+            {
+                /* A descriptor is being returned without an associated buffer being
+                 * allocated. */
+            }
+        }
+    }
+
+    if( pxReturn == NULL )
+    {
+        iptraceFAILED_TO_OBTAIN_NETWORK_BUFFER();
+    }
+    else
+    {
+        /* No action. */
+        iptraceNETWORK_BUFFER_OBTAINED( pxReturn );
+    }
+
+    return pxReturn;
 }
 /*-----------------------------------------------------------*/
 
 void vReleaseNetworkBufferAndDescriptor( NetworkBufferDescriptor_t * const pxNetworkBuffer )
 {
-BaseType_t xListItemAlreadyInFreeList;
+    BaseType_t xListItemAlreadyInFreeList;
 
-	/* Ensure the buffer is returned to the list of free buffers before the
-	counting semaphore is 'given' to say a buffer is available.  Release the
-	storage allocated to the buffer payload.  THIS FILE SHOULD NOT BE USED
-	IF THE PROJECT INCLUDES A MEMORY ALLOCATOR THAT WILL FRAGMENT THE HEAP
-	MEMORY.  For example, heap_2 must not be used, heap_4 can be used. */
-	vReleaseNetworkBuffer( pxNetworkBuffer->pucEthernetBuffer );
-	pxNetworkBuffer->pucEthernetBuffer = NULL;
+    /* Ensure the buffer is returned to the list of free buffers before the
+    * counting semaphore is 'given' to say a buffer is available.  Release the
+    * storage allocated to the buffer payload.  THIS FILE SHOULD NOT BE USED
+    * IF THE PROJECT INCLUDES A MEMORY ALLOCATOR THAT WILL FRAGMENT THE HEAP
+    * MEMORY.  For example, heap_2 must not be used, heap_4 can be used. */
+    vReleaseNetworkBuffer( pxNetworkBuffer->pucEthernetBuffer );
+    pxNetworkBuffer->pucEthernetBuffer = NULL;
 
-	taskENTER_CRITICAL();
-	{
-		xListItemAlreadyInFreeList = listIS_CONTAINED_WITHIN( &xFreeBuffersList, &( pxNetworkBuffer->xBufferListItem ) );
+    taskENTER_CRITICAL();
+    {
+        xListItemAlreadyInFreeList = listIS_CONTAINED_WITHIN( &xFreeBuffersList, &( pxNetworkBuffer->xBufferListItem ) );
 
-		if( xListItemAlreadyInFreeList == pdFALSE )
-		{
-			vListInsertEnd( &xFreeBuffersList, &( pxNetworkBuffer->xBufferListItem ) );
-		}
-	}
-	taskEXIT_CRITICAL();
+        if( xListItemAlreadyInFreeList == pdFALSE )
+        {
+            vListInsertEnd( &xFreeBuffersList, &( pxNetworkBuffer->xBufferListItem ) );
+        }
+    }
+    taskEXIT_CRITICAL();
 
-	/*
-	 * Update the network state machine, unless the program fails to release its 'xNetworkBufferSemaphore'.
-	 * The program should only try to release its semaphore if 'xListItemAlreadyInFreeList' is false.
-	 */
-	if( xListItemAlreadyInFreeList == pdFALSE )
-	{
-		if ( xSemaphoreGive( xNetworkBufferSemaphore ) == pdTRUE )
-		{
-			iptraceNETWORK_BUFFER_RELEASED( pxNetworkBuffer );
-		}
-	}
-	else
-	{
-		/* No action. */
-		iptraceNETWORK_BUFFER_RELEASED( pxNetworkBuffer );
-	}
+    /*
+     * Update the network state machine, unless the program fails to release its 'xNetworkBufferSemaphore'.
+     * The program should only try to release its semaphore if 'xListItemAlreadyInFreeList' is false.
+     */
+    if( xListItemAlreadyInFreeList == pdFALSE )
+    {
+        if( xSemaphoreGive( xNetworkBufferSemaphore ) == pdTRUE )
+        {
+            iptraceNETWORK_BUFFER_RELEASED( pxNetworkBuffer );
+        }
+    }
+    else
+    {
+        /* No action. */
+        iptraceNETWORK_BUFFER_RELEASED( pxNetworkBuffer );
+    }
 }
 /*-----------------------------------------------------------*/
 
@@ -352,44 +356,45 @@ BaseType_t xListItemAlreadyInFreeList;
  */
 UBaseType_t uxGetNumberOfFreeNetworkBuffers( void )
 {
-	return listCURRENT_LIST_LENGTH( &xFreeBuffersList );
+    return listCURRENT_LIST_LENGTH( &xFreeBuffersList );
 }
 /*-----------------------------------------------------------*/
 
 UBaseType_t uxGetMinimumFreeNetworkBuffers( void )
 {
-	return uxMinimumFreeNetworkBuffers;
+    return uxMinimumFreeNetworkBuffers;
 }
 /*-----------------------------------------------------------*/
 
-NetworkBufferDescriptor_t *pxResizeNetworkBufferWithDescriptor( NetworkBufferDescriptor_t * pxNetworkBuffer, size_t xNewSizeBytes )
+NetworkBufferDescriptor_t * pxResizeNetworkBufferWithDescriptor( NetworkBufferDescriptor_t * pxNetworkBuffer,
+                                                                 size_t xNewSizeBytes )
 {
-size_t xOriginalLength;
-uint8_t *pucBuffer;
+    size_t xOriginalLength;
+    uint8_t * pucBuffer;
 
-	xOriginalLength = pxNetworkBuffer->xDataLength + ipBUFFER_PADDING;
-	xNewSizeBytes = xNewSizeBytes + ipBUFFER_PADDING;
+    xOriginalLength = pxNetworkBuffer->xDataLength + ipBUFFER_PADDING;
+    xNewSizeBytes = xNewSizeBytes + ipBUFFER_PADDING;
 
-	pucBuffer = pucGetNetworkBuffer( &( xNewSizeBytes ) );
+    pucBuffer = pucGetNetworkBuffer( &( xNewSizeBytes ) );
 
-	if( pucBuffer == NULL )
-	{
-		/* In case the allocation fails, return NULL. */
-		pxNetworkBuffer = NULL;
-	}
-	else
-	{
-		pxNetworkBuffer->xDataLength = xNewSizeBytes;
-		if( xNewSizeBytes > xOriginalLength )
-		{
-			xNewSizeBytes = xOriginalLength;
-		}
+    if( pucBuffer == NULL )
+    {
+        /* In case the allocation fails, return NULL. */
+        pxNetworkBuffer = NULL;
+    }
+    else
+    {
+        pxNetworkBuffer->xDataLength = xNewSizeBytes;
 
-		memcpy( pucBuffer - ipBUFFER_PADDING, pxNetworkBuffer->pucEthernetBuffer - ipBUFFER_PADDING, xNewSizeBytes );
-		vReleaseNetworkBuffer( pxNetworkBuffer->pucEthernetBuffer );
-		pxNetworkBuffer->pucEthernetBuffer = pucBuffer;
-	}
+        if( xNewSizeBytes > xOriginalLength )
+        {
+            xNewSizeBytes = xOriginalLength;
+        }
 
-	return pxNetworkBuffer;
+        memcpy( pucBuffer - ipBUFFER_PADDING, pxNetworkBuffer->pucEthernetBuffer - ipBUFFER_PADDING, xNewSizeBytes );
+        vReleaseNetworkBuffer( pxNetworkBuffer->pucEthernetBuffer );
+        pxNetworkBuffer->pucEthernetBuffer = pucBuffer;
+    }
+
+    return pxNetworkBuffer;
 }
-

--- a/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/portable/Compiler/CompilerName/pack_struct_end.h
+++ b/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/portable/Compiler/CompilerName/pack_struct_end.h
@@ -1,32 +1,32 @@
 /*
-FreeRTOS+TCP V2.2.1
-Copyright (C) 2018 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of
-this software and associated documentation files (the "Software"), to deal in
-the Software without restriction, including without limitation the rights to
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
-the Software, and to permit persons to whom the Software is furnished to do so,
-subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
-COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
-IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
- http://aws.amazon.com/freertos
- http://www.FreeRTOS.org
-*/
+ * FreeRTOS+TCP V2.2.1
+ * Copyright (C) 2018 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
 
 /*****************************************************************************
- *
- * See the following URL for an explanation of this file:
- * http://www.FreeRTOS.org/FreeRTOS-Plus/FreeRTOS_Plus_TCP/Embedded_Compiler_Porting.html
- *
- *****************************************************************************/
+*
+* See the following URL for an explanation of this file:
+* http://www.FreeRTOS.org/FreeRTOS-Plus/FreeRTOS_Plus_TCP/Embedded_Compiler_Porting.html
+*
+*****************************************************************************/
 ; /* FIX ME. Update for the compiler specifier needed at end of a struct declartion to pack the struct. */

--- a/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/portable/Compiler/CompilerName/pack_struct_start.h
+++ b/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/portable/Compiler/CompilerName/pack_struct_start.h
@@ -1,32 +1,32 @@
 /*
-FreeRTOS+TCP V2.2.1
-Copyright (C) 2018 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of
-this software and associated documentation files (the "Software"), to deal in
-the Software without restriction, including without limitation the rights to
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
-the Software, and to permit persons to whom the Software is furnished to do so,
-subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
-COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
-IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
- http://aws.amazon.com/freertos
- http://www.FreeRTOS.org
-*/
+ * FreeRTOS+TCP V2.2.1
+ * Copyright (C) 2018 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
 
 /*****************************************************************************
- *
- * See the following URL for an explanation of this file:
- * http://www.FreeRTOS.org/FreeRTOS-Plus/FreeRTOS_Plus_TCP/Embedded_Compiler_Porting.html
- *
- *****************************************************************************/
+*
+* See the following URL for an explanation of this file:
+* http://www.FreeRTOS.org/FreeRTOS-Plus/FreeRTOS_Plus_TCP/Embedded_Compiler_Porting.html
+*
+*****************************************************************************/
 /* FIX ME. Update for the compiler specifier needed at the start of a struct declartion to pack the struct. */

--- a/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/portable/Compiler/GCC/pack_struct_end.h
+++ b/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/portable/Compiler/GCC/pack_struct_end.h
@@ -1,46 +1,32 @@
 /*
-FreeRTOS+TCP V2.2.1
-Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of
-this software and associated documentation files (the "Software"), to deal in
-the Software without restriction, including without limitation the rights to
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
-the Software, and to permit persons to whom the Software is furnished to do so,
-subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
-COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
-IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
- http://aws.amazon.com/freertos
- http://www.FreeRTOS.org
-*/
+ * FreeRTOS+TCP V2.2.1
+ * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
 
 /*****************************************************************************
- *
- * See the following URL for an explanation of this file:
- * http://www.FreeRTOS.org/FreeRTOS-Plus/FreeRTOS_Plus_TCP/Embedded_Compiler_Porting.html
- *
- *****************************************************************************/
-__attribute__( (packed) );
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+*
+* See the following URL for an explanation of this file:
+* http://www.FreeRTOS.org/FreeRTOS-Plus/FreeRTOS_Plus_TCP/Embedded_Compiler_Porting.html
+*
+*****************************************************************************/
+__attribute__( ( packed ) );

--- a/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/portable/Compiler/GCC/pack_struct_start.h
+++ b/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/portable/Compiler/GCC/pack_struct_start.h
@@ -1,48 +1,33 @@
 /*
-FreeRTOS+TCP V2.2.1
-Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of
-this software and associated documentation files (the "Software"), to deal in
-the Software without restriction, including without limitation the rights to
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
-the Software, and to permit persons to whom the Software is furnished to do so,
-subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
-COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
-IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
- http://aws.amazon.com/freertos
- http://www.FreeRTOS.org
-*/
+ * FreeRTOS+TCP V2.2.1
+ * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
 
 /*****************************************************************************
- *
- * See the following URL for an explanation of this file:
- * http://www.FreeRTOS.org/FreeRTOS-Plus/FreeRTOS_Plus_TCP/Embedded_Compiler_Porting.html
- *
- *****************************************************************************/
+*
+* See the following URL for an explanation of this file:
+* http://www.FreeRTOS.org/FreeRTOS-Plus/FreeRTOS_Plus_TCP/Embedded_Compiler_Porting.html
+*
+*****************************************************************************/
 
 /* Nothing to do here. */
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/portable/Compiler/IAR/pack_struct_end.h
+++ b/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/portable/Compiler/IAR/pack_struct_end.h
@@ -1,47 +1,33 @@
 /*
-FreeRTOS+TCP V2.2.1
-Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of
-this software and associated documentation files (the "Software"), to deal in
-the Software without restriction, including without limitation the rights to
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
-the Software, and to permit persons to whom the Software is furnished to do so,
-subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
-COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
-IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
- http://aws.amazon.com/freertos
- http://www.FreeRTOS.org
-*/
+ * FreeRTOS+TCP V2.2.1
+ * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
 
 /*****************************************************************************
- *
- * See the following URL for an explanation of this file:
- * http://www.FreeRTOS.org/FreeRTOS-Plus/FreeRTOS_Plus_TCP/Embedded_Compiler_Porting.html
- *
- *****************************************************************************/
+*
+* See the following URL for an explanation of this file:
+* http://www.FreeRTOS.org/FreeRTOS-Plus/FreeRTOS_Plus_TCP/Embedded_Compiler_Porting.html
+*
+*****************************************************************************/
 
 ;
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/portable/Compiler/IAR/pack_struct_start.h
+++ b/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/portable/Compiler/IAR/pack_struct_start.h
@@ -1,49 +1,33 @@
 /*
-FreeRTOS+TCP V2.2.1
-Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of
-this software and associated documentation files (the "Software"), to deal in
-the Software without restriction, including without limitation the rights to
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
-the Software, and to permit persons to whom the Software is furnished to do so,
-subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
-COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
-IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
- http://aws.amazon.com/freertos
- http://www.FreeRTOS.org
-*/
+ * FreeRTOS+TCP V2.2.1
+ * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
 
 /*****************************************************************************
- *
- * See the following URL for an explanation of this file:
- * http://www.FreeRTOS.org/FreeRTOS-Plus/FreeRTOS_Plus_TCP/Embedded_Compiler_Porting.html
- *
- *****************************************************************************/
+*
+* See the following URL for an explanation of this file:
+* http://www.FreeRTOS.org/FreeRTOS-Plus/FreeRTOS_Plus_TCP/Embedded_Compiler_Porting.html
+*
+*****************************************************************************/
 
 __packed
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/portable/Compiler/Keil/pack_struct_end.h
+++ b/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/portable/Compiler/Keil/pack_struct_end.h
@@ -1,33 +1,33 @@
 /*
-FreeRTOS+TCP V2.2.1
-Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of
-this software and associated documentation files (the "Software"), to deal in
-the Software without restriction, including without limitation the rights to
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
-the Software, and to permit persons to whom the Software is furnished to do so,
-subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
-COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
-IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
- http://aws.amazon.com/freertos
- http://www.FreeRTOS.org
-*/
+ * FreeRTOS+TCP V2.2.1
+ * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
 
 /*****************************************************************************
- *
- * See the following URL for an explanation of this file:
- * http://www.FreeRTOS.org/FreeRTOS-Plus/FreeRTOS_Plus_TCP/Embedded_Compiler_Porting.html
- *
- *****************************************************************************/
+*
+* See the following URL for an explanation of this file:
+* http://www.FreeRTOS.org/FreeRTOS-Plus/FreeRTOS_Plus_TCP/Embedded_Compiler_Porting.html
+*
+*****************************************************************************/
 ;
 #pragma pack(pop)

--- a/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/portable/Compiler/Keil/pack_struct_start.h
+++ b/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/portable/Compiler/Keil/pack_struct_start.h
@@ -1,48 +1,33 @@
 /*
-FreeRTOS+TCP V2.2.1
-Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of
-this software and associated documentation files (the "Software"), to deal in
-the Software without restriction, including without limitation the rights to
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
-the Software, and to permit persons to whom the Software is furnished to do so,
-subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
-COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
-IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
- http://aws.amazon.com/freertos
- http://www.FreeRTOS.org
-*/
+ * FreeRTOS+TCP V2.2.1
+ * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
 
 /*****************************************************************************
- *
- * See the following URL for an explanation of this file:
- * http://www.FreeRTOS.org/FreeRTOS-Plus/FreeRTOS_Plus_TCP/Embedded_Compiler_Porting.html
- *
- *****************************************************************************/
+*
+* See the following URL for an explanation of this file:
+* http://www.FreeRTOS.org/FreeRTOS-Plus/FreeRTOS_Plus_TCP/Embedded_Compiler_Porting.html
+*
+*****************************************************************************/
 
 #pragma pack(push,1)
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/portable/Compiler/MSVC/pack_struct_end.h
+++ b/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/portable/Compiler/MSVC/pack_struct_end.h
@@ -1,48 +1,34 @@
 /*
-FreeRTOS+TCP V2.2.1
-Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of
-this software and associated documentation files (the "Software"), to deal in
-the Software without restriction, including without limitation the rights to
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
-the Software, and to permit persons to whom the Software is furnished to do so,
-subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
-COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
-IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
- http://aws.amazon.com/freertos
- http://www.FreeRTOS.org
-*/
+ * FreeRTOS+TCP V2.2.1
+ * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
 
 /*****************************************************************************
- *
- * See the following URL for an explanation of this file:
- * http://www.FreeRTOS.org/FreeRTOS-Plus/FreeRTOS_Plus_TCP/Embedded_Compiler_Porting.html
- *
- *****************************************************************************/
+*
+* See the following URL for an explanation of this file:
+* http://www.FreeRTOS.org/FreeRTOS-Plus/FreeRTOS_Plus_TCP/Embedded_Compiler_Porting.html
+*
+*****************************************************************************/
 
 ;
 #pragma pack( pop )
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/portable/Compiler/MSVC/pack_struct_start.h
+++ b/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/portable/Compiler/MSVC/pack_struct_start.h
@@ -1,47 +1,33 @@
 /*
-FreeRTOS+TCP V2.2.1
-Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of
-this software and associated documentation files (the "Software"), to deal in
-the Software without restriction, including without limitation the rights to
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
-the Software, and to permit persons to whom the Software is furnished to do so,
-subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
-COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
-IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
- http://aws.amazon.com/freertos
- http://www.FreeRTOS.org
-*/
+ * FreeRTOS+TCP V2.2.1
+ * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
 
 /*****************************************************************************
- *
- * See the following URL for an explanation of this file:
- * http://www.FreeRTOS.org/FreeRTOS-Plus/FreeRTOS_Plus_TCP/Embedded_Compiler_Porting.html
- *
- *****************************************************************************/
+*
+* See the following URL for an explanation of this file:
+* http://www.FreeRTOS.org/FreeRTOS-Plus/FreeRTOS_Plus_TCP/Embedded_Compiler_Porting.html
+*
+*****************************************************************************/
 
 #pragma pack( push, 1 )
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/portable/Compiler/Renesas/pack_struct_end.h
+++ b/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/portable/Compiler/Renesas/pack_struct_end.h
@@ -1,60 +1,45 @@
 /*
-FreeRTOS+TCP V2.2.1
-Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of
-this software and associated documentation files (the "Software"), to deal in
-the Software without restriction, including without limitation the rights to
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
-the Software, and to permit persons to whom the Software is furnished to do so,
-subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
-COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
-IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
- http://aws.amazon.com/freertos
- http://www.FreeRTOS.org
-*/
+ * FreeRTOS+TCP V2.2.1
+ * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
 
 /*****************************************************************************
- *
- * See the following URL for an explanation of this file:
- * http://www.FreeRTOS.org/FreeRTOS-Plus/FreeRTOS_Plus_TCP/Embedded_Compiler_Porting.html
- *
- *****************************************************************************/
+*
+* See the following URL for an explanation of this file:
+* http://www.FreeRTOS.org/FreeRTOS-Plus/FreeRTOS_Plus_TCP/Embedded_Compiler_Porting.html
+*
+*****************************************************************************/
 
 
 #ifdef _SH
-	#ifdef __RENESAS__
-		;
-		#pragma unpack
-	#endif
+    #ifdef __RENESAS__
+        ;
+        #pragma unpack
+    #endif
 #endif
 #ifdef __RX
-	#ifdef __CCRX__
-		;
-		#pragma packoption
-	#endif
+    #ifdef __CCRX__
+        ;
+        #pragma packoption
+    #endif
 #endif
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/portable/Compiler/Renesas/pack_struct_start.h
+++ b/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/portable/Compiler/Renesas/pack_struct_start.h
@@ -1,58 +1,43 @@
 /*
-FreeRTOS+TCP V2.2.1
-Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of
-this software and associated documentation files (the "Software"), to deal in
-the Software without restriction, including without limitation the rights to
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
-the Software, and to permit persons to whom the Software is furnished to do so,
-subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
-COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
-IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
- http://aws.amazon.com/freertos
- http://www.FreeRTOS.org
-*/
+ * FreeRTOS+TCP V2.2.1
+ * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
 
 /*****************************************************************************
- *
- * See the following URL for an explanation of this file:
- * http://www.FreeRTOS.org/FreeRTOS-Plus/FreeRTOS_Plus_TCP/Embedded_Compiler_Porting.html
- *
- *****************************************************************************/
+*
+* See the following URL for an explanation of this file:
+* http://www.FreeRTOS.org/FreeRTOS-Plus/FreeRTOS_Plus_TCP/Embedded_Compiler_Porting.html
+*
+*****************************************************************************/
 
 
 #ifdef _SH
-	#ifdef __RENESAS__
-		#pragma pack 1
-	#endif
+    #ifdef __RENESAS__
+        #pragma pack 1
+    #endif
 #endif
 #ifdef __RX
-	#ifdef __CCRX__
-		#pragma pack
-	#endif
+    #ifdef __CCRX__
+        #pragma pack
+    #endif
 #endif
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/portable/NetworkInterface/ATSAM4E/NetworkInterface.c
+++ b/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/portable/NetworkInterface/ATSAM4E/NetworkInterface.c
@@ -1,27 +1,27 @@
 /*
-FreeRTOS+TCP V2.2.1
-Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of
-this software and associated documentation files (the "Software"), to deal in
-the Software without restriction, including without limitation the rights to
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
-the Software, and to permit persons to whom the Software is furnished to do so,
-subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
-COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
-IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
- http://aws.amazon.com/freertos
- http://www.FreeRTOS.org
-*/
+ * FreeRTOS+TCP V2.2.1
+ * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
 
 /* Standard includes. */
 #include <stdint.h>
@@ -47,46 +47,47 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include <sysclk.h>
 #include <ethernet_phy.h>
 
-#ifndef	BMSR_LINK_STATUS
-	#define BMSR_LINK_STATUS            0x0004  //!< Link status
+#ifndef BMSR_LINK_STATUS
+    #define BMSR_LINK_STATUS    0x0004          /*!< Link status */
 #endif
 
-#ifndef	PHY_LS_HIGH_CHECK_TIME_MS
-	/* Check if the LinkSStatus in the PHY is still high after 15 seconds of not
-	receiving packets. */
-	#define PHY_LS_HIGH_CHECK_TIME_MS	15000
+#ifndef PHY_LS_HIGH_CHECK_TIME_MS
+
+    /* Check if the LinkSStatus in the PHY is still high after 15 seconds of not
+     * receiving packets. */
+    #define PHY_LS_HIGH_CHECK_TIME_MS    15000
 #endif
 
-#ifndef	PHY_LS_LOW_CHECK_TIME_MS
-	/* Check if the LinkSStatus in the PHY is still low every second. */
-	#define PHY_LS_LOW_CHECK_TIME_MS	1000
+#ifndef PHY_LS_LOW_CHECK_TIME_MS
+    /* Check if the LinkSStatus in the PHY is still low every second. */
+    #define PHY_LS_LOW_CHECK_TIME_MS    1000
 #endif
 
 /* Interrupt events to process.  Currently only the Rx event is processed
-although code for other events is included to allow for possible future
-expansion. */
-#define EMAC_IF_RX_EVENT        1UL
-#define EMAC_IF_TX_EVENT        2UL
-#define EMAC_IF_ERR_EVENT       4UL
-#define EMAC_IF_ALL_EVENT       ( EMAC_IF_RX_EVENT | EMAC_IF_TX_EVENT | EMAC_IF_ERR_EVENT )
+ * although code for other events is included to allow for possible future
+ * expansion. */
+#define EMAC_IF_RX_EVENT              1UL
+#define EMAC_IF_TX_EVENT              2UL
+#define EMAC_IF_ERR_EVENT             4UL
+#define EMAC_IF_ALL_EVENT             ( EMAC_IF_RX_EVENT | EMAC_IF_TX_EVENT | EMAC_IF_ERR_EVENT )
 
-#define ETHERNET_CONF_PHY_ADDR  BOARD_GMAC_PHY_ADDR
+#define ETHERNET_CONF_PHY_ADDR        BOARD_GMAC_PHY_ADDR
 
-#define HZ_PER_MHZ				( 1000000UL )
+#define HZ_PER_MHZ                    ( 1000000UL )
 
-#ifndef	EMAC_MAX_BLOCK_TIME_MS
-	#define	EMAC_MAX_BLOCK_TIME_MS	100ul
+#ifndef EMAC_MAX_BLOCK_TIME_MS
+    #define EMAC_MAX_BLOCK_TIME_MS    100ul
 #endif
 
 #if !defined( GMAC_USES_TX_CALLBACK ) || ( GMAC_USES_TX_CALLBACK != 1 )
-	#error Please define GMAC_USES_TX_CALLBACK as 1
+    #error Please define GMAC_USES_TX_CALLBACK as 1
 #endif
 
 /* Default the size of the stack used by the EMAC deferred handler task to 4x
-the size of the stack used by the idle task - but allow this to be overridden in
-FreeRTOSConfig.h as configMINIMAL_STACK_SIZE is a user definable constant. */
+ *  the size of the stack used by the idle task - but allow this to be overridden in
+ *  FreeRTOSConfig.h as configMINIMAL_STACK_SIZE is a user definable constant. */
 #ifndef configEMAC_TASK_STACK_SIZE
-	#define configEMAC_TASK_STACK_SIZE ( 4 * configMINIMAL_STACK_SIZE )
+    #define configEMAC_TASK_STACK_SIZE    ( 4 * configMINIMAL_STACK_SIZE )
 #endif
 
 /*-----------------------------------------------------------*/
@@ -96,20 +97,21 @@ FreeRTOSConfig.h as configMINIMAL_STACK_SIZE is a user definable constant. */
  */
 static BaseType_t xGMACWaitLS( TickType_t xMaxTime );
 
-#if( ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM == 1 ) && ( ipconfigHAS_TX_CRC_OFFLOADING == 0 )
-	void vGMACGenerateChecksum( uint8_t *apBuffer );
+#if ( ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM == 1 ) && ( ipconfigHAS_TX_CRC_OFFLOADING == 0 )
+    void vGMACGenerateChecksum( uint8_t * apBuffer );
 #endif
 
 /*
  * Called from the ASF GMAC driver.
  */
 static void prvRxCallback( uint32_t ulStatus );
-static void prvTxCallback( uint32_t ulStatus, uint8_t *puc_buffer );
+static void prvTxCallback( uint32_t ulStatus,
+                           uint8_t * puc_buffer );
 
 /*
  * A deferred interrupt handler task that processes GMAC interrupts.
  */
-static void prvEMACHandlerTask( void *pvParameters );
+static void prvEMACHandlerTask( void * pvParameters );
 
 /*
  * Initialise the ASF GMAC driver.
@@ -124,8 +126,8 @@ static uint32_t prvEMACRxPoll( void );
 /*-----------------------------------------------------------*/
 
 /* Bit map of outstanding ETH interrupt events for processing.  Currently only
-the Rx interrupt is handled, although code is included for other events to
-enable future expansion. */
+ * the Rx interrupt is handled, although code is included for other events to
+ * enable future expansion. */
 static volatile uint32_t ulISREvents;
 
 /* A copy of PHY register 1: 'PHY_REG_01_BMSR' */
@@ -133,8 +135,8 @@ static uint32_t ulPHYLinkStatus = 0;
 static volatile BaseType_t xGMACSwitchRequired;
 
 /* ethernet_phy_addr: the address of the PHY in use.
-Atmel was a bit ambiguous about it so the address will be stored
-in this variable, see ethernet_phy.c */
+ * Atmel was a bit ambiguous about it so the address will be stored
+ * in this variable, see ethernet_phy.c */
 extern int ethernet_phy_addr;
 
 /* LLMNR multicast address. */
@@ -147,16 +149,16 @@ static gmac_device_t gs_gmac_dev;
 extern const uint8_t ucMACAddress[ 6 ];
 
 /* Holds the handle of the task used as a deferred interrupt processor.  The
-handle is used so direct notifications can be sent to the task for all EMAC/DMA
-related interrupts. */
+ * handle is used so direct notifications can be sent to the task for all EMAC/DMA
+ * related interrupts. */
 TaskHandle_t xEMACTaskHandle = NULL;
 
 static QueueHandle_t xTxBufferQueue;
 int tx_release_count[ 4 ];
 
 /* xTXDescriptorSemaphore is a counting semaphore with
-a maximum count of GMAC_TX_BUFFERS, which is the number of
-DMA TX descriptors. */
+ * a maximum count of GMAC_TX_BUFFERS, which is the number of
+ * DMA TX descriptors. */
 static SemaphoreHandle_t xTXDescriptorSemaphore = NULL;
 
 /*-----------------------------------------------------------*/
@@ -164,474 +166,490 @@ static SemaphoreHandle_t xTXDescriptorSemaphore = NULL;
 /*
  * GMAC interrupt handler.
  */
-void GMAC_Handler(void)
+void GMAC_Handler( void )
 {
-	xGMACSwitchRequired = pdFALSE;
+    xGMACSwitchRequired = pdFALSE;
 
-	/* gmac_handler() may call prvRxCallback() which may change
-	the value of xGMACSwitchRequired. */
-	gmac_handler( &gs_gmac_dev );
+    /* gmac_handler() may call prvRxCallback() which may change
+     * the value of xGMACSwitchRequired. */
+    gmac_handler( &gs_gmac_dev );
 
-	if( xGMACSwitchRequired != pdFALSE )
-	{
-		portEND_SWITCHING_ISR( xGMACSwitchRequired );
-	}
+    if( xGMACSwitchRequired != pdFALSE )
+    {
+        portEND_SWITCHING_ISR( xGMACSwitchRequired );
+    }
 }
 /*-----------------------------------------------------------*/
 
 static void prvRxCallback( uint32_t ulStatus )
 {
-	if( ( ( ulStatus & GMAC_RSR_REC ) != 0 ) && ( xEMACTaskHandle != NULL ) )
-	{
-		/* let the prvEMACHandlerTask know that there was an RX event. */
-		ulISREvents |= EMAC_IF_RX_EVENT;
-		/* Only an RX interrupt can wakeup prvEMACHandlerTask. */
-		vTaskNotifyGiveFromISR( xEMACTaskHandle, ( BaseType_t * ) &xGMACSwitchRequired );
-	}
+    if( ( ( ulStatus & GMAC_RSR_REC ) != 0 ) && ( xEMACTaskHandle != NULL ) )
+    {
+        /* let the prvEMACHandlerTask know that there was an RX event. */
+        ulISREvents |= EMAC_IF_RX_EVENT;
+        /* Only an RX interrupt can wakeup prvEMACHandlerTask. */
+        vTaskNotifyGiveFromISR( xEMACTaskHandle, ( BaseType_t * ) &xGMACSwitchRequired );
+    }
 }
 /*-----------------------------------------------------------*/
 
-static void prvTxCallback( uint32_t ulStatus, uint8_t *puc_buffer )
+static void prvTxCallback( uint32_t ulStatus,
+                           uint8_t * puc_buffer )
 {
-	if( ( xTxBufferQueue != NULL ) && ( xEMACTaskHandle != NULL ) )
-	{
-		/* let the prvEMACHandlerTask know that there was an RX event. */
-		ulISREvents |= EMAC_IF_TX_EVENT;
+    if( ( xTxBufferQueue != NULL ) && ( xEMACTaskHandle != NULL ) )
+    {
+        /* let the prvEMACHandlerTask know that there was an RX event. */
+        ulISREvents |= EMAC_IF_TX_EVENT;
 
-		vTaskNotifyGiveFromISR( xEMACTaskHandle, ( BaseType_t * ) &xGMACSwitchRequired );
-		xQueueSendFromISR( xTxBufferQueue, &puc_buffer, ( BaseType_t * ) &xGMACSwitchRequired );
-		tx_release_count[ 2 ]++;
-	}
+        vTaskNotifyGiveFromISR( xEMACTaskHandle, ( BaseType_t * ) &xGMACSwitchRequired );
+        xQueueSendFromISR( xTxBufferQueue, &puc_buffer, ( BaseType_t * ) &xGMACSwitchRequired );
+        tx_release_count[ 2 ]++;
+    }
 }
 /*-----------------------------------------------------------*/
 
 BaseType_t xNetworkInterfaceInitialise( void )
 {
-const TickType_t x5_Seconds = 5000UL;
+    const TickType_t x5_Seconds = 5000UL;
 
-	if( xEMACTaskHandle == NULL )
-	{
-		prvGMACInit();
+    if( xEMACTaskHandle == NULL )
+    {
+        prvGMACInit();
 
-		/* Wait at most 5 seconds for a Link Status in the PHY. */
-		xGMACWaitLS( pdMS_TO_TICKS( x5_Seconds ) );
+        /* Wait at most 5 seconds for a Link Status in the PHY. */
+        xGMACWaitLS( pdMS_TO_TICKS( x5_Seconds ) );
 
-		/* The handler task is created at the highest possible priority to
-		ensure the interrupt handler can return directly to it. */
-		xTaskCreate( prvEMACHandlerTask, "EMAC", configEMAC_TASK_STACK_SIZE, NULL, configMAX_PRIORITIES - 1, &xEMACTaskHandle );
-		configASSERT( xEMACTaskHandle != NULL );
-	}
+        /* The handler task is created at the highest possible priority to
+         * ensure the interrupt handler can return directly to it. */
+        xTaskCreate( prvEMACHandlerTask, "EMAC", configEMAC_TASK_STACK_SIZE, NULL, configMAX_PRIORITIES - 1, &xEMACTaskHandle );
+        configASSERT( xEMACTaskHandle != NULL );
+    }
 
-	if( xTxBufferQueue == NULL )
-	{
-		xTxBufferQueue = xQueueCreate( GMAC_TX_BUFFERS, sizeof( void * ) );
-		configASSERT( xTxBufferQueue != NULL );
-	}
+    if( xTxBufferQueue == NULL )
+    {
+        xTxBufferQueue = xQueueCreate( GMAC_TX_BUFFERS, sizeof( void * ) );
+        configASSERT( xTxBufferQueue != NULL );
+    }
 
-	if( xTXDescriptorSemaphore == NULL )
-	{
-		xTXDescriptorSemaphore = xSemaphoreCreateCounting( ( UBaseType_t ) GMAC_TX_BUFFERS, ( UBaseType_t ) GMAC_TX_BUFFERS );
-		configASSERT( xTXDescriptorSemaphore != NULL );
-	}
-	/* When returning non-zero, the stack will become active and
-    start DHCP (in configured) */
-	return ( ulPHYLinkStatus & BMSR_LINK_STATUS ) != 0;
+    if( xTXDescriptorSemaphore == NULL )
+    {
+        xTXDescriptorSemaphore = xSemaphoreCreateCounting( ( UBaseType_t ) GMAC_TX_BUFFERS, ( UBaseType_t ) GMAC_TX_BUFFERS );
+        configASSERT( xTXDescriptorSemaphore != NULL );
+    }
+
+    /* When returning non-zero, the stack will become active and
+     * start DHCP (in configured) */
+    return ( ulPHYLinkStatus & BMSR_LINK_STATUS ) != 0;
 }
 /*-----------------------------------------------------------*/
 
 BaseType_t xGetPhyLinkStatus( void )
 {
-BaseType_t xResult;
+    BaseType_t xResult;
 
-	/* This function returns true if the Link Status in the PHY is high. */
-	if( ( ulPHYLinkStatus & BMSR_LINK_STATUS ) != 0 )
-	{
-		xResult = pdTRUE;
-	}
-	else
-	{
-		xResult = pdFALSE;
-	}
+    /* This function returns true if the Link Status in the PHY is high. */
+    if( ( ulPHYLinkStatus & BMSR_LINK_STATUS ) != 0 )
+    {
+        xResult = pdTRUE;
+    }
+    else
+    {
+        xResult = pdFALSE;
+    }
 
-	return xResult;
+    return xResult;
 }
 /*-----------------------------------------------------------*/
 
-BaseType_t xNetworkInterfaceOutput( NetworkBufferDescriptor_t * const pxDescriptor, BaseType_t bReleaseAfterSend )
+BaseType_t xNetworkInterfaceOutput( NetworkBufferDescriptor_t * const pxDescriptor,
+                                    BaseType_t bReleaseAfterSend )
 {
 /* Do not wait too long for a free TX DMA buffer. */
-const TickType_t xBlockTimeTicks = pdMS_TO_TICKS( 50u );
+    const TickType_t xBlockTimeTicks = pdMS_TO_TICKS( 50u );
 
-	do {
-		if( ( ulPHYLinkStatus & BMSR_LINK_STATUS ) == 0 )
-		{
-			/* Do not attempt to send packets as long as the Link Status is low. */
-			break;
-		}
-		if( xTXDescriptorSemaphore == NULL )
-		{
-			/* Semaphore has not been created yet? */
-			break;
-		}
-		if( xSemaphoreTake( xTXDescriptorSemaphore, xBlockTimeTicks ) != pdPASS )
-		{
-			/* Time-out waiting for a free TX descriptor. */
-			tx_release_count[ 3 ]++;
-			break;
-		}
-		#if( ipconfigZERO_COPY_TX_DRIVER != 0 )
-		{
-			/* Confirm that the pxDescriptor may be kept by the driver. */
-			configASSERT( bReleaseAfterSend != pdFALSE );
-		}
-		#endif /* ipconfigZERO_COPY_TX_DRIVER */
+    do
+    {
+        if( ( ulPHYLinkStatus & BMSR_LINK_STATUS ) == 0 )
+        {
+            /* Do not attempt to send packets as long as the Link Status is low. */
+            break;
+        }
 
-		gmac_dev_write( &gs_gmac_dev, (void *)pxDescriptor->pucEthernetBuffer, pxDescriptor->xDataLength, prvTxCallback );
+        if( xTXDescriptorSemaphore == NULL )
+        {
+            /* Semaphore has not been created yet? */
+            break;
+        }
 
-		#if( ipconfigZERO_COPY_TX_DRIVER != 0 )
-		{
-			/* Confirm that the pxDescriptor may be kept by the driver. */
-			bReleaseAfterSend = pdFALSE;
-		}
-		#endif /* ipconfigZERO_COPY_TX_DRIVER */
-		/* Not interested in a call-back after TX. */
-		iptraceNETWORK_INTERFACE_TRANSMIT();
-	} while( ipFALSE_BOOL );
+        if( xSemaphoreTake( xTXDescriptorSemaphore, xBlockTimeTicks ) != pdPASS )
+        {
+            /* Time-out waiting for a free TX descriptor. */
+            tx_release_count[ 3 ]++;
+            break;
+        }
 
-	if( bReleaseAfterSend != pdFALSE )
-	{
-		vReleaseNetworkBufferAndDescriptor( pxDescriptor );
-	}
-	return pdTRUE;
+        #if ( ipconfigZERO_COPY_TX_DRIVER != 0 )
+            {
+                /* Confirm that the pxDescriptor may be kept by the driver. */
+                configASSERT( bReleaseAfterSend != pdFALSE );
+            }
+        #endif /* ipconfigZERO_COPY_TX_DRIVER */
+
+        gmac_dev_write( &gs_gmac_dev, ( void * ) pxDescriptor->pucEthernetBuffer, pxDescriptor->xDataLength, prvTxCallback );
+
+        #if ( ipconfigZERO_COPY_TX_DRIVER != 0 )
+            {
+                /* Confirm that the pxDescriptor may be kept by the driver. */
+                bReleaseAfterSend = pdFALSE;
+            }
+        #endif /* ipconfigZERO_COPY_TX_DRIVER */
+        /* Not interested in a call-back after TX. */
+        iptraceNETWORK_INTERFACE_TRANSMIT();
+    } while( ipFALSE_BOOL );
+
+    if( bReleaseAfterSend != pdFALSE )
+    {
+        vReleaseNetworkBufferAndDescriptor( pxDescriptor );
+    }
+
+    return pdTRUE;
 }
 /*-----------------------------------------------------------*/
 
 static BaseType_t prvGMACInit( void )
 {
-uint32_t ncfgr;
+    uint32_t ncfgr;
 
-	gmac_options_t gmac_option;
+    gmac_options_t gmac_option;
 
-	memset( &gmac_option, '\0', sizeof( gmac_option ) );
-	gmac_option.uc_copy_all_frame = 0;
-	gmac_option.uc_no_boardcast = 0;
-	memcpy( gmac_option.uc_mac_addr, ucMACAddress, sizeof( gmac_option.uc_mac_addr ) );
+    memset( &gmac_option, '\0', sizeof( gmac_option ) );
+    gmac_option.uc_copy_all_frame = 0;
+    gmac_option.uc_no_boardcast = 0;
+    memcpy( gmac_option.uc_mac_addr, ucMACAddress, sizeof( gmac_option.uc_mac_addr ) );
 
-	gs_gmac_dev.p_hw = GMAC;
-	gmac_dev_init( GMAC, &gs_gmac_dev, &gmac_option );
+    gs_gmac_dev.p_hw = GMAC;
+    gmac_dev_init( GMAC, &gs_gmac_dev, &gmac_option );
 
-	NVIC_SetPriority( GMAC_IRQn, configMAC_INTERRUPT_PRIORITY );
-	NVIC_EnableIRQ( GMAC_IRQn );
+    NVIC_SetPriority( GMAC_IRQn, configMAC_INTERRUPT_PRIORITY );
+    NVIC_EnableIRQ( GMAC_IRQn );
 
-	/* Contact the Ethernet PHY and store it's address in 'ethernet_phy_addr' */
-	ethernet_phy_init( GMAC, ETHERNET_CONF_PHY_ADDR, sysclk_get_cpu_hz() );
+    /* Contact the Ethernet PHY and store it's address in 'ethernet_phy_addr' */
+    ethernet_phy_init( GMAC, ETHERNET_CONF_PHY_ADDR, sysclk_get_cpu_hz() );
 
-	ethernet_phy_auto_negotiate( GMAC, ethernet_phy_addr );
-	ethernet_phy_set_link( GMAC, ethernet_phy_addr, 1 );
+    ethernet_phy_auto_negotiate( GMAC, ethernet_phy_addr );
+    ethernet_phy_set_link( GMAC, ethernet_phy_addr, 1 );
 
-	/* The GMAC driver will call a hook prvRxCallback(), which
-	in turn will wake-up the task by calling vTaskNotifyGiveFromISR() */
-	gmac_dev_set_rx_callback( &gs_gmac_dev, prvRxCallback );
-	gmac_set_address( GMAC, 1, (uint8_t*)llmnr_mac_address );
+    /* The GMAC driver will call a hook prvRxCallback(), which
+     * in turn will wake-up the task by calling vTaskNotifyGiveFromISR() */
+    gmac_dev_set_rx_callback( &gs_gmac_dev, prvRxCallback );
+    gmac_set_address( GMAC, 1, ( uint8_t * ) llmnr_mac_address );
 
-	ncfgr = GMAC_NCFGR_SPD | GMAC_NCFGR_FD;
+    ncfgr = GMAC_NCFGR_SPD | GMAC_NCFGR_FD;
 
-	GMAC->GMAC_NCFGR = ( GMAC->GMAC_NCFGR & ~( GMAC_NCFGR_SPD | GMAC_NCFGR_FD ) ) | ncfgr;
+    GMAC->GMAC_NCFGR = ( GMAC->GMAC_NCFGR & ~( GMAC_NCFGR_SPD | GMAC_NCFGR_FD ) ) | ncfgr;
 
-	return 1;
+    return 1;
 }
 /*-----------------------------------------------------------*/
 
 static inline unsigned long ulReadMDIO( unsigned /*short*/ usAddress )
 {
-uint32_t ulValue, ulReturn;
-int rc;
+    uint32_t ulValue, ulReturn;
+    int rc;
 
-	gmac_enable_management( GMAC, 1 );
-	rc = gmac_phy_read( GMAC, ethernet_phy_addr, usAddress, &ulValue );
-	gmac_enable_management( GMAC, 0 );
-	if( rc == GMAC_OK )
-	{
-		ulReturn = ulValue;
-	}
-	else
-	{
-		ulReturn = 0UL;
-	}
+    gmac_enable_management( GMAC, 1 );
+    rc = gmac_phy_read( GMAC, ethernet_phy_addr, usAddress, &ulValue );
+    gmac_enable_management( GMAC, 0 );
 
-	return ulReturn;
+    if( rc == GMAC_OK )
+    {
+        ulReturn = ulValue;
+    }
+    else
+    {
+        ulReturn = 0UL;
+    }
+
+    return ulReturn;
 }
 /*-----------------------------------------------------------*/
 
 static BaseType_t xGMACWaitLS( TickType_t xMaxTime )
 {
-TickType_t xStartTime = xTaskGetTickCount();
-TickType_t xEndTime;
-BaseType_t xReturn;
-const TickType_t xShortTime = pdMS_TO_TICKS( 100UL );
+    TickType_t xStartTime = xTaskGetTickCount();
+    TickType_t xEndTime;
+    BaseType_t xReturn;
+    const TickType_t xShortTime = pdMS_TO_TICKS( 100UL );
 
-	for( ;; )
-	{
-		xEndTime = xTaskGetTickCount();
+    for( ; ; )
+    {
+        xEndTime = xTaskGetTickCount();
 
-		if( ( xEndTime - xStartTime ) > xMaxTime )
-		{
-			/* Wated more than xMaxTime, return. */
-			xReturn = pdFALSE;
-			break;
-		}
+        if( ( xEndTime - xStartTime ) > xMaxTime )
+        {
+            /* Wated more than xMaxTime, return. */
+            xReturn = pdFALSE;
+            break;
+        }
 
-		/* Check the link status again. */
-		ulPHYLinkStatus = ulReadMDIO( PHY_REG_01_BMSR );
+        /* Check the link status again. */
+        ulPHYLinkStatus = ulReadMDIO( PHY_REG_01_BMSR );
 
-		if( ( ulPHYLinkStatus & BMSR_LINK_STATUS ) != 0 )
-		{
-			/* Link is up - return. */
-			xReturn = pdTRUE;
-			break;
-		}
+        if( ( ulPHYLinkStatus & BMSR_LINK_STATUS ) != 0 )
+        {
+            /* Link is up - return. */
+            xReturn = pdTRUE;
+            break;
+        }
 
-		/* Link is down - wait in the Blocked state for a short while (to allow
-		other tasks to execute) before checking again. */
-		vTaskDelay( xShortTime );
-	}
+        /* Link is down - wait in the Blocked state for a short while (to allow
+         * other tasks to execute) before checking again. */
+        vTaskDelay( xShortTime );
+    }
 
-	FreeRTOS_printf( ( "xGMACWaitLS: %ld (PHY %d) freq %lu Mz\n",
-		xReturn,
-		ethernet_phy_addr,
-		sysclk_get_cpu_hz() / HZ_PER_MHZ ) );
+    FreeRTOS_printf( ( "xGMACWaitLS: %ld (PHY %d) freq %lu Mz\n",
+                       xReturn,
+                       ethernet_phy_addr,
+                       sysclk_get_cpu_hz() / HZ_PER_MHZ ) );
 
-	return xReturn;
+    return xReturn;
 }
 /*-----------------------------------------------------------*/
 
-//#if( ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM == 1 ) && ( ipconfigHAS_TX_CRC_OFFLOADING == 0 )
+/*#if( ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM == 1 ) && ( ipconfigHAS_TX_CRC_OFFLOADING == 0 ) */
 
-	void vGMACGenerateChecksum( uint8_t *apBuffer )
-	{
-	ProtocolPacket_t *xProtPacket = (ProtocolPacket_t *)apBuffer;
+void vGMACGenerateChecksum( uint8_t * apBuffer )
+{
+    ProtocolPacket_t * xProtPacket = ( ProtocolPacket_t * ) apBuffer;
 
-		if ( xProtPacket->xTCPPacket.xEthernetHeader.usFrameType == ipIPv4_FRAME_TYPE )
-		{
-			IPHeader_t *pxIPHeader = &(xProtPacket->xTCPPacket.xIPHeader);
+    if( xProtPacket->xTCPPacket.xEthernetHeader.usFrameType == ipIPv4_FRAME_TYPE )
+    {
+        IPHeader_t * pxIPHeader = &( xProtPacket->xTCPPacket.xIPHeader );
 
-			/* Calculate the IP header checksum. */
-			pxIPHeader->usHeaderChecksum = 0x00;
-			pxIPHeader->usHeaderChecksum = usGenerateChecksum( 0U, ( uint8_t * ) &( pxIPHeader->ucVersionHeaderLength ), ipSIZE_OF_IPv4_HEADER );
-			pxIPHeader->usHeaderChecksum = ~FreeRTOS_htons( pxIPHeader->usHeaderChecksum );
+        /* Calculate the IP header checksum. */
+        pxIPHeader->usHeaderChecksum = 0x00;
+        pxIPHeader->usHeaderChecksum = usGenerateChecksum( 0U, ( uint8_t * ) &( pxIPHeader->ucVersionHeaderLength ), ipSIZE_OF_IPv4_HEADER );
+        pxIPHeader->usHeaderChecksum = ~FreeRTOS_htons( pxIPHeader->usHeaderChecksum );
 
-			/* Calculate the TCP checksum for an outgoing packet. */
-			usGenerateProtocolChecksum( ( uint8_t * ) apBuffer, pdTRUE );
-		}
-	}
+        /* Calculate the TCP checksum for an outgoing packet. */
+        usGenerateProtocolChecksum( ( uint8_t * ) apBuffer, pdTRUE );
+    }
+}
 
-//#endif
+/*#endif */
 /*-----------------------------------------------------------*/
 
 static uint32_t prvEMACRxPoll( void )
 {
-unsigned char *pucUseBuffer;
-uint32_t ulReceiveCount, ulResult, ulReturnValue = 0;
-static NetworkBufferDescriptor_t *pxNextNetworkBufferDescriptor = NULL;
-const UBaseType_t xMinDescriptorsToLeave = 2UL;
-const TickType_t xBlockTime = pdMS_TO_TICKS( 100UL );
-static IPStackEvent_t xRxEvent = { eNetworkRxEvent, NULL };
+    unsigned char * pucUseBuffer;
+    uint32_t ulReceiveCount, ulResult, ulReturnValue = 0;
+    static NetworkBufferDescriptor_t * pxNextNetworkBufferDescriptor = NULL;
+    const UBaseType_t xMinDescriptorsToLeave = 2UL;
+    const TickType_t xBlockTime = pdMS_TO_TICKS( 100UL );
+    static IPStackEvent_t xRxEvent = { eNetworkRxEvent, NULL };
 
-	for( ;; )
-	{
-		/* If pxNextNetworkBufferDescriptor was not left pointing at a valid
-		descriptor then allocate one now. */
-		if( ( pxNextNetworkBufferDescriptor == NULL ) && ( uxGetNumberOfFreeNetworkBuffers() > xMinDescriptorsToLeave ) )
-		{
-			pxNextNetworkBufferDescriptor = pxGetNetworkBufferWithDescriptor( ipTOTAL_ETHERNET_FRAME_SIZE, xBlockTime );
-		}
+    for( ; ; )
+    {
+        /* If pxNextNetworkBufferDescriptor was not left pointing at a valid
+         * descriptor then allocate one now. */
+        if( ( pxNextNetworkBufferDescriptor == NULL ) && ( uxGetNumberOfFreeNetworkBuffers() > xMinDescriptorsToLeave ) )
+        {
+            pxNextNetworkBufferDescriptor = pxGetNetworkBufferWithDescriptor( ipTOTAL_ETHERNET_FRAME_SIZE, xBlockTime );
+        }
 
-		if( pxNextNetworkBufferDescriptor != NULL )
-		{
-			/* Point pucUseBuffer to the buffer pointed to by the descriptor. */
-			pucUseBuffer = ( unsigned char* ) ( pxNextNetworkBufferDescriptor->pucEthernetBuffer - ipconfigPACKET_FILLER_SIZE );
-		}
-		else
-		{
-			/* As long as pxNextNetworkBufferDescriptor is NULL, the incoming
-			messages will be flushed and ignored. */
-			pucUseBuffer = NULL;
-		}
+        if( pxNextNetworkBufferDescriptor != NULL )
+        {
+            /* Point pucUseBuffer to the buffer pointed to by the descriptor. */
+            pucUseBuffer = ( unsigned char * ) ( pxNextNetworkBufferDescriptor->pucEthernetBuffer - ipconfigPACKET_FILLER_SIZE );
+        }
+        else
+        {
+            /* As long as pxNextNetworkBufferDescriptor is NULL, the incoming
+             * messages will be flushed and ignored. */
+            pucUseBuffer = NULL;
+        }
 
-		/* Read the next packet from the hardware into pucUseBuffer. */
-		ulResult = gmac_dev_read( &gs_gmac_dev, pucUseBuffer, ipTOTAL_ETHERNET_FRAME_SIZE, &ulReceiveCount );
+        /* Read the next packet from the hardware into pucUseBuffer. */
+        ulResult = gmac_dev_read( &gs_gmac_dev, pucUseBuffer, ipTOTAL_ETHERNET_FRAME_SIZE, &ulReceiveCount );
 
-		if( ( ulResult != GMAC_OK ) || ( ulReceiveCount == 0 ) )
-		{
-			/* No data from the hardware. */
-			break;
-		}
+        if( ( ulResult != GMAC_OK ) || ( ulReceiveCount == 0 ) )
+        {
+            /* No data from the hardware. */
+            break;
+        }
 
-		if( pxNextNetworkBufferDescriptor == NULL )
-		{
-			/* Data was read from the hardware, but no descriptor was available
-			for it, so it will be dropped. */
-			iptraceETHERNET_RX_EVENT_LOST();
-			continue;
-		}
+        if( pxNextNetworkBufferDescriptor == NULL )
+        {
+            /* Data was read from the hardware, but no descriptor was available
+             * for it, so it will be dropped. */
+            iptraceETHERNET_RX_EVENT_LOST();
+            continue;
+        }
 
-		iptraceNETWORK_INTERFACE_RECEIVE();
-		pxNextNetworkBufferDescriptor->xDataLength = ( size_t ) ulReceiveCount;
-		xRxEvent.pvData = ( void * ) pxNextNetworkBufferDescriptor;
+        iptraceNETWORK_INTERFACE_RECEIVE();
+        pxNextNetworkBufferDescriptor->xDataLength = ( size_t ) ulReceiveCount;
+        xRxEvent.pvData = ( void * ) pxNextNetworkBufferDescriptor;
 
-		/* Send the descriptor to the IP task for processing. */
-		if( xSendEventStructToIPTask( &xRxEvent, xBlockTime ) != pdTRUE )
-		{
-			/* The buffer could not be sent to the stack so must be released
-			again. */
-			vReleaseNetworkBufferAndDescriptor( pxNextNetworkBufferDescriptor );
-			iptraceETHERNET_RX_EVENT_LOST();
-			FreeRTOS_printf( ( "prvEMACRxPoll: Can not queue return packet!\n" ) );
-		}
+        /* Send the descriptor to the IP task for processing. */
+        if( xSendEventStructToIPTask( &xRxEvent, xBlockTime ) != pdTRUE )
+        {
+            /* The buffer could not be sent to the stack so must be released
+             * again. */
+            vReleaseNetworkBufferAndDescriptor( pxNextNetworkBufferDescriptor );
+            iptraceETHERNET_RX_EVENT_LOST();
+            FreeRTOS_printf( ( "prvEMACRxPoll: Can not queue return packet!\n" ) );
+        }
 
-		/* Now the buffer has either been passed to the IP-task,
-		or it has been released in the code above. */
-		pxNextNetworkBufferDescriptor = NULL;
-		ulReturnValue++;
-	}
+        /* Now the buffer has either been passed to the IP-task,
+         * or it has been released in the code above. */
+        pxNextNetworkBufferDescriptor = NULL;
+        ulReturnValue++;
+    }
 
-	return ulReturnValue;
+    return ulReturnValue;
 }
 /*-----------------------------------------------------------*/
 
-static void prvEMACHandlerTask( void *pvParameters )
+static void prvEMACHandlerTask( void * pvParameters )
 {
-TimeOut_t xPhyTime;
-TickType_t xPhyRemTime;
-UBaseType_t uxLastMinBufferCount = 0, uxCount;
-UBaseType_t uxCurrentCount;
-#if( ipconfigCHECK_IP_QUEUE_SPACE != 0 )
-	UBaseType_t uxLastMinQueueSpace;
-#endif
-#if( ipconfigZERO_COPY_TX_DRIVER != 0 )
-	NetworkBufferDescriptor_t *pxBuffer;
-#endif
-uint8_t *pucBuffer;
-BaseType_t xResult = 0;
-uint32_t xStatus;
-const TickType_t ulMaxBlockTime = pdMS_TO_TICKS( EMAC_MAX_BLOCK_TIME_MS );
+    TimeOut_t xPhyTime;
+    TickType_t xPhyRemTime;
+    UBaseType_t uxLastMinBufferCount = 0, uxCount;
+    UBaseType_t uxCurrentCount;
 
-	/* Remove compiler warnings about unused parameters. */
-	( void ) pvParameters;
+    #if ( ipconfigCHECK_IP_QUEUE_SPACE != 0 )
+        UBaseType_t uxLastMinQueueSpace;
+    #endif
+    #if ( ipconfigZERO_COPY_TX_DRIVER != 0 )
+        NetworkBufferDescriptor_t * pxBuffer;
+    #endif
+    uint8_t * pucBuffer;
+    BaseType_t xResult = 0;
+    uint32_t xStatus;
+    const TickType_t ulMaxBlockTime = pdMS_TO_TICKS( EMAC_MAX_BLOCK_TIME_MS );
 
-	configASSERT( xEMACTaskHandle != NULL );
+    /* Remove compiler warnings about unused parameters. */
+    ( void ) pvParameters;
 
-	vTaskSetTimeOutState( &xPhyTime );
-	xPhyRemTime = pdMS_TO_TICKS( PHY_LS_LOW_CHECK_TIME_MS );
+    configASSERT( xEMACTaskHandle != NULL );
 
-	for( ;; )
-	{
-		uxCurrentCount = uxGetMinimumFreeNetworkBuffers();
-		if( uxLastMinBufferCount != uxCurrentCount )
-		{
-			/* The logging produced below may be helpful
-			while tuning +TCP: see how many buffers are in use. */
-			uxLastMinBufferCount = uxCurrentCount;
-			FreeRTOS_printf( ( "Network buffers: %lu lowest %lu\n",
-				uxGetNumberOfFreeNetworkBuffers(), uxCurrentCount ) );
-		}
+    vTaskSetTimeOutState( &xPhyTime );
+    xPhyRemTime = pdMS_TO_TICKS( PHY_LS_LOW_CHECK_TIME_MS );
 
-		#if( ipconfigCHECK_IP_QUEUE_SPACE != 0 )
-		{
-			uxCurrentCount = uxGetMinimumIPQueueSpace();
-			if( uxLastMinQueueSpace != uxCurrentCount )
-			{
-				/* The logging produced below may be helpful
-				while tuning +TCP: see how many buffers are in use. */
-				uxLastMinQueueSpace = uxCurrentCount;
-				FreeRTOS_printf( ( "Queue space: lowest %lu\n", uxCurrentCount ) );
-			}
-		}
-		#endif /* ipconfigCHECK_IP_QUEUE_SPACE */
+    for( ; ; )
+    {
+        uxCurrentCount = uxGetMinimumFreeNetworkBuffers();
 
-		if( ( ulISREvents & EMAC_IF_ALL_EVENT ) == 0 )
-		{
-			/* No events to process now, wait for the next. */
-			ulTaskNotifyTake( pdFALSE, ulMaxBlockTime );
-		}
+        if( uxLastMinBufferCount != uxCurrentCount )
+        {
+            /* The logging produced below may be helpful
+             * while tuning +TCP: see how many buffers are in use. */
+            uxLastMinBufferCount = uxCurrentCount;
+            FreeRTOS_printf( ( "Network buffers: %lu lowest %lu\n",
+                               uxGetNumberOfFreeNetworkBuffers(), uxCurrentCount ) );
+        }
 
-		if( ( ulISREvents & EMAC_IF_RX_EVENT ) != 0 )
-		{
-			ulISREvents &= ~EMAC_IF_RX_EVENT;
+        #if ( ipconfigCHECK_IP_QUEUE_SPACE != 0 )
+            {
+                uxCurrentCount = uxGetMinimumIPQueueSpace();
 
-			/* Wait for the EMAC interrupt to indicate that another packet has been
-			received. */
-			xResult = prvEMACRxPoll();
-		}
+                if( uxLastMinQueueSpace != uxCurrentCount )
+                {
+                    /* The logging produced below may be helpful
+                     * while tuning +TCP: see how many buffers are in use. */
+                    uxLastMinQueueSpace = uxCurrentCount;
+                    FreeRTOS_printf( ( "Queue space: lowest %lu\n", uxCurrentCount ) );
+                }
+            }
+        #endif /* ipconfigCHECK_IP_QUEUE_SPACE */
 
-		if( ( ulISREvents & EMAC_IF_TX_EVENT ) != 0 )
-		{
-			/* Future extension: code to release TX buffers if zero-copy is used. */
-			ulISREvents &= ~EMAC_IF_TX_EVENT;
-			while( xQueueReceive( xTxBufferQueue, &pucBuffer, 0 ) != pdFALSE )
-			{
-				#if( ipconfigZERO_COPY_TX_DRIVER != 0 )
-				{
-					pxBuffer = pxPacketBuffer_to_NetworkBuffer( pucBuffer );
-					if( pxBuffer != NULL )
-					{
-						vReleaseNetworkBufferAndDescriptor( pxBuffer );
-						tx_release_count[ 0 ]++;
-					}
-					else
-					{
-						tx_release_count[ 1 ]++;
-					}
-				}
-				#else
-				{
-					tx_release_count[ 0 ]++;
-				}
-				#endif
-				uxCount = uxQueueMessagesWaiting( ( QueueHandle_t ) xTXDescriptorSemaphore );
-				if( uxCount < GMAC_TX_BUFFERS )
-				{
-					/* Tell the counting semaphore that one more TX descriptor is available. */
-					xSemaphoreGive( xTXDescriptorSemaphore );
-				}
-			}
-		}
+        if( ( ulISREvents & EMAC_IF_ALL_EVENT ) == 0 )
+        {
+            /* No events to process now, wait for the next. */
+            ulTaskNotifyTake( pdFALSE, ulMaxBlockTime );
+        }
 
-		if( ( ulISREvents & EMAC_IF_ERR_EVENT ) != 0 )
-		{
-			/* Future extension: logging about errors that occurred. */
-			ulISREvents &= ~EMAC_IF_ERR_EVENT;
-		}
+        if( ( ulISREvents & EMAC_IF_RX_EVENT ) != 0 )
+        {
+            ulISREvents &= ~EMAC_IF_RX_EVENT;
 
-		if( xResult > 0 )
-		{
-			/* A packet was received. No need to check for the PHY status now,
-			but set a timer to check it later on. */
-			vTaskSetTimeOutState( &xPhyTime );
-			xPhyRemTime = pdMS_TO_TICKS( PHY_LS_HIGH_CHECK_TIME_MS );
-			xResult = 0;
-		}
-		else if( xTaskCheckForTimeOut( &xPhyTime, &xPhyRemTime ) != pdFALSE )
-		{
-			/* Check the link status again. */
-			xStatus = ulReadMDIO( PHY_REG_01_BMSR );
+            /* Wait for the EMAC interrupt to indicate that another packet has been
+             * received. */
+            xResult = prvEMACRxPoll();
+        }
 
-			if( ( ulPHYLinkStatus & BMSR_LINK_STATUS ) != ( xStatus & BMSR_LINK_STATUS ) )
-			{
-				ulPHYLinkStatus = xStatus;
-				FreeRTOS_printf( ( "prvEMACHandlerTask: PHY LS now %d\n", ( ulPHYLinkStatus & BMSR_LINK_STATUS ) != 0 ) );
-			}
+        if( ( ulISREvents & EMAC_IF_TX_EVENT ) != 0 )
+        {
+            /* Future extension: code to release TX buffers if zero-copy is used. */
+            ulISREvents &= ~EMAC_IF_TX_EVENT;
 
-			vTaskSetTimeOutState( &xPhyTime );
-			if( ( ulPHYLinkStatus & BMSR_LINK_STATUS ) != 0 )
-			{
-				xPhyRemTime = pdMS_TO_TICKS( PHY_LS_HIGH_CHECK_TIME_MS );
-			}
-			else
-			{
-				xPhyRemTime = pdMS_TO_TICKS( PHY_LS_LOW_CHECK_TIME_MS );
-			}
-		}
-	}
+            while( xQueueReceive( xTxBufferQueue, &pucBuffer, 0 ) != pdFALSE )
+            {
+                #if ( ipconfigZERO_COPY_TX_DRIVER != 0 )
+                    {
+                        pxBuffer = pxPacketBuffer_to_NetworkBuffer( pucBuffer );
+
+                        if( pxBuffer != NULL )
+                        {
+                            vReleaseNetworkBufferAndDescriptor( pxBuffer );
+                            tx_release_count[ 0 ]++;
+                        }
+                        else
+                        {
+                            tx_release_count[ 1 ]++;
+                        }
+                    }
+                #else /* if ( ipconfigZERO_COPY_TX_DRIVER != 0 ) */
+                    {
+                        tx_release_count[ 0 ]++;
+                    }
+                #endif /* if ( ipconfigZERO_COPY_TX_DRIVER != 0 ) */
+                uxCount = uxQueueMessagesWaiting( ( QueueHandle_t ) xTXDescriptorSemaphore );
+
+                if( uxCount < GMAC_TX_BUFFERS )
+                {
+                    /* Tell the counting semaphore that one more TX descriptor is available. */
+                    xSemaphoreGive( xTXDescriptorSemaphore );
+                }
+            }
+        }
+
+        if( ( ulISREvents & EMAC_IF_ERR_EVENT ) != 0 )
+        {
+            /* Future extension: logging about errors that occurred. */
+            ulISREvents &= ~EMAC_IF_ERR_EVENT;
+        }
+
+        if( xResult > 0 )
+        {
+            /* A packet was received. No need to check for the PHY status now,
+             * but set a timer to check it later on. */
+            vTaskSetTimeOutState( &xPhyTime );
+            xPhyRemTime = pdMS_TO_TICKS( PHY_LS_HIGH_CHECK_TIME_MS );
+            xResult = 0;
+        }
+        else if( xTaskCheckForTimeOut( &xPhyTime, &xPhyRemTime ) != pdFALSE )
+        {
+            /* Check the link status again. */
+            xStatus = ulReadMDIO( PHY_REG_01_BMSR );
+
+            if( ( ulPHYLinkStatus & BMSR_LINK_STATUS ) != ( xStatus & BMSR_LINK_STATUS ) )
+            {
+                ulPHYLinkStatus = xStatus;
+                FreeRTOS_printf( ( "prvEMACHandlerTask: PHY LS now %d\n", ( ulPHYLinkStatus & BMSR_LINK_STATUS ) != 0 ) );
+            }
+
+            vTaskSetTimeOutState( &xPhyTime );
+
+            if( ( ulPHYLinkStatus & BMSR_LINK_STATUS ) != 0 )
+            {
+                xPhyRemTime = pdMS_TO_TICKS( PHY_LS_HIGH_CHECK_TIME_MS );
+            }
+            else
+            {
+                xPhyRemTime = pdMS_TO_TICKS( PHY_LS_LOW_CHECK_TIME_MS );
+            }
+        }
+    }
 }
 /*-----------------------------------------------------------*/

--- a/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/portable/NetworkInterface/ATSAM4E/component/gmac.h
+++ b/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/portable/NetworkInterface/ATSAM4E/component/gmac.h
@@ -48,697 +48,699 @@
 /** \addtogroup SAM4E_GMAC Gigabit Ethernet MAC */
 /*@{*/
 
-#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#if !( defined( __ASSEMBLY__ ) || defined( __IAR_SYSTEMS_ASM__ ) )
 /** \brief GmacSa hardware registers */
-typedef struct {
-  RwReg   GMAC_SAB;        /**< \brief (GmacSa Offset: 0x0) Specific Address 1 Bottom [31:0] Register */
-  RwReg   GMAC_SAT;        /**< \brief (GmacSa Offset: 0x4) Specific Address 1 Top [47:32] Register */
-} GmacSa;
+    typedef struct
+    {
+        RwReg GMAC_SAB; /**< \brief (GmacSa Offset: 0x0) Specific Address 1 Bottom [31:0] Register */
+        RwReg GMAC_SAT; /**< \brief (GmacSa Offset: 0x4) Specific Address 1 Top [47:32] Register */
+    } GmacSa;
 /** \brief Gmac hardware registers */
-#define GMACSA_NUMBER 4
-typedef struct {
-  RwReg   GMAC_NCR;        /**< \brief (Gmac Offset: 0x000) Network Control Register */
-  RwReg   GMAC_NCFGR;      /**< \brief (Gmac Offset: 0x004) Network Configuration Register */
-  RoReg   GMAC_NSR;        /**< \brief (Gmac Offset: 0x008) Network Status Register */
-  RwReg   GMAC_UR;         /**< \brief (Gmac Offset: 0x00C) User Register */
-  RwReg   GMAC_DCFGR;      /**< \brief (Gmac Offset: 0x010) DMA Configuration Register */
-  RwReg   GMAC_TSR;        /**< \brief (Gmac Offset: 0x014) Transmit Status Register */
-  RwReg   GMAC_RBQB;       /**< \brief (Gmac Offset: 0x018) Receive Buffer Queue Base Address */
-  RwReg   GMAC_TBQB;       /**< \brief (Gmac Offset: 0x01C) Transmit Buffer Queue Base Address */
-  RwReg   GMAC_RSR;        /**< \brief (Gmac Offset: 0x020) Receive Status Register */
-  RoReg   GMAC_ISR;        /**< \brief (Gmac Offset: 0x024) Interrupt Status Register */
-  WoReg   GMAC_IER;        /**< \brief (Gmac Offset: 0x028) Interrupt Enable Register */
-  WoReg   GMAC_IDR;        /**< \brief (Gmac Offset: 0x02C) Interrupt Disable Register */
-  RoReg   GMAC_IMR;        /**< \brief (Gmac Offset: 0x030) Interrupt Mask Register */
-  RwReg   GMAC_MAN;        /**< \brief (Gmac Offset: 0x034) PHY Maintenance Register */
-  RoReg   GMAC_RPQ;        /**< \brief (Gmac Offset: 0x038) Received Pause Quantum Register */
-  RwReg   GMAC_TPQ;        /**< \brief (Gmac Offset: 0x03C) Transmit Pause Quantum Register */
-  RwReg   GMAC_TPSF;       /**< \brief (Gmac Offset: 0x040) TX Partial Store and Forward Register */
-  RwReg   GMAC_RPSF;       /**< \brief (Gmac Offset: 0x044) RX Partial Store and Forward Register */
-  RoReg   Reserved1[14];
-  RwReg   GMAC_HRB;        /**< \brief (Gmac Offset: 0x080) Hash Register Bottom [31:0] */
-  RwReg   GMAC_HRT;        /**< \brief (Gmac Offset: 0x084) Hash Register Top [63:32] */
-  GmacSa  GMAC_SA[GMACSA_NUMBER]; /**< \brief (Gmac Offset: 0x088) 1 .. 4 */
-  RwReg   GMAC_TIDM[4];    /**< \brief (Gmac Offset: 0x0A8) Type ID Match 1 Register */
-  RwReg   GMAC_WOL;        /**< \brief (Gmac Offset: 0x0B8) Wake on LAN Register */
-  RwReg   GMAC_IPGS;       /**< \brief (Gmac Offset: 0x0BC) IPG Stretch Register */
-  RwReg   GMAC_SVLAN;      /**< \brief (Gmac Offset: 0x0C0) Stacked VLAN Register */
-  RwReg   GMAC_TPFCP;      /**< \brief (Gmac Offset: 0x0C4) Transmit PFC Pause Register */
-  RwReg   GMAC_SAMB1;      /**< \brief (Gmac Offset: 0x0C8) Specific Address 1 Mask Bottom [31:0] Register */
-  RwReg   GMAC_SAMT1;      /**< \brief (Gmac Offset: 0x0CC) Specific Address 1 Mask Top [47:32] Register */
-  RoReg   Reserved2[12];
-  RoReg   GMAC_OTLO;       /**< \brief (Gmac Offset: 0x100) Octets Transmitted [31:0] Register */
-  RoReg   GMAC_OTHI;       /**< \brief (Gmac Offset: 0x104) Octets Transmitted [47:32] Register */
-  RoReg   GMAC_FT;         /**< \brief (Gmac Offset: 0x108) Frames Transmitted Register */
-  RoReg   GMAC_BCFT;       /**< \brief (Gmac Offset: 0x10C) Broadcast Frames Transmitted Register */
-  RoReg   GMAC_MFT;        /**< \brief (Gmac Offset: 0x110) Multicast Frames Transmitted Register */
-  RoReg   GMAC_PFT;        /**< \brief (Gmac Offset: 0x114) Pause Frames Transmitted Register */
-  RoReg   GMAC_BFT64;      /**< \brief (Gmac Offset: 0x118) 64 Byte Frames Transmitted Register */
-  RoReg   GMAC_TBFT127;    /**< \brief (Gmac Offset: 0x11C) 65 to 127 Byte Frames Transmitted Register */
-  RoReg   GMAC_TBFT255;    /**< \brief (Gmac Offset: 0x120) 128 to 255 Byte Frames Transmitted Register */
-  RoReg   GMAC_TBFT511;    /**< \brief (Gmac Offset: 0x124) 256 to 511 Byte Frames Transmitted Register */
-  RoReg   GMAC_TBFT1023;   /**< \brief (Gmac Offset: 0x128) 512 to 1023 Byte Frames Transmitted Register */
-  RoReg   GMAC_TBFT1518;   /**< \brief (Gmac Offset: 0x12C) 1024 to 1518 Byte Frames Transmitted Register */
-  RoReg   GMAC_GTBFT1518;  /**< \brief (Gmac Offset: 0x130) Greater Than 1518 Byte Frames Transmitted Register */
-  RoReg   GMAC_TUR;        /**< \brief (Gmac Offset: 0x134) Transmit Under Runs Register */
-  RoReg   GMAC_SCF;        /**< \brief (Gmac Offset: 0x138) Single Collision Frames Register */
-  RoReg   GMAC_MCF;        /**< \brief (Gmac Offset: 0x13C) Multiple Collision Frames Register */
-  RoReg   GMAC_EC;         /**< \brief (Gmac Offset: 0x140) Excessive Collisions Register */
-  RoReg   GMAC_LC;         /**< \brief (Gmac Offset: 0x144) Late Collisions Register */
-  RoReg   GMAC_DTF;        /**< \brief (Gmac Offset: 0x148) Deferred Transmission Frames Register */
-  RoReg   GMAC_CSE;        /**< \brief (Gmac Offset: 0x14C) Carrier Sense Errors Register */
-  RoReg   GMAC_ORLO;       /**< \brief (Gmac Offset: 0x150) Octets Received [31:0] Received */
-  RoReg   GMAC_ORHI;       /**< \brief (Gmac Offset: 0x154) Octets Received [47:32] Received */
-  RoReg   GMAC_FR;         /**< \brief (Gmac Offset: 0x158) Frames Received Register */
-  RoReg   GMAC_BCFR;       /**< \brief (Gmac Offset: 0x15C) Broadcast Frames Received Register */
-  RoReg   GMAC_MFR;        /**< \brief (Gmac Offset: 0x160) Multicast Frames Received Register */
-  RoReg   GMAC_PFR;        /**< \brief (Gmac Offset: 0x164) Pause Frames Received Register */
-  RoReg   GMAC_BFR64;      /**< \brief (Gmac Offset: 0x168) 64 Byte Frames Received Register */
-  RoReg   GMAC_TBFR127;    /**< \brief (Gmac Offset: 0x16C) 65 to 127 Byte Frames Received Register */
-  RoReg   GMAC_TBFR255;    /**< \brief (Gmac Offset: 0x170) 128 to 255 Byte Frames Received Register */
-  RoReg   GMAC_TBFR511;    /**< \brief (Gmac Offset: 0x174) 256 to 511Byte Frames Received Register */
-  RoReg   GMAC_TBFR1023;   /**< \brief (Gmac Offset: 0x178) 512 to 1023 Byte Frames Received Register */
-  RoReg   GMAC_TBFR1518;   /**< \brief (Gmac Offset: 0x17C) 1024 to 1518 Byte Frames Received Register */
-  RoReg   GMAC_TMXBFR;     /**< \brief (Gmac Offset: 0x180) 1519 to Maximum Byte Frames Received Register */
-  RoReg   GMAC_UFR;        /**< \brief (Gmac Offset: 0x184) Undersize Frames Received Register */
-  RoReg   GMAC_OFR;        /**< \brief (Gmac Offset: 0x188) Oversize Frames Received Register */
-  RoReg   GMAC_JR;         /**< \brief (Gmac Offset: 0x18C) Jabbers Received Register */
-  RoReg   GMAC_FCSE;       /**< \brief (Gmac Offset: 0x190) Frame Check Sequence Errors Register */
-  RoReg   GMAC_LFFE;       /**< \brief (Gmac Offset: 0x194) Length Field Frame Errors Register */
-  RoReg   GMAC_RSE;        /**< \brief (Gmac Offset: 0x198) Receive Symbol Errors Register */
-  RoReg   GMAC_AE;         /**< \brief (Gmac Offset: 0x19C) Alignment Errors Register */
-  RoReg   GMAC_RRE;        /**< \brief (Gmac Offset: 0x1A0) Receive Resource Errors Register */
-  RoReg   GMAC_ROE;        /**< \brief (Gmac Offset: 0x1A4) Receive Overrun Register */
-  RoReg   GMAC_IHCE;       /**< \brief (Gmac Offset: 0x1A8) IP Header Checksum Errors Register */
-  RoReg   GMAC_TCE;        /**< \brief (Gmac Offset: 0x1AC) TCP Checksum Errors Register */
-  RoReg   GMAC_UCE;        /**< \brief (Gmac Offset: 0x1B0) UDP Checksum Errors Register */
-  RoReg   Reserved3[5];
-  RwReg   GMAC_TSSS;       /**< \brief (Gmac Offset: 0x1C8) 1588 Timer Sync Strobe Seconds Register */
-  RwReg   GMAC_TSSN;       /**< \brief (Gmac Offset: 0x1CC) 1588 Timer Sync Strobe Nanoseconds Register */
-  RwReg   GMAC_TS;         /**< \brief (Gmac Offset: 0x1D0) 1588 Timer Seconds Register */
-  RwReg   GMAC_TN;         /**< \brief (Gmac Offset: 0x1D4) 1588 Timer Nanoseconds Register */
-  WoReg   GMAC_TA;         /**< \brief (Gmac Offset: 0x1D8) 1588 Timer Adjust Register */
-  RwReg   GMAC_TI;         /**< \brief (Gmac Offset: 0x1DC) 1588 Timer Increment Register */
-  RoReg   GMAC_EFTS;       /**< \brief (Gmac Offset: 0x1E0) PTP Event Frame Transmitted Seconds */
-  RoReg   GMAC_EFTN;       /**< \brief (Gmac Offset: 0x1E4) PTP Event Frame Transmitted Nanoseconds */
-  RoReg   GMAC_EFRS;       /**< \brief (Gmac Offset: 0x1E8) PTP Event Frame Received Seconds */
-  RoReg   GMAC_EFRN;       /**< \brief (Gmac Offset: 0x1EC) PTP Event Frame Received Nanoseconds */
-  RoReg   GMAC_PEFTS;      /**< \brief (Gmac Offset: 0x1F0) PTP Peer Event Frame Transmitted Seconds */
-  RoReg   GMAC_PEFTN;      /**< \brief (Gmac Offset: 0x1F4) PTP Peer Event Frame Transmitted Nanoseconds */
-  RoReg   GMAC_PEFRS;      /**< \brief (Gmac Offset: 0x1F8) PTP Peer Event Frame Received Seconds */
-  RoReg   GMAC_PEFRN;      /**< \brief (Gmac Offset: 0x1FC) PTP Peer Event Frame Received Nanoseconds */
-  RoReg   Reserved4[128];
-  RoReg   GMAC_ISRPQ[7];   /**< \brief (Gmac Offset: 0x400) Interrupt Status Register Priority Queue */
-  RoReg   Reserved5[9];
-  RwReg   GMAC_TBQBAPQ[7]; /**< \brief (Gmac Offset: 0x440) Transmit Buffer Queue Base Address Priority Queue */
-  RoReg   Reserved6[9];
-  RwReg   GMAC_RBQBAPQ[7]; /**< \brief (Gmac Offset: 0x480) Receive Buffer Queue Base Address Priority Queue */
-  RoReg   Reserved7[1];
-  RwReg   GMAC_RBSRPQ[7];  /**< \brief (Gmac Offset: 0x4A0) Receive Buffer Size Register Priority Queue */
-  RoReg   Reserved8[17];
-  RwReg   GMAC_ST1RPQ[16]; /**< \brief (Gmac Offset: 0x500) Screening Type1 Register Priority Queue */
-  RwReg   GMAC_ST2RPQ[16]; /**< \brief (Gmac Offset: 0x540) Screening Type2 Register Priority Queue */
-  RoReg   Reserved9[32];
-  WoReg   GMAC_IERPQ[7];   /**< \brief (Gmac Offset: 0x600) Interrupt Enable Register Priority Queue */
-  RoReg   Reserved10[1];
-  WoReg   GMAC_IDRPQ[7];   /**< \brief (Gmac Offset: 0x620) Interrupt Disable Register Priority Queue */
-  RoReg   Reserved11[1];
-  RwReg   GMAC_IMRPQ[7];   /**< \brief (Gmac Offset: 0x640) Interrupt Mask Register Priority Queue */
-} Gmac;
+    #define GMACSA_NUMBER    4
+    typedef struct
+    {
+        RwReg GMAC_NCR;                  /**< \brief (Gmac Offset: 0x000) Network Control Register */
+        RwReg GMAC_NCFGR;                /**< \brief (Gmac Offset: 0x004) Network Configuration Register */
+        RoReg GMAC_NSR;                  /**< \brief (Gmac Offset: 0x008) Network Status Register */
+        RwReg GMAC_UR;                   /**< \brief (Gmac Offset: 0x00C) User Register */
+        RwReg GMAC_DCFGR;                /**< \brief (Gmac Offset: 0x010) DMA Configuration Register */
+        RwReg GMAC_TSR;                  /**< \brief (Gmac Offset: 0x014) Transmit Status Register */
+        RwReg GMAC_RBQB;                 /**< \brief (Gmac Offset: 0x018) Receive Buffer Queue Base Address */
+        RwReg GMAC_TBQB;                 /**< \brief (Gmac Offset: 0x01C) Transmit Buffer Queue Base Address */
+        RwReg GMAC_RSR;                  /**< \brief (Gmac Offset: 0x020) Receive Status Register */
+        RoReg GMAC_ISR;                  /**< \brief (Gmac Offset: 0x024) Interrupt Status Register */
+        WoReg GMAC_IER;                  /**< \brief (Gmac Offset: 0x028) Interrupt Enable Register */
+        WoReg GMAC_IDR;                  /**< \brief (Gmac Offset: 0x02C) Interrupt Disable Register */
+        RoReg GMAC_IMR;                  /**< \brief (Gmac Offset: 0x030) Interrupt Mask Register */
+        RwReg GMAC_MAN;                  /**< \brief (Gmac Offset: 0x034) PHY Maintenance Register */
+        RoReg GMAC_RPQ;                  /**< \brief (Gmac Offset: 0x038) Received Pause Quantum Register */
+        RwReg GMAC_TPQ;                  /**< \brief (Gmac Offset: 0x03C) Transmit Pause Quantum Register */
+        RwReg GMAC_TPSF;                 /**< \brief (Gmac Offset: 0x040) TX Partial Store and Forward Register */
+        RwReg GMAC_RPSF;                 /**< \brief (Gmac Offset: 0x044) RX Partial Store and Forward Register */
+        RoReg Reserved1[ 14 ];
+        RwReg GMAC_HRB;                  /**< \brief (Gmac Offset: 0x080) Hash Register Bottom [31:0] */
+        RwReg GMAC_HRT;                  /**< \brief (Gmac Offset: 0x084) Hash Register Top [63:32] */
+        GmacSa GMAC_SA[ GMACSA_NUMBER ]; /**< \brief (Gmac Offset: 0x088) 1 .. 4 */
+        RwReg GMAC_TIDM[ 4 ];            /**< \brief (Gmac Offset: 0x0A8) Type ID Match 1 Register */
+        RwReg GMAC_WOL;                  /**< \brief (Gmac Offset: 0x0B8) Wake on LAN Register */
+        RwReg GMAC_IPGS;                 /**< \brief (Gmac Offset: 0x0BC) IPG Stretch Register */
+        RwReg GMAC_SVLAN;                /**< \brief (Gmac Offset: 0x0C0) Stacked VLAN Register */
+        RwReg GMAC_TPFCP;                /**< \brief (Gmac Offset: 0x0C4) Transmit PFC Pause Register */
+        RwReg GMAC_SAMB1;                /**< \brief (Gmac Offset: 0x0C8) Specific Address 1 Mask Bottom [31:0] Register */
+        RwReg GMAC_SAMT1;                /**< \brief (Gmac Offset: 0x0CC) Specific Address 1 Mask Top [47:32] Register */
+        RoReg Reserved2[ 12 ];
+        RoReg GMAC_OTLO;                 /**< \brief (Gmac Offset: 0x100) Octets Transmitted [31:0] Register */
+        RoReg GMAC_OTHI;                 /**< \brief (Gmac Offset: 0x104) Octets Transmitted [47:32] Register */
+        RoReg GMAC_FT;                   /**< \brief (Gmac Offset: 0x108) Frames Transmitted Register */
+        RoReg GMAC_BCFT;                 /**< \brief (Gmac Offset: 0x10C) Broadcast Frames Transmitted Register */
+        RoReg GMAC_MFT;                  /**< \brief (Gmac Offset: 0x110) Multicast Frames Transmitted Register */
+        RoReg GMAC_PFT;                  /**< \brief (Gmac Offset: 0x114) Pause Frames Transmitted Register */
+        RoReg GMAC_BFT64;                /**< \brief (Gmac Offset: 0x118) 64 Byte Frames Transmitted Register */
+        RoReg GMAC_TBFT127;              /**< \brief (Gmac Offset: 0x11C) 65 to 127 Byte Frames Transmitted Register */
+        RoReg GMAC_TBFT255;              /**< \brief (Gmac Offset: 0x120) 128 to 255 Byte Frames Transmitted Register */
+        RoReg GMAC_TBFT511;              /**< \brief (Gmac Offset: 0x124) 256 to 511 Byte Frames Transmitted Register */
+        RoReg GMAC_TBFT1023;             /**< \brief (Gmac Offset: 0x128) 512 to 1023 Byte Frames Transmitted Register */
+        RoReg GMAC_TBFT1518;             /**< \brief (Gmac Offset: 0x12C) 1024 to 1518 Byte Frames Transmitted Register */
+        RoReg GMAC_GTBFT1518;            /**< \brief (Gmac Offset: 0x130) Greater Than 1518 Byte Frames Transmitted Register */
+        RoReg GMAC_TUR;                  /**< \brief (Gmac Offset: 0x134) Transmit Under Runs Register */
+        RoReg GMAC_SCF;                  /**< \brief (Gmac Offset: 0x138) Single Collision Frames Register */
+        RoReg GMAC_MCF;                  /**< \brief (Gmac Offset: 0x13C) Multiple Collision Frames Register */
+        RoReg GMAC_EC;                   /**< \brief (Gmac Offset: 0x140) Excessive Collisions Register */
+        RoReg GMAC_LC;                   /**< \brief (Gmac Offset: 0x144) Late Collisions Register */
+        RoReg GMAC_DTF;                  /**< \brief (Gmac Offset: 0x148) Deferred Transmission Frames Register */
+        RoReg GMAC_CSE;                  /**< \brief (Gmac Offset: 0x14C) Carrier Sense Errors Register */
+        RoReg GMAC_ORLO;                 /**< \brief (Gmac Offset: 0x150) Octets Received [31:0] Received */
+        RoReg GMAC_ORHI;                 /**< \brief (Gmac Offset: 0x154) Octets Received [47:32] Received */
+        RoReg GMAC_FR;                   /**< \brief (Gmac Offset: 0x158) Frames Received Register */
+        RoReg GMAC_BCFR;                 /**< \brief (Gmac Offset: 0x15C) Broadcast Frames Received Register */
+        RoReg GMAC_MFR;                  /**< \brief (Gmac Offset: 0x160) Multicast Frames Received Register */
+        RoReg GMAC_PFR;                  /**< \brief (Gmac Offset: 0x164) Pause Frames Received Register */
+        RoReg GMAC_BFR64;                /**< \brief (Gmac Offset: 0x168) 64 Byte Frames Received Register */
+        RoReg GMAC_TBFR127;              /**< \brief (Gmac Offset: 0x16C) 65 to 127 Byte Frames Received Register */
+        RoReg GMAC_TBFR255;              /**< \brief (Gmac Offset: 0x170) 128 to 255 Byte Frames Received Register */
+        RoReg GMAC_TBFR511;              /**< \brief (Gmac Offset: 0x174) 256 to 511Byte Frames Received Register */
+        RoReg GMAC_TBFR1023;             /**< \brief (Gmac Offset: 0x178) 512 to 1023 Byte Frames Received Register */
+        RoReg GMAC_TBFR1518;             /**< \brief (Gmac Offset: 0x17C) 1024 to 1518 Byte Frames Received Register */
+        RoReg GMAC_TMXBFR;               /**< \brief (Gmac Offset: 0x180) 1519 to Maximum Byte Frames Received Register */
+        RoReg GMAC_UFR;                  /**< \brief (Gmac Offset: 0x184) Undersize Frames Received Register */
+        RoReg GMAC_OFR;                  /**< \brief (Gmac Offset: 0x188) Oversize Frames Received Register */
+        RoReg GMAC_JR;                   /**< \brief (Gmac Offset: 0x18C) Jabbers Received Register */
+        RoReg GMAC_FCSE;                 /**< \brief (Gmac Offset: 0x190) Frame Check Sequence Errors Register */
+        RoReg GMAC_LFFE;                 /**< \brief (Gmac Offset: 0x194) Length Field Frame Errors Register */
+        RoReg GMAC_RSE;                  /**< \brief (Gmac Offset: 0x198) Receive Symbol Errors Register */
+        RoReg GMAC_AE;                   /**< \brief (Gmac Offset: 0x19C) Alignment Errors Register */
+        RoReg GMAC_RRE;                  /**< \brief (Gmac Offset: 0x1A0) Receive Resource Errors Register */
+        RoReg GMAC_ROE;                  /**< \brief (Gmac Offset: 0x1A4) Receive Overrun Register */
+        RoReg GMAC_IHCE;                 /**< \brief (Gmac Offset: 0x1A8) IP Header Checksum Errors Register */
+        RoReg GMAC_TCE;                  /**< \brief (Gmac Offset: 0x1AC) TCP Checksum Errors Register */
+        RoReg GMAC_UCE;                  /**< \brief (Gmac Offset: 0x1B0) UDP Checksum Errors Register */
+        RoReg Reserved3[ 5 ];
+        RwReg GMAC_TSSS;                 /**< \brief (Gmac Offset: 0x1C8) 1588 Timer Sync Strobe Seconds Register */
+        RwReg GMAC_TSSN;                 /**< \brief (Gmac Offset: 0x1CC) 1588 Timer Sync Strobe Nanoseconds Register */
+        RwReg GMAC_TS;                   /**< \brief (Gmac Offset: 0x1D0) 1588 Timer Seconds Register */
+        RwReg GMAC_TN;                   /**< \brief (Gmac Offset: 0x1D4) 1588 Timer Nanoseconds Register */
+        WoReg GMAC_TA;                   /**< \brief (Gmac Offset: 0x1D8) 1588 Timer Adjust Register */
+        RwReg GMAC_TI;                   /**< \brief (Gmac Offset: 0x1DC) 1588 Timer Increment Register */
+        RoReg GMAC_EFTS;                 /**< \brief (Gmac Offset: 0x1E0) PTP Event Frame Transmitted Seconds */
+        RoReg GMAC_EFTN;                 /**< \brief (Gmac Offset: 0x1E4) PTP Event Frame Transmitted Nanoseconds */
+        RoReg GMAC_EFRS;                 /**< \brief (Gmac Offset: 0x1E8) PTP Event Frame Received Seconds */
+        RoReg GMAC_EFRN;                 /**< \brief (Gmac Offset: 0x1EC) PTP Event Frame Received Nanoseconds */
+        RoReg GMAC_PEFTS;                /**< \brief (Gmac Offset: 0x1F0) PTP Peer Event Frame Transmitted Seconds */
+        RoReg GMAC_PEFTN;                /**< \brief (Gmac Offset: 0x1F4) PTP Peer Event Frame Transmitted Nanoseconds */
+        RoReg GMAC_PEFRS;                /**< \brief (Gmac Offset: 0x1F8) PTP Peer Event Frame Received Seconds */
+        RoReg GMAC_PEFRN;                /**< \brief (Gmac Offset: 0x1FC) PTP Peer Event Frame Received Nanoseconds */
+        RoReg Reserved4[ 128 ];
+        RoReg GMAC_ISRPQ[ 7 ];           /**< \brief (Gmac Offset: 0x400) Interrupt Status Register Priority Queue */
+        RoReg Reserved5[ 9 ];
+        RwReg GMAC_TBQBAPQ[ 7 ];         /**< \brief (Gmac Offset: 0x440) Transmit Buffer Queue Base Address Priority Queue */
+        RoReg Reserved6[ 9 ];
+        RwReg GMAC_RBQBAPQ[ 7 ];         /**< \brief (Gmac Offset: 0x480) Receive Buffer Queue Base Address Priority Queue */
+        RoReg Reserved7[ 1 ];
+        RwReg GMAC_RBSRPQ[ 7 ];          /**< \brief (Gmac Offset: 0x4A0) Receive Buffer Size Register Priority Queue */
+        RoReg Reserved8[ 17 ];
+        RwReg GMAC_ST1RPQ[ 16 ];         /**< \brief (Gmac Offset: 0x500) Screening Type1 Register Priority Queue */
+        RwReg GMAC_ST2RPQ[ 16 ];         /**< \brief (Gmac Offset: 0x540) Screening Type2 Register Priority Queue */
+        RoReg Reserved9[ 32 ];
+        WoReg GMAC_IERPQ[ 7 ];           /**< \brief (Gmac Offset: 0x600) Interrupt Enable Register Priority Queue */
+        RoReg Reserved10[ 1 ];
+        WoReg GMAC_IDRPQ[ 7 ];           /**< \brief (Gmac Offset: 0x620) Interrupt Disable Register Priority Queue */
+        RoReg Reserved11[ 1 ];
+        RwReg GMAC_IMRPQ[ 7 ];           /**< \brief (Gmac Offset: 0x640) Interrupt Mask Register Priority Queue */
+    } Gmac;
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 /* -------- GMAC_NCR : (GMAC Offset: 0x000) Network Control Register -------- */
-#define GMAC_NCR_LB (0x1u << 0) /**< \brief (GMAC_NCR) Loop Back */
-#define GMAC_NCR_LBL (0x1u << 1) /**< \brief (GMAC_NCR) Loop Back Local */
-#define GMAC_NCR_RXEN (0x1u << 2) /**< \brief (GMAC_NCR) Receive Enable */
-#define GMAC_NCR_TXEN (0x1u << 3) /**< \brief (GMAC_NCR) Transmit Enable */
-#define GMAC_NCR_MPE (0x1u << 4) /**< \brief (GMAC_NCR) Management Port Enable */
-#define GMAC_NCR_CLRSTAT (0x1u << 5) /**< \brief (GMAC_NCR) Clear Statistics Registers */
-#define GMAC_NCR_INCSTAT (0x1u << 6) /**< \brief (GMAC_NCR) Increment Statistics Registers */
-#define GMAC_NCR_WESTAT (0x1u << 7) /**< \brief (GMAC_NCR) Write Enable for Statistics Registers */
-#define GMAC_NCR_BP (0x1u << 8) /**< \brief (GMAC_NCR) Back pressure */
-#define GMAC_NCR_TSTART (0x1u << 9) /**< \brief (GMAC_NCR) Start Transmission */
-#define GMAC_NCR_THALT (0x1u << 10) /**< \brief (GMAC_NCR) Transmit Halt */
-#define GMAC_NCR_TXPF (0x1u << 11) /**< \brief (GMAC_NCR) Transmit Pause Frame */
-#define GMAC_NCR_TXZQPF (0x1u << 12) /**< \brief (GMAC_NCR) Transmit Zero Quantum Pause Frame */
-#define GMAC_NCR_RDS (0x1u << 14) /**< \brief (GMAC_NCR) Read Snapshot */
-#define GMAC_NCR_SRTSM (0x1u << 15) /**< \brief (GMAC_NCR) Store Receive Time Stamp to Memory */
-#define GMAC_NCR_ENPBPR (0x1u << 16) /**< \brief (GMAC_NCR) Enable PFC Priority-based Pause Reception */
-#define GMAC_NCR_TXPBPF (0x1u << 17) /**< \brief (GMAC_NCR) Transmit PFC Priority-based Pause Frame */
-#define GMAC_NCR_FNP (0x1u << 18) /**< \brief (GMAC_NCR) Flush Next Packet */
+#define GMAC_NCR_LB                   ( 0x1u << 0 )                     /**< \brief (GMAC_NCR) Loop Back */
+#define GMAC_NCR_LBL                  ( 0x1u << 1 )                     /**< \brief (GMAC_NCR) Loop Back Local */
+#define GMAC_NCR_RXEN                 ( 0x1u << 2 )                     /**< \brief (GMAC_NCR) Receive Enable */
+#define GMAC_NCR_TXEN                 ( 0x1u << 3 )                     /**< \brief (GMAC_NCR) Transmit Enable */
+#define GMAC_NCR_MPE                  ( 0x1u << 4 )                     /**< \brief (GMAC_NCR) Management Port Enable */
+#define GMAC_NCR_CLRSTAT              ( 0x1u << 5 )                     /**< \brief (GMAC_NCR) Clear Statistics Registers */
+#define GMAC_NCR_INCSTAT              ( 0x1u << 6 )                     /**< \brief (GMAC_NCR) Increment Statistics Registers */
+#define GMAC_NCR_WESTAT               ( 0x1u << 7 )                     /**< \brief (GMAC_NCR) Write Enable for Statistics Registers */
+#define GMAC_NCR_BP                   ( 0x1u << 8 )                     /**< \brief (GMAC_NCR) Back pressure */
+#define GMAC_NCR_TSTART               ( 0x1u << 9 )                     /**< \brief (GMAC_NCR) Start Transmission */
+#define GMAC_NCR_THALT                ( 0x1u << 10 )                    /**< \brief (GMAC_NCR) Transmit Halt */
+#define GMAC_NCR_TXPF                 ( 0x1u << 11 )                    /**< \brief (GMAC_NCR) Transmit Pause Frame */
+#define GMAC_NCR_TXZQPF               ( 0x1u << 12 )                    /**< \brief (GMAC_NCR) Transmit Zero Quantum Pause Frame */
+#define GMAC_NCR_RDS                  ( 0x1u << 14 )                    /**< \brief (GMAC_NCR) Read Snapshot */
+#define GMAC_NCR_SRTSM                ( 0x1u << 15 )                    /**< \brief (GMAC_NCR) Store Receive Time Stamp to Memory */
+#define GMAC_NCR_ENPBPR               ( 0x1u << 16 )                    /**< \brief (GMAC_NCR) Enable PFC Priority-based Pause Reception */
+#define GMAC_NCR_TXPBPF               ( 0x1u << 17 )                    /**< \brief (GMAC_NCR) Transmit PFC Priority-based Pause Frame */
+#define GMAC_NCR_FNP                  ( 0x1u << 18 )                    /**< \brief (GMAC_NCR) Flush Next Packet */
 /* -------- GMAC_NCFGR : (GMAC Offset: 0x004) Network Configuration Register -------- */
-#define GMAC_NCFGR_SPD (0x1u << 0) /**< \brief (GMAC_NCFGR) Speed */
-#define GMAC_NCFGR_FD (0x1u << 1) /**< \brief (GMAC_NCFGR) Full Duplex */
-#define GMAC_NCFGR_DNVLAN (0x1u << 2) /**< \brief (GMAC_NCFGR) Discard Non-VLAN FRAMES */
-#define GMAC_NCFGR_JFRAME (0x1u << 3) /**< \brief (GMAC_NCFGR) Jumbo Frame Size */
-#define GMAC_NCFGR_CAF (0x1u << 4) /**< \brief (GMAC_NCFGR) Copy All Frames */
-#define GMAC_NCFGR_NBC (0x1u << 5) /**< \brief (GMAC_NCFGR) No Broadcast */
-#define GMAC_NCFGR_MTIHEN (0x1u << 6) /**< \brief (GMAC_NCFGR) Multicast Hash Enable */
-#define GMAC_NCFGR_UNIHEN (0x1u << 7) /**< \brief (GMAC_NCFGR) Unicast Hash Enable */
-#define GMAC_NCFGR_MAXFS (0x1u << 8) /**< \brief (GMAC_NCFGR) 1536 Maximum Frame Size */
-#define GMAC_NCFGR_GBE (0x1u << 10) /**< \brief (GMAC_NCFGR) Gigabit Mode Enable */
-#define GMAC_NCFGR_PIS (0x1u << 11) /**< \brief (GMAC_NCFGR) Physical Interface Select */
-#define GMAC_NCFGR_RTY (0x1u << 12) /**< \brief (GMAC_NCFGR) Retry Test */
-#define GMAC_NCFGR_PEN (0x1u << 13) /**< \brief (GMAC_NCFGR) Pause Enable */
-#define GMAC_NCFGR_RXBUFO_Pos 14
-#define GMAC_NCFGR_RXBUFO_Msk (0x3u << GMAC_NCFGR_RXBUFO_Pos) /**< \brief (GMAC_NCFGR) Receive Buffer Offset */
-#define GMAC_NCFGR_RXBUFO(value) ((GMAC_NCFGR_RXBUFO_Msk & ((value) << GMAC_NCFGR_RXBUFO_Pos)))
-#define GMAC_NCFGR_LFERD (0x1u << 16) /**< \brief (GMAC_NCFGR) Length Field Error Frame Discard */
-#define GMAC_NCFGR_RFCS (0x1u << 17) /**< \brief (GMAC_NCFGR) Remove FCS */
-#define GMAC_NCFGR_CLK_Pos 18
-#define GMAC_NCFGR_CLK_Msk (0x7u << GMAC_NCFGR_CLK_Pos) /**< \brief (GMAC_NCFGR) MDC CLock Division */
-#define   GMAC_NCFGR_CLK_MCK_8 (0x0u << 18) /**< \brief (GMAC_NCFGR) MCK divided by 8 (MCK up to 20 MHz) */
-#define   GMAC_NCFGR_CLK_MCK_16 (0x1u << 18) /**< \brief (GMAC_NCFGR) MCK divided by 16 (MCK up to 40 MHz) */
-#define   GMAC_NCFGR_CLK_MCK_32 (0x2u << 18) /**< \brief (GMAC_NCFGR) MCK divided by 32 (MCK up to 80 MHz) */
-#define   GMAC_NCFGR_CLK_MCK_48 (0x3u << 18) /**< \brief (GMAC_NCFGR) MCK divided by 48 (MCK up to 120MHz) */
-#define   GMAC_NCFGR_CLK_MCK_64 (0x4u << 18) /**< \brief (GMAC_NCFGR) MCK divided by 64 (MCK up to 160 MHz) */
-#define   GMAC_NCFGR_CLK_MCK_96 (0x5u << 18) /**< \brief (GMAC_NCFGR) MCK divided by 96 (MCK up to 240 MHz) */
-#define   GMAC_NCFGR_CLK_MCK_128 (0x6u << 18) /**< \brief (GMAC_NCFGR) MCK divided by 128 (MCK up to 320 MHz) */
-#define   GMAC_NCFGR_CLK_MCK_224 (0x7u << 18) /**< \brief (GMAC_NCFGR) MCK divided by 224 (MCK up to 540 MHz) */
-#define GMAC_NCFGR_DBW_Pos 21
-#define GMAC_NCFGR_DBW_Msk (0x3u << GMAC_NCFGR_DBW_Pos) /**< \brief (GMAC_NCFGR) Data Bus Width */
-#define   GMAC_NCFGR_DBW_DBW32 (0x0u << 21) /**< \brief (GMAC_NCFGR) 32-bit data bus width */
-#define   GMAC_NCFGR_DBW_DBW64 (0x1u << 21) /**< \brief (GMAC_NCFGR) 64-bit data bus width */
-#define GMAC_NCFGR_DCPF (0x1u << 23) /**< \brief (GMAC_NCFGR) Disable Copy of Pause Frames */
-#define GMAC_NCFGR_RXCOEN (0x1u << 24) /**< \brief (GMAC_NCFGR) Receive Checksum Offload Enable */
-#define GMAC_NCFGR_EFRHD (0x1u << 25) /**< \brief (GMAC_NCFGR) Enable Frames Received in Half Duplex */
-#define GMAC_NCFGR_IRXFCS (0x1u << 26) /**< \brief (GMAC_NCFGR) Ignore RX FCS */
-#define GMAC_NCFGR_IPGSEN (0x1u << 28) /**< \brief (GMAC_NCFGR) IP Stretch Enable */
-#define GMAC_NCFGR_RXBP (0x1u << 29) /**< \brief (GMAC_NCFGR) Receive Bad Preamble */
-#define GMAC_NCFGR_IRXER (0x1u << 30) /**< \brief (GMAC_NCFGR) Ignore IPG rx_er */
+#define GMAC_NCFGR_SPD                ( 0x1u << 0 )                     /**< \brief (GMAC_NCFGR) Speed */
+#define GMAC_NCFGR_FD                 ( 0x1u << 1 )                     /**< \brief (GMAC_NCFGR) Full Duplex */
+#define GMAC_NCFGR_DNVLAN             ( 0x1u << 2 )                     /**< \brief (GMAC_NCFGR) Discard Non-VLAN FRAMES */
+#define GMAC_NCFGR_JFRAME             ( 0x1u << 3 )                     /**< \brief (GMAC_NCFGR) Jumbo Frame Size */
+#define GMAC_NCFGR_CAF                ( 0x1u << 4 )                     /**< \brief (GMAC_NCFGR) Copy All Frames */
+#define GMAC_NCFGR_NBC                ( 0x1u << 5 )                     /**< \brief (GMAC_NCFGR) No Broadcast */
+#define GMAC_NCFGR_MTIHEN             ( 0x1u << 6 )                     /**< \brief (GMAC_NCFGR) Multicast Hash Enable */
+#define GMAC_NCFGR_UNIHEN             ( 0x1u << 7 )                     /**< \brief (GMAC_NCFGR) Unicast Hash Enable */
+#define GMAC_NCFGR_MAXFS              ( 0x1u << 8 )                     /**< \brief (GMAC_NCFGR) 1536 Maximum Frame Size */
+#define GMAC_NCFGR_GBE                ( 0x1u << 10 )                    /**< \brief (GMAC_NCFGR) Gigabit Mode Enable */
+#define GMAC_NCFGR_PIS                ( 0x1u << 11 )                    /**< \brief (GMAC_NCFGR) Physical Interface Select */
+#define GMAC_NCFGR_RTY                ( 0x1u << 12 )                    /**< \brief (GMAC_NCFGR) Retry Test */
+#define GMAC_NCFGR_PEN                ( 0x1u << 13 )                    /**< \brief (GMAC_NCFGR) Pause Enable */
+#define GMAC_NCFGR_RXBUFO_Pos         14
+#define GMAC_NCFGR_RXBUFO_Msk         ( 0x3u << GMAC_NCFGR_RXBUFO_Pos ) /**< \brief (GMAC_NCFGR) Receive Buffer Offset */
+#define GMAC_NCFGR_RXBUFO( value )    ( ( GMAC_NCFGR_RXBUFO_Msk & ( ( value ) << GMAC_NCFGR_RXBUFO_Pos ) ) )
+#define GMAC_NCFGR_LFERD              ( 0x1u << 16 )                    /**< \brief (GMAC_NCFGR) Length Field Error Frame Discard */
+#define GMAC_NCFGR_RFCS               ( 0x1u << 17 )                    /**< \brief (GMAC_NCFGR) Remove FCS */
+#define GMAC_NCFGR_CLK_Pos            18
+#define GMAC_NCFGR_CLK_Msk            ( 0x7u << GMAC_NCFGR_CLK_Pos )    /**< \brief (GMAC_NCFGR) MDC CLock Division */
+#define   GMAC_NCFGR_CLK_MCK_8        ( 0x0u << 18 )                    /**< \brief (GMAC_NCFGR) MCK divided by 8 (MCK up to 20 MHz) */
+#define   GMAC_NCFGR_CLK_MCK_16       ( 0x1u << 18 )                    /**< \brief (GMAC_NCFGR) MCK divided by 16 (MCK up to 40 MHz) */
+#define   GMAC_NCFGR_CLK_MCK_32       ( 0x2u << 18 )                    /**< \brief (GMAC_NCFGR) MCK divided by 32 (MCK up to 80 MHz) */
+#define   GMAC_NCFGR_CLK_MCK_48       ( 0x3u << 18 )                    /**< \brief (GMAC_NCFGR) MCK divided by 48 (MCK up to 120MHz) */
+#define   GMAC_NCFGR_CLK_MCK_64       ( 0x4u << 18 )                    /**< \brief (GMAC_NCFGR) MCK divided by 64 (MCK up to 160 MHz) */
+#define   GMAC_NCFGR_CLK_MCK_96       ( 0x5u << 18 )                    /**< \brief (GMAC_NCFGR) MCK divided by 96 (MCK up to 240 MHz) */
+#define   GMAC_NCFGR_CLK_MCK_128      ( 0x6u << 18 )                    /**< \brief (GMAC_NCFGR) MCK divided by 128 (MCK up to 320 MHz) */
+#define   GMAC_NCFGR_CLK_MCK_224      ( 0x7u << 18 )                    /**< \brief (GMAC_NCFGR) MCK divided by 224 (MCK up to 540 MHz) */
+#define GMAC_NCFGR_DBW_Pos            21
+#define GMAC_NCFGR_DBW_Msk            ( 0x3u << GMAC_NCFGR_DBW_Pos )    /**< \brief (GMAC_NCFGR) Data Bus Width */
+#define   GMAC_NCFGR_DBW_DBW32        ( 0x0u << 21 )                    /**< \brief (GMAC_NCFGR) 32-bit data bus width */
+#define   GMAC_NCFGR_DBW_DBW64        ( 0x1u << 21 )                    /**< \brief (GMAC_NCFGR) 64-bit data bus width */
+#define GMAC_NCFGR_DCPF               ( 0x1u << 23 )                    /**< \brief (GMAC_NCFGR) Disable Copy of Pause Frames */
+#define GMAC_NCFGR_RXCOEN             ( 0x1u << 24 )                    /**< \brief (GMAC_NCFGR) Receive Checksum Offload Enable */
+#define GMAC_NCFGR_EFRHD              ( 0x1u << 25 )                    /**< \brief (GMAC_NCFGR) Enable Frames Received in Half Duplex */
+#define GMAC_NCFGR_IRXFCS             ( 0x1u << 26 )                    /**< \brief (GMAC_NCFGR) Ignore RX FCS */
+#define GMAC_NCFGR_IPGSEN             ( 0x1u << 28 )                    /**< \brief (GMAC_NCFGR) IP Stretch Enable */
+#define GMAC_NCFGR_RXBP               ( 0x1u << 29 )                    /**< \brief (GMAC_NCFGR) Receive Bad Preamble */
+#define GMAC_NCFGR_IRXER              ( 0x1u << 30 )                    /**< \brief (GMAC_NCFGR) Ignore IPG rx_er */
 /* -------- GMAC_NSR : (GMAC Offset: 0x008) Network Status Register -------- */
-#define GMAC_NSR_MDIO (0x1u << 1) /**< \brief (GMAC_NSR) MDIO Input Status */
-#define GMAC_NSR_IDLE (0x1u << 2) /**< \brief (GMAC_NSR) PHY Management Logic Idle */
+#define GMAC_NSR_MDIO                 ( 0x1u << 1 )                     /**< \brief (GMAC_NSR) MDIO Input Status */
+#define GMAC_NSR_IDLE                 ( 0x1u << 2 )                     /**< \brief (GMAC_NSR) PHY Management Logic Idle */
 /* -------- GMAC_UR : (GMAC Offset: 0x00C) User Register -------- */
-#define GMAC_UR_RGMII (0x1u << 0) /**< \brief (GMAC_UR) RGMII Mode */
-#define GMAC_UR_HDFC (0x1u << 6) /**< \brief (GMAC_UR) Half Duplex Flow Control */
-#define GMAC_UR_BPDG (0x1u << 7) /**< \brief (GMAC_UR) BPDG Bypass Deglitchers */
+#define GMAC_UR_RGMII                 ( 0x1u << 0 )                     /**< \brief (GMAC_UR) RGMII Mode */
+#define GMAC_UR_HDFC                  ( 0x1u << 6 )                     /**< \brief (GMAC_UR) Half Duplex Flow Control */
+#define GMAC_UR_BPDG                  ( 0x1u << 7 )                     /**< \brief (GMAC_UR) BPDG Bypass Deglitchers */
 /* -------- GMAC_DCFGR : (GMAC Offset: 0x010) DMA Configuration Register -------- */
-#define GMAC_DCFGR_FBLDO_Pos 0
-#define GMAC_DCFGR_FBLDO_Msk (0x1fu << GMAC_DCFGR_FBLDO_Pos) /**< \brief (GMAC_DCFGR) Fixed Burst Length for DMA Data Operations: */
-#define   GMAC_DCFGR_FBLDO_SINGLE (0x1u << 0) /**< \brief (GMAC_DCFGR) 00001: Always use SINGLE AHB bursts */
-#define   GMAC_DCFGR_FBLDO_INCR4 (0x4u << 0) /**< \brief (GMAC_DCFGR) 001xx: Attempt to use INCR4 AHB bursts (Default) */
-#define   GMAC_DCFGR_FBLDO_INCR8 (0x8u << 0) /**< \brief (GMAC_DCFGR) 01xxx: Attempt to use INCR8 AHB bursts */
-#define   GMAC_DCFGR_FBLDO_INCR16 (0x10u << 0) /**< \brief (GMAC_DCFGR) 1xxxx: Attempt to use INCR16 AHB bursts */
-#define GMAC_DCFGR_ESMA (0x1u << 6) /**< \brief (GMAC_DCFGR) Endian Swap Mode Enable for Management Descriptor Accesses */
-#define GMAC_DCFGR_ESPA (0x1u << 7) /**< \brief (GMAC_DCFGR) Endian Swap Mode Enable for Packet Data Accesses */
-#define GMAC_DCFGR_RXBMS_Pos 8
-#define GMAC_DCFGR_RXBMS_Msk (0x3u << GMAC_DCFGR_RXBMS_Pos) /**< \brief (GMAC_DCFGR) Receiver Packet Buffer Memory Size Select */
-#define   GMAC_DCFGR_RXBMS_EIGHTH (0x0u << 8) /**< \brief (GMAC_DCFGR) 1 Kbyte Memory Size */
-#define   GMAC_DCFGR_RXBMS_QUARTER (0x1u << 8) /**< \brief (GMAC_DCFGR) 2 Kbytes Memory Size */
-#define   GMAC_DCFGR_RXBMS_HALF (0x2u << 8) /**< \brief (GMAC_DCFGR) 4 Kbytes Memory Size */
-#define   GMAC_DCFGR_RXBMS_FULL (0x3u << 8) /**< \brief (GMAC_DCFGR) 8 Kbytes Memory Size */
-#define GMAC_DCFGR_TXPBMS (0x1u << 10) /**< \brief (GMAC_DCFGR) Transmitter Packet Buffer Memory Size Select */
-#define GMAC_DCFGR_TXCOEN (0x1u << 11) /**< \brief (GMAC_DCFGR) Transmitter Checksum Generation Offload Enable */
-#define GMAC_DCFGR_DRBS_Pos 16
-#define GMAC_DCFGR_DRBS_Msk (0xffu << GMAC_DCFGR_DRBS_Pos) /**< \brief (GMAC_DCFGR) DMA Receive Buffer Size */
-#define GMAC_DCFGR_DRBS(value) ((GMAC_DCFGR_DRBS_Msk & ((value) << GMAC_DCFGR_DRBS_Pos)))
-#define GMAC_DCFGR_DDRP (0x1u << 24) /**< \brief (GMAC_DCFGR) DMA Discard Receive Packets */
+#define GMAC_DCFGR_FBLDO_Pos          0
+#define GMAC_DCFGR_FBLDO_Msk          ( 0x1fu << GMAC_DCFGR_FBLDO_Pos ) /**< \brief (GMAC_DCFGR) Fixed Burst Length for DMA Data Operations: */
+#define   GMAC_DCFGR_FBLDO_SINGLE     ( 0x1u << 0 )                     /**< \brief (GMAC_DCFGR) 00001: Always use SINGLE AHB bursts */
+#define   GMAC_DCFGR_FBLDO_INCR4      ( 0x4u << 0 )                     /**< \brief (GMAC_DCFGR) 001xx: Attempt to use INCR4 AHB bursts (Default) */
+#define   GMAC_DCFGR_FBLDO_INCR8      ( 0x8u << 0 )                     /**< \brief (GMAC_DCFGR) 01xxx: Attempt to use INCR8 AHB bursts */
+#define   GMAC_DCFGR_FBLDO_INCR16     ( 0x10u << 0 )                    /**< \brief (GMAC_DCFGR) 1xxxx: Attempt to use INCR16 AHB bursts */
+#define GMAC_DCFGR_ESMA               ( 0x1u << 6 )                     /**< \brief (GMAC_DCFGR) Endian Swap Mode Enable for Management Descriptor Accesses */
+#define GMAC_DCFGR_ESPA               ( 0x1u << 7 )                     /**< \brief (GMAC_DCFGR) Endian Swap Mode Enable for Packet Data Accesses */
+#define GMAC_DCFGR_RXBMS_Pos          8
+#define GMAC_DCFGR_RXBMS_Msk          ( 0x3u << GMAC_DCFGR_RXBMS_Pos )  /**< \brief (GMAC_DCFGR) Receiver Packet Buffer Memory Size Select */
+#define   GMAC_DCFGR_RXBMS_EIGHTH     ( 0x0u << 8 )                     /**< \brief (GMAC_DCFGR) 1 Kbyte Memory Size */
+#define   GMAC_DCFGR_RXBMS_QUARTER    ( 0x1u << 8 )                     /**< \brief (GMAC_DCFGR) 2 Kbytes Memory Size */
+#define   GMAC_DCFGR_RXBMS_HALF       ( 0x2u << 8 )                     /**< \brief (GMAC_DCFGR) 4 Kbytes Memory Size */
+#define   GMAC_DCFGR_RXBMS_FULL       ( 0x3u << 8 )                     /**< \brief (GMAC_DCFGR) 8 Kbytes Memory Size */
+#define GMAC_DCFGR_TXPBMS             ( 0x1u << 10 )                    /**< \brief (GMAC_DCFGR) Transmitter Packet Buffer Memory Size Select */
+#define GMAC_DCFGR_TXCOEN             ( 0x1u << 11 )                    /**< \brief (GMAC_DCFGR) Transmitter Checksum Generation Offload Enable */
+#define GMAC_DCFGR_DRBS_Pos           16
+#define GMAC_DCFGR_DRBS_Msk           ( 0xffu << GMAC_DCFGR_DRBS_Pos )  /**< \brief (GMAC_DCFGR) DMA Receive Buffer Size */
+#define GMAC_DCFGR_DRBS( value )    ( ( GMAC_DCFGR_DRBS_Msk & ( ( value ) << GMAC_DCFGR_DRBS_Pos ) ) )
+#define GMAC_DCFGR_DDRP               ( 0x1u << 24 )                    /**< \brief (GMAC_DCFGR) DMA Discard Receive Packets */
 /* -------- GMAC_TSR : (GMAC Offset: 0x014) Transmit Status Register -------- */
-#define GMAC_TSR_UBR (0x1u << 0) /**< \brief (GMAC_TSR) Used Bit Read */
-#define GMAC_TSR_COL (0x1u << 1) /**< \brief (GMAC_TSR) Collision Occurred */
-#define GMAC_TSR_RLE (0x1u << 2) /**< \brief (GMAC_TSR) Retry Limit Exceeded */
-#define GMAC_TSR_TXGO (0x1u << 3) /**< \brief (GMAC_TSR) Transmit Go */
-#define GMAC_TSR_TFC (0x1u << 4) /**< \brief (GMAC_TSR) Transmit Frame Corruption due to AHB error */
-#define GMAC_TSR_TXCOMP (0x1u << 5) /**< \brief (GMAC_TSR) Transmit Complete */
-#define GMAC_TSR_UND (0x1u << 6) /**< \brief (GMAC_TSR) Transmit Under Run */
-#define GMAC_TSR_LCO (0x1u << 7) /**< \brief (GMAC_TSR) Late Collision Occurred */
-#define GMAC_TSR_HRESP (0x1u << 8) /**< \brief (GMAC_TSR) HRESP Not OK */
+#define GMAC_TSR_UBR                  ( 0x1u << 0 )                     /**< \brief (GMAC_TSR) Used Bit Read */
+#define GMAC_TSR_COL                  ( 0x1u << 1 )                     /**< \brief (GMAC_TSR) Collision Occurred */
+#define GMAC_TSR_RLE                  ( 0x1u << 2 )                     /**< \brief (GMAC_TSR) Retry Limit Exceeded */
+#define GMAC_TSR_TXGO                 ( 0x1u << 3 )                     /**< \brief (GMAC_TSR) Transmit Go */
+#define GMAC_TSR_TFC                  ( 0x1u << 4 )                     /**< \brief (GMAC_TSR) Transmit Frame Corruption due to AHB error */
+#define GMAC_TSR_TXCOMP               ( 0x1u << 5 )                     /**< \brief (GMAC_TSR) Transmit Complete */
+#define GMAC_TSR_UND                  ( 0x1u << 6 )                     /**< \brief (GMAC_TSR) Transmit Under Run */
+#define GMAC_TSR_LCO                  ( 0x1u << 7 )                     /**< \brief (GMAC_TSR) Late Collision Occurred */
+#define GMAC_TSR_HRESP                ( 0x1u << 8 )                     /**< \brief (GMAC_TSR) HRESP Not OK */
 /* -------- GMAC_RBQB : (GMAC Offset: 0x018) Receive Buffer Queue Base Address -------- */
-#define GMAC_RBQB_ADDR_Pos 2
-#define GMAC_RBQB_ADDR_Msk (0x3fffffffu << GMAC_RBQB_ADDR_Pos) /**< \brief (GMAC_RBQB) Receive buffer queue base address */
-#define GMAC_RBQB_ADDR(value) ((GMAC_RBQB_ADDR_Msk & ((value) << GMAC_RBQB_ADDR_Pos)))
+#define GMAC_RBQB_ADDR_Pos            2
+#define GMAC_RBQB_ADDR_Msk            ( 0x3fffffffu << GMAC_RBQB_ADDR_Pos ) /**< \brief (GMAC_RBQB) Receive buffer queue base address */
+#define GMAC_RBQB_ADDR( value )    ( ( GMAC_RBQB_ADDR_Msk & ( ( value ) << GMAC_RBQB_ADDR_Pos ) ) )
 /* -------- GMAC_TBQB : (GMAC Offset: 0x01C) Transmit Buffer Queue Base Address -------- */
-#define GMAC_TBQB_ADDR_Pos 2
-#define GMAC_TBQB_ADDR_Msk (0x3fffffffu << GMAC_TBQB_ADDR_Pos) /**< \brief (GMAC_TBQB) Transmit Buffer Queue Base Address */
-#define GMAC_TBQB_ADDR(value) ((GMAC_TBQB_ADDR_Msk & ((value) << GMAC_TBQB_ADDR_Pos)))
+#define GMAC_TBQB_ADDR_Pos            2
+#define GMAC_TBQB_ADDR_Msk            ( 0x3fffffffu << GMAC_TBQB_ADDR_Pos ) /**< \brief (GMAC_TBQB) Transmit Buffer Queue Base Address */
+#define GMAC_TBQB_ADDR( value )    ( ( GMAC_TBQB_ADDR_Msk & ( ( value ) << GMAC_TBQB_ADDR_Pos ) ) )
 /* -------- GMAC_RSR : (GMAC Offset: 0x020) Receive Status Register -------- */
-#define GMAC_RSR_BNA (0x1u << 0) /**< \brief (GMAC_RSR) Buffer Not Available */
-#define GMAC_RSR_REC (0x1u << 1) /**< \brief (GMAC_RSR) Frame Received */
-#define GMAC_RSR_RXOVR (0x1u << 2) /**< \brief (GMAC_RSR) Receive Overrun */
-#define GMAC_RSR_HNO (0x1u << 3) /**< \brief (GMAC_RSR) HRESP Not OK */
+#define GMAC_RSR_BNA                  ( 0x1u << 0 )  /**< \brief (GMAC_RSR) Buffer Not Available */
+#define GMAC_RSR_REC                  ( 0x1u << 1 )  /**< \brief (GMAC_RSR) Frame Received */
+#define GMAC_RSR_RXOVR                ( 0x1u << 2 )  /**< \brief (GMAC_RSR) Receive Overrun */
+#define GMAC_RSR_HNO                  ( 0x1u << 3 )  /**< \brief (GMAC_RSR) HRESP Not OK */
 /* -------- GMAC_ISR : (GMAC Offset: 0x024) Interrupt Status Register -------- */
-#define GMAC_ISR_MFS (0x1u << 0) /**< \brief (GMAC_ISR) Management Frame Sent */
-#define GMAC_ISR_RCOMP (0x1u << 1) /**< \brief (GMAC_ISR) Receive Complete */
-#define GMAC_ISR_RXUBR (0x1u << 2) /**< \brief (GMAC_ISR) RX Used Bit Read */
-#define GMAC_ISR_TXUBR (0x1u << 3) /**< \brief (GMAC_ISR) TX Used Bit Read */
-#define GMAC_ISR_TUR (0x1u << 4) /**< \brief (GMAC_ISR) Transmit Under Run */
-#define GMAC_ISR_RLEX (0x1u << 5) /**< \brief (GMAC_ISR) Retry Limit Exceeded or Late Collision */
-#define GMAC_ISR_TFC (0x1u << 6) /**< \brief (GMAC_ISR) Transmit Frame Corruption due to AHB error */
-#define GMAC_ISR_TCOMP (0x1u << 7) /**< \brief (GMAC_ISR) Transmit Complete */
-#define GMAC_ISR_ROVR (0x1u << 10) /**< \brief (GMAC_ISR) Receive Overrun */
-#define GMAC_ISR_HRESP (0x1u << 11) /**< \brief (GMAC_ISR) HRESP Not OK */
-#define GMAC_ISR_PFNZ (0x1u << 12) /**< \brief (GMAC_ISR) Pause Frame with Non-zero Pause Quantum Received */
-#define GMAC_ISR_PTZ (0x1u << 13) /**< \brief (GMAC_ISR) Pause Time Zero */
-#define GMAC_ISR_PFTR (0x1u << 14) /**< \brief (GMAC_ISR) Pause Frame Transmitted */
-#define GMAC_ISR_EXINT (0x1u << 15) /**< \brief (GMAC_ISR) External Interrupt */
-#define GMAC_ISR_DRQFR (0x1u << 18) /**< \brief (GMAC_ISR) PTP Delay Request Frame Received */
-#define GMAC_ISR_SFR (0x1u << 19) /**< \brief (GMAC_ISR) PTP Sync Frame Received */
-#define GMAC_ISR_DRQFT (0x1u << 20) /**< \brief (GMAC_ISR) PTP Delay Request Frame Transmitted */
-#define GMAC_ISR_SFT (0x1u << 21) /**< \brief (GMAC_ISR) PTP Sync Frame Transmitted */
-#define GMAC_ISR_PDRQFR (0x1u << 22) /**< \brief (GMAC_ISR) PDelay Request Frame Received */
-#define GMAC_ISR_PDRSFR (0x1u << 23) /**< \brief (GMAC_ISR) PDelay Response Frame Received */
-#define GMAC_ISR_PDRQFT (0x1u << 24) /**< \brief (GMAC_ISR) PDelay Request Frame Transmitted */
-#define GMAC_ISR_PDRSFT (0x1u << 25) /**< \brief (GMAC_ISR) PDelay Response Frame Transmitted */
-#define GMAC_ISR_SRI (0x1u << 26) /**< \brief (GMAC_ISR) TSU Seconds Register Increment */
-#define GMAC_ISR_WOL (0x1u << 28) /**< \brief (GMAC_ISR) Wake On LAN */
+#define GMAC_ISR_MFS                  ( 0x1u << 0 )  /**< \brief (GMAC_ISR) Management Frame Sent */
+#define GMAC_ISR_RCOMP                ( 0x1u << 1 )  /**< \brief (GMAC_ISR) Receive Complete */
+#define GMAC_ISR_RXUBR                ( 0x1u << 2 )  /**< \brief (GMAC_ISR) RX Used Bit Read */
+#define GMAC_ISR_TXUBR                ( 0x1u << 3 )  /**< \brief (GMAC_ISR) TX Used Bit Read */
+#define GMAC_ISR_TUR                  ( 0x1u << 4 )  /**< \brief (GMAC_ISR) Transmit Under Run */
+#define GMAC_ISR_RLEX                 ( 0x1u << 5 )  /**< \brief (GMAC_ISR) Retry Limit Exceeded or Late Collision */
+#define GMAC_ISR_TFC                  ( 0x1u << 6 )  /**< \brief (GMAC_ISR) Transmit Frame Corruption due to AHB error */
+#define GMAC_ISR_TCOMP                ( 0x1u << 7 )  /**< \brief (GMAC_ISR) Transmit Complete */
+#define GMAC_ISR_ROVR                 ( 0x1u << 10 ) /**< \brief (GMAC_ISR) Receive Overrun */
+#define GMAC_ISR_HRESP                ( 0x1u << 11 ) /**< \brief (GMAC_ISR) HRESP Not OK */
+#define GMAC_ISR_PFNZ                 ( 0x1u << 12 ) /**< \brief (GMAC_ISR) Pause Frame with Non-zero Pause Quantum Received */
+#define GMAC_ISR_PTZ                  ( 0x1u << 13 ) /**< \brief (GMAC_ISR) Pause Time Zero */
+#define GMAC_ISR_PFTR                 ( 0x1u << 14 ) /**< \brief (GMAC_ISR) Pause Frame Transmitted */
+#define GMAC_ISR_EXINT                ( 0x1u << 15 ) /**< \brief (GMAC_ISR) External Interrupt */
+#define GMAC_ISR_DRQFR                ( 0x1u << 18 ) /**< \brief (GMAC_ISR) PTP Delay Request Frame Received */
+#define GMAC_ISR_SFR                  ( 0x1u << 19 ) /**< \brief (GMAC_ISR) PTP Sync Frame Received */
+#define GMAC_ISR_DRQFT                ( 0x1u << 20 ) /**< \brief (GMAC_ISR) PTP Delay Request Frame Transmitted */
+#define GMAC_ISR_SFT                  ( 0x1u << 21 ) /**< \brief (GMAC_ISR) PTP Sync Frame Transmitted */
+#define GMAC_ISR_PDRQFR               ( 0x1u << 22 ) /**< \brief (GMAC_ISR) PDelay Request Frame Received */
+#define GMAC_ISR_PDRSFR               ( 0x1u << 23 ) /**< \brief (GMAC_ISR) PDelay Response Frame Received */
+#define GMAC_ISR_PDRQFT               ( 0x1u << 24 ) /**< \brief (GMAC_ISR) PDelay Request Frame Transmitted */
+#define GMAC_ISR_PDRSFT               ( 0x1u << 25 ) /**< \brief (GMAC_ISR) PDelay Response Frame Transmitted */
+#define GMAC_ISR_SRI                  ( 0x1u << 26 ) /**< \brief (GMAC_ISR) TSU Seconds Register Increment */
+#define GMAC_ISR_WOL                  ( 0x1u << 28 ) /**< \brief (GMAC_ISR) Wake On LAN */
 /* -------- GMAC_IER : (GMAC Offset: 0x028) Interrupt Enable Register -------- */
-#define GMAC_IER_MFS (0x1u << 0) /**< \brief (GMAC_IER) Management Frame Sent */
-#define GMAC_IER_RCOMP (0x1u << 1) /**< \brief (GMAC_IER) Receive Complete */
-#define GMAC_IER_RXUBR (0x1u << 2) /**< \brief (GMAC_IER) RX Used Bit Read */
-#define GMAC_IER_TXUBR (0x1u << 3) /**< \brief (GMAC_IER) TX Used Bit Read */
-#define GMAC_IER_TUR (0x1u << 4) /**< \brief (GMAC_IER) Transmit Under Run */
-#define GMAC_IER_RLEX (0x1u << 5) /**< \brief (GMAC_IER) Retry Limit Exceeded or Late Collision */
-#define GMAC_IER_TFC (0x1u << 6) /**< \brief (GMAC_IER) Transmit Frame Corruption due to AHB error */
-#define GMAC_IER_TCOMP (0x1u << 7) /**< \brief (GMAC_IER) Transmit Complete */
-#define GMAC_IER_ROVR (0x1u << 10) /**< \brief (GMAC_IER) Receive Overrun */
-#define GMAC_IER_HRESP (0x1u << 11) /**< \brief (GMAC_IER) HRESP Not OK */
-#define GMAC_IER_PFNZ (0x1u << 12) /**< \brief (GMAC_IER) Pause Frame with Non-zero Pause Quantum Received */
-#define GMAC_IER_PTZ (0x1u << 13) /**< \brief (GMAC_IER) Pause Time Zero */
-#define GMAC_IER_PFTR (0x1u << 14) /**< \brief (GMAC_IER) Pause Frame Transmitted */
-#define GMAC_IER_EXINT (0x1u << 15) /**< \brief (GMAC_IER) External Interrupt */
-#define GMAC_IER_DRQFR (0x1u << 18) /**< \brief (GMAC_IER) PTP Delay Request Frame Received */
-#define GMAC_IER_SFR (0x1u << 19) /**< \brief (GMAC_IER) PTP Sync Frame Received */
-#define GMAC_IER_DRQFT (0x1u << 20) /**< \brief (GMAC_IER) PTP Delay Request Frame Transmitted */
-#define GMAC_IER_SFT (0x1u << 21) /**< \brief (GMAC_IER) PTP Sync Frame Transmitted */
-#define GMAC_IER_PDRQFR (0x1u << 22) /**< \brief (GMAC_IER) PDelay Request Frame Received */
-#define GMAC_IER_PDRSFR (0x1u << 23) /**< \brief (GMAC_IER) PDelay Response Frame Received */
-#define GMAC_IER_PDRQFT (0x1u << 24) /**< \brief (GMAC_IER) PDelay Request Frame Transmitted */
-#define GMAC_IER_PDRSFT (0x1u << 25) /**< \brief (GMAC_IER) PDelay Response Frame Transmitted */
-#define GMAC_IER_SRI (0x1u << 26) /**< \brief (GMAC_IER) TSU Seconds Register Increment */
-#define GMAC_IER_WOL (0x1u << 28) /**< \brief (GMAC_IER) Wake On LAN */
+#define GMAC_IER_MFS                  ( 0x1u << 0 )  /**< \brief (GMAC_IER) Management Frame Sent */
+#define GMAC_IER_RCOMP                ( 0x1u << 1 )  /**< \brief (GMAC_IER) Receive Complete */
+#define GMAC_IER_RXUBR                ( 0x1u << 2 )  /**< \brief (GMAC_IER) RX Used Bit Read */
+#define GMAC_IER_TXUBR                ( 0x1u << 3 )  /**< \brief (GMAC_IER) TX Used Bit Read */
+#define GMAC_IER_TUR                  ( 0x1u << 4 )  /**< \brief (GMAC_IER) Transmit Under Run */
+#define GMAC_IER_RLEX                 ( 0x1u << 5 )  /**< \brief (GMAC_IER) Retry Limit Exceeded or Late Collision */
+#define GMAC_IER_TFC                  ( 0x1u << 6 )  /**< \brief (GMAC_IER) Transmit Frame Corruption due to AHB error */
+#define GMAC_IER_TCOMP                ( 0x1u << 7 )  /**< \brief (GMAC_IER) Transmit Complete */
+#define GMAC_IER_ROVR                 ( 0x1u << 10 ) /**< \brief (GMAC_IER) Receive Overrun */
+#define GMAC_IER_HRESP                ( 0x1u << 11 ) /**< \brief (GMAC_IER) HRESP Not OK */
+#define GMAC_IER_PFNZ                 ( 0x1u << 12 ) /**< \brief (GMAC_IER) Pause Frame with Non-zero Pause Quantum Received */
+#define GMAC_IER_PTZ                  ( 0x1u << 13 ) /**< \brief (GMAC_IER) Pause Time Zero */
+#define GMAC_IER_PFTR                 ( 0x1u << 14 ) /**< \brief (GMAC_IER) Pause Frame Transmitted */
+#define GMAC_IER_EXINT                ( 0x1u << 15 ) /**< \brief (GMAC_IER) External Interrupt */
+#define GMAC_IER_DRQFR                ( 0x1u << 18 ) /**< \brief (GMAC_IER) PTP Delay Request Frame Received */
+#define GMAC_IER_SFR                  ( 0x1u << 19 ) /**< \brief (GMAC_IER) PTP Sync Frame Received */
+#define GMAC_IER_DRQFT                ( 0x1u << 20 ) /**< \brief (GMAC_IER) PTP Delay Request Frame Transmitted */
+#define GMAC_IER_SFT                  ( 0x1u << 21 ) /**< \brief (GMAC_IER) PTP Sync Frame Transmitted */
+#define GMAC_IER_PDRQFR               ( 0x1u << 22 ) /**< \brief (GMAC_IER) PDelay Request Frame Received */
+#define GMAC_IER_PDRSFR               ( 0x1u << 23 ) /**< \brief (GMAC_IER) PDelay Response Frame Received */
+#define GMAC_IER_PDRQFT               ( 0x1u << 24 ) /**< \brief (GMAC_IER) PDelay Request Frame Transmitted */
+#define GMAC_IER_PDRSFT               ( 0x1u << 25 ) /**< \brief (GMAC_IER) PDelay Response Frame Transmitted */
+#define GMAC_IER_SRI                  ( 0x1u << 26 ) /**< \brief (GMAC_IER) TSU Seconds Register Increment */
+#define GMAC_IER_WOL                  ( 0x1u << 28 ) /**< \brief (GMAC_IER) Wake On LAN */
 /* -------- GMAC_IDR : (GMAC Offset: 0x02C) Interrupt Disable Register -------- */
-#define GMAC_IDR_MFS (0x1u << 0) /**< \brief (GMAC_IDR) Management Frame Sent */
-#define GMAC_IDR_RCOMP (0x1u << 1) /**< \brief (GMAC_IDR) Receive Complete */
-#define GMAC_IDR_RXUBR (0x1u << 2) /**< \brief (GMAC_IDR) RX Used Bit Read */
-#define GMAC_IDR_TXUBR (0x1u << 3) /**< \brief (GMAC_IDR) TX Used Bit Read */
-#define GMAC_IDR_TUR (0x1u << 4) /**< \brief (GMAC_IDR) Transmit Under Run */
-#define GMAC_IDR_RLEX (0x1u << 5) /**< \brief (GMAC_IDR) Retry Limit Exceeded or Late Collision */
-#define GMAC_IDR_TFC (0x1u << 6) /**< \brief (GMAC_IDR) Transmit Frame Corruption due to AHB error */
-#define GMAC_IDR_TCOMP (0x1u << 7) /**< \brief (GMAC_IDR) Transmit Complete */
-#define GMAC_IDR_ROVR (0x1u << 10) /**< \brief (GMAC_IDR) Receive Overrun */
-#define GMAC_IDR_HRESP (0x1u << 11) /**< \brief (GMAC_IDR) HRESP Not OK */
-#define GMAC_IDR_PFNZ (0x1u << 12) /**< \brief (GMAC_IDR) Pause Frame with Non-zero Pause Quantum Received */
-#define GMAC_IDR_PTZ (0x1u << 13) /**< \brief (GMAC_IDR) Pause Time Zero */
-#define GMAC_IDR_PFTR (0x1u << 14) /**< \brief (GMAC_IDR) Pause Frame Transmitted */
-#define GMAC_IDR_EXINT (0x1u << 15) /**< \brief (GMAC_IDR) External Interrupt */
-#define GMAC_IDR_DRQFR (0x1u << 18) /**< \brief (GMAC_IDR) PTP Delay Request Frame Received */
-#define GMAC_IDR_SFR (0x1u << 19) /**< \brief (GMAC_IDR) PTP Sync Frame Received */
-#define GMAC_IDR_DRQFT (0x1u << 20) /**< \brief (GMAC_IDR) PTP Delay Request Frame Transmitted */
-#define GMAC_IDR_SFT (0x1u << 21) /**< \brief (GMAC_IDR) PTP Sync Frame Transmitted */
-#define GMAC_IDR_PDRQFR (0x1u << 22) /**< \brief (GMAC_IDR) PDelay Request Frame Received */
-#define GMAC_IDR_PDRSFR (0x1u << 23) /**< \brief (GMAC_IDR) PDelay Response Frame Received */
-#define GMAC_IDR_PDRQFT (0x1u << 24) /**< \brief (GMAC_IDR) PDelay Request Frame Transmitted */
-#define GMAC_IDR_PDRSFT (0x1u << 25) /**< \brief (GMAC_IDR) PDelay Response Frame Transmitted */
-#define GMAC_IDR_SRI (0x1u << 26) /**< \brief (GMAC_IDR) TSU Seconds Register Increment */
-#define GMAC_IDR_WOL (0x1u << 28) /**< \brief (GMAC_IDR) Wake On LAN */
+#define GMAC_IDR_MFS                  ( 0x1u << 0 )  /**< \brief (GMAC_IDR) Management Frame Sent */
+#define GMAC_IDR_RCOMP                ( 0x1u << 1 )  /**< \brief (GMAC_IDR) Receive Complete */
+#define GMAC_IDR_RXUBR                ( 0x1u << 2 )  /**< \brief (GMAC_IDR) RX Used Bit Read */
+#define GMAC_IDR_TXUBR                ( 0x1u << 3 )  /**< \brief (GMAC_IDR) TX Used Bit Read */
+#define GMAC_IDR_TUR                  ( 0x1u << 4 )  /**< \brief (GMAC_IDR) Transmit Under Run */
+#define GMAC_IDR_RLEX                 ( 0x1u << 5 )  /**< \brief (GMAC_IDR) Retry Limit Exceeded or Late Collision */
+#define GMAC_IDR_TFC                  ( 0x1u << 6 )  /**< \brief (GMAC_IDR) Transmit Frame Corruption due to AHB error */
+#define GMAC_IDR_TCOMP                ( 0x1u << 7 )  /**< \brief (GMAC_IDR) Transmit Complete */
+#define GMAC_IDR_ROVR                 ( 0x1u << 10 ) /**< \brief (GMAC_IDR) Receive Overrun */
+#define GMAC_IDR_HRESP                ( 0x1u << 11 ) /**< \brief (GMAC_IDR) HRESP Not OK */
+#define GMAC_IDR_PFNZ                 ( 0x1u << 12 ) /**< \brief (GMAC_IDR) Pause Frame with Non-zero Pause Quantum Received */
+#define GMAC_IDR_PTZ                  ( 0x1u << 13 ) /**< \brief (GMAC_IDR) Pause Time Zero */
+#define GMAC_IDR_PFTR                 ( 0x1u << 14 ) /**< \brief (GMAC_IDR) Pause Frame Transmitted */
+#define GMAC_IDR_EXINT                ( 0x1u << 15 ) /**< \brief (GMAC_IDR) External Interrupt */
+#define GMAC_IDR_DRQFR                ( 0x1u << 18 ) /**< \brief (GMAC_IDR) PTP Delay Request Frame Received */
+#define GMAC_IDR_SFR                  ( 0x1u << 19 ) /**< \brief (GMAC_IDR) PTP Sync Frame Received */
+#define GMAC_IDR_DRQFT                ( 0x1u << 20 ) /**< \brief (GMAC_IDR) PTP Delay Request Frame Transmitted */
+#define GMAC_IDR_SFT                  ( 0x1u << 21 ) /**< \brief (GMAC_IDR) PTP Sync Frame Transmitted */
+#define GMAC_IDR_PDRQFR               ( 0x1u << 22 ) /**< \brief (GMAC_IDR) PDelay Request Frame Received */
+#define GMAC_IDR_PDRSFR               ( 0x1u << 23 ) /**< \brief (GMAC_IDR) PDelay Response Frame Received */
+#define GMAC_IDR_PDRQFT               ( 0x1u << 24 ) /**< \brief (GMAC_IDR) PDelay Request Frame Transmitted */
+#define GMAC_IDR_PDRSFT               ( 0x1u << 25 ) /**< \brief (GMAC_IDR) PDelay Response Frame Transmitted */
+#define GMAC_IDR_SRI                  ( 0x1u << 26 ) /**< \brief (GMAC_IDR) TSU Seconds Register Increment */
+#define GMAC_IDR_WOL                  ( 0x1u << 28 ) /**< \brief (GMAC_IDR) Wake On LAN */
 /* -------- GMAC_IMR : (GMAC Offset: 0x030) Interrupt Mask Register -------- */
-#define GMAC_IMR_MFS (0x1u << 0) /**< \brief (GMAC_IMR) Management Frame Sent */
-#define GMAC_IMR_RCOMP (0x1u << 1) /**< \brief (GMAC_IMR) Receive Complete */
-#define GMAC_IMR_RXUBR (0x1u << 2) /**< \brief (GMAC_IMR) RX Used Bit Read */
-#define GMAC_IMR_TXUBR (0x1u << 3) /**< \brief (GMAC_IMR) TX Used Bit Read */
-#define GMAC_IMR_TUR (0x1u << 4) /**< \brief (GMAC_IMR) Transmit Under Run */
-#define GMAC_IMR_RLEX (0x1u << 5) /**< \brief (GMAC_IMR) Retry Limit Exceeded or Late Collision */
-#define GMAC_IMR_TFC (0x1u << 6) /**< \brief (GMAC_IMR) Transmit Frame Corruption due to AHB error */
-#define GMAC_IMR_TCOMP (0x1u << 7) /**< \brief (GMAC_IMR) Transmit Complete */
-#define GMAC_IMR_ROVR (0x1u << 10) /**< \brief (GMAC_IMR) Receive Overrun */
-#define GMAC_IMR_HRESP (0x1u << 11) /**< \brief (GMAC_IMR) HRESP Not OK */
-#define GMAC_IMR_PFNZ (0x1u << 12) /**< \brief (GMAC_IMR) Pause Frame with Non-zero Pause Quantum Received */
-#define GMAC_IMR_PTZ (0x1u << 13) /**< \brief (GMAC_IMR) Pause Time Zero */
-#define GMAC_IMR_PFTR (0x1u << 14) /**< \brief (GMAC_IMR) Pause Frame Transmitted */
-#define GMAC_IMR_EXINT (0x1u << 15) /**< \brief (GMAC_IMR) External Interrupt */
-#define GMAC_IMR_DRQFR (0x1u << 18) /**< \brief (GMAC_IMR) PTP Delay Request Frame Received */
-#define GMAC_IMR_SFR (0x1u << 19) /**< \brief (GMAC_IMR) PTP Sync Frame Received */
-#define GMAC_IMR_DRQFT (0x1u << 20) /**< \brief (GMAC_IMR) PTP Delay Request Frame Transmitted */
-#define GMAC_IMR_SFT (0x1u << 21) /**< \brief (GMAC_IMR) PTP Sync Frame Transmitted */
-#define GMAC_IMR_PDRQFR (0x1u << 22) /**< \brief (GMAC_IMR) PDelay Request Frame Received */
-#define GMAC_IMR_PDRSFR (0x1u << 23) /**< \brief (GMAC_IMR) PDelay Response Frame Received */
-#define GMAC_IMR_PDRQFT (0x1u << 24) /**< \brief (GMAC_IMR) PDelay Request Frame Transmitted */
-#define GMAC_IMR_PDRSFT (0x1u << 25) /**< \brief (GMAC_IMR) PDelay Response Frame Transmitted */
+#define GMAC_IMR_MFS                  ( 0x1u << 0 )  /**< \brief (GMAC_IMR) Management Frame Sent */
+#define GMAC_IMR_RCOMP                ( 0x1u << 1 )  /**< \brief (GMAC_IMR) Receive Complete */
+#define GMAC_IMR_RXUBR                ( 0x1u << 2 )  /**< \brief (GMAC_IMR) RX Used Bit Read */
+#define GMAC_IMR_TXUBR                ( 0x1u << 3 )  /**< \brief (GMAC_IMR) TX Used Bit Read */
+#define GMAC_IMR_TUR                  ( 0x1u << 4 )  /**< \brief (GMAC_IMR) Transmit Under Run */
+#define GMAC_IMR_RLEX                 ( 0x1u << 5 )  /**< \brief (GMAC_IMR) Retry Limit Exceeded or Late Collision */
+#define GMAC_IMR_TFC                  ( 0x1u << 6 )  /**< \brief (GMAC_IMR) Transmit Frame Corruption due to AHB error */
+#define GMAC_IMR_TCOMP                ( 0x1u << 7 )  /**< \brief (GMAC_IMR) Transmit Complete */
+#define GMAC_IMR_ROVR                 ( 0x1u << 10 ) /**< \brief (GMAC_IMR) Receive Overrun */
+#define GMAC_IMR_HRESP                ( 0x1u << 11 ) /**< \brief (GMAC_IMR) HRESP Not OK */
+#define GMAC_IMR_PFNZ                 ( 0x1u << 12 ) /**< \brief (GMAC_IMR) Pause Frame with Non-zero Pause Quantum Received */
+#define GMAC_IMR_PTZ                  ( 0x1u << 13 ) /**< \brief (GMAC_IMR) Pause Time Zero */
+#define GMAC_IMR_PFTR                 ( 0x1u << 14 ) /**< \brief (GMAC_IMR) Pause Frame Transmitted */
+#define GMAC_IMR_EXINT                ( 0x1u << 15 ) /**< \brief (GMAC_IMR) External Interrupt */
+#define GMAC_IMR_DRQFR                ( 0x1u << 18 ) /**< \brief (GMAC_IMR) PTP Delay Request Frame Received */
+#define GMAC_IMR_SFR                  ( 0x1u << 19 ) /**< \brief (GMAC_IMR) PTP Sync Frame Received */
+#define GMAC_IMR_DRQFT                ( 0x1u << 20 ) /**< \brief (GMAC_IMR) PTP Delay Request Frame Transmitted */
+#define GMAC_IMR_SFT                  ( 0x1u << 21 ) /**< \brief (GMAC_IMR) PTP Sync Frame Transmitted */
+#define GMAC_IMR_PDRQFR               ( 0x1u << 22 ) /**< \brief (GMAC_IMR) PDelay Request Frame Received */
+#define GMAC_IMR_PDRSFR               ( 0x1u << 23 ) /**< \brief (GMAC_IMR) PDelay Response Frame Received */
+#define GMAC_IMR_PDRQFT               ( 0x1u << 24 ) /**< \brief (GMAC_IMR) PDelay Request Frame Transmitted */
+#define GMAC_IMR_PDRSFT               ( 0x1u << 25 ) /**< \brief (GMAC_IMR) PDelay Response Frame Transmitted */
 /* -------- GMAC_MAN : (GMAC Offset: 0x034) PHY Maintenance Register -------- */
-#define GMAC_MAN_DATA_Pos 0
-#define GMAC_MAN_DATA_Msk (0xffffu << GMAC_MAN_DATA_Pos) /**< \brief (GMAC_MAN) PHY Data */
-#define GMAC_MAN_DATA(value) ((GMAC_MAN_DATA_Msk & ((value) << GMAC_MAN_DATA_Pos)))
-#define GMAC_MAN_WTN_Pos 16
-#define GMAC_MAN_WTN_Msk (0x3u << GMAC_MAN_WTN_Pos) /**< \brief (GMAC_MAN) Write Ten */
-#define GMAC_MAN_WTN(value) ((GMAC_MAN_WTN_Msk & ((value) << GMAC_MAN_WTN_Pos)))
-#define GMAC_MAN_REGA_Pos 18
-#define GMAC_MAN_REGA_Msk (0x1fu << GMAC_MAN_REGA_Pos) /**< \brief (GMAC_MAN) Register Address */
-#define GMAC_MAN_REGA(value) ((GMAC_MAN_REGA_Msk & ((value) << GMAC_MAN_REGA_Pos)))
-#define GMAC_MAN_PHYA_Pos 23
-#define GMAC_MAN_PHYA_Msk (0x1fu << GMAC_MAN_PHYA_Pos) /**< \brief (GMAC_MAN) PHY Address */
-#define GMAC_MAN_PHYA(value) ((GMAC_MAN_PHYA_Msk & ((value) << GMAC_MAN_PHYA_Pos)))
-#define GMAC_MAN_OP_Pos 28
-#define GMAC_MAN_OP_Msk (0x3u << GMAC_MAN_OP_Pos) /**< \brief (GMAC_MAN) Operation */
-#define GMAC_MAN_OP(value) ((GMAC_MAN_OP_Msk & ((value) << GMAC_MAN_OP_Pos)))
-#define GMAC_MAN_CLTTO (0x1u << 30) /**< \brief (GMAC_MAN) Clause 22 Operation */
-#define GMAC_MAN_WZO (0x1u << 31) /**< \brief (GMAC_MAN) Write ZERO */
+#define GMAC_MAN_DATA_Pos             0
+#define GMAC_MAN_DATA_Msk             ( 0xffffu << GMAC_MAN_DATA_Pos ) /**< \brief (GMAC_MAN) PHY Data */
+#define GMAC_MAN_DATA( value )    ( ( GMAC_MAN_DATA_Msk & ( ( value ) << GMAC_MAN_DATA_Pos ) ) )
+#define GMAC_MAN_WTN_Pos              16
+#define GMAC_MAN_WTN_Msk              ( 0x3u << GMAC_MAN_WTN_Pos ) /**< \brief (GMAC_MAN) Write Ten */
+#define GMAC_MAN_WTN( value )     ( ( GMAC_MAN_WTN_Msk & ( ( value ) << GMAC_MAN_WTN_Pos ) ) )
+#define GMAC_MAN_REGA_Pos             18
+#define GMAC_MAN_REGA_Msk             ( 0x1fu << GMAC_MAN_REGA_Pos ) /**< \brief (GMAC_MAN) Register Address */
+#define GMAC_MAN_REGA( value )    ( ( GMAC_MAN_REGA_Msk & ( ( value ) << GMAC_MAN_REGA_Pos ) ) )
+#define GMAC_MAN_PHYA_Pos             23
+#define GMAC_MAN_PHYA_Msk             ( 0x1fu << GMAC_MAN_PHYA_Pos ) /**< \brief (GMAC_MAN) PHY Address */
+#define GMAC_MAN_PHYA( value )    ( ( GMAC_MAN_PHYA_Msk & ( ( value ) << GMAC_MAN_PHYA_Pos ) ) )
+#define GMAC_MAN_OP_Pos               28
+#define GMAC_MAN_OP_Msk               ( 0x3u << GMAC_MAN_OP_Pos ) /**< \brief (GMAC_MAN) Operation */
+#define GMAC_MAN_OP( value )      ( ( GMAC_MAN_OP_Msk & ( ( value ) << GMAC_MAN_OP_Pos ) ) )
+#define GMAC_MAN_CLTTO                ( 0x1u << 30 )              /**< \brief (GMAC_MAN) Clause 22 Operation */
+#define GMAC_MAN_WZO                  ( 0x1u << 31 )              /**< \brief (GMAC_MAN) Write ZERO */
 /* -------- GMAC_RPQ : (GMAC Offset: 0x038) Received Pause Quantum Register -------- */
-#define GMAC_RPQ_RPQ_Pos 0
-#define GMAC_RPQ_RPQ_Msk (0xffffu << GMAC_RPQ_RPQ_Pos) /**< \brief (GMAC_RPQ) Received Pause Quantum */
+#define GMAC_RPQ_RPQ_Pos              0
+#define GMAC_RPQ_RPQ_Msk              ( 0xffffu << GMAC_RPQ_RPQ_Pos ) /**< \brief (GMAC_RPQ) Received Pause Quantum */
 /* -------- GMAC_TPQ : (GMAC Offset: 0x03C) Transmit Pause Quantum Register -------- */
-#define GMAC_TPQ_TPQ_Pos 0
-#define GMAC_TPQ_TPQ_Msk (0xffffu << GMAC_TPQ_TPQ_Pos) /**< \brief (GMAC_TPQ) Transmit Pause Quantum */
-#define GMAC_TPQ_TPQ(value) ((GMAC_TPQ_TPQ_Msk & ((value) << GMAC_TPQ_TPQ_Pos)))
+#define GMAC_TPQ_TPQ_Pos              0
+#define GMAC_TPQ_TPQ_Msk              ( 0xffffu << GMAC_TPQ_TPQ_Pos ) /**< \brief (GMAC_TPQ) Transmit Pause Quantum */
+#define GMAC_TPQ_TPQ( value )    ( ( GMAC_TPQ_TPQ_Msk & ( ( value ) << GMAC_TPQ_TPQ_Pos ) ) )
 /* -------- GMAC_TPSF : (GMAC Offset: 0x040) TX Partial Store and Forward Register -------- */
-#define GMAC_TPSF_TPB1ADR_Pos 0
-#define GMAC_TPSF_TPB1ADR_Msk (0xfffu << GMAC_TPSF_TPB1ADR_Pos) /**< \brief (GMAC_TPSF) tx_pbuf_addr-1:0 */
-#define GMAC_TPSF_TPB1ADR(value) ((GMAC_TPSF_TPB1ADR_Msk & ((value) << GMAC_TPSF_TPB1ADR_Pos)))
-#define GMAC_TPSF_ENTXP (0x1u << 31) /**< \brief (GMAC_TPSF) Enable TX Partial Store and Forward Operation */
+#define GMAC_TPSF_TPB1ADR_Pos         0
+#define GMAC_TPSF_TPB1ADR_Msk         ( 0xfffu << GMAC_TPSF_TPB1ADR_Pos ) /**< \brief (GMAC_TPSF) tx_pbuf_addr-1:0 */
+#define GMAC_TPSF_TPB1ADR( value )    ( ( GMAC_TPSF_TPB1ADR_Msk & ( ( value ) << GMAC_TPSF_TPB1ADR_Pos ) ) )
+#define GMAC_TPSF_ENTXP               ( 0x1u << 31 )                      /**< \brief (GMAC_TPSF) Enable TX Partial Store and Forward Operation */
 /* -------- GMAC_RPSF : (GMAC Offset: 0x044) RX Partial Store and Forward Register -------- */
-#define GMAC_RPSF_RPB1ADR_Pos 0
-#define GMAC_RPSF_RPB1ADR_Msk (0xfffu << GMAC_RPSF_RPB1ADR_Pos) /**< \brief (GMAC_RPSF) rx_pbuf_addr-1:0 */
-#define GMAC_RPSF_RPB1ADR(value) ((GMAC_RPSF_RPB1ADR_Msk & ((value) << GMAC_RPSF_RPB1ADR_Pos)))
-#define GMAC_RPSF_ENRXP (0x1u << 31) /**< \brief (GMAC_RPSF) Enable RX Partial Store and Forward Operation */
+#define GMAC_RPSF_RPB1ADR_Pos         0
+#define GMAC_RPSF_RPB1ADR_Msk         ( 0xfffu << GMAC_RPSF_RPB1ADR_Pos ) /**< \brief (GMAC_RPSF) rx_pbuf_addr-1:0 */
+#define GMAC_RPSF_RPB1ADR( value )    ( ( GMAC_RPSF_RPB1ADR_Msk & ( ( value ) << GMAC_RPSF_RPB1ADR_Pos ) ) )
+#define GMAC_RPSF_ENRXP               ( 0x1u << 31 )                      /**< \brief (GMAC_RPSF) Enable RX Partial Store and Forward Operation */
 /* -------- GMAC_HRB : (GMAC Offset: 0x080) Hash Register Bottom [31:0] -------- */
-#define GMAC_HRB_ADDR_Pos 0
-#define GMAC_HRB_ADDR_Msk (0xffffffffu << GMAC_HRB_ADDR_Pos) /**< \brief (GMAC_HRB) Hash Address */
-#define GMAC_HRB_ADDR(value) ((GMAC_HRB_ADDR_Msk & ((value) << GMAC_HRB_ADDR_Pos)))
+#define GMAC_HRB_ADDR_Pos             0
+#define GMAC_HRB_ADDR_Msk             ( 0xffffffffu << GMAC_HRB_ADDR_Pos ) /**< \brief (GMAC_HRB) Hash Address */
+#define GMAC_HRB_ADDR( value )    ( ( GMAC_HRB_ADDR_Msk & ( ( value ) << GMAC_HRB_ADDR_Pos ) ) )
 /* -------- GMAC_HRT : (GMAC Offset: 0x084) Hash Register Top [63:32] -------- */
-#define GMAC_HRT_ADDR_Pos 0
-#define GMAC_HRT_ADDR_Msk (0xffffffffu << GMAC_HRT_ADDR_Pos) /**< \brief (GMAC_HRT) Hash Address */
-#define GMAC_HRT_ADDR(value) ((GMAC_HRT_ADDR_Msk & ((value) << GMAC_HRT_ADDR_Pos)))
+#define GMAC_HRT_ADDR_Pos             0
+#define GMAC_HRT_ADDR_Msk             ( 0xffffffffu << GMAC_HRT_ADDR_Pos ) /**< \brief (GMAC_HRT) Hash Address */
+#define GMAC_HRT_ADDR( value )    ( ( GMAC_HRT_ADDR_Msk & ( ( value ) << GMAC_HRT_ADDR_Pos ) ) )
 /* -------- GMAC_SAB1 : (GMAC Offset: 0x088) Specific Address 1 Bottom [31:0] Register -------- */
-#define GMAC_SAB1_ADDR_Pos 0
-#define GMAC_SAB1_ADDR_Msk (0xffffffffu << GMAC_SAB1_ADDR_Pos) /**< \brief (GMAC_SAB1) Specific Address 1 */
-#define GMAC_SAB1_ADDR(value) ((GMAC_SAB1_ADDR_Msk & ((value) << GMAC_SAB1_ADDR_Pos)))
+#define GMAC_SAB1_ADDR_Pos            0
+#define GMAC_SAB1_ADDR_Msk            ( 0xffffffffu << GMAC_SAB1_ADDR_Pos ) /**< \brief (GMAC_SAB1) Specific Address 1 */
+#define GMAC_SAB1_ADDR( value )    ( ( GMAC_SAB1_ADDR_Msk & ( ( value ) << GMAC_SAB1_ADDR_Pos ) ) )
 /* -------- GMAC_SAT1 : (GMAC Offset: 0x08C) Specific Address 1 Top [47:32] Register -------- */
-#define GMAC_SAT1_ADDR_Pos 0
-#define GMAC_SAT1_ADDR_Msk (0xffffu << GMAC_SAT1_ADDR_Pos) /**< \brief (GMAC_SAT1) Specific Address 1 */
-#define GMAC_SAT1_ADDR(value) ((GMAC_SAT1_ADDR_Msk & ((value) << GMAC_SAT1_ADDR_Pos)))
+#define GMAC_SAT1_ADDR_Pos            0
+#define GMAC_SAT1_ADDR_Msk            ( 0xffffu << GMAC_SAT1_ADDR_Pos ) /**< \brief (GMAC_SAT1) Specific Address 1 */
+#define GMAC_SAT1_ADDR( value )    ( ( GMAC_SAT1_ADDR_Msk & ( ( value ) << GMAC_SAT1_ADDR_Pos ) ) )
 /* -------- GMAC_SAB2 : (GMAC Offset: 0x090) Specific Address 2 Bottom [31:0] Register -------- */
-#define GMAC_SAB2_ADDR_Pos 0
-#define GMAC_SAB2_ADDR_Msk (0xffffffffu << GMAC_SAB2_ADDR_Pos) /**< \brief (GMAC_SAB2) Specific Address 2 */
-#define GMAC_SAB2_ADDR(value) ((GMAC_SAB2_ADDR_Msk & ((value) << GMAC_SAB2_ADDR_Pos)))
+#define GMAC_SAB2_ADDR_Pos            0
+#define GMAC_SAB2_ADDR_Msk            ( 0xffffffffu << GMAC_SAB2_ADDR_Pos ) /**< \brief (GMAC_SAB2) Specific Address 2 */
+#define GMAC_SAB2_ADDR( value )    ( ( GMAC_SAB2_ADDR_Msk & ( ( value ) << GMAC_SAB2_ADDR_Pos ) ) )
 /* -------- GMAC_SAT2 : (GMAC Offset: 0x094) Specific Address 2 Top [47:32] Register -------- */
-#define GMAC_SAT2_ADDR_Pos 0
-#define GMAC_SAT2_ADDR_Msk (0xffffu << GMAC_SAT2_ADDR_Pos) /**< \brief (GMAC_SAT2) Specific Address 2 */
-#define GMAC_SAT2_ADDR(value) ((GMAC_SAT2_ADDR_Msk & ((value) << GMAC_SAT2_ADDR_Pos)))
+#define GMAC_SAT2_ADDR_Pos            0
+#define GMAC_SAT2_ADDR_Msk            ( 0xffffu << GMAC_SAT2_ADDR_Pos ) /**< \brief (GMAC_SAT2) Specific Address 2 */
+#define GMAC_SAT2_ADDR( value )    ( ( GMAC_SAT2_ADDR_Msk & ( ( value ) << GMAC_SAT2_ADDR_Pos ) ) )
 /* -------- GMAC_SAB3 : (GMAC Offset: 0x098) Specific Address 3 Bottom [31:0] Register -------- */
-#define GMAC_SAB3_ADDR_Pos 0
-#define GMAC_SAB3_ADDR_Msk (0xffffffffu << GMAC_SAB3_ADDR_Pos) /**< \brief (GMAC_SAB3) Specific Address 3 */
-#define GMAC_SAB3_ADDR(value) ((GMAC_SAB3_ADDR_Msk & ((value) << GMAC_SAB3_ADDR_Pos)))
+#define GMAC_SAB3_ADDR_Pos            0
+#define GMAC_SAB3_ADDR_Msk            ( 0xffffffffu << GMAC_SAB3_ADDR_Pos ) /**< \brief (GMAC_SAB3) Specific Address 3 */
+#define GMAC_SAB3_ADDR( value )    ( ( GMAC_SAB3_ADDR_Msk & ( ( value ) << GMAC_SAB3_ADDR_Pos ) ) )
 /* -------- GMAC_SAT3 : (GMAC Offset: 0x09C) Specific Address 3 Top [47:32] Register -------- */
-#define GMAC_SAT3_ADDR_Pos 0
-#define GMAC_SAT3_ADDR_Msk (0xffffu << GMAC_SAT3_ADDR_Pos) /**< \brief (GMAC_SAT3) Specific Address 3 */
-#define GMAC_SAT3_ADDR(value) ((GMAC_SAT3_ADDR_Msk & ((value) << GMAC_SAT3_ADDR_Pos)))
+#define GMAC_SAT3_ADDR_Pos            0
+#define GMAC_SAT3_ADDR_Msk            ( 0xffffu << GMAC_SAT3_ADDR_Pos ) /**< \brief (GMAC_SAT3) Specific Address 3 */
+#define GMAC_SAT3_ADDR( value )    ( ( GMAC_SAT3_ADDR_Msk & ( ( value ) << GMAC_SAT3_ADDR_Pos ) ) )
 /* -------- GMAC_SAB4 : (GMAC Offset: 0x0A0) Specific Address 4 Bottom [31:0] Register -------- */
-#define GMAC_SAB4_ADDR_Pos 0
-#define GMAC_SAB4_ADDR_Msk (0xffffffffu << GMAC_SAB4_ADDR_Pos) /**< \brief (GMAC_SAB4) Specific Address 4 */
-#define GMAC_SAB4_ADDR(value) ((GMAC_SAB4_ADDR_Msk & ((value) << GMAC_SAB4_ADDR_Pos)))
+#define GMAC_SAB4_ADDR_Pos            0
+#define GMAC_SAB4_ADDR_Msk            ( 0xffffffffu << GMAC_SAB4_ADDR_Pos ) /**< \brief (GMAC_SAB4) Specific Address 4 */
+#define GMAC_SAB4_ADDR( value )    ( ( GMAC_SAB4_ADDR_Msk & ( ( value ) << GMAC_SAB4_ADDR_Pos ) ) )
 /* -------- GMAC_SAT4 : (GMAC Offset: 0x0A4) Specific Address 4 Top [47:32] Register -------- */
-#define GMAC_SAT4_ADDR_Pos 0
-#define GMAC_SAT4_ADDR_Msk (0xffffu << GMAC_SAT4_ADDR_Pos) /**< \brief (GMAC_SAT4) Specific Address 4 */
-#define GMAC_SAT4_ADDR(value) ((GMAC_SAT4_ADDR_Msk & ((value) << GMAC_SAT4_ADDR_Pos)))
+#define GMAC_SAT4_ADDR_Pos            0
+#define GMAC_SAT4_ADDR_Msk            ( 0xffffu << GMAC_SAT4_ADDR_Pos ) /**< \brief (GMAC_SAT4) Specific Address 4 */
+#define GMAC_SAT4_ADDR( value )    ( ( GMAC_SAT4_ADDR_Msk & ( ( value ) << GMAC_SAT4_ADDR_Pos ) ) )
 /* -------- GMAC_TIDM[4] : (GMAC Offset: 0x0A8) Type ID Match 1 Register -------- */
-#define GMAC_TIDM_TID_Pos 0
-#define GMAC_TIDM_TID_Msk (0xffffu << GMAC_TIDM_TID_Pos) /**< \brief (GMAC_TIDM[4]) Type ID Match 1 */
-#define GMAC_TIDM_TID(value) ((GMAC_TIDM_TID_Msk & ((value) << GMAC_TIDM_TID_Pos)))
+#define GMAC_TIDM_TID_Pos             0
+#define GMAC_TIDM_TID_Msk             ( 0xffffu << GMAC_TIDM_TID_Pos ) /**< \brief (GMAC_TIDM[4]) Type ID Match 1 */
+#define GMAC_TIDM_TID( value )    ( ( GMAC_TIDM_TID_Msk & ( ( value ) << GMAC_TIDM_TID_Pos ) ) )
 /* -------- GMAC_WOL : (GMAC Offset: 0x0B8) Wake on LAN Register -------- */
-#define GMAC_WOL_IP_Pos 0
-#define GMAC_WOL_IP_Msk (0xffffu << GMAC_WOL_IP_Pos) /**< \brief (GMAC_WOL) ARP Request IP Address */
-#define GMAC_WOL_IP(value) ((GMAC_WOL_IP_Msk & ((value) << GMAC_WOL_IP_Pos)))
-#define GMAC_WOL_MAG (0x1u << 16) /**< \brief (GMAC_WOL) Magic Packet Event Enable */
-#define GMAC_WOL_ARP (0x1u << 17) /**< \brief (GMAC_WOL) ARP Request IP Address */
-#define GMAC_WOL_SA1 (0x1u << 18) /**< \brief (GMAC_WOL) Specific Address Register 1 Event Enable */
-#define GMAC_WOL_MTI (0x1u << 19) /**< \brief (GMAC_WOL) Multicast Hash Event Enable */
+#define GMAC_WOL_IP_Pos               0
+#define GMAC_WOL_IP_Msk               ( 0xffffu << GMAC_WOL_IP_Pos ) /**< \brief (GMAC_WOL) ARP Request IP Address */
+#define GMAC_WOL_IP( value )    ( ( GMAC_WOL_IP_Msk & ( ( value ) << GMAC_WOL_IP_Pos ) ) )
+#define GMAC_WOL_MAG                  ( 0x1u << 16 )                 /**< \brief (GMAC_WOL) Magic Packet Event Enable */
+#define GMAC_WOL_ARP                  ( 0x1u << 17 )                 /**< \brief (GMAC_WOL) ARP Request IP Address */
+#define GMAC_WOL_SA1                  ( 0x1u << 18 )                 /**< \brief (GMAC_WOL) Specific Address Register 1 Event Enable */
+#define GMAC_WOL_MTI                  ( 0x1u << 19 )                 /**< \brief (GMAC_WOL) Multicast Hash Event Enable */
 /* -------- GMAC_IPGS : (GMAC Offset: 0x0BC) IPG Stretch Register -------- */
-#define GMAC_IPGS_FL_Pos 0
-#define GMAC_IPGS_FL_Msk (0xffffu << GMAC_IPGS_FL_Pos) /**< \brief (GMAC_IPGS) Frame Length */
-#define GMAC_IPGS_FL(value) ((GMAC_IPGS_FL_Msk & ((value) << GMAC_IPGS_FL_Pos)))
+#define GMAC_IPGS_FL_Pos              0
+#define GMAC_IPGS_FL_Msk              ( 0xffffu << GMAC_IPGS_FL_Pos ) /**< \brief (GMAC_IPGS) Frame Length */
+#define GMAC_IPGS_FL( value )    ( ( GMAC_IPGS_FL_Msk & ( ( value ) << GMAC_IPGS_FL_Pos ) ) )
 /* -------- GMAC_SVLAN : (GMAC Offset: 0x0C0) Stacked VLAN Register -------- */
-#define GMAC_SVLAN_VLAN_TYPE_Pos 0
-#define GMAC_SVLAN_VLAN_TYPE_Msk (0xffffu << GMAC_SVLAN_VLAN_TYPE_Pos) /**< \brief (GMAC_SVLAN) User Defined VLAN_TYPE Field */
-#define GMAC_SVLAN_VLAN_TYPE(value) ((GMAC_SVLAN_VLAN_TYPE_Msk & ((value) << GMAC_SVLAN_VLAN_TYPE_Pos)))
-#define GMAC_SVLAN_ESVLAN (0x1u << 31) /**< \brief (GMAC_SVLAN) Enable Stacked VLAN Processing Mode */
+#define GMAC_SVLAN_VLAN_TYPE_Pos      0
+#define GMAC_SVLAN_VLAN_TYPE_Msk      ( 0xffffu << GMAC_SVLAN_VLAN_TYPE_Pos ) /**< \brief (GMAC_SVLAN) User Defined VLAN_TYPE Field */
+#define GMAC_SVLAN_VLAN_TYPE( value )    ( ( GMAC_SVLAN_VLAN_TYPE_Msk & ( ( value ) << GMAC_SVLAN_VLAN_TYPE_Pos ) ) )
+#define GMAC_SVLAN_ESVLAN             ( 0x1u << 31 )                          /**< \brief (GMAC_SVLAN) Enable Stacked VLAN Processing Mode */
 /* -------- GMAC_TPFCP : (GMAC Offset: 0x0C4) Transmit PFC Pause Register -------- */
-#define GMAC_TPFCP_PEV_Pos 0
-#define GMAC_TPFCP_PEV_Msk (0xffu << GMAC_TPFCP_PEV_Pos) /**< \brief (GMAC_TPFCP) Priority Enable Vector */
-#define GMAC_TPFCP_PEV(value) ((GMAC_TPFCP_PEV_Msk & ((value) << GMAC_TPFCP_PEV_Pos)))
-#define GMAC_TPFCP_PQ_Pos 8
-#define GMAC_TPFCP_PQ_Msk (0xffu << GMAC_TPFCP_PQ_Pos) /**< \brief (GMAC_TPFCP) Pause Quantum */
-#define GMAC_TPFCP_PQ(value) ((GMAC_TPFCP_PQ_Msk & ((value) << GMAC_TPFCP_PQ_Pos)))
+#define GMAC_TPFCP_PEV_Pos            0
+#define GMAC_TPFCP_PEV_Msk            ( 0xffu << GMAC_TPFCP_PEV_Pos ) /**< \brief (GMAC_TPFCP) Priority Enable Vector */
+#define GMAC_TPFCP_PEV( value )    ( ( GMAC_TPFCP_PEV_Msk & ( ( value ) << GMAC_TPFCP_PEV_Pos ) ) )
+#define GMAC_TPFCP_PQ_Pos             8
+#define GMAC_TPFCP_PQ_Msk             ( 0xffu << GMAC_TPFCP_PQ_Pos ) /**< \brief (GMAC_TPFCP) Pause Quantum */
+#define GMAC_TPFCP_PQ( value )     ( ( GMAC_TPFCP_PQ_Msk & ( ( value ) << GMAC_TPFCP_PQ_Pos ) ) )
 /* -------- GMAC_SAMB1 : (GMAC Offset: 0x0C8) Specific Address 1 Mask Bottom [31:0] Register -------- */
-#define GMAC_SAMB1_ADDR_Pos 0
-#define GMAC_SAMB1_ADDR_Msk (0xffffffffu << GMAC_SAMB1_ADDR_Pos) /**< \brief (GMAC_SAMB1) Specific Address 1 Mask */
-#define GMAC_SAMB1_ADDR(value) ((GMAC_SAMB1_ADDR_Msk & ((value) << GMAC_SAMB1_ADDR_Pos)))
+#define GMAC_SAMB1_ADDR_Pos           0
+#define GMAC_SAMB1_ADDR_Msk           ( 0xffffffffu << GMAC_SAMB1_ADDR_Pos ) /**< \brief (GMAC_SAMB1) Specific Address 1 Mask */
+#define GMAC_SAMB1_ADDR( value )    ( ( GMAC_SAMB1_ADDR_Msk & ( ( value ) << GMAC_SAMB1_ADDR_Pos ) ) )
 /* -------- GMAC_SAMT1 : (GMAC Offset: 0x0CC) Specific Address 1 Mask Top [47:32] Register -------- */
-#define GMAC_SAMT1_ADDR_Pos 0
-#define GMAC_SAMT1_ADDR_Msk (0xffffu << GMAC_SAMT1_ADDR_Pos) /**< \brief (GMAC_SAMT1) Specific Address 1 Mask */
-#define GMAC_SAMT1_ADDR(value) ((GMAC_SAMT1_ADDR_Msk & ((value) << GMAC_SAMT1_ADDR_Pos)))
+#define GMAC_SAMT1_ADDR_Pos           0
+#define GMAC_SAMT1_ADDR_Msk           ( 0xffffu << GMAC_SAMT1_ADDR_Pos ) /**< \brief (GMAC_SAMT1) Specific Address 1 Mask */
+#define GMAC_SAMT1_ADDR( value )    ( ( GMAC_SAMT1_ADDR_Msk & ( ( value ) << GMAC_SAMT1_ADDR_Pos ) ) )
 /* -------- GMAC_OTLO : (GMAC Offset: 0x100) Octets Transmitted [31:0] Register -------- */
-#define GMAC_OTLO_TXO_Pos 0
-#define GMAC_OTLO_TXO_Msk (0xffffffffu << GMAC_OTLO_TXO_Pos) /**< \brief (GMAC_OTLO) Transmitted Octets */
+#define GMAC_OTLO_TXO_Pos             0
+#define GMAC_OTLO_TXO_Msk             ( 0xffffffffu << GMAC_OTLO_TXO_Pos ) /**< \brief (GMAC_OTLO) Transmitted Octets */
 /* -------- GMAC_OTHI : (GMAC Offset: 0x104) Octets Transmitted [47:32] Register -------- */
-#define GMAC_OTHI_TXO_Pos 0
-#define GMAC_OTHI_TXO_Msk (0xffffu << GMAC_OTHI_TXO_Pos) /**< \brief (GMAC_OTHI) Transmitted Octets */
+#define GMAC_OTHI_TXO_Pos             0
+#define GMAC_OTHI_TXO_Msk             ( 0xffffu << GMAC_OTHI_TXO_Pos ) /**< \brief (GMAC_OTHI) Transmitted Octets */
 /* -------- GMAC_FT : (GMAC Offset: 0x108) Frames Transmitted Register -------- */
-#define GMAC_FT_FTX_Pos 0
-#define GMAC_FT_FTX_Msk (0xffffffffu << GMAC_FT_FTX_Pos) /**< \brief (GMAC_FT) Frames Transmitted without Error */
+#define GMAC_FT_FTX_Pos               0
+#define GMAC_FT_FTX_Msk               ( 0xffffffffu << GMAC_FT_FTX_Pos ) /**< \brief (GMAC_FT) Frames Transmitted without Error */
 /* -------- GMAC_BCFT : (GMAC Offset: 0x10C) Broadcast Frames Transmitted Register -------- */
-#define GMAC_BCFT_BFTX_Pos 0
-#define GMAC_BCFT_BFTX_Msk (0xffffffffu << GMAC_BCFT_BFTX_Pos) /**< \brief (GMAC_BCFT) Broadcast Frames Transmitted without Error */
+#define GMAC_BCFT_BFTX_Pos            0
+#define GMAC_BCFT_BFTX_Msk            ( 0xffffffffu << GMAC_BCFT_BFTX_Pos ) /**< \brief (GMAC_BCFT) Broadcast Frames Transmitted without Error */
 /* -------- GMAC_MFT : (GMAC Offset: 0x110) Multicast Frames Transmitted Register -------- */
-#define GMAC_MFT_MFTX_Pos 0
-#define GMAC_MFT_MFTX_Msk (0xffffffffu << GMAC_MFT_MFTX_Pos) /**< \brief (GMAC_MFT) Multicast Frames Transmitted without Error */
+#define GMAC_MFT_MFTX_Pos             0
+#define GMAC_MFT_MFTX_Msk             ( 0xffffffffu << GMAC_MFT_MFTX_Pos ) /**< \brief (GMAC_MFT) Multicast Frames Transmitted without Error */
 /* -------- GMAC_PFT : (GMAC Offset: 0x114) Pause Frames Transmitted Register -------- */
-#define GMAC_PFT_PFTX_Pos 0
-#define GMAC_PFT_PFTX_Msk (0xffffu << GMAC_PFT_PFTX_Pos) /**< \brief (GMAC_PFT) Pause Frames Transmitted Register */
+#define GMAC_PFT_PFTX_Pos             0
+#define GMAC_PFT_PFTX_Msk             ( 0xffffu << GMAC_PFT_PFTX_Pos ) /**< \brief (GMAC_PFT) Pause Frames Transmitted Register */
 /* -------- GMAC_BFT64 : (GMAC Offset: 0x118) 64 Byte Frames Transmitted Register -------- */
-#define GMAC_BFT64_NFTX_Pos 0
-#define GMAC_BFT64_NFTX_Msk (0xffffffffu << GMAC_BFT64_NFTX_Pos) /**< \brief (GMAC_BFT64) 64 Byte Frames Transmitted without Error */
+#define GMAC_BFT64_NFTX_Pos           0
+#define GMAC_BFT64_NFTX_Msk           ( 0xffffffffu << GMAC_BFT64_NFTX_Pos ) /**< \brief (GMAC_BFT64) 64 Byte Frames Transmitted without Error */
 /* -------- GMAC_TBFT127 : (GMAC Offset: 0x11C) 65 to 127 Byte Frames Transmitted Register -------- */
-#define GMAC_TBFT127_NFTX_Pos 0
-#define GMAC_TBFT127_NFTX_Msk (0xffffffffu << GMAC_TBFT127_NFTX_Pos) /**< \brief (GMAC_TBFT127) 65 to 127 Byte Frames Transmitted without Error */
+#define GMAC_TBFT127_NFTX_Pos         0
+#define GMAC_TBFT127_NFTX_Msk         ( 0xffffffffu << GMAC_TBFT127_NFTX_Pos ) /**< \brief (GMAC_TBFT127) 65 to 127 Byte Frames Transmitted without Error */
 /* -------- GMAC_TBFT255 : (GMAC Offset: 0x120) 128 to 255 Byte Frames Transmitted Register -------- */
-#define GMAC_TBFT255_NFTX_Pos 0
-#define GMAC_TBFT255_NFTX_Msk (0xffffffffu << GMAC_TBFT255_NFTX_Pos) /**< \brief (GMAC_TBFT255) 128 to 255 Byte Frames Transmitted without Error */
+#define GMAC_TBFT255_NFTX_Pos         0
+#define GMAC_TBFT255_NFTX_Msk         ( 0xffffffffu << GMAC_TBFT255_NFTX_Pos ) /**< \brief (GMAC_TBFT255) 128 to 255 Byte Frames Transmitted without Error */
 /* -------- GMAC_TBFT511 : (GMAC Offset: 0x124) 256 to 511 Byte Frames Transmitted Register -------- */
-#define GMAC_TBFT511_NFTX_Pos 0
-#define GMAC_TBFT511_NFTX_Msk (0xffffffffu << GMAC_TBFT511_NFTX_Pos) /**< \brief (GMAC_TBFT511) 256 to 511 Byte Frames Transmitted without Error */
+#define GMAC_TBFT511_NFTX_Pos         0
+#define GMAC_TBFT511_NFTX_Msk         ( 0xffffffffu << GMAC_TBFT511_NFTX_Pos ) /**< \brief (GMAC_TBFT511) 256 to 511 Byte Frames Transmitted without Error */
 /* -------- GMAC_TBFT1023 : (GMAC Offset: 0x128) 512 to 1023 Byte Frames Transmitted Register -------- */
-#define GMAC_TBFT1023_NFTX_Pos 0
-#define GMAC_TBFT1023_NFTX_Msk (0xffffffffu << GMAC_TBFT1023_NFTX_Pos) /**< \brief (GMAC_TBFT1023) 512 to 1023 Byte Frames Transmitted without Error */
+#define GMAC_TBFT1023_NFTX_Pos        0
+#define GMAC_TBFT1023_NFTX_Msk        ( 0xffffffffu << GMAC_TBFT1023_NFTX_Pos ) /**< \brief (GMAC_TBFT1023) 512 to 1023 Byte Frames Transmitted without Error */
 /* -------- GMAC_TBFT1518 : (GMAC Offset: 0x12C) 1024 to 1518 Byte Frames Transmitted Register -------- */
-#define GMAC_TBFT1518_NFTX_Pos 0
-#define GMAC_TBFT1518_NFTX_Msk (0xffffffffu << GMAC_TBFT1518_NFTX_Pos) /**< \brief (GMAC_TBFT1518) 1024 to 1518 Byte Frames Transmitted without Error */
+#define GMAC_TBFT1518_NFTX_Pos        0
+#define GMAC_TBFT1518_NFTX_Msk        ( 0xffffffffu << GMAC_TBFT1518_NFTX_Pos ) /**< \brief (GMAC_TBFT1518) 1024 to 1518 Byte Frames Transmitted without Error */
 /* -------- GMAC_GTBFT1518 : (GMAC Offset: 0x130) Greater Than 1518 Byte Frames Transmitted Register -------- */
-#define GMAC_GTBFT1518_NFTX_Pos 0
-#define GMAC_GTBFT1518_NFTX_Msk (0xffffffffu << GMAC_GTBFT1518_NFTX_Pos) /**< \brief (GMAC_GTBFT1518) Greater than 1518 Byte Frames Transmitted without Error */
+#define GMAC_GTBFT1518_NFTX_Pos       0
+#define GMAC_GTBFT1518_NFTX_Msk       ( 0xffffffffu << GMAC_GTBFT1518_NFTX_Pos ) /**< \brief (GMAC_GTBFT1518) Greater than 1518 Byte Frames Transmitted without Error */
 /* -------- GMAC_TUR : (GMAC Offset: 0x134) Transmit Under Runs Register -------- */
-#define GMAC_TUR_TXUNR_Pos 0
-#define GMAC_TUR_TXUNR_Msk (0x3ffu << GMAC_TUR_TXUNR_Pos) /**< \brief (GMAC_TUR) Transmit Under Runs */
+#define GMAC_TUR_TXUNR_Pos            0
+#define GMAC_TUR_TXUNR_Msk            ( 0x3ffu << GMAC_TUR_TXUNR_Pos ) /**< \brief (GMAC_TUR) Transmit Under Runs */
 /* -------- GMAC_SCF : (GMAC Offset: 0x138) Single Collision Frames Register -------- */
-#define GMAC_SCF_SCOL_Pos 0
-#define GMAC_SCF_SCOL_Msk (0x3ffffu << GMAC_SCF_SCOL_Pos) /**< \brief (GMAC_SCF) Single Collision */
+#define GMAC_SCF_SCOL_Pos             0
+#define GMAC_SCF_SCOL_Msk             ( 0x3ffffu << GMAC_SCF_SCOL_Pos ) /**< \brief (GMAC_SCF) Single Collision */
 /* -------- GMAC_MCF : (GMAC Offset: 0x13C) Multiple Collision Frames Register -------- */
-#define GMAC_MCF_MCOL_Pos 0
-#define GMAC_MCF_MCOL_Msk (0x3ffffu << GMAC_MCF_MCOL_Pos) /**< \brief (GMAC_MCF) Multiple Collision */
+#define GMAC_MCF_MCOL_Pos             0
+#define GMAC_MCF_MCOL_Msk             ( 0x3ffffu << GMAC_MCF_MCOL_Pos ) /**< \brief (GMAC_MCF) Multiple Collision */
 /* -------- GMAC_EC : (GMAC Offset: 0x140) Excessive Collisions Register -------- */
-#define GMAC_EC_XCOL_Pos 0
-#define GMAC_EC_XCOL_Msk (0x3ffu << GMAC_EC_XCOL_Pos) /**< \brief (GMAC_EC) Excessive Collisions */
+#define GMAC_EC_XCOL_Pos              0
+#define GMAC_EC_XCOL_Msk              ( 0x3ffu << GMAC_EC_XCOL_Pos ) /**< \brief (GMAC_EC) Excessive Collisions */
 /* -------- GMAC_LC : (GMAC Offset: 0x144) Late Collisions Register -------- */
-#define GMAC_LC_LCOL_Pos 0
-#define GMAC_LC_LCOL_Msk (0x3ffu << GMAC_LC_LCOL_Pos) /**< \brief (GMAC_LC) Late Collisions */
+#define GMAC_LC_LCOL_Pos              0
+#define GMAC_LC_LCOL_Msk              ( 0x3ffu << GMAC_LC_LCOL_Pos ) /**< \brief (GMAC_LC) Late Collisions */
 /* -------- GMAC_DTF : (GMAC Offset: 0x148) Deferred Transmission Frames Register -------- */
-#define GMAC_DTF_DEFT_Pos 0
-#define GMAC_DTF_DEFT_Msk (0x3ffffu << GMAC_DTF_DEFT_Pos) /**< \brief (GMAC_DTF) Deferred Transmission */
+#define GMAC_DTF_DEFT_Pos             0
+#define GMAC_DTF_DEFT_Msk             ( 0x3ffffu << GMAC_DTF_DEFT_Pos ) /**< \brief (GMAC_DTF) Deferred Transmission */
 /* -------- GMAC_CSE : (GMAC Offset: 0x14C) Carrier Sense Errors Register -------- */
-#define GMAC_CSE_CSR_Pos 0
-#define GMAC_CSE_CSR_Msk (0x3ffu << GMAC_CSE_CSR_Pos) /**< \brief (GMAC_CSE) Carrier Sense Error */
+#define GMAC_CSE_CSR_Pos              0
+#define GMAC_CSE_CSR_Msk              ( 0x3ffu << GMAC_CSE_CSR_Pos ) /**< \brief (GMAC_CSE) Carrier Sense Error */
 /* -------- GMAC_ORLO : (GMAC Offset: 0x150) Octets Received [31:0] Received -------- */
-#define GMAC_ORLO_RXO_Pos 0
-#define GMAC_ORLO_RXO_Msk (0xffffffffu << GMAC_ORLO_RXO_Pos) /**< \brief (GMAC_ORLO) Received Octets */
+#define GMAC_ORLO_RXO_Pos             0
+#define GMAC_ORLO_RXO_Msk             ( 0xffffffffu << GMAC_ORLO_RXO_Pos ) /**< \brief (GMAC_ORLO) Received Octets */
 /* -------- GMAC_ORHI : (GMAC Offset: 0x154) Octets Received [47:32] Received -------- */
-#define GMAC_ORHI_RXO_Pos 0
-#define GMAC_ORHI_RXO_Msk (0xffffu << GMAC_ORHI_RXO_Pos) /**< \brief (GMAC_ORHI) Received Octets */
+#define GMAC_ORHI_RXO_Pos             0
+#define GMAC_ORHI_RXO_Msk             ( 0xffffu << GMAC_ORHI_RXO_Pos ) /**< \brief (GMAC_ORHI) Received Octets */
 /* -------- GMAC_FR : (GMAC Offset: 0x158) Frames Received Register -------- */
-#define GMAC_FR_FRX_Pos 0
-#define GMAC_FR_FRX_Msk (0xffffffffu << GMAC_FR_FRX_Pos) /**< \brief (GMAC_FR) Frames Received without Error */
+#define GMAC_FR_FRX_Pos               0
+#define GMAC_FR_FRX_Msk               ( 0xffffffffu << GMAC_FR_FRX_Pos ) /**< \brief (GMAC_FR) Frames Received without Error */
 /* -------- GMAC_BCFR : (GMAC Offset: 0x15C) Broadcast Frames Received Register -------- */
-#define GMAC_BCFR_BFRX_Pos 0
-#define GMAC_BCFR_BFRX_Msk (0xffffffffu << GMAC_BCFR_BFRX_Pos) /**< \brief (GMAC_BCFR) Broadcast Frames Received without Error */
+#define GMAC_BCFR_BFRX_Pos            0
+#define GMAC_BCFR_BFRX_Msk            ( 0xffffffffu << GMAC_BCFR_BFRX_Pos ) /**< \brief (GMAC_BCFR) Broadcast Frames Received without Error */
 /* -------- GMAC_MFR : (GMAC Offset: 0x160) Multicast Frames Received Register -------- */
-#define GMAC_MFR_MFRX_Pos 0
-#define GMAC_MFR_MFRX_Msk (0xffffffffu << GMAC_MFR_MFRX_Pos) /**< \brief (GMAC_MFR) Multicast Frames Received without Error */
+#define GMAC_MFR_MFRX_Pos             0
+#define GMAC_MFR_MFRX_Msk             ( 0xffffffffu << GMAC_MFR_MFRX_Pos ) /**< \brief (GMAC_MFR) Multicast Frames Received without Error */
 /* -------- GMAC_PFR : (GMAC Offset: 0x164) Pause Frames Received Register -------- */
-#define GMAC_PFR_PFRX_Pos 0
-#define GMAC_PFR_PFRX_Msk (0xffffu << GMAC_PFR_PFRX_Pos) /**< \brief (GMAC_PFR) Pause Frames Received Register */
+#define GMAC_PFR_PFRX_Pos             0
+#define GMAC_PFR_PFRX_Msk             ( 0xffffu << GMAC_PFR_PFRX_Pos ) /**< \brief (GMAC_PFR) Pause Frames Received Register */
 /* -------- GMAC_BFR64 : (GMAC Offset: 0x168) 64 Byte Frames Received Register -------- */
-#define GMAC_BFR64_NFRX_Pos 0
-#define GMAC_BFR64_NFRX_Msk (0xffffffffu << GMAC_BFR64_NFRX_Pos) /**< \brief (GMAC_BFR64) 64 Byte Frames Received without Error */
+#define GMAC_BFR64_NFRX_Pos           0
+#define GMAC_BFR64_NFRX_Msk           ( 0xffffffffu << GMAC_BFR64_NFRX_Pos ) /**< \brief (GMAC_BFR64) 64 Byte Frames Received without Error */
 /* -------- GMAC_TBFR127 : (GMAC Offset: 0x16C) 65 to 127 Byte Frames Received Register -------- */
-#define GMAC_TBFR127_NFRX_Pos 0
-#define GMAC_TBFR127_NFRX_Msk (0xffffffffu << GMAC_TBFR127_NFRX_Pos) /**< \brief (GMAC_TBFR127) 65 to 127 Byte Frames Received without Error */
+#define GMAC_TBFR127_NFRX_Pos         0
+#define GMAC_TBFR127_NFRX_Msk         ( 0xffffffffu << GMAC_TBFR127_NFRX_Pos ) /**< \brief (GMAC_TBFR127) 65 to 127 Byte Frames Received without Error */
 /* -------- GMAC_TBFR255 : (GMAC Offset: 0x170) 128 to 255 Byte Frames Received Register -------- */
-#define GMAC_TBFR255_NFRX_Pos 0
-#define GMAC_TBFR255_NFRX_Msk (0xffffffffu << GMAC_TBFR255_NFRX_Pos) /**< \brief (GMAC_TBFR255) 128 to 255 Byte Frames Received without Error */
+#define GMAC_TBFR255_NFRX_Pos         0
+#define GMAC_TBFR255_NFRX_Msk         ( 0xffffffffu << GMAC_TBFR255_NFRX_Pos ) /**< \brief (GMAC_TBFR255) 128 to 255 Byte Frames Received without Error */
 /* -------- GMAC_TBFR511 : (GMAC Offset: 0x174) 256 to 511Byte Frames Received Register -------- */
-#define GMAC_TBFR511_NFRX_Pos 0
-#define GMAC_TBFR511_NFRX_Msk (0xffffffffu << GMAC_TBFR511_NFRX_Pos) /**< \brief (GMAC_TBFR511) 256 to 511 Byte Frames Received without Error */
+#define GMAC_TBFR511_NFRX_Pos         0
+#define GMAC_TBFR511_NFRX_Msk         ( 0xffffffffu << GMAC_TBFR511_NFRX_Pos ) /**< \brief (GMAC_TBFR511) 256 to 511 Byte Frames Received without Error */
 /* -------- GMAC_TBFR1023 : (GMAC Offset: 0x178) 512 to 1023 Byte Frames Received Register -------- */
-#define GMAC_TBFR1023_NFRX_Pos 0
-#define GMAC_TBFR1023_NFRX_Msk (0xffffffffu << GMAC_TBFR1023_NFRX_Pos) /**< \brief (GMAC_TBFR1023) 512 to 1023 Byte Frames Received without Error */
+#define GMAC_TBFR1023_NFRX_Pos        0
+#define GMAC_TBFR1023_NFRX_Msk        ( 0xffffffffu << GMAC_TBFR1023_NFRX_Pos ) /**< \brief (GMAC_TBFR1023) 512 to 1023 Byte Frames Received without Error */
 /* -------- GMAC_TBFR1518 : (GMAC Offset: 0x17C) 1024 to 1518 Byte Frames Received Register -------- */
-#define GMAC_TBFR1518_NFRX_Pos 0
-#define GMAC_TBFR1518_NFRX_Msk (0xffffffffu << GMAC_TBFR1518_NFRX_Pos) /**< \brief (GMAC_TBFR1518) 1024 to 1518 Byte Frames Received without Error */
+#define GMAC_TBFR1518_NFRX_Pos        0
+#define GMAC_TBFR1518_NFRX_Msk        ( 0xffffffffu << GMAC_TBFR1518_NFRX_Pos ) /**< \brief (GMAC_TBFR1518) 1024 to 1518 Byte Frames Received without Error */
 /* -------- GMAC_TMXBFR : (GMAC Offset: 0x180) 1519 to Maximum Byte Frames Received Register -------- */
-#define GMAC_TMXBFR_NFRX_Pos 0
-#define GMAC_TMXBFR_NFRX_Msk (0xffffffffu << GMAC_TMXBFR_NFRX_Pos) /**< \brief (GMAC_TMXBFR) 1519 to Maximum Byte Frames Received without Error */
+#define GMAC_TMXBFR_NFRX_Pos          0
+#define GMAC_TMXBFR_NFRX_Msk          ( 0xffffffffu << GMAC_TMXBFR_NFRX_Pos ) /**< \brief (GMAC_TMXBFR) 1519 to Maximum Byte Frames Received without Error */
 /* -------- GMAC_UFR : (GMAC Offset: 0x184) Undersize Frames Received Register -------- */
-#define GMAC_UFR_UFRX_Pos 0
-#define GMAC_UFR_UFRX_Msk (0x3ffu << GMAC_UFR_UFRX_Pos) /**< \brief (GMAC_UFR) Undersize Frames Received */
+#define GMAC_UFR_UFRX_Pos             0
+#define GMAC_UFR_UFRX_Msk             ( 0x3ffu << GMAC_UFR_UFRX_Pos ) /**< \brief (GMAC_UFR) Undersize Frames Received */
 /* -------- GMAC_OFR : (GMAC Offset: 0x188) Oversize Frames Received Register -------- */
-#define GMAC_OFR_OFRX_Pos 0
-#define GMAC_OFR_OFRX_Msk (0x3ffu << GMAC_OFR_OFRX_Pos) /**< \brief (GMAC_OFR) Oversized Frames Received */
+#define GMAC_OFR_OFRX_Pos             0
+#define GMAC_OFR_OFRX_Msk             ( 0x3ffu << GMAC_OFR_OFRX_Pos ) /**< \brief (GMAC_OFR) Oversized Frames Received */
 /* -------- GMAC_JR : (GMAC Offset: 0x18C) Jabbers Received Register -------- */
-#define GMAC_JR_JRX_Pos 0
-#define GMAC_JR_JRX_Msk (0x3ffu << GMAC_JR_JRX_Pos) /**< \brief (GMAC_JR) Jabbers Received */
+#define GMAC_JR_JRX_Pos               0
+#define GMAC_JR_JRX_Msk               ( 0x3ffu << GMAC_JR_JRX_Pos ) /**< \brief (GMAC_JR) Jabbers Received */
 /* -------- GMAC_FCSE : (GMAC Offset: 0x190) Frame Check Sequence Errors Register -------- */
-#define GMAC_FCSE_FCKR_Pos 0
-#define GMAC_FCSE_FCKR_Msk (0x3ffu << GMAC_FCSE_FCKR_Pos) /**< \brief (GMAC_FCSE) Frame Check Sequence Errors */
+#define GMAC_FCSE_FCKR_Pos            0
+#define GMAC_FCSE_FCKR_Msk            ( 0x3ffu << GMAC_FCSE_FCKR_Pos ) /**< \brief (GMAC_FCSE) Frame Check Sequence Errors */
 /* -------- GMAC_LFFE : (GMAC Offset: 0x194) Length Field Frame Errors Register -------- */
-#define GMAC_LFFE_LFER_Pos 0
-#define GMAC_LFFE_LFER_Msk (0x3ffu << GMAC_LFFE_LFER_Pos) /**< \brief (GMAC_LFFE) Length Field Frame Errors */
+#define GMAC_LFFE_LFER_Pos            0
+#define GMAC_LFFE_LFER_Msk            ( 0x3ffu << GMAC_LFFE_LFER_Pos ) /**< \brief (GMAC_LFFE) Length Field Frame Errors */
 /* -------- GMAC_RSE : (GMAC Offset: 0x198) Receive Symbol Errors Register -------- */
-#define GMAC_RSE_RXSE_Pos 0
-#define GMAC_RSE_RXSE_Msk (0x3ffu << GMAC_RSE_RXSE_Pos) /**< \brief (GMAC_RSE) Receive Symbol Errors */
+#define GMAC_RSE_RXSE_Pos             0
+#define GMAC_RSE_RXSE_Msk             ( 0x3ffu << GMAC_RSE_RXSE_Pos ) /**< \brief (GMAC_RSE) Receive Symbol Errors */
 /* -------- GMAC_AE : (GMAC Offset: 0x19C) Alignment Errors Register -------- */
-#define GMAC_AE_AER_Pos 0
-#define GMAC_AE_AER_Msk (0x3ffu << GMAC_AE_AER_Pos) /**< \brief (GMAC_AE) Alignment Errors */
+#define GMAC_AE_AER_Pos               0
+#define GMAC_AE_AER_Msk               ( 0x3ffu << GMAC_AE_AER_Pos ) /**< \brief (GMAC_AE) Alignment Errors */
 /* -------- GMAC_RRE : (GMAC Offset: 0x1A0) Receive Resource Errors Register -------- */
-#define GMAC_RRE_RXRER_Pos 0
-#define GMAC_RRE_RXRER_Msk (0x3ffffu << GMAC_RRE_RXRER_Pos) /**< \brief (GMAC_RRE) Receive Resource Errors */
+#define GMAC_RRE_RXRER_Pos            0
+#define GMAC_RRE_RXRER_Msk            ( 0x3ffffu << GMAC_RRE_RXRER_Pos ) /**< \brief (GMAC_RRE) Receive Resource Errors */
 /* -------- GMAC_ROE : (GMAC Offset: 0x1A4) Receive Overrun Register -------- */
-#define GMAC_ROE_RXOVR_Pos 0
-#define GMAC_ROE_RXOVR_Msk (0x3ffu << GMAC_ROE_RXOVR_Pos) /**< \brief (GMAC_ROE) Receive Overruns */
+#define GMAC_ROE_RXOVR_Pos            0
+#define GMAC_ROE_RXOVR_Msk            ( 0x3ffu << GMAC_ROE_RXOVR_Pos ) /**< \brief (GMAC_ROE) Receive Overruns */
 /* -------- GMAC_IHCE : (GMAC Offset: 0x1A8) IP Header Checksum Errors Register -------- */
-#define GMAC_IHCE_HCKER_Pos 0
-#define GMAC_IHCE_HCKER_Msk (0xffu << GMAC_IHCE_HCKER_Pos) /**< \brief (GMAC_IHCE) IP Header Checksum Errors */
+#define GMAC_IHCE_HCKER_Pos           0
+#define GMAC_IHCE_HCKER_Msk           ( 0xffu << GMAC_IHCE_HCKER_Pos ) /**< \brief (GMAC_IHCE) IP Header Checksum Errors */
 /* -------- GMAC_TCE : (GMAC Offset: 0x1AC) TCP Checksum Errors Register -------- */
-#define GMAC_TCE_TCKER_Pos 0
-#define GMAC_TCE_TCKER_Msk (0xffu << GMAC_TCE_TCKER_Pos) /**< \brief (GMAC_TCE) TCP Checksum Errors */
+#define GMAC_TCE_TCKER_Pos            0
+#define GMAC_TCE_TCKER_Msk            ( 0xffu << GMAC_TCE_TCKER_Pos ) /**< \brief (GMAC_TCE) TCP Checksum Errors */
 /* -------- GMAC_UCE : (GMAC Offset: 0x1B0) UDP Checksum Errors Register -------- */
-#define GMAC_UCE_UCKER_Pos 0
-#define GMAC_UCE_UCKER_Msk (0xffu << GMAC_UCE_UCKER_Pos) /**< \brief (GMAC_UCE) UDP Checksum Errors */
+#define GMAC_UCE_UCKER_Pos            0
+#define GMAC_UCE_UCKER_Msk            ( 0xffu << GMAC_UCE_UCKER_Pos ) /**< \brief (GMAC_UCE) UDP Checksum Errors */
 /* -------- GMAC_TSSS : (GMAC Offset: 0x1C8) 1588 Timer Sync Strobe Seconds Register -------- */
-#define GMAC_TSSS_VTS_Pos 0
-#define GMAC_TSSS_VTS_Msk (0xffffffffu << GMAC_TSSS_VTS_Pos) /**< \brief (GMAC_TSSS) Value of Timer Seconds Register Capture */
-#define GMAC_TSSS_VTS(value) ((GMAC_TSSS_VTS_Msk & ((value) << GMAC_TSSS_VTS_Pos)))
+#define GMAC_TSSS_VTS_Pos             0
+#define GMAC_TSSS_VTS_Msk             ( 0xffffffffu << GMAC_TSSS_VTS_Pos ) /**< \brief (GMAC_TSSS) Value of Timer Seconds Register Capture */
+#define GMAC_TSSS_VTS( value )    ( ( GMAC_TSSS_VTS_Msk & ( ( value ) << GMAC_TSSS_VTS_Pos ) ) )
 /* -------- GMAC_TSSN : (GMAC Offset: 0x1CC) 1588 Timer Sync Strobe Nanoseconds Register -------- */
-#define GMAC_TSSN_VTN_Pos 0
-#define GMAC_TSSN_VTN_Msk (0x3fffffffu << GMAC_TSSN_VTN_Pos) /**< \brief (GMAC_TSSN) Value Timer Nanoseconds Register Capture */
-#define GMAC_TSSN_VTN(value) ((GMAC_TSSN_VTN_Msk & ((value) << GMAC_TSSN_VTN_Pos)))
+#define GMAC_TSSN_VTN_Pos             0
+#define GMAC_TSSN_VTN_Msk             ( 0x3fffffffu << GMAC_TSSN_VTN_Pos ) /**< \brief (GMAC_TSSN) Value Timer Nanoseconds Register Capture */
+#define GMAC_TSSN_VTN( value )    ( ( GMAC_TSSN_VTN_Msk & ( ( value ) << GMAC_TSSN_VTN_Pos ) ) )
 /* -------- GMAC_TS : (GMAC Offset: 0x1D0) 1588 Timer Seconds Register -------- */
-#define GMAC_TS_TCS_Pos 0
-#define GMAC_TS_TCS_Msk (0xffffffffu << GMAC_TS_TCS_Pos) /**< \brief (GMAC_TS) Timer Count in Seconds */
-#define GMAC_TS_TCS(value) ((GMAC_TS_TCS_Msk & ((value) << GMAC_TS_TCS_Pos)))
+#define GMAC_TS_TCS_Pos               0
+#define GMAC_TS_TCS_Msk               ( 0xffffffffu << GMAC_TS_TCS_Pos ) /**< \brief (GMAC_TS) Timer Count in Seconds */
+#define GMAC_TS_TCS( value )    ( ( GMAC_TS_TCS_Msk & ( ( value ) << GMAC_TS_TCS_Pos ) ) )
 /* -------- GMAC_TN : (GMAC Offset: 0x1D4) 1588 Timer Nanoseconds Register -------- */
-#define GMAC_TN_TNS_Pos 0
-#define GMAC_TN_TNS_Msk (0x3fffffffu << GMAC_TN_TNS_Pos) /**< \brief (GMAC_TN) Timer Count in Nanoseconds */
-#define GMAC_TN_TNS(value) ((GMAC_TN_TNS_Msk & ((value) << GMAC_TN_TNS_Pos)))
+#define GMAC_TN_TNS_Pos               0
+#define GMAC_TN_TNS_Msk               ( 0x3fffffffu << GMAC_TN_TNS_Pos ) /**< \brief (GMAC_TN) Timer Count in Nanoseconds */
+#define GMAC_TN_TNS( value )    ( ( GMAC_TN_TNS_Msk & ( ( value ) << GMAC_TN_TNS_Pos ) ) )
 /* -------- GMAC_TA : (GMAC Offset: 0x1D8) 1588 Timer Adjust Register -------- */
-#define GMAC_TA_ITDT_Pos 0
-#define GMAC_TA_ITDT_Msk (0x3fffffffu << GMAC_TA_ITDT_Pos) /**< \brief (GMAC_TA) Increment/Decrement */
-#define GMAC_TA_ITDT(value) ((GMAC_TA_ITDT_Msk & ((value) << GMAC_TA_ITDT_Pos)))
-#define GMAC_TA_ADJ (0x1u << 31) /**< \brief (GMAC_TA) Adjust 1588 Timer */
+#define GMAC_TA_ITDT_Pos              0
+#define GMAC_TA_ITDT_Msk              ( 0x3fffffffu << GMAC_TA_ITDT_Pos ) /**< \brief (GMAC_TA) Increment/Decrement */
+#define GMAC_TA_ITDT( value )    ( ( GMAC_TA_ITDT_Msk & ( ( value ) << GMAC_TA_ITDT_Pos ) ) )
+#define GMAC_TA_ADJ                   ( 0x1u << 31 )                      /**< \brief (GMAC_TA) Adjust 1588 Timer */
 /* -------- GMAC_TI : (GMAC Offset: 0x1DC) 1588 Timer Increment Register -------- */
-#define GMAC_TI_CNS_Pos 0
-#define GMAC_TI_CNS_Msk (0xffu << GMAC_TI_CNS_Pos) /**< \brief (GMAC_TI) Count Nanoseconds */
-#define GMAC_TI_CNS(value) ((GMAC_TI_CNS_Msk & ((value) << GMAC_TI_CNS_Pos)))
-#define GMAC_TI_ACNS_Pos 8
-#define GMAC_TI_ACNS_Msk (0xffu << GMAC_TI_ACNS_Pos) /**< \brief (GMAC_TI) Alternative Count Nanoseconds */
-#define GMAC_TI_ACNS(value) ((GMAC_TI_ACNS_Msk & ((value) << GMAC_TI_ACNS_Pos)))
-#define GMAC_TI_NIT_Pos 16
-#define GMAC_TI_NIT_Msk (0xffu << GMAC_TI_NIT_Pos) /**< \brief (GMAC_TI) Number of Increments */
-#define GMAC_TI_NIT(value) ((GMAC_TI_NIT_Msk & ((value) << GMAC_TI_NIT_Pos)))
+#define GMAC_TI_CNS_Pos               0
+#define GMAC_TI_CNS_Msk               ( 0xffu << GMAC_TI_CNS_Pos ) /**< \brief (GMAC_TI) Count Nanoseconds */
+#define GMAC_TI_CNS( value )     ( ( GMAC_TI_CNS_Msk & ( ( value ) << GMAC_TI_CNS_Pos ) ) )
+#define GMAC_TI_ACNS_Pos              8
+#define GMAC_TI_ACNS_Msk              ( 0xffu << GMAC_TI_ACNS_Pos ) /**< \brief (GMAC_TI) Alternative Count Nanoseconds */
+#define GMAC_TI_ACNS( value )    ( ( GMAC_TI_ACNS_Msk & ( ( value ) << GMAC_TI_ACNS_Pos ) ) )
+#define GMAC_TI_NIT_Pos               16
+#define GMAC_TI_NIT_Msk               ( 0xffu << GMAC_TI_NIT_Pos ) /**< \brief (GMAC_TI) Number of Increments */
+#define GMAC_TI_NIT( value )     ( ( GMAC_TI_NIT_Msk & ( ( value ) << GMAC_TI_NIT_Pos ) ) )
 /* -------- GMAC_EFTS : (GMAC Offset: 0x1E0) PTP Event Frame Transmitted Seconds -------- */
-#define GMAC_EFTS_RUD_Pos 0
-#define GMAC_EFTS_RUD_Msk (0xffffffffu << GMAC_EFTS_RUD_Pos) /**< \brief (GMAC_EFTS) Register Update */
+#define GMAC_EFTS_RUD_Pos             0
+#define GMAC_EFTS_RUD_Msk             ( 0xffffffffu << GMAC_EFTS_RUD_Pos ) /**< \brief (GMAC_EFTS) Register Update */
 /* -------- GMAC_EFTN : (GMAC Offset: 0x1E4) PTP Event Frame Transmitted Nanoseconds -------- */
-#define GMAC_EFTN_RUD_Pos 0
-#define GMAC_EFTN_RUD_Msk (0x3fffffffu << GMAC_EFTN_RUD_Pos) /**< \brief (GMAC_EFTN) Register Update */
+#define GMAC_EFTN_RUD_Pos             0
+#define GMAC_EFTN_RUD_Msk             ( 0x3fffffffu << GMAC_EFTN_RUD_Pos ) /**< \brief (GMAC_EFTN) Register Update */
 /* -------- GMAC_EFRS : (GMAC Offset: 0x1E8) PTP Event Frame Received Seconds -------- */
-#define GMAC_EFRS_RUD_Pos 0
-#define GMAC_EFRS_RUD_Msk (0xffffffffu << GMAC_EFRS_RUD_Pos) /**< \brief (GMAC_EFRS) Register Update */
+#define GMAC_EFRS_RUD_Pos             0
+#define GMAC_EFRS_RUD_Msk             ( 0xffffffffu << GMAC_EFRS_RUD_Pos ) /**< \brief (GMAC_EFRS) Register Update */
 /* -------- GMAC_EFRN : (GMAC Offset: 0x1EC) PTP Event Frame Received Nanoseconds -------- */
-#define GMAC_EFRN_RUD_Pos 0
-#define GMAC_EFRN_RUD_Msk (0x3fffffffu << GMAC_EFRN_RUD_Pos) /**< \brief (GMAC_EFRN) Register Update */
+#define GMAC_EFRN_RUD_Pos             0
+#define GMAC_EFRN_RUD_Msk             ( 0x3fffffffu << GMAC_EFRN_RUD_Pos ) /**< \brief (GMAC_EFRN) Register Update */
 /* -------- GMAC_PEFTS : (GMAC Offset: 0x1F0) PTP Peer Event Frame Transmitted Seconds -------- */
-#define GMAC_PEFTS_RUD_Pos 0
-#define GMAC_PEFTS_RUD_Msk (0xffffffffu << GMAC_PEFTS_RUD_Pos) /**< \brief (GMAC_PEFTS) Register Update */
+#define GMAC_PEFTS_RUD_Pos            0
+#define GMAC_PEFTS_RUD_Msk            ( 0xffffffffu << GMAC_PEFTS_RUD_Pos ) /**< \brief (GMAC_PEFTS) Register Update */
 /* -------- GMAC_PEFTN : (GMAC Offset: 0x1F4) PTP Peer Event Frame Transmitted Nanoseconds -------- */
-#define GMAC_PEFTN_RUD_Pos 0
-#define GMAC_PEFTN_RUD_Msk (0x3fffffffu << GMAC_PEFTN_RUD_Pos) /**< \brief (GMAC_PEFTN) Register Update */
+#define GMAC_PEFTN_RUD_Pos            0
+#define GMAC_PEFTN_RUD_Msk            ( 0x3fffffffu << GMAC_PEFTN_RUD_Pos ) /**< \brief (GMAC_PEFTN) Register Update */
 /* -------- GMAC_PEFRS : (GMAC Offset: 0x1F8) PTP Peer Event Frame Received Seconds -------- */
-#define GMAC_PEFRS_RUD_Pos 0
-#define GMAC_PEFRS_RUD_Msk (0xffffffffu << GMAC_PEFRS_RUD_Pos) /**< \brief (GMAC_PEFRS) Register Update */
+#define GMAC_PEFRS_RUD_Pos            0
+#define GMAC_PEFRS_RUD_Msk            ( 0xffffffffu << GMAC_PEFRS_RUD_Pos ) /**< \brief (GMAC_PEFRS) Register Update */
 /* -------- GMAC_PEFRN : (GMAC Offset: 0x1FC) PTP Peer Event Frame Received Nanoseconds -------- */
-#define GMAC_PEFRN_RUD_Pos 0
-#define GMAC_PEFRN_RUD_Msk (0x3fffffffu << GMAC_PEFRN_RUD_Pos) /**< \brief (GMAC_PEFRN) Register Update */
+#define GMAC_PEFRN_RUD_Pos            0
+#define GMAC_PEFRN_RUD_Msk            ( 0x3fffffffu << GMAC_PEFRN_RUD_Pos ) /**< \brief (GMAC_PEFRN) Register Update */
 /* -------- GMAC_ISRPQ[7] : (GMAC Offset: 0x400) Interrupt Status Register Priority Queue -------- */
-#define GMAC_ISRPQ_RCOMP (0x1u << 1) /**< \brief (GMAC_ISRPQ[7]) Receive Complete */
-#define GMAC_ISRPQ_RXUBR (0x1u << 2) /**< \brief (GMAC_ISRPQ[7]) RX Used Bit Read */
-#define GMAC_ISRPQ_RLEX (0x1u << 5) /**< \brief (GMAC_ISRPQ[7]) Retry Limit Exceeded or Late Collision */
-#define GMAC_ISRPQ_TFC (0x1u << 6) /**< \brief (GMAC_ISRPQ[7]) Transmit Frame Corruption due to AHB error */
-#define GMAC_ISRPQ_TCOMP (0x1u << 7) /**< \brief (GMAC_ISRPQ[7]) Transmit Complete */
-#define GMAC_ISRPQ_ROVR (0x1u << 10) /**< \brief (GMAC_ISRPQ[7]) Receive Overrun */
-#define GMAC_ISRPQ_HRESP (0x1u << 11) /**< \brief (GMAC_ISRPQ[7]) HRESP Not OK */
+#define GMAC_ISRPQ_RCOMP              ( 0x1u << 1 )                         /**< \brief (GMAC_ISRPQ[7]) Receive Complete */
+#define GMAC_ISRPQ_RXUBR              ( 0x1u << 2 )                         /**< \brief (GMAC_ISRPQ[7]) RX Used Bit Read */
+#define GMAC_ISRPQ_RLEX               ( 0x1u << 5 )                         /**< \brief (GMAC_ISRPQ[7]) Retry Limit Exceeded or Late Collision */
+#define GMAC_ISRPQ_TFC                ( 0x1u << 6 )                         /**< \brief (GMAC_ISRPQ[7]) Transmit Frame Corruption due to AHB error */
+#define GMAC_ISRPQ_TCOMP              ( 0x1u << 7 )                         /**< \brief (GMAC_ISRPQ[7]) Transmit Complete */
+#define GMAC_ISRPQ_ROVR               ( 0x1u << 10 )                        /**< \brief (GMAC_ISRPQ[7]) Receive Overrun */
+#define GMAC_ISRPQ_HRESP              ( 0x1u << 11 )                        /**< \brief (GMAC_ISRPQ[7]) HRESP Not OK */
 /* -------- GMAC_TBQBAPQ[7] : (GMAC Offset: 0x440) Transmit Buffer Queue Base Address Priority Queue -------- */
-#define GMAC_TBQBAPQ_TXBQBA_Pos 2
-#define GMAC_TBQBAPQ_TXBQBA_Msk (0x3fu << GMAC_TBQBAPQ_TXBQBA_Pos) /**< \brief (GMAC_TBQBAPQ[7]) Transmit Buffer Queue Base Address */
-#define GMAC_TBQBAPQ_TXBQBA(value) ((GMAC_TBQBAPQ_TXBQBA_Msk & ((value) << GMAC_TBQBAPQ_TXBQBA_Pos)))
+#define GMAC_TBQBAPQ_TXBQBA_Pos       2
+#define GMAC_TBQBAPQ_TXBQBA_Msk       ( 0x3fu << GMAC_TBQBAPQ_TXBQBA_Pos ) /**< \brief (GMAC_TBQBAPQ[7]) Transmit Buffer Queue Base Address */
+#define GMAC_TBQBAPQ_TXBQBA( value )    ( ( GMAC_TBQBAPQ_TXBQBA_Msk & ( ( value ) << GMAC_TBQBAPQ_TXBQBA_Pos ) ) )
 /* -------- GMAC_RBQBAPQ[7] : (GMAC Offset: 0x480) Receive Buffer Queue Base Address Priority Queue -------- */
-#define GMAC_RBQBAPQ_RXBQBA_Pos 2
-#define GMAC_RBQBAPQ_RXBQBA_Msk (0x3fu << GMAC_RBQBAPQ_RXBQBA_Pos) /**< \brief (GMAC_RBQBAPQ[7]) Receive Buffer Queue Base Address */
-#define GMAC_RBQBAPQ_RXBQBA(value) ((GMAC_RBQBAPQ_RXBQBA_Msk & ((value) << GMAC_RBQBAPQ_RXBQBA_Pos)))
+#define GMAC_RBQBAPQ_RXBQBA_Pos       2
+#define GMAC_RBQBAPQ_RXBQBA_Msk       ( 0x3fu << GMAC_RBQBAPQ_RXBQBA_Pos ) /**< \brief (GMAC_RBQBAPQ[7]) Receive Buffer Queue Base Address */
+#define GMAC_RBQBAPQ_RXBQBA( value )    ( ( GMAC_RBQBAPQ_RXBQBA_Msk & ( ( value ) << GMAC_RBQBAPQ_RXBQBA_Pos ) ) )
 /* -------- GMAC_RBSRPQ[7] : (GMAC Offset: 0x4A0) Receive Buffer Size Register Priority Queue -------- */
-#define GMAC_RBSRPQ_RBS_Pos 0
-#define GMAC_RBSRPQ_RBS_Msk (0xffffu << GMAC_RBSRPQ_RBS_Pos) /**< \brief (GMAC_RBSRPQ[7]) Receive Buffer Size */
-#define GMAC_RBSRPQ_RBS(value) ((GMAC_RBSRPQ_RBS_Msk & ((value) << GMAC_RBSRPQ_RBS_Pos)))
+#define GMAC_RBSRPQ_RBS_Pos           0
+#define GMAC_RBSRPQ_RBS_Msk           ( 0xffffu << GMAC_RBSRPQ_RBS_Pos ) /**< \brief (GMAC_RBSRPQ[7]) Receive Buffer Size */
+#define GMAC_RBSRPQ_RBS( value )    ( ( GMAC_RBSRPQ_RBS_Msk & ( ( value ) << GMAC_RBSRPQ_RBS_Pos ) ) )
 /* -------- GMAC_ST1RPQ[16] : (GMAC Offset: 0x500) Screening Type1 Register Priority Queue -------- */
-#define GMAC_ST1RPQ_QNB_Pos 0
-#define GMAC_ST1RPQ_QNB_Msk (0xfu << GMAC_ST1RPQ_QNB_Pos) /**< \brief (GMAC_ST1RPQ[16]) Que Number (0->7) */
-#define GMAC_ST1RPQ_QNB(value) ((GMAC_ST1RPQ_QNB_Msk & ((value) << GMAC_ST1RPQ_QNB_Pos)))
-#define GMAC_ST1RPQ_DSTCM_Pos 4
-#define GMAC_ST1RPQ_DSTCM_Msk (0xffu << GMAC_ST1RPQ_DSTCM_Pos) /**< \brief (GMAC_ST1RPQ[16]) Differentiated Services or Traffic Class Match */
-#define GMAC_ST1RPQ_DSTCM(value) ((GMAC_ST1RPQ_DSTCM_Msk & ((value) << GMAC_ST1RPQ_DSTCM_Pos)))
-#define GMAC_ST1RPQ_UDPM_Pos 12
-#define GMAC_ST1RPQ_UDPM_Msk (0xffffu << GMAC_ST1RPQ_UDPM_Pos) /**< \brief (GMAC_ST1RPQ[16]) UDP Port Match */
-#define GMAC_ST1RPQ_UDPM(value) ((GMAC_ST1RPQ_UDPM_Msk & ((value) << GMAC_ST1RPQ_UDPM_Pos)))
-#define GMAC_ST1RPQ_DSTCE (0x1u << 28) /**< \brief (GMAC_ST1RPQ[16]) Differentiated Services or Traffic Class Match Enable */
-#define GMAC_ST1RPQ_UDPE (0x1u << 29) /**< \brief (GMAC_ST1RPQ[16]) UDP Port Match Enable */
+#define GMAC_ST1RPQ_QNB_Pos           0
+#define GMAC_ST1RPQ_QNB_Msk           ( 0xfu << GMAC_ST1RPQ_QNB_Pos ) /**< \brief (GMAC_ST1RPQ[16]) Que Number (0->7) */
+#define GMAC_ST1RPQ_QNB( value )      ( ( GMAC_ST1RPQ_QNB_Msk & ( ( value ) << GMAC_ST1RPQ_QNB_Pos ) ) )
+#define GMAC_ST1RPQ_DSTCM_Pos         4
+#define GMAC_ST1RPQ_DSTCM_Msk         ( 0xffu << GMAC_ST1RPQ_DSTCM_Pos ) /**< \brief (GMAC_ST1RPQ[16]) Differentiated Services or Traffic Class Match */
+#define GMAC_ST1RPQ_DSTCM( value )    ( ( GMAC_ST1RPQ_DSTCM_Msk & ( ( value ) << GMAC_ST1RPQ_DSTCM_Pos ) ) )
+#define GMAC_ST1RPQ_UDPM_Pos          12
+#define GMAC_ST1RPQ_UDPM_Msk          ( 0xffffu << GMAC_ST1RPQ_UDPM_Pos ) /**< \brief (GMAC_ST1RPQ[16]) UDP Port Match */
+#define GMAC_ST1RPQ_UDPM( value )     ( ( GMAC_ST1RPQ_UDPM_Msk & ( ( value ) << GMAC_ST1RPQ_UDPM_Pos ) ) )
+#define GMAC_ST1RPQ_DSTCE             ( 0x1u << 28 )                      /**< \brief (GMAC_ST1RPQ[16]) Differentiated Services or Traffic Class Match Enable */
+#define GMAC_ST1RPQ_UDPE              ( 0x1u << 29 )                      /**< \brief (GMAC_ST1RPQ[16]) UDP Port Match Enable */
 /* -------- GMAC_ST2RPQ[16] : (GMAC Offset: 0x540) Screening Type2 Register Priority Queue -------- */
-#define GMAC_ST2RPQ_QNB_Pos 0
-#define GMAC_ST2RPQ_QNB_Msk (0xfu << GMAC_ST2RPQ_QNB_Pos) /**< \brief (GMAC_ST2RPQ[16]) Que Number (0->7) */
-#define GMAC_ST2RPQ_QNB(value) ((GMAC_ST2RPQ_QNB_Msk & ((value) << GMAC_ST2RPQ_QNB_Pos)))
-#define GMAC_ST2RPQ_VLANP_Pos 4
-#define GMAC_ST2RPQ_VLANP_Msk (0xfu << GMAC_ST2RPQ_VLANP_Pos) /**< \brief (GMAC_ST2RPQ[16]) VLAN Priority */
-#define GMAC_ST2RPQ_VLANP(value) ((GMAC_ST2RPQ_VLANP_Msk & ((value) << GMAC_ST2RPQ_VLANP_Pos)))
-#define GMAC_ST2RPQ_VLANE (0x1u << 8) /**< \brief (GMAC_ST2RPQ[16]) VLAN Enable */
+#define GMAC_ST2RPQ_QNB_Pos           0
+#define GMAC_ST2RPQ_QNB_Msk           ( 0xfu << GMAC_ST2RPQ_QNB_Pos ) /**< \brief (GMAC_ST2RPQ[16]) Que Number (0->7) */
+#define GMAC_ST2RPQ_QNB( value )      ( ( GMAC_ST2RPQ_QNB_Msk & ( ( value ) << GMAC_ST2RPQ_QNB_Pos ) ) )
+#define GMAC_ST2RPQ_VLANP_Pos         4
+#define GMAC_ST2RPQ_VLANP_Msk         ( 0xfu << GMAC_ST2RPQ_VLANP_Pos ) /**< \brief (GMAC_ST2RPQ[16]) VLAN Priority */
+#define GMAC_ST2RPQ_VLANP( value )    ( ( GMAC_ST2RPQ_VLANP_Msk & ( ( value ) << GMAC_ST2RPQ_VLANP_Pos ) ) )
+#define GMAC_ST2RPQ_VLANE             ( 0x1u << 8 )                     /**< \brief (GMAC_ST2RPQ[16]) VLAN Enable */
 /* -------- GMAC_IERPQ[7] : (GMAC Offset: 0x600) Interrupt Enable Register Priority Queue -------- */
-#define GMAC_IERPQ_RCOMP (0x1u << 1) /**< \brief (GMAC_IERPQ[7]) Receive Complete */
-#define GMAC_IERPQ_RXUBR (0x1u << 2) /**< \brief (GMAC_IERPQ[7]) RX Used Bit Read */
-#define GMAC_IERPQ_RLEX (0x1u << 5) /**< \brief (GMAC_IERPQ[7]) Retry Limit Exceeded or Late Collision */
-#define GMAC_IERPQ_TFC (0x1u << 6) /**< \brief (GMAC_IERPQ[7]) Transmit Frame Corruption due to AHB error */
-#define GMAC_IERPQ_TCOMP (0x1u << 7) /**< \brief (GMAC_IERPQ[7]) Transmit Complete */
-#define GMAC_IERPQ_ROVR (0x1u << 10) /**< \brief (GMAC_IERPQ[7]) Receive Overrun */
-#define GMAC_IERPQ_HRESP (0x1u << 11) /**< \brief (GMAC_IERPQ[7]) HRESP Not OK */
+#define GMAC_IERPQ_RCOMP              ( 0x1u << 1 )                     /**< \brief (GMAC_IERPQ[7]) Receive Complete */
+#define GMAC_IERPQ_RXUBR              ( 0x1u << 2 )                     /**< \brief (GMAC_IERPQ[7]) RX Used Bit Read */
+#define GMAC_IERPQ_RLEX               ( 0x1u << 5 )                     /**< \brief (GMAC_IERPQ[7]) Retry Limit Exceeded or Late Collision */
+#define GMAC_IERPQ_TFC                ( 0x1u << 6 )                     /**< \brief (GMAC_IERPQ[7]) Transmit Frame Corruption due to AHB error */
+#define GMAC_IERPQ_TCOMP              ( 0x1u << 7 )                     /**< \brief (GMAC_IERPQ[7]) Transmit Complete */
+#define GMAC_IERPQ_ROVR               ( 0x1u << 10 )                    /**< \brief (GMAC_IERPQ[7]) Receive Overrun */
+#define GMAC_IERPQ_HRESP              ( 0x1u << 11 )                    /**< \brief (GMAC_IERPQ[7]) HRESP Not OK */
 /* -------- GMAC_IDRPQ[7] : (GMAC Offset: 0x620) Interrupt Disable Register Priority Queue -------- */
-#define GMAC_IDRPQ_RCOMP (0x1u << 1) /**< \brief (GMAC_IDRPQ[7]) Receive Complete */
-#define GMAC_IDRPQ_RXUBR (0x1u << 2) /**< \brief (GMAC_IDRPQ[7]) RX Used Bit Read */
-#define GMAC_IDRPQ_RLEX (0x1u << 5) /**< \brief (GMAC_IDRPQ[7]) Retry Limit Exceeded or Late Collision */
-#define GMAC_IDRPQ_TFC (0x1u << 6) /**< \brief (GMAC_IDRPQ[7]) Transmit Frame Corruption due to AHB error */
-#define GMAC_IDRPQ_TCOMP (0x1u << 7) /**< \brief (GMAC_IDRPQ[7]) Transmit Complete */
-#define GMAC_IDRPQ_ROVR (0x1u << 10) /**< \brief (GMAC_IDRPQ[7]) Receive Overrun */
-#define GMAC_IDRPQ_HRESP (0x1u << 11) /**< \brief (GMAC_IDRPQ[7]) HRESP Not OK */
+#define GMAC_IDRPQ_RCOMP              ( 0x1u << 1 )                     /**< \brief (GMAC_IDRPQ[7]) Receive Complete */
+#define GMAC_IDRPQ_RXUBR              ( 0x1u << 2 )                     /**< \brief (GMAC_IDRPQ[7]) RX Used Bit Read */
+#define GMAC_IDRPQ_RLEX               ( 0x1u << 5 )                     /**< \brief (GMAC_IDRPQ[7]) Retry Limit Exceeded or Late Collision */
+#define GMAC_IDRPQ_TFC                ( 0x1u << 6 )                     /**< \brief (GMAC_IDRPQ[7]) Transmit Frame Corruption due to AHB error */
+#define GMAC_IDRPQ_TCOMP              ( 0x1u << 7 )                     /**< \brief (GMAC_IDRPQ[7]) Transmit Complete */
+#define GMAC_IDRPQ_ROVR               ( 0x1u << 10 )                    /**< \brief (GMAC_IDRPQ[7]) Receive Overrun */
+#define GMAC_IDRPQ_HRESP              ( 0x1u << 11 )                    /**< \brief (GMAC_IDRPQ[7]) HRESP Not OK */
 /* -------- GMAC_IMRPQ[7] : (GMAC Offset: 0x640) Interrupt Mask Register Priority Queue -------- */
-#define GMAC_IMRPQ_RCOMP (0x1u << 1) /**< \brief (GMAC_IMRPQ[7]) Receive Complete */
-#define GMAC_IMRPQ_RXUBR (0x1u << 2) /**< \brief (GMAC_IMRPQ[7]) RX Used Bit Read */
-#define GMAC_IMRPQ_RLEX (0x1u << 5) /**< \brief (GMAC_IMRPQ[7]) Retry Limit Exceeded or Late Collision */
-#define GMAC_IMRPQ_AHB (0x1u << 6) /**< \brief (GMAC_IMRPQ[7]) AHB Error */
-#define GMAC_IMRPQ_TCOMP (0x1u << 7) /**< \brief (GMAC_IMRPQ[7]) Transmit Complete */
-#define GMAC_IMRPQ_ROVR (0x1u << 10) /**< \brief (GMAC_IMRPQ[7]) Receive Overrun */
-#define GMAC_IMRPQ_HRESP (0x1u << 11) /**< \brief (GMAC_IMRPQ[7]) HRESP Not OK */
+#define GMAC_IMRPQ_RCOMP              ( 0x1u << 1 )                     /**< \brief (GMAC_IMRPQ[7]) Receive Complete */
+#define GMAC_IMRPQ_RXUBR              ( 0x1u << 2 )                     /**< \brief (GMAC_IMRPQ[7]) RX Used Bit Read */
+#define GMAC_IMRPQ_RLEX               ( 0x1u << 5 )                     /**< \brief (GMAC_IMRPQ[7]) Retry Limit Exceeded or Late Collision */
+#define GMAC_IMRPQ_AHB                ( 0x1u << 6 )                     /**< \brief (GMAC_IMRPQ[7]) AHB Error */
+#define GMAC_IMRPQ_TCOMP              ( 0x1u << 7 )                     /**< \brief (GMAC_IMRPQ[7]) Transmit Complete */
+#define GMAC_IMRPQ_ROVR               ( 0x1u << 10 )                    /**< \brief (GMAC_IMRPQ[7]) Receive Overrun */
+#define GMAC_IMRPQ_HRESP              ( 0x1u << 11 )                    /**< \brief (GMAC_IMRPQ[7]) HRESP Not OK */
 
 /*@}*/
 

--- a/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/portable/NetworkInterface/ATSAM4E/ethernet_phy.h
+++ b/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/portable/NetworkInterface/ATSAM4E/ethernet_phy.h
@@ -42,174 +42,175 @@
  */
 
 #ifndef ETHERNET_PHY_H_INCLUDED
-#define ETHERNET_PHY_H_INCLUDED
+    #define ETHERNET_PHY_H_INCLUDED
 
-#include "compiler.h"
+    #include "compiler.h"
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+    #ifdef __cplusplus
+        extern "C" {
+    #endif
 
-// IEEE defined Registers
-#define GMII_BMCR        0x00   // Basic Control
-#define GMII_BMSR        0x01   // Basic Status
-#define GMII_PHYID1      0x02   // PHY Idendifier 1
-#define GMII_PHYID2      0x03   // PHY Idendifier 2
-#define GMII_ANAR        0x04   // Auto_Negotiation Advertisement
-#define GMII_ANLPAR      0x05   // Auto_negotiation Link Partner Ability
-#define GMII_ANER        0x06   // Auto-negotiation Expansion
-#define GMII_ANNPR       0x07   // Auto-negotiation Next Page
-#define GMII_ANLPNPAR    0x08   // Link Partner Next Page Ability
-//#define GMII_1000BTCR    9   // 1000Base-T Control  // Reserved
-//#define GMII_1000BTSR   10   // 1000Base-T Status   // Reserved
-#define GMII_AFECR1        0x11   // AFE Control 1
-//#define GMII_ERDWR      12   // Extend Register - Data Write Register
-//#define GMII_ERDRR      13   // Extend Register - Data Read Register
-//14    reserved
-#define GMII_RXERCR        0x15   // RXER Counter
+/* IEEE defined Registers */
+    #define GMII_BMCR        0x00 /* Basic Control */
+    #define GMII_BMSR        0x01 /* Basic Status */
+    #define GMII_PHYID1      0x02 /* PHY Idendifier 1 */
+    #define GMII_PHYID2      0x03 /* PHY Idendifier 2 */
+    #define GMII_ANAR        0x04 /* Auto_Negotiation Advertisement */
+    #define GMII_ANLPAR      0x05 /* Auto_negotiation Link Partner Ability */
+    #define GMII_ANER        0x06 /* Auto-negotiation Expansion */
+    #define GMII_ANNPR       0x07 /* Auto-negotiation Next Page */
+    #define GMII_ANLPNPAR    0x08 /* Link Partner Next Page Ability */
+/*#define GMII_1000BTCR    9   // 1000Base-T Control  // Reserved */
+/*#define GMII_1000BTSR   10   // 1000Base-T Status   // Reserved */
+    #define GMII_AFECR1      0x11 /* AFE Control 1 */
+/*#define GMII_ERDWR      12   // Extend Register - Data Write Register */
+/*#define GMII_ERDRR      13   // Extend Register - Data Read Register */
+/*14    reserved */
+    #define GMII_RXERCR             0x15 /* RXER Counter */
 
-	#define PHY_REG_01_BMSR            0x01 // Basic mode status register
-	#define PHY_REG_02_PHYSID1         0x02 // PHYS ID 1
-	#define PHY_REG_03_PHYSID2         0x03 // PHYS ID 2
-	#define PHY_REG_04_ADVERTISE       0x04 // Advertisement control reg
-	#define PHY_REG_05_LPA             0x05 // Link partner ability reg
-	#define	PHY_REG_06_ANER            0x06 //	6	RW		Auto-Negotiation Expansion Register
-	#define	PHY_REG_07_ANNPTR          0x07 //	7	RW		Auto-Negotiation Next Page TX
-	#define	PHY_REG_08_RESERVED0       0x08 // 0x08..0x0Fh	8-15	RW		RESERVED
+    #define PHY_REG_01_BMSR         0x01 /* Basic mode status register */
+    #define PHY_REG_02_PHYSID1      0x02 /* PHYS ID 1 */
+    #define PHY_REG_03_PHYSID2      0x03 /* PHYS ID 2 */
+    #define PHY_REG_04_ADVERTISE    0x04 /* Advertisement control reg */
+    #define PHY_REG_05_LPA          0x05 /* Link partner ability reg */
+    #define PHY_REG_06_ANER         0x06 /*	6	RW		Auto-Negotiation Expansion Register */
+    #define PHY_REG_07_ANNPTR       0x07 /*	7	RW		Auto-Negotiation Next Page TX */
+    #define PHY_REG_08_RESERVED0    0x08 /* 0x08..0x0Fh	8-15	RW		RESERVED */
 
-	#define	PHY_REG_10_PHYSTS     0x10	// 16	RO		PHY Status Register
-	#define	PHY_REG_11_MICR       0x11	// 17	RW		MII Interrupt Control Register
-	#define	PHY_REG_12_MISR       0x12	// 18	RO		MII Interrupt Status Register
-	#define	PHY_REG_13_RESERVED1  0x13	// 19	RW		RESERVED
-	#define	PHY_REG_14_FCSCR      0x14	// 20	RO		False Carrier Sense Counter Register
-	#define	PHY_REG_15_RECR       0x15	// 21	RO		Receive Error Counter Register
-	#define	PHY_REG_16_PCSR       0x16	// 22	RW		PCS Sub-Layer Configuration and Status Register
-	#define	PHY_REG_17_RBR        0x17	// 23	RW		RMII and Bypass Register
-	#define	PHY_REG_18_LEDCR      0x18	// 24	RW		LED Direct Control Register
-	#define	PHY_REG_19_PHYCR      0x19	// 25	RW		PHY Control Register
-	#define	PHY_REG_1A_10BTSCR    0x1A	// 26	RW		10Base-T Status/Control Register
-	#define	PHY_REG_1B_CDCTRL1    0x1B	// 27	RW		CD Test Control Register and BIST Extensions Register
-	#define	PHY_REG_1B_INT_CTRL   0x1B	// 27	RW		KSZ8041NL interrupt control
-	#define	PHY_REG_1C_RESERVED2  0x1C	// 28	RW		RESERVED
-	#define	PHY_REG_1D_EDCR       0x1D	// 29	RW		Energy Detect Control Register
-	#define	PHY_REG_1E_RESERVED3  0x1E	//
-	#define	PHY_REG_1F_RESERVED4  0x1F	// 30-31	RW		RESERVED
+    #define PHY_REG_10_PHYSTS       0x10 /* 16	RO		PHY Status Register */
+    #define PHY_REG_11_MICR         0x11 /* 17	RW		MII Interrupt Control Register */
+    #define PHY_REG_12_MISR         0x12 /* 18	RO		MII Interrupt Status Register */
+    #define PHY_REG_13_RESERVED1    0x13 /* 19	RW		RESERVED */
+    #define PHY_REG_14_FCSCR        0x14 /* 20	RO		False Carrier Sense Counter Register */
+    #define PHY_REG_15_RECR         0x15 /* 21	RO		Receive Error Counter Register */
+    #define PHY_REG_16_PCSR         0x16 /* 22	RW		PCS Sub-Layer Configuration and Status Register */
+    #define PHY_REG_17_RBR          0x17 /* 23	RW		RMII and Bypass Register */
+    #define PHY_REG_18_LEDCR        0x18 /* 24	RW		LED Direct Control Register */
+    #define PHY_REG_19_PHYCR        0x19 /* 25	RW		PHY Control Register */
+    #define PHY_REG_1A_10BTSCR      0x1A /* 26	RW		10Base-T Status/Control Register */
+    #define PHY_REG_1B_CDCTRL1      0x1B /* 27	RW		CD Test Control Register and BIST Extensions Register */
+    #define PHY_REG_1B_INT_CTRL     0x1B /* 27	RW		KSZ8041NL interrupt control */
+    #define PHY_REG_1C_RESERVED2    0x1C /* 28	RW		RESERVED */
+    #define PHY_REG_1D_EDCR         0x1D /* 29	RW		Energy Detect Control Register */
+    #define PHY_REG_1E_RESERVED3    0x1E /* */
+    #define PHY_REG_1F_RESERVED4    0x1F /* 30-31	RW		RESERVED */
 
-	#define	PHY_REG_1E_PHYCR_1    0x1E	//
-	#define	PHY_REG_1F_PHYCR_2    0x1F	//
+    #define PHY_REG_1E_PHYCR_1      0x1E /* */
+    #define PHY_REG_1F_PHYCR_2      0x1F /* */
 
-	#define	PHY_SPEED_10       1
-	#define	PHY_SPEED_100      2
-	#define	PHY_SPEED_AUTO     (PHY_SPEED_10|PHY_SPEED_100)
+    #define PHY_SPEED_10            1
+    #define PHY_SPEED_100           2
+    #define PHY_SPEED_AUTO          ( PHY_SPEED_10 | PHY_SPEED_100 )
 
-	#define	PHY_MDIX_DIRECT    1
-	#define	PHY_MDIX_CROSSED   2
-	#define	PHY_MDIX_AUTO      (PHY_MDIX_CROSSED|PHY_MDIX_DIRECT)
+    #define PHY_MDIX_DIRECT         1
+    #define PHY_MDIX_CROSSED        2
+    #define PHY_MDIX_AUTO           ( PHY_MDIX_CROSSED | PHY_MDIX_DIRECT )
 
-	#define	PHY_DUPLEX_HALF    1
-	#define	PHY_DUPLEX_FULL    2
-	#define	PHY_DUPLEX_AUTO    (PHY_DUPLEX_FULL|PHY_DUPLEX_HALF)
+    #define PHY_DUPLEX_HALF         1
+    #define PHY_DUPLEX_FULL         2
+    #define PHY_DUPLEX_AUTO         ( PHY_DUPLEX_FULL | PHY_DUPLEX_HALF )
 
-	typedef struct _SPhyProps {
-		unsigned char speed;
-		unsigned char mdix;
-		unsigned char duplex;
-		unsigned char spare;
-	} SPhyProps;
+    typedef struct _SPhyProps
+    {
+        unsigned char speed;
+        unsigned char mdix;
+        unsigned char duplex;
+        unsigned char spare;
+    } SPhyProps;
 
-	const char *phyPrintable (const SPhyProps *apProps);
+    const char * phyPrintable( const SPhyProps * apProps );
 
-	extern SPhyProps phyProps;
+    extern SPhyProps phyProps;
 
-#define GMII_OMSOR        0x16   // Operation Mode Strap Override
-#define GMII_OMSSR       0x17   // Operation Mode Strap Status
-#define GMII_ECR      0x18   // Expanded Control
-//#define GMII_DPPSR      19   // Digital PMA/PCS Status
-//20    reserved
-//#define GMII_RXERCR     21   // RXER Counter Register
-//22-26 reserved
-#define GMII_ICSR        0x1B   // Interrupt Control/Status
-//#define GMII_DDC1R       28   // Digital Debug Control 1 Register
-#define GMII_LCSR        0x1D   // LinkMD Control/Status
+    #define GMII_OMSOR    0x16 /* Operation Mode Strap Override */
+    #define GMII_OMSSR    0x17 /* Operation Mode Strap Status */
+    #define GMII_ECR      0x18 /* Expanded Control */
+/*#define GMII_DPPSR      19   // Digital PMA/PCS Status */
+/*20    reserved */
+/*#define GMII_RXERCR     21   // RXER Counter Register */
+/*22-26 reserved */
+    #define GMII_ICSR    0x1B   /* Interrupt Control/Status */
+/*#define GMII_DDC1R       28   // Digital Debug Control 1 Register */
+    #define GMII_LCSR    0x1D   /* LinkMD Control/Status */
 
-//29-30 reserved
-#define GMII_PCR1       0x1E   // PHY Control 1
-#define GMII_PCR2       0x1F   // PHY Control 2
+/*29-30 reserved */
+    #define GMII_PCR1    0x1E  /* PHY Control 1 */
+    #define GMII_PCR2    0x1F  /* PHY Control 2 */
 
 /*
-//Extend Registers
-#define GMII_CCR        256  // Common Control Register
-#define GMII_SSR        257  // Strap Status Register
-#define GMII_OMSOR      258  // Operation Mode Strap Override Register
-#define GMII_OMSSR      259  // Operation Mode Strap Status Register
-#define GMII_RCCPSR     260  // RGMII Clock and Control Pad Skew Register
-#define GMII_RRDPSR     261  // RGMII RX Data Pad Skew Register
-#define GMII_ATR        263  // Analog Test Register
-*/
+ * //Extend Registers
+ #define GMII_CCR        256  // Common Control Register
+ #define GMII_SSR        257  // Strap Status Register
+ #define GMII_OMSOR      258  // Operation Mode Strap Override Register
+ #define GMII_OMSSR      259  // Operation Mode Strap Status Register
+ #define GMII_RCCPSR     260  // RGMII Clock and Control Pad Skew Register
+ #define GMII_RRDPSR     261  // RGMII RX Data Pad Skew Register
+ #define GMII_ATR        263  // Analog Test Register
+ */
 
 
-// Bit definitions: GMII_BMCR 0x00 Basic Control
-#define GMII_RESET             (1 << 15) // 1= Software Reset; 0=Normal Operation
-#define GMII_LOOPBACK          (1 << 14) // 1=loopback Enabled; 0=Normal Operation
-#define GMII_SPEED_SELECT      (1 << 13) // 1=100Mbps; 0=10Mbps
-#define GMII_AUTONEG           (1 << 12) // Auto-negotiation Enable
-#define GMII_POWER_DOWN        (1 << 11) // 1=Power down 0=Normal operation
-#define GMII_ISOLATE           (1 << 10) // 1 = Isolates 0 = Normal operation
-#define GMII_RESTART_AUTONEG   (1 << 9)  // 1 = Restart auto-negotiation 0 = Normal operation
-#define GMII_DUPLEX_MODE       (1 << 8)  // 1 = Full duplex operation 0 = Normal operation
-#define GMII_COLLISION_TEST    (1 << 7)  // 1 = Enable COL test; 0 = Disable COL test
-//#define GMII_SPEED_SELECT_MSB  (1 << 6)  // Reserved
-//      Reserved                6 to 0   // Read as 0, ignore on write
+/* Bit definitions: GMII_BMCR 0x00 Basic Control */
+    #define GMII_RESET              ( 1 << 15 ) /* 1= Software Reset; 0=Normal Operation */
+    #define GMII_LOOPBACK           ( 1 << 14 ) /* 1=loopback Enabled; 0=Normal Operation */
+    #define GMII_SPEED_SELECT       ( 1 << 13 ) /* 1=100Mbps; 0=10Mbps */
+    #define GMII_AUTONEG            ( 1 << 12 ) /* Auto-negotiation Enable */
+    #define GMII_POWER_DOWN         ( 1 << 11 ) /* 1=Power down 0=Normal operation */
+    #define GMII_ISOLATE            ( 1 << 10 ) /* 1 = Isolates 0 = Normal operation */
+    #define GMII_RESTART_AUTONEG    ( 1 << 9 )  /* 1 = Restart auto-negotiation 0 = Normal operation */
+    #define GMII_DUPLEX_MODE        ( 1 << 8 )  /* 1 = Full duplex operation 0 = Normal operation */
+    #define GMII_COLLISION_TEST     ( 1 << 7 )  /* 1 = Enable COL test; 0 = Disable COL test */
+/*#define GMII_SPEED_SELECT_MSB  (1 << 6)  // Reserved */
+/*      Reserved                6 to 0   // Read as 0, ignore on write */
 
-// Bit definitions: GMII_BMSR 0x01 Basic Status
-#define GMII_100BASE_T4        (1 << 15) // 100BASE-T4 Capable
-#define GMII_100BASE_TX_FD     (1 << 14) // 100BASE-TX Full Duplex Capable
-#define GMII_100BASE_T4_HD     (1 << 13) // 100BASE-TX Half Duplex Capable
-#define GMII_10BASE_T_FD       (1 << 12) // 10BASE-T Full Duplex Capable
-#define GMII_10BASE_T_HD       (1 << 11) // 10BASE-T Half Duplex Capable
-//      Reserved                10 to79  // Read as 0, ignore on write
-//#define GMII_EXTEND_STATUS     (1 << 8)  // 1 = Extend Status Information In Reg 15
-//      Reserved                7
-#define GMII_MF_PREAMB_SUPPR   (1 << 6)  // MII Frame Preamble Suppression
-#define GMII_AUTONEG_COMP      (1 << 5)  // Auto-negotiation Complete
-#define GMII_REMOTE_FAULT      (1 << 4)  // Remote Fault
-#define GMII_AUTONEG_ABILITY   (1 << 3)  // Auto Configuration Ability
-#define GMII_LINK_STATUS       (1 << 2)  // Link Status
-#define GMII_JABBER_DETECT     (1 << 1)  // Jabber Detect
-#define GMII_EXTEND_CAPAB      (1 << 0)  // Extended Capability
-
-
-// Bit definitions: GMII_PHYID1 0x02 PHY Idendifier 1
-// Bit definitions: GMII_PHYID2 0x03 PHY Idendifier 2
-#define GMII_LSB_MASK           0x3F
-#define GMII_OUI_MSB            0x0022
-#define GMII_OUI_LSB            0x05
+/* Bit definitions: GMII_BMSR 0x01 Basic Status */
+    #define GMII_100BASE_T4       ( 1 << 15 ) /* 100BASE-T4 Capable */
+    #define GMII_100BASE_TX_FD    ( 1 << 14 ) /* 100BASE-TX Full Duplex Capable */
+    #define GMII_100BASE_T4_HD    ( 1 << 13 ) /* 100BASE-TX Half Duplex Capable */
+    #define GMII_10BASE_T_FD      ( 1 << 12 ) /* 10BASE-T Full Duplex Capable */
+    #define GMII_10BASE_T_HD      ( 1 << 11 ) /* 10BASE-T Half Duplex Capable */
+/*      Reserved                10 to79  // Read as 0, ignore on write */
+/*#define GMII_EXTEND_STATUS     (1 << 8)  // 1 = Extend Status Information In Reg 15 */
+/*      Reserved                7 */
+    #define GMII_MF_PREAMB_SUPPR    ( 1 << 6 ) /* MII Frame Preamble Suppression */
+    #define GMII_AUTONEG_COMP       ( 1 << 5 ) /* Auto-negotiation Complete */
+    #define GMII_REMOTE_FAULT       ( 1 << 4 ) /* Remote Fault */
+    #define GMII_AUTONEG_ABILITY    ( 1 << 3 ) /* Auto Configuration Ability */
+    #define GMII_LINK_STATUS        ( 1 << 2 ) /* Link Status */
+    #define GMII_JABBER_DETECT      ( 1 << 1 ) /* Jabber Detect */
+    #define GMII_EXTEND_CAPAB       ( 1 << 0 ) /* Extended Capability */
 
 
-// Bit definitions: GMII_ANAR   0x04 Auto_Negotiation Advertisement
-// Bit definitions: GMII_ANLPAR 0x05 Auto_negotiation Link Partner Ability
-#define GMII_NP               (1 << 15) // Next page Indication
-//      Reserved               7
-#define GMII_RF               (1 << 13) // Remote Fault
-//      Reserved               12       // Write as 0, ignore on read
-#define GMII_PAUSE_MASK       (3 << 11) // 0,0 = No Pause 1,0 = Asymmetric Pause(link partner)
-                                        // 0,1 = Symmetric Pause 1,1 = Symmetric&Asymmetric Pause(local device)
-#define GMII_100T4               (1 << 9)  // 100BASE-T4 Support
-#define GMII_100TX_FDX           (1 << 8)  // 100BASE-TX Full Duplex Support
-#define GMII_100TX_HDX           (1 << 7)  // 100BASE-TX Support
-#define GMII_10_FDX           (1 << 6)  // 10BASE-T Full Duplex Support
-#define GMII_10_HDX           (1 << 5)  // 10BASE-T Support
-//      Selector                 4 to 0   // Protocol Selection Bits
-#define GMII_AN_IEEE_802_3      0x0001    // [00001] = IEEE 802.3
+/* Bit definitions: GMII_PHYID1 0x02 PHY Idendifier 1 */
+/* Bit definitions: GMII_PHYID2 0x03 PHY Idendifier 2 */
+    #define GMII_LSB_MASK    0x3F
+    #define GMII_OUI_MSB     0x0022
+    #define GMII_OUI_LSB     0x05
 
 
-// Bit definitions: GMII_ANER 0x06 Auto-negotiation Expansion
-//      Reserved                15 to 5  // Read as 0, ignore on write
-#define GMII_PDF              (1 << 4) // Local Device Parallel Detection Fault
-#define GMII_LP_NP_ABLE       (1 << 3) // Link Partner Next Page Able
-#define GMII_NP_ABLE          (1 << 2) // Local Device Next Page Able
-#define GMII_PAGE_RX          (1 << 1) // New Page Received
-#define GMII_LP_AN_ABLE       (1 << 0) // Link Partner Auto-negotiation Able
+/* Bit definitions: GMII_ANAR   0x04 Auto_Negotiation Advertisement */
+/* Bit definitions: GMII_ANLPAR 0x05 Auto_negotiation Link Partner Ability */
+    #define GMII_NP               ( 1 << 15 ) /* Next page Indication */
+/*      Reserved               7 */
+    #define GMII_RF               ( 1 << 13 ) /* Remote Fault */
+/*      Reserved               12       // Write as 0, ignore on read */
+    #define GMII_PAUSE_MASK       ( 3 << 11 ) /* 0,0 = No Pause 1,0 = Asymmetric Pause(link partner) */
+                                              /* 0,1 = Symmetric Pause 1,1 = Symmetric&Asymmetric Pause(local device) */
+    #define GMII_100T4            ( 1 << 9 )  /* 100BASE-T4 Support */
+    #define GMII_100TX_FDX        ( 1 << 8 )  /* 100BASE-TX Full Duplex Support */
+    #define GMII_100TX_HDX        ( 1 << 7 )  /* 100BASE-TX Support */
+    #define GMII_10_FDX           ( 1 << 6 )  /* 10BASE-T Full Duplex Support */
+    #define GMII_10_HDX           ( 1 << 5 )  /* 10BASE-T Support */
+/*      Selector                 4 to 0   // Protocol Selection Bits */
+    #define GMII_AN_IEEE_802_3    0x0001      /* [00001] = IEEE 802.3 */
+
+
+/* Bit definitions: GMII_ANER 0x06 Auto-negotiation Expansion */
+/*      Reserved                15 to 5  // Read as 0, ignore on write */
+    #define GMII_PDF           ( 1 << 4 ) /* Local Device Parallel Detection Fault */
+    #define GMII_LP_NP_ABLE    ( 1 << 3 ) /* Link Partner Next Page Able */
+    #define GMII_NP_ABLE       ( 1 << 2 ) /* Local Device Next Page Able */
+    #define GMII_PAGE_RX       ( 1 << 1 ) /* New Page Received */
+    #define GMII_LP_AN_ABLE    ( 1 << 0 ) /* Link Partner Auto-negotiation Able */
 
 /**
  * \brief Perform a HW initialization to the PHY and set up clocks.
@@ -227,7 +228,9 @@ extern "C" {
  *
  * Return GMAC_OK if successfully, GMAC_TIMEOUT if timeout.
  */
-uint8_t ethernet_phy_init(Gmac *p_gmac, uint8_t uc_phy_addr, uint32_t ul_mck);
+    uint8_t ethernet_phy_init( Gmac * p_gmac,
+                               uint8_t uc_phy_addr,
+                               uint32_t ul_mck );
 
 
 /**
@@ -240,8 +243,9 @@ uint8_t ethernet_phy_init(Gmac *p_gmac, uint8_t uc_phy_addr, uint32_t ul_mck);
  *
  * Return GMAC_OK if successfully, GMAC_TIMEOUT if timeout.
  */
-uint8_t ethernet_phy_set_link(Gmac *p_gmac, uint8_t uc_phy_addr,
-		uint8_t uc_apply_setting_flag);
+    uint8_t ethernet_phy_set_link( Gmac * p_gmac,
+                                   uint8_t uc_phy_addr,
+                                   uint8_t uc_apply_setting_flag );
 
 
 /**
@@ -252,7 +256,8 @@ uint8_t ethernet_phy_set_link(Gmac *p_gmac, uint8_t uc_phy_addr,
  *
  * Return GMAC_OK if successfully, GMAC_TIMEOUT if timeout.
  */
-uint8_t ethernet_phy_auto_negotiate(Gmac *p_gmac, uint8_t uc_phy_addr);
+    uint8_t ethernet_phy_auto_negotiate( Gmac * p_gmac,
+                                         uint8_t uc_phy_addr );
 
 /**
  * \brief Issue a SW reset to reset all registers of the PHY.
@@ -262,20 +267,21 @@ uint8_t ethernet_phy_auto_negotiate(Gmac *p_gmac, uint8_t uc_phy_addr);
  *
  * \Return GMAC_OK if successfully, GMAC_TIMEOUT if timeout.
  */
-uint8_t ethernet_phy_reset(Gmac *p_gmac, uint8_t uc_phy_addr);
+    uint8_t ethernet_phy_reset( Gmac * p_gmac,
+                                uint8_t uc_phy_addr );
 
-typedef struct xPHY_PROPS {
-	signed char phy_result;
-	uint32_t phy_params;
-	uint32_t phy_stat1;
-	uint32_t phy_stat2;
-	unsigned char phy_chn;
-} PhyProps_t;
-extern PhyProps_t phy_props;
+    typedef struct xPHY_PROPS
+    {
+        signed char phy_result;
+        uint32_t phy_params;
+        uint32_t phy_stat1;
+        uint32_t phy_stat2;
+        unsigned char phy_chn;
+    } PhyProps_t;
+    extern PhyProps_t phy_props;
 
-#ifdef __cplusplus
-} /* extern "C" */
-#endif
+    #ifdef __cplusplus
+        } /* extern "C" */
+    #endif
 
 #endif /* #ifndef ETHERNET_PHY_H_INCLUDED */
-

--- a/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/portable/NetworkInterface/ATSAM4E/gmac.h
+++ b/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/portable/NetworkInterface/ATSAM4E/gmac.h
@@ -1,4 +1,4 @@
- /**
+/**
  * \file
  *
  * \brief GMAC (Ethernet MAC) driver for SAM.
@@ -42,234 +42,246 @@
  */
 
 #ifndef GMAC_H_INCLUDED
-#define GMAC_H_INCLUDED
+    #define GMAC_H_INCLUDED
 
-#include "compiler.h"
+    #include "compiler.h"
 
-/// @cond 0
+/*/ @cond 0 */
 /**INDENT-OFF**/
-#ifdef __cplusplus
-extern "C" {
-#endif
+    #ifdef __cplusplus
+        extern "C" {
+    #endif
 /**INDENT-ON**/
-/// @endcond
+/*/ @endcond */
 
 /** The buffer addresses written into the descriptors must be aligned, so the
-    last few bits are zero.  These bits have special meaning for the GMAC
-    peripheral and cannot be used as part of the address. */
-#define GMAC_RXD_ADDR_MASK      0xFFFFFFFC
-#define GMAC_RXD_WRAP         (1ul << 1)  /**< Wrap bit */
-#define GMAC_RXD_OWNERSHIP    (1ul << 0)  /**< Ownership bit */
+ *  last few bits are zero.  These bits have special meaning for the GMAC
+ *  peripheral and cannot be used as part of the address. */
+    #define GMAC_RXD_ADDR_MASK         0xFFFFFFFC
+    #define GMAC_RXD_WRAP              ( 1ul << 1 )  /**< Wrap bit */
+    #define GMAC_RXD_OWNERSHIP         ( 1ul << 0 )  /**< Ownership bit */
 
-#define GMAC_RXD_BROADCAST    (1ul << 31) /**< Broadcast detected */
-#define GMAC_RXD_MULTIHASH    (1ul << 30) /**< Multicast hash match */
-#define GMAC_RXD_UNIHASH      (1ul << 29) /**< Unicast hash match */
-#define GMAC_RXD_ADDR_FOUND      (1ul << 27) /**< Specific address match found */
-#define GMAC_RXD_ADDR        (3ul << 25) /**< Address match */
-#define GMAC_RXD_RXCOEN        (1ul << 24) /**< RXCOEN related function */
-#define GMAC_RXD_TYPE         (3ul << 22) /**< Type ID match */
-#define GMAC_RXD_VLAN         (1ul << 21) /**< VLAN tag detected */
-#define GMAC_RXD_PRIORITY     (1ul << 20) /**< Priority tag detected */
-#define GMAC_RXD_PRIORITY_MASK  (3ul << 17) /**< VLAN priority */
-#define GMAC_RXD_CFI          (1ul << 16) /**< Concatenation Format Indicator only if bit 21 is set */
-#define GMAC_RXD_EOF          (1ul << 15) /**< End of frame */
-#define GMAC_RXD_SOF          (1ul << 14) /**< Start of frame */
-#define GMAC_RXD_FCS          (1ul << 13) /**< Frame check sequence */
-#define GMAC_RXD_OFFSET_MASK                /**< Receive buffer offset */
-#define GMAC_RXD_LEN_MASK       (0xFFF)     /**< Length of frame including FCS (if selected) */
-#define GMAC_RXD_LENJUMBO_MASK  (0x3FFF)    /**< Jumbo frame length */
+    #define GMAC_RXD_BROADCAST         ( 1ul << 31 ) /**< Broadcast detected */
+    #define GMAC_RXD_MULTIHASH         ( 1ul << 30 ) /**< Multicast hash match */
+    #define GMAC_RXD_UNIHASH           ( 1ul << 29 ) /**< Unicast hash match */
+    #define GMAC_RXD_ADDR_FOUND        ( 1ul << 27 ) /**< Specific address match found */
+    #define GMAC_RXD_ADDR              ( 3ul << 25 ) /**< Address match */
+    #define GMAC_RXD_RXCOEN            ( 1ul << 24 ) /**< RXCOEN related function */
+    #define GMAC_RXD_TYPE              ( 3ul << 22 ) /**< Type ID match */
+    #define GMAC_RXD_VLAN              ( 1ul << 21 ) /**< VLAN tag detected */
+    #define GMAC_RXD_PRIORITY          ( 1ul << 20 ) /**< Priority tag detected */
+    #define GMAC_RXD_PRIORITY_MASK     ( 3ul << 17 ) /**< VLAN priority */
+    #define GMAC_RXD_CFI               ( 1ul << 16 ) /**< Concatenation Format Indicator only if bit 21 is set */
+    #define GMAC_RXD_EOF               ( 1ul << 15 ) /**< End of frame */
+    #define GMAC_RXD_SOF               ( 1ul << 14 ) /**< Start of frame */
+    #define GMAC_RXD_FCS               ( 1ul << 13 ) /**< Frame check sequence */
+    #define GMAC_RXD_OFFSET_MASK                     /**< Receive buffer offset */
+    #define GMAC_RXD_LEN_MASK          ( 0xFFF )     /**< Length of frame including FCS (if selected) */
+    #define GMAC_RXD_LENJUMBO_MASK     ( 0x3FFF )    /**< Jumbo frame length */
 
-#define GMAC_TXD_USED         (1ul << 31) /**< Frame is transmitted */
-#define GMAC_TXD_WRAP         (1ul << 30) /**< Last descriptor */
-#define GMAC_TXD_ERROR        (1ul << 29) /**< Retry limit exceeded, error */
-#define GMAC_TXD_UNDERRUN     (1ul << 28) /**< Transmit underrun */
-#define GMAC_TXD_EXHAUSTED    (1ul << 27) /**< Buffer exhausted */
-#define GMAC_TXD_LATE    (1ul << 26) /**< Late collision,transmit  error  */
-#define GMAC_TXD_CHECKSUM_ERROR   (7ul << 20) /**< Checksum error */
-#define GMAC_TXD_NOCRC        (1ul << 16) /**< No CRC */
-#define GMAC_TXD_LAST         (1ul << 15) /**< Last buffer in frame */
-#define GMAC_TXD_LEN_MASK       (0x1FFF)     /**< Length of buffer */
+    #define GMAC_TXD_USED              ( 1ul << 31 ) /**< Frame is transmitted */
+    #define GMAC_TXD_WRAP              ( 1ul << 30 ) /**< Last descriptor */
+    #define GMAC_TXD_ERROR             ( 1ul << 29 ) /**< Retry limit exceeded, error */
+    #define GMAC_TXD_UNDERRUN          ( 1ul << 28 ) /**< Transmit underrun */
+    #define GMAC_TXD_EXHAUSTED         ( 1ul << 27 ) /**< Buffer exhausted */
+    #define GMAC_TXD_LATE              ( 1ul << 26 ) /**< Late collision,transmit  error  */
+    #define GMAC_TXD_CHECKSUM_ERROR    ( 7ul << 20 ) /**< Checksum error */
+    #define GMAC_TXD_NOCRC             ( 1ul << 16 ) /**< No CRC */
+    #define GMAC_TXD_LAST              ( 1ul << 15 ) /**< Last buffer in frame */
+    #define GMAC_TXD_LEN_MASK          ( 0x1FFF )    /**< Length of buffer */
 
 /** The MAC can support frame lengths up to 1536 bytes */
-#define GMAC_FRAME_LENTGH_MAX       1536
+    #define GMAC_FRAME_LENTGH_MAX      1536
 
-#define GMAC_RX_UNITSIZE            128     /**< Fixed size for RX buffer  */
-#define GMAC_TX_UNITSIZE            1518    /**< Size for ETH frame length */
+    #define GMAC_RX_UNITSIZE           128  /**< Fixed size for RX buffer  */
+    #define GMAC_TX_UNITSIZE           1518 /**< Size for ETH frame length */
 
 /** GMAC clock speed */
-#define GMAC_MCK_SPEED_240MHZ        (240*1000*1000)
-#define GMAC_MCK_SPEED_160MHZ        (160*1000*1000)
-#define GMAC_MCK_SPEED_120MHZ        (120*1000*1000)
-#define GMAC_MCK_SPEED_80MHZ          (80*1000*1000)
-#define GMAC_MCK_SPEED_40MHZ          (40*1000*1000)
-#define GMAC_MCK_SPEED_20MHZ          (20*1000*1000)
+    #define GMAC_MCK_SPEED_240MHZ      ( 240 * 1000 * 1000 )
+    #define GMAC_MCK_SPEED_160MHZ      ( 160 * 1000 * 1000 )
+    #define GMAC_MCK_SPEED_120MHZ      ( 120 * 1000 * 1000 )
+    #define GMAC_MCK_SPEED_80MHZ       ( 80 * 1000 * 1000 )
+    #define GMAC_MCK_SPEED_40MHZ       ( 40 * 1000 * 1000 )
+    #define GMAC_MCK_SPEED_20MHZ       ( 20 * 1000 * 1000 )
 
 /** GMAC maintain code default value*/
-#define GMAC_MAN_CODE_VALUE    (10)
+    #define GMAC_MAN_CODE_VALUE        ( 10 )
 
 /** GMAC maintain start of frame default value*/
-#define GMAC_MAN_SOF_VALUE     (1)
+    #define GMAC_MAN_SOF_VALUE         ( 1 )
 
 /** GMAC maintain read/write*/
-#define GMAC_MAN_RW_TYPE       (2)
+    #define GMAC_MAN_RW_TYPE           ( 2 )
 
 /** GMAC maintain read only*/
-#define GMAC_MAN_READ_ONLY     (1)
+    #define GMAC_MAN_READ_ONLY         ( 1 )
 
 /** GMAC address length */
-#define GMAC_ADDR_LENGTH       (6)
+    #define GMAC_ADDR_LENGTH           ( 6 )
 
 
-#define GMAC_DUPLEX_HALF 0
-#define GMAC_DUPLEX_FULL 1
+    #define GMAC_DUPLEX_HALF           0
+    #define GMAC_DUPLEX_FULL           1
 
-#define GMAC_SPEED_10M      0
-#define GMAC_SPEED_100M     1
+    #define GMAC_SPEED_10M             0
+    #define GMAC_SPEED_100M            1
 
 /**
  * \brief Return codes for GMAC APIs.
  */
-typedef enum {
-	GMAC_OK = 0,         /** 0  Operation OK */
-	GMAC_TIMEOUT = 1,    /** 1  GMAC operation timeout */
-	GMAC_TX_BUSY,        /** 2  TX in progress */
-	GMAC_RX_NULL,        /** 3  No data received */
-	GMAC_SIZE_TOO_SMALL, /** 4  Buffer size not enough */
-	GMAC_PARAM,          /** 5  Parameter error, TX packet invalid or RX size too small */
-	GMAC_INVALID = 0xFF, /* Invalid */
-} gmac_status_t;
+    typedef enum
+    {
+        GMAC_OK = 0,         /** 0  Operation OK */
+        GMAC_TIMEOUT = 1,    /** 1  GMAC operation timeout */
+        GMAC_TX_BUSY,        /** 2  TX in progress */
+        GMAC_RX_NULL,        /** 3  No data received */
+        GMAC_SIZE_TOO_SMALL, /** 4  Buffer size not enough */
+        GMAC_PARAM,          /** 5  Parameter error, TX packet invalid or RX size too small */
+        GMAC_INVALID = 0xFF, /* Invalid */
+    } gmac_status_t;
 
 /**
  * \brief Media Independent Interface (MII) type.
  */
-typedef enum {
-	GMAC_PHY_MII = 0,         /** MII mode */
-	GMAC_PHY_RMII = 1,    /** Reduced MII mode */
-	GMAC_PHY_INVALID = 0xFF, /* Invalid mode*/
-} gmac_mii_mode_t;
+    typedef enum
+    {
+        GMAC_PHY_MII = 0,        /** MII mode */
+        GMAC_PHY_RMII = 1,       /** Reduced MII mode */
+        GMAC_PHY_INVALID = 0xFF, /* Invalid mode*/
+    } gmac_mii_mode_t;
 
 /** Receive buffer descriptor struct */
-COMPILER_PACK_SET(8)
-typedef struct gmac_rx_descriptor {
-	union gmac_rx_addr {
-		uint32_t val;
-		struct gmac_rx_addr_bm {
-			uint32_t b_ownership:1, /**< User clear, GMAC sets this to 1 once it has successfully written a frame to memory */
-			b_wrap:1,   /**< Marks last descriptor in receive buffer */
-			addr_dw:30; /**< Address in number of DW */
-		} bm;
-	} addr; /**< Address, Wrap & Ownership */
-	union gmac_rx_status {
-		uint32_t val;
-		struct gmac_rx_status_bm {
-			uint32_t len:13,       /**  0..12  Length of frame including FCS */
-			b_fcs:1,               /**  13     Receive buffer offset,  bits 13:12 of frame length for jumbo frame */
-			b_sof:1,               /**  14     Start of frame */
-			b_eof:1,               /**  15     End of frame */
-			b_cfi:1,               /**  16     Concatenation Format Indicator */
-			vlan_priority:3,       /**  17..19 VLAN priority (if VLAN detected) */
-			b_priority_detected:1, /**  20     Priority tag detected */
-			b_vlan_detected:1,     /**  21     VLAN tag detected */
-			b_type_id_match:2,     /**  22..23 Type ID match */
-			b_checksumoffload:1,   /**  24     Checksum offload specific function */
-			b_addrmatch:2,         /**  25..26 Address register match */
-			b_ext_addr_match:1,    /**  27     External address match found */
-			reserved:1,            /**  28     */
-			b_uni_hash_match:1,    /**  29     Unicast hash match */
-			b_multi_hash_match:1,  /**  30     Multicast hash match */
-			b_boardcast_detect:1;  /**  31     Global broadcast address detected */
-		} bm;
-	} status;
-} gmac_rx_descriptor_t;
+    COMPILER_PACK_SET( 8 )
+    typedef struct gmac_rx_descriptor
+    {
+        union gmac_rx_addr
+        {
+            uint32_t val;
+            struct gmac_rx_addr_bm
+            {
+                uint32_t b_ownership : 1, /**< User clear, GMAC sets this to 1 once it has successfully written a frame to memory */
+                         b_wrap : 1,      /**< Marks last descriptor in receive buffer */
+                         addr_dw : 30;    /**< Address in number of DW */
+            } bm;
+        } addr;                           /**< Address, Wrap & Ownership */
+        union gmac_rx_status
+        {
+            uint32_t val;
+            struct gmac_rx_status_bm
+            {
+                uint32_t len : 13,                /**  0..12  Length of frame including FCS */
+                         b_fcs : 1,               /**  13     Receive buffer offset,  bits 13:12 of frame length for jumbo frame */
+                         b_sof : 1,               /**  14     Start of frame */
+                         b_eof : 1,               /**  15     End of frame */
+                         b_cfi : 1,               /**  16     Concatenation Format Indicator */
+                         vlan_priority : 3,       /**  17..19 VLAN priority (if VLAN detected) */
+                         b_priority_detected : 1, /**  20     Priority tag detected */
+                         b_vlan_detected : 1,     /**  21     VLAN tag detected */
+                         b_type_id_match : 2,     /**  22..23 Type ID match */
+                         b_checksumoffload : 1,   /**  24     Checksum offload specific function */
+                         b_addrmatch : 2,         /**  25..26 Address register match */
+                         b_ext_addr_match : 1,    /**  27     External address match found */
+                         reserved : 1,            /**  28     */
+                         b_uni_hash_match : 1,    /**  29     Unicast hash match */
+                         b_multi_hash_match : 1,  /**  30     Multicast hash match */
+                         b_boardcast_detect : 1;  /**  31     Global broadcast address detected */
+            } bm;
+        } status;
+    } gmac_rx_descriptor_t;
 
 /** Transmit buffer descriptor struct */
-COMPILER_PACK_SET(8)
-typedef struct gmac_tx_descriptor {
-	uint32_t addr;
-	union gmac_tx_status {
-		uint32_t val;
-		struct gmac_tx_status_bm {
-			uint32_t len:14,     /**  0..13 Length of buffer */
-			reserved:1,          /** 14            */
-			b_last_buffer:1,     /** 15     Last buffer (in the current frame) */
-			b_no_crc:1,          /** 16     No CRC */
-			reserved1:3,         /** 17..19        */
-			b_checksumoffload:3, /** 20..22 Transmit checksum generation offload errors */
-			reserved2:3,         /** 23..25        */
-			b_lco:1,             /** 26     Late collision, transmit error detected */
-			b_exhausted:1,       /** 27     Buffer exhausted in mid frame */
-			b_underrun:1,        /** 28     Transmit underrun */
-			b_error:1,           /** 29     Retry limit exceeded, error detected */
-			b_wrap:1,            /** 30     Marks last descriptor in TD list */
-			b_used:1;            /** 31     User clear, GMAC sets this to 1 once a frame has been successfully transmitted */
-		} bm;
-	} status;
-} gmac_tx_descriptor_t;
+    COMPILER_PACK_SET( 8 )
+    typedef struct gmac_tx_descriptor
+    {
+        uint32_t addr;
+        union gmac_tx_status
+        {
+            uint32_t val;
+            struct gmac_tx_status_bm
+            {
+                uint32_t len : 14,              /**  0..13 Length of buffer */
+                         reserved : 1,          /** 14            */
+                         b_last_buffer : 1,     /** 15     Last buffer (in the current frame) */
+                         b_no_crc : 1,          /** 16     No CRC */
+                         reserved1 : 3,         /** 17..19        */
+                         b_checksumoffload : 3, /** 20..22 Transmit checksum generation offload errors */
+                         reserved2 : 3,         /** 23..25        */
+                         b_lco : 1,             /** 26     Late collision, transmit error detected */
+                         b_exhausted : 1,       /** 27     Buffer exhausted in mid frame */
+                         b_underrun : 1,        /** 28     Transmit underrun */
+                         b_error : 1,           /** 29     Retry limit exceeded, error detected */
+                         b_wrap : 1,            /** 30     Marks last descriptor in TD list */
+                         b_used : 1;            /** 31     User clear, GMAC sets this to 1 once a frame has been successfully transmitted */
+            } bm;
+        } status;
+    } gmac_tx_descriptor_t;
 
-COMPILER_PACK_RESET()
+    COMPILER_PACK_RESET()
 
 /**
  * \brief Input parameters when initializing the gmac module mode.
  */
-typedef struct gmac_options {
-	/*  Enable/Disable CopyAllFrame */
-	uint8_t uc_copy_all_frame;
-	/* Enable/Disable NoBroadCast */
-	uint8_t uc_no_boardcast;
-	/* MAC address */
-	uint8_t uc_mac_addr[GMAC_ADDR_LENGTH];
-} gmac_options_t;
+    typedef struct gmac_options
+    {
+        /*  Enable/Disable CopyAllFrame */
+        uint8_t uc_copy_all_frame;
+        /* Enable/Disable NoBroadCast */
+        uint8_t uc_no_boardcast;
+        /* MAC address */
+        uint8_t uc_mac_addr[ GMAC_ADDR_LENGTH ];
+    } gmac_options_t;
 
 /** RX callback */
-typedef void (*gmac_dev_tx_cb_t) (uint32_t ul_status);
+    typedef void (* gmac_dev_tx_cb_t) ( uint32_t ul_status );
 /** Wakeup callback */
-typedef void (*gmac_dev_wakeup_cb_t) (void);
+    typedef void (* gmac_dev_wakeup_cb_t) ( void );
 
 /**
  * GMAC driver structure.
  */
-typedef struct gmac_device {
+    typedef struct gmac_device
+    {
+        /** Pointer to HW register base */
+        Gmac * p_hw;
 
-	/** Pointer to HW register base */
-	Gmac *p_hw;
-	/**
-	 * Pointer to allocated TX buffer.
-	 * Section 3.6 of AMBA 2.0 spec states that burst should not cross
-	 * 1K Boundaries.
-	 * Receive buffer manager writes are burst of 2 words => 3 lsb bits
-	 * of the address shall be set to 0.
-	 */
-	uint8_t *p_tx_buffer;
-	/** Pointer to allocated RX buffer */
-	uint8_t *p_rx_buffer;
-	/** Pointer to Rx TDs (must be 8-byte aligned) */
-	gmac_rx_descriptor_t *p_rx_dscr;
-	/** Pointer to Tx TDs (must be 8-byte aligned) */
-	gmac_tx_descriptor_t *p_tx_dscr;
-	/** Optional callback to be invoked once a frame has been received */
-	gmac_dev_tx_cb_t func_rx_cb;
-#if( GMAC_USES_WAKEUP_CALLBACK )
-	/** Optional callback to be invoked once several TDs have been released */
-	gmac_dev_wakeup_cb_t func_wakeup_cb;
-#endif
-#if( GMAC_USES_TX_CALLBACK != 0 )
-	/** Optional callback list to be invoked once TD has been processed */
-	gmac_dev_tx_cb_t *func_tx_cb_list;
-#endif
-	/** RX TD list size */
-	uint32_t ul_rx_list_size;
-	/** RX index for current processing TD */
-	uint32_t ul_rx_idx;
-	/** TX TD list size */
-	uint32_t ul_tx_list_size;
-	/** Circular buffer head pointer by upper layer (buffer to be sent) */
-	int32_t l_tx_head;
-	/** Circular buffer tail pointer incremented by handlers (buffer sent) */
-	int32_t l_tx_tail;
+        /**
+         * Pointer to allocated TX buffer.
+         * Section 3.6 of AMBA 2.0 spec states that burst should not cross
+         * 1K Boundaries.
+         * Receive buffer manager writes are burst of 2 words => 3 lsb bits
+         * of the address shall be set to 0.
+         */
+        uint8_t * p_tx_buffer;
+        /** Pointer to allocated RX buffer */
+        uint8_t * p_rx_buffer;
+        /** Pointer to Rx TDs (must be 8-byte aligned) */
+        gmac_rx_descriptor_t * p_rx_dscr;
+        /** Pointer to Tx TDs (must be 8-byte aligned) */
+        gmac_tx_descriptor_t * p_tx_dscr;
+        /** Optional callback to be invoked once a frame has been received */
+        gmac_dev_tx_cb_t func_rx_cb;
+        #if ( GMAC_USES_WAKEUP_CALLBACK )
+            /** Optional callback to be invoked once several TDs have been released */
+            gmac_dev_wakeup_cb_t func_wakeup_cb;
+        #endif
+        #if ( GMAC_USES_TX_CALLBACK != 0 )
+            /** Optional callback list to be invoked once TD has been processed */
+            gmac_dev_tx_cb_t * func_tx_cb_list;
+        #endif
+        /** RX TD list size */
+        uint32_t ul_rx_list_size;
+        /** RX index for current processing TD */
+        uint32_t ul_rx_idx;
+        /** TX TD list size */
+        uint32_t ul_tx_list_size;
+        /** Circular buffer head pointer by upper layer (buffer to be sent) */
+        int32_t l_tx_head;
+        /** Circular buffer tail pointer incremented by handlers (buffer sent) */
+        int32_t l_tx_tail;
 
-	/** Number of free TD before wakeup callback is invoked */
-	uint32_t uc_wakeup_threshold;
-} gmac_device_t;
+        /** Number of free TD before wakeup callback is invoked */
+        uint32_t uc_wakeup_threshold;
+    } gmac_device_t;
 
 /**
  * \brief Write network control value.
@@ -277,10 +289,11 @@ typedef struct gmac_device {
  * \param p_gmac   Pointer to the GMAC instance.
  * \param ul_ncr   Network control value.
  */
-static inline void gmac_network_control(Gmac* p_gmac, uint32_t ul_ncr)
-{
-	p_gmac->GMAC_NCR = ul_ncr;
-}
+    static inline void gmac_network_control( Gmac * p_gmac,
+                                             uint32_t ul_ncr )
+    {
+        p_gmac->GMAC_NCR = ul_ncr;
+    }
 
 /**
  * \brief Get network control value.
@@ -288,10 +301,10 @@ static inline void gmac_network_control(Gmac* p_gmac, uint32_t ul_ncr)
  * \param p_gmac   Pointer to the GMAC instance.
  */
 
-static inline uint32_t gmac_get_network_control(Gmac* p_gmac)
-{
-	return p_gmac->GMAC_NCR;
-}
+    static inline uint32_t gmac_get_network_control( Gmac * p_gmac )
+    {
+        return p_gmac->GMAC_NCR;
+    }
 
 /**
  * \brief Enable/Disable GMAC receive.
@@ -299,14 +312,18 @@ static inline uint32_t gmac_get_network_control(Gmac* p_gmac)
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable GMAC receiver, else to enable it.
  */
-static inline void gmac_enable_receive(Gmac* p_gmac, uint8_t uc_enable)
-{
-	if (uc_enable) {
-		p_gmac->GMAC_NCR |= GMAC_NCR_RXEN;
-	} else {
-		p_gmac->GMAC_NCR &= ~GMAC_NCR_RXEN;
-	}
-}
+    static inline void gmac_enable_receive( Gmac * p_gmac,
+                                            uint8_t uc_enable )
+    {
+        if( uc_enable )
+        {
+            p_gmac->GMAC_NCR |= GMAC_NCR_RXEN;
+        }
+        else
+        {
+            p_gmac->GMAC_NCR &= ~GMAC_NCR_RXEN;
+        }
+    }
 
 /**
  * \brief Enable/Disable GMAC transmit.
@@ -314,14 +331,18 @@ static inline void gmac_enable_receive(Gmac* p_gmac, uint8_t uc_enable)
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable GMAC transmit, else to enable it.
  */
-static inline void gmac_enable_transmit(Gmac* p_gmac, uint8_t uc_enable)
-{
-	if (uc_enable) {
-		p_gmac->GMAC_NCR |= GMAC_NCR_TXEN;
-	} else {
-		p_gmac->GMAC_NCR &= ~GMAC_NCR_TXEN;
-	}
-}
+    static inline void gmac_enable_transmit( Gmac * p_gmac,
+                                             uint8_t uc_enable )
+    {
+        if( uc_enable )
+        {
+            p_gmac->GMAC_NCR |= GMAC_NCR_TXEN;
+        }
+        else
+        {
+            p_gmac->GMAC_NCR &= ~GMAC_NCR_TXEN;
+        }
+    }
 
 /**
  * \brief Enable/Disable GMAC management.
@@ -329,34 +350,38 @@ static inline void gmac_enable_transmit(Gmac* p_gmac, uint8_t uc_enable)
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable GMAC management, else to enable it.
  */
-static inline void gmac_enable_management(Gmac* p_gmac, uint8_t uc_enable)
-{
-	if (uc_enable) {
-		p_gmac->GMAC_NCR |= GMAC_NCR_MPE;
-	} else {
-		p_gmac->GMAC_NCR &= ~GMAC_NCR_MPE;
-	}
-}
+    static inline void gmac_enable_management( Gmac * p_gmac,
+                                               uint8_t uc_enable )
+    {
+        if( uc_enable )
+        {
+            p_gmac->GMAC_NCR |= GMAC_NCR_MPE;
+        }
+        else
+        {
+            p_gmac->GMAC_NCR &= ~GMAC_NCR_MPE;
+        }
+    }
 
 /**
  * \brief Clear all statistics registers.
  *
  * \param p_gmac   Pointer to the GMAC instance.
  */
-static inline void gmac_clear_statistics(Gmac* p_gmac)
-{
-	p_gmac->GMAC_NCR |= GMAC_NCR_CLRSTAT;
-}
+    static inline void gmac_clear_statistics( Gmac * p_gmac )
+    {
+        p_gmac->GMAC_NCR |= GMAC_NCR_CLRSTAT;
+    }
 
 /**
  * \brief Increase all statistics registers.
  *
  * \param p_gmac   Pointer to the GMAC instance.
  */
-static inline void gmac_increase_statistics(Gmac* p_gmac)
-{
-	p_gmac->GMAC_NCR |= GMAC_NCR_INCSTAT;
-}
+    static inline void gmac_increase_statistics( Gmac * p_gmac )
+    {
+        p_gmac->GMAC_NCR |= GMAC_NCR_INCSTAT;
+    }
 
 /**
  * \brief Enable/Disable statistics registers writing.
@@ -364,15 +389,18 @@ static inline void gmac_increase_statistics(Gmac* p_gmac)
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable the statistics registers writing, else to enable it.
  */
-static inline void gmac_enable_statistics_write(Gmac* p_gmac,
-		uint8_t uc_enable)
-{
-	if (uc_enable) {
-		p_gmac->GMAC_NCR |= GMAC_NCR_WESTAT;
-	} else {
-		p_gmac->GMAC_NCR &= ~GMAC_NCR_WESTAT;
-	}
-}
+    static inline void gmac_enable_statistics_write( Gmac * p_gmac,
+                                                     uint8_t uc_enable )
+    {
+        if( uc_enable )
+        {
+            p_gmac->GMAC_NCR |= GMAC_NCR_WESTAT;
+        }
+        else
+        {
+            p_gmac->GMAC_NCR &= ~GMAC_NCR_WESTAT;
+        }
+    }
 
 /**
  * \brief In half-duplex mode, forces collisions on all received frames.
@@ -380,64 +408,68 @@ static inline void gmac_enable_statistics_write(Gmac* p_gmac,
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable the back pressure, else to enable it.
  */
-static inline void gmac_enable_back_pressure(Gmac* p_gmac, uint8_t uc_enable)
-{
-	if (uc_enable) {
-		p_gmac->GMAC_NCR |= GMAC_NCR_BP;
-	} else {
-		p_gmac->GMAC_NCR &= ~GMAC_NCR_BP;
-	}
-}
+    static inline void gmac_enable_back_pressure( Gmac * p_gmac,
+                                                  uint8_t uc_enable )
+    {
+        if( uc_enable )
+        {
+            p_gmac->GMAC_NCR |= GMAC_NCR_BP;
+        }
+        else
+        {
+            p_gmac->GMAC_NCR &= ~GMAC_NCR_BP;
+        }
+    }
 
 /**
  * \brief Start transmission.
  *
  * \param p_gmac   Pointer to the GMAC instance.
  */
-static inline void gmac_start_transmission(Gmac* p_gmac)
-{
-	p_gmac->GMAC_NCR |= GMAC_NCR_TSTART;
-}
+    static inline void gmac_start_transmission( Gmac * p_gmac )
+    {
+        p_gmac->GMAC_NCR |= GMAC_NCR_TSTART;
+    }
 
 /**
  * \brief Halt transmission.
  *
  * \param p_gmac   Pointer to the GMAC instance.
  */
-static inline void gmac_halt_transmission(Gmac* p_gmac)
-{
-	p_gmac->GMAC_NCR |= GMAC_NCR_THALT;
-}
+    static inline void gmac_halt_transmission( Gmac * p_gmac )
+    {
+        p_gmac->GMAC_NCR |= GMAC_NCR_THALT;
+    }
 
 /**
  * \brief Transmit pause frame.
  *
  * \param p_gmac   Pointer to the GMAC instance.
  */
-static inline void gmac_tx_pause_frame(Gmac* p_gmac)
-{
-	p_gmac->GMAC_NCR |= GMAC_NCR_TXPF;
-}
+    static inline void gmac_tx_pause_frame( Gmac * p_gmac )
+    {
+        p_gmac->GMAC_NCR |= GMAC_NCR_TXPF;
+    }
 
 /**
  * \brief Transmit zero quantum pause frame.
  *
  * \param p_gmac   Pointer to the GMAC instance.
  */
-static inline void gmac_tx_pause_zero_quantum_frame(Gmac* p_gmac)
-{
-	p_gmac->GMAC_NCR |= GMAC_NCR_TXZQPF;
-}
+    static inline void gmac_tx_pause_zero_quantum_frame( Gmac * p_gmac )
+    {
+        p_gmac->GMAC_NCR |= GMAC_NCR_TXZQPF;
+    }
 
 /**
  * \brief Read snapshot.
  *
  * \param p_gmac   Pointer to the GMAC instance.
  */
-static inline void gmac_read_snapshot(Gmac* p_gmac)
-{
-	p_gmac->GMAC_NCR |= GMAC_NCR_RDS;
-}
+    static inline void gmac_read_snapshot( Gmac * p_gmac )
+    {
+        p_gmac->GMAC_NCR |= GMAC_NCR_RDS;
+    }
 
 /**
  * \brief Store receivetime stamp to memory.
@@ -445,14 +477,18 @@ static inline void gmac_read_snapshot(Gmac* p_gmac)
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to normal operation, else to enable the store.
  */
-static inline void gmac_store_rx_time_stamp(Gmac* p_gmac, uint8_t uc_enable)
-{
-	if (uc_enable) {
-		p_gmac->GMAC_NCR |= GMAC_NCR_SRTSM;
-	} else {
-		p_gmac->GMAC_NCR &= ~GMAC_NCR_SRTSM;
-	}
-}
+    static inline void gmac_store_rx_time_stamp( Gmac * p_gmac,
+                                                 uint8_t uc_enable )
+    {
+        if( uc_enable )
+        {
+            p_gmac->GMAC_NCR |= GMAC_NCR_SRTSM;
+        }
+        else
+        {
+            p_gmac->GMAC_NCR &= ~GMAC_NCR_SRTSM;
+        }
+    }
 
 /**
  * \brief Enable PFC priority-based pause reception.
@@ -460,45 +496,50 @@ static inline void gmac_store_rx_time_stamp(Gmac* p_gmac, uint8_t uc_enable)
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   1 to set the reception, 0 to disable.
  */
-static inline void gmac_enable_pfc_pause_frame(Gmac* p_gmac, uint8_t uc_enable)
-{
-	if (uc_enable) {
-		p_gmac->GMAC_NCR |= GMAC_NCR_ENPBPR;
-	} else {
-		p_gmac->GMAC_NCR &= ~GMAC_NCR_ENPBPR;
-	}
-}
+    static inline void gmac_enable_pfc_pause_frame( Gmac * p_gmac,
+                                                    uint8_t uc_enable )
+    {
+        if( uc_enable )
+        {
+            p_gmac->GMAC_NCR |= GMAC_NCR_ENPBPR;
+        }
+        else
+        {
+            p_gmac->GMAC_NCR &= ~GMAC_NCR_ENPBPR;
+        }
+    }
 
 /**
  * \brief Transmit PFC priority-based pause reception.
  *
  * \param p_gmac   Pointer to the GMAC instance.
  */
-static inline void gmac_transmit_pfc_pause_frame(Gmac* p_gmac)
-{
-		p_gmac->GMAC_NCR |= GMAC_NCR_TXPBPF;
-}
+    static inline void gmac_transmit_pfc_pause_frame( Gmac * p_gmac )
+    {
+        p_gmac->GMAC_NCR |= GMAC_NCR_TXPBPF;
+    }
 
 /**
  * \brief Flush next packet.
  *
  * \param p_gmac   Pointer to the GMAC instance.
  */
-static inline void gmac_flush_next_packet(Gmac* p_gmac)
-{
-		p_gmac->GMAC_NCR |= GMAC_NCR_FNP;
-}
+    static inline void gmac_flush_next_packet( Gmac * p_gmac )
+    {
+        p_gmac->GMAC_NCR |= GMAC_NCR_FNP;
+    }
 
 /**
  * \brief Set up network configuration register.
  *
  * \param p_gmac   Pointer to the GMAC instance.
-  * \param ul_cfg   Network configuration value.
+ * \param ul_cfg   Network configuration value.
  */
-static inline void gmac_set_configure(Gmac* p_gmac, uint32_t ul_cfg)
-{
-	p_gmac->GMAC_NCFGR = ul_cfg;
-}
+    static inline void gmac_set_configure( Gmac * p_gmac,
+                                           uint32_t ul_cfg )
+    {
+        p_gmac->GMAC_NCFGR = ul_cfg;
+    }
 
 /**
  * \brief Get network configuration.
@@ -507,22 +548,23 @@ static inline void gmac_set_configure(Gmac* p_gmac, uint32_t ul_cfg)
  *
  * \return Network configuration.
  */
-static inline uint32_t gmac_get_configure(Gmac* p_gmac)
-{
-	return p_gmac->GMAC_NCFGR;
-}
+    static inline uint32_t gmac_get_configure( Gmac * p_gmac )
+    {
+        return p_gmac->GMAC_NCFGR;
+    }
 
 
 /* Get and set DMA Configuration Register */
-static inline void gmac_set_dma(Gmac* p_gmac, uint32_t ul_cfg)
-{
-	p_gmac->GMAC_DCFGR = ul_cfg;
-}
+    static inline void gmac_set_dma( Gmac * p_gmac,
+                                     uint32_t ul_cfg )
+    {
+        p_gmac->GMAC_DCFGR = ul_cfg;
+    }
 
-static inline uint32_t gmac_get_dma(Gmac* p_gmac)
-{
-	return p_gmac->GMAC_DCFGR;
-}
+    static inline uint32_t gmac_get_dma( Gmac * p_gmac )
+    {
+        return p_gmac->GMAC_DCFGR;
+    }
 
 /**
  * \brief Set speed.
@@ -530,14 +572,18 @@ static inline uint32_t gmac_get_dma(Gmac* p_gmac)
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_speed 1 to indicate 100Mbps, 0 to 10Mbps.
  */
-static inline void gmac_set_speed(Gmac* p_gmac, uint8_t uc_speed)
-{
-	if (uc_speed) {
-		p_gmac->GMAC_NCFGR |= GMAC_NCFGR_SPD;
-	} else {
-		p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_SPD;
-	}
-}
+    static inline void gmac_set_speed( Gmac * p_gmac,
+                                       uint8_t uc_speed )
+    {
+        if( uc_speed )
+        {
+            p_gmac->GMAC_NCFGR |= GMAC_NCFGR_SPD;
+        }
+        else
+        {
+            p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_SPD;
+        }
+    }
 
 /**
  * \brief Enable/Disable Full-Duplex mode.
@@ -545,14 +591,18 @@ static inline void gmac_set_speed(Gmac* p_gmac, uint8_t uc_speed)
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable the Full-Duplex mode, else to enable it.
  */
-static inline void gmac_enable_full_duplex(Gmac* p_gmac, uint8_t uc_enable)
-{
-	if (uc_enable) {
-		p_gmac->GMAC_NCFGR |= GMAC_NCFGR_FD;
-	} else {
-		p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_FD;
-	}
-}
+    static inline void gmac_enable_full_duplex( Gmac * p_gmac,
+                                                uint8_t uc_enable )
+    {
+        if( uc_enable )
+        {
+            p_gmac->GMAC_NCFGR |= GMAC_NCFGR_FD;
+        }
+        else
+        {
+            p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_FD;
+        }
+    }
 
 /**
  * \brief Enable/Disable Copy(Receive) All Valid Frames.
@@ -560,14 +610,18 @@ static inline void gmac_enable_full_duplex(Gmac* p_gmac, uint8_t uc_enable)
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable copying all valid frames, else to enable it.
  */
-static inline void gmac_enable_copy_all(Gmac* p_gmac, uint8_t uc_enable)
-{
-	if (uc_enable) {
-		p_gmac->GMAC_NCFGR |= GMAC_NCFGR_CAF;
-	} else {
-		p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_CAF;
-	}
-}
+    static inline void gmac_enable_copy_all( Gmac * p_gmac,
+                                             uint8_t uc_enable )
+    {
+        if( uc_enable )
+        {
+            p_gmac->GMAC_NCFGR |= GMAC_NCFGR_CAF;
+        }
+        else
+        {
+            p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_CAF;
+        }
+    }
 
 /**
  * \brief Enable/Disable jumbo frames (up to 10240 bytes).
@@ -575,14 +629,18 @@ static inline void gmac_enable_copy_all(Gmac* p_gmac, uint8_t uc_enable)
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable the jumbo frames, else to enable it.
  */
-static inline void gmac_enable_jumbo_frames(Gmac* p_gmac, uint8_t uc_enable)
-{
-	if (uc_enable) {
-		p_gmac->GMAC_NCFGR |= GMAC_NCFGR_JFRAME;
-	} else {
-		p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_JFRAME;
-	}
-}
+    static inline void gmac_enable_jumbo_frames( Gmac * p_gmac,
+                                                 uint8_t uc_enable )
+    {
+        if( uc_enable )
+        {
+            p_gmac->GMAC_NCFGR |= GMAC_NCFGR_JFRAME;
+        }
+        else
+        {
+            p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_JFRAME;
+        }
+    }
 
 /**
  * \brief Disable/Enable broadcast receiving.
@@ -590,14 +648,18 @@ static inline void gmac_enable_jumbo_frames(Gmac* p_gmac, uint8_t uc_enable)
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   1 to disable the broadcast, else to enable it.
  */
-static inline void gmac_disable_broadcast(Gmac* p_gmac, uint8_t uc_enable)
-{
-	if (uc_enable) {
-		p_gmac->GMAC_NCFGR |= GMAC_NCFGR_NBC;
-	} else {
-		p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_NBC;
-	}
-}
+    static inline void gmac_disable_broadcast( Gmac * p_gmac,
+                                               uint8_t uc_enable )
+    {
+        if( uc_enable )
+        {
+            p_gmac->GMAC_NCFGR |= GMAC_NCFGR_NBC;
+        }
+        else
+        {
+            p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_NBC;
+        }
+    }
 
 /**
  * \brief Enable/Disable multicast hash.
@@ -605,14 +667,18 @@ static inline void gmac_disable_broadcast(Gmac* p_gmac, uint8_t uc_enable)
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable the multicast hash, else to enable it.
  */
-static inline void gmac_enable_multicast_hash(Gmac* p_gmac, uint8_t uc_enable)
-{
-	if (uc_enable) {
-		p_gmac->GMAC_NCFGR |= GMAC_NCFGR_UNIHEN;
-	} else {
-		p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_UNIHEN;
-	}
-}
+    static inline void gmac_enable_multicast_hash( Gmac * p_gmac,
+                                                   uint8_t uc_enable )
+    {
+        if( uc_enable )
+        {
+            p_gmac->GMAC_NCFGR |= GMAC_NCFGR_UNIHEN;
+        }
+        else
+        {
+            p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_UNIHEN;
+        }
+    }
 
 /**
  * \brief Enable/Disable big frames (over 1518, up to 1536).
@@ -620,14 +686,18 @@ static inline void gmac_enable_multicast_hash(Gmac* p_gmac, uint8_t uc_enable)
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable big frames else to enable it.
  */
-static inline void gmac_enable_big_frame(Gmac* p_gmac, uint8_t uc_enable)
-{
-	if (uc_enable) {
-		p_gmac->GMAC_NCFGR |= GMAC_NCFGR_MAXFS;
-	} else {
-		p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_MAXFS;
-	}
-}
+    static inline void gmac_enable_big_frame( Gmac * p_gmac,
+                                              uint8_t uc_enable )
+    {
+        if( uc_enable )
+        {
+            p_gmac->GMAC_NCFGR |= GMAC_NCFGR_MAXFS;
+        }
+        else
+        {
+            p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_MAXFS;
+        }
+    }
 
 /**
  * \brief Set MDC clock divider.
@@ -637,29 +707,43 @@ static inline void gmac_enable_big_frame(Gmac* p_gmac, uint8_t uc_enable)
  *
  * \return GMAC_OK if successfully.
  */
-static inline uint8_t gmac_set_mdc_clock(Gmac* p_gmac, uint32_t ul_mck)
-{
-	uint32_t ul_clk;
-	
-	if (ul_mck > GMAC_MCK_SPEED_240MHZ) {
-		return GMAC_INVALID;
-	} else if (ul_mck > GMAC_MCK_SPEED_160MHZ) {
-		ul_clk = GMAC_NCFGR_CLK_MCK_96;
-	} else if (ul_mck > GMAC_MCK_SPEED_120MHZ) {
-		ul_clk = GMAC_NCFGR_CLK_MCK_64;
-	} else if (ul_mck > GMAC_MCK_SPEED_80MHZ) {
-		ul_clk = GMAC_NCFGR_CLK_MCK_48;
-	} else if (ul_mck > GMAC_MCK_SPEED_40MHZ) {
-		ul_clk = GMAC_NCFGR_CLK_MCK_32;
-	} else if (ul_mck > GMAC_MCK_SPEED_20MHZ) {
-		ul_clk = GMAC_NCFGR_CLK_MCK_16;
-	} else {
-		ul_clk = GMAC_NCFGR_CLK_MCK_8;
-	}
-	;
-	p_gmac->GMAC_NCFGR = (p_gmac->GMAC_NCFGR & ~GMAC_NCFGR_CLK_Msk) | ul_clk;
-	return GMAC_OK;
-}
+    static inline uint8_t gmac_set_mdc_clock( Gmac * p_gmac,
+                                              uint32_t ul_mck )
+    {
+        uint32_t ul_clk;
+
+        if( ul_mck > GMAC_MCK_SPEED_240MHZ )
+        {
+            return GMAC_INVALID;
+        }
+        else if( ul_mck > GMAC_MCK_SPEED_160MHZ )
+        {
+            ul_clk = GMAC_NCFGR_CLK_MCK_96;
+        }
+        else if( ul_mck > GMAC_MCK_SPEED_120MHZ )
+        {
+            ul_clk = GMAC_NCFGR_CLK_MCK_64;
+        }
+        else if( ul_mck > GMAC_MCK_SPEED_80MHZ )
+        {
+            ul_clk = GMAC_NCFGR_CLK_MCK_48;
+        }
+        else if( ul_mck > GMAC_MCK_SPEED_40MHZ )
+        {
+            ul_clk = GMAC_NCFGR_CLK_MCK_32;
+        }
+        else if( ul_mck > GMAC_MCK_SPEED_20MHZ )
+        {
+            ul_clk = GMAC_NCFGR_CLK_MCK_16;
+        }
+        else
+        {
+            ul_clk = GMAC_NCFGR_CLK_MCK_8;
+        }
+
+        p_gmac->GMAC_NCFGR = ( p_gmac->GMAC_NCFGR & ~GMAC_NCFGR_CLK_Msk ) | ul_clk;
+        return GMAC_OK;
+    }
 
 /**
  * \brief Enable/Disable retry test.
@@ -667,14 +751,18 @@ static inline uint8_t gmac_set_mdc_clock(Gmac* p_gmac, uint32_t ul_mck)
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable the GMAC receiver, else to enable it.
  */
-static inline void gmac_enable_retry_test(Gmac* p_gmac, uint8_t uc_enable)
-{
-	if (uc_enable) {
-		p_gmac->GMAC_NCFGR |= GMAC_NCFGR_RTY;
-	} else {
-		p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_RTY;
-	}
-}
+    static inline void gmac_enable_retry_test( Gmac * p_gmac,
+                                               uint8_t uc_enable )
+    {
+        if( uc_enable )
+        {
+            p_gmac->GMAC_NCFGR |= GMAC_NCFGR_RTY;
+        }
+        else
+        {
+            p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_RTY;
+        }
+    }
 
 /**
  * \brief Enable/Disable pause (when a valid pause frame is received).
@@ -682,25 +770,30 @@ static inline void gmac_enable_retry_test(Gmac* p_gmac, uint8_t uc_enable)
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable pause frame, else to enable it.
  */
-static inline void gmac_enable_pause_frame(Gmac* p_gmac, uint8_t uc_enable)
-{
-	if (uc_enable) {
-		p_gmac->GMAC_NCFGR |= GMAC_NCFGR_PEN;
-	} else {
-		p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_PEN;
-	}
-}
+    static inline void gmac_enable_pause_frame( Gmac * p_gmac,
+                                                uint8_t uc_enable )
+    {
+        if( uc_enable )
+        {
+            p_gmac->GMAC_NCFGR |= GMAC_NCFGR_PEN;
+        }
+        else
+        {
+            p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_PEN;
+        }
+    }
 
 /**
  * \brief Set receive buffer offset to 0 ~ 3.
  *
  * \param p_gmac   Pointer to the GMAC instance.
  */
-static inline void gmac_set_rx_buffer_offset(Gmac* p_gmac, uint8_t uc_offset)
-{
-	p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_RXBUFO_Msk;
-	p_gmac->GMAC_NCFGR |= GMAC_NCFGR_RXBUFO(uc_offset);
-}
+    static inline void gmac_set_rx_buffer_offset( Gmac * p_gmac,
+                                                  uint8_t uc_offset )
+    {
+        p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_RXBUFO_Msk;
+        p_gmac->GMAC_NCFGR |= GMAC_NCFGR_RXBUFO( uc_offset );
+    }
 
 /**
  * \brief Enable/Disable receive length field checking.
@@ -708,14 +801,18 @@ static inline void gmac_set_rx_buffer_offset(Gmac* p_gmac, uint8_t uc_offset)
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable receive length field checking, else to enable it.
  */
-static inline void gmac_enable_rx_length_check(Gmac* p_gmac, uint8_t uc_enable)
-{
-	if (uc_enable) {
-		p_gmac->GMAC_NCFGR |= GMAC_NCFGR_LFERD;
-	} else {
-		p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_LFERD;
-	}
-}
+    static inline void gmac_enable_rx_length_check( Gmac * p_gmac,
+                                                    uint8_t uc_enable )
+    {
+        if( uc_enable )
+        {
+            p_gmac->GMAC_NCFGR |= GMAC_NCFGR_LFERD;
+        }
+        else
+        {
+            p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_LFERD;
+        }
+    }
 
 /**
  * \brief Enable/Disable discarding FCS field of received frames.
@@ -723,14 +820,18 @@ static inline void gmac_enable_rx_length_check(Gmac* p_gmac, uint8_t uc_enable)
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable discarding FCS field of received frames, else to enable it.
  */
-static inline void gmac_enable_discard_fcs(Gmac* p_gmac, uint8_t uc_enable)
-{
-	if (uc_enable) {
-		p_gmac->GMAC_NCFGR |= GMAC_NCFGR_RFCS;
-	} else {
-		p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_RFCS;
-	}
-}
+    static inline void gmac_enable_discard_fcs( Gmac * p_gmac,
+                                                uint8_t uc_enable )
+    {
+        if( uc_enable )
+        {
+            p_gmac->GMAC_NCFGR |= GMAC_NCFGR_RFCS;
+        }
+        else
+        {
+            p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_RFCS;
+        }
+    }
 
 
 /**
@@ -740,14 +841,18 @@ static inline void gmac_enable_discard_fcs(Gmac* p_gmac, uint8_t uc_enable)
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable the received in half-duplex mode, else to enable it.
  */
-static inline void gmac_enable_efrhd(Gmac* p_gmac, uint8_t uc_enable)
-{
-	if (uc_enable) {
-		p_gmac->GMAC_NCFGR |= GMAC_NCFGR_EFRHD;
-	} else {
-		p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_EFRHD;
-	}
-}
+    static inline void gmac_enable_efrhd( Gmac * p_gmac,
+                                          uint8_t uc_enable )
+    {
+        if( uc_enable )
+        {
+            p_gmac->GMAC_NCFGR |= GMAC_NCFGR_EFRHD;
+        }
+        else
+        {
+            p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_EFRHD;
+        }
+    }
 
 /**
  * \brief Enable/Disable ignore RX FCS.
@@ -755,14 +860,18 @@ static inline void gmac_enable_efrhd(Gmac* p_gmac, uint8_t uc_enable)
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable ignore RX FCS, else to enable it.
  */
-static inline void gmac_enable_ignore_rx_fcs(Gmac* p_gmac, uint8_t uc_enable)
-{
-	if (uc_enable) {
-		p_gmac->GMAC_NCFGR |= GMAC_NCFGR_IRXFCS;
-	} else {
-		p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_IRXFCS;
-	}
-}
+    static inline void gmac_enable_ignore_rx_fcs( Gmac * p_gmac,
+                                                  uint8_t uc_enable )
+    {
+        if( uc_enable )
+        {
+            p_gmac->GMAC_NCFGR |= GMAC_NCFGR_IRXFCS;
+        }
+        else
+        {
+            p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_IRXFCS;
+        }
+    }
 
 /**
  * \brief Get Network Status.
@@ -771,10 +880,10 @@ static inline void gmac_enable_ignore_rx_fcs(Gmac* p_gmac, uint8_t uc_enable)
  *
  * \return Network status.
  */
-static inline uint32_t gmac_get_status(Gmac* p_gmac)
-{
-	return p_gmac->GMAC_NSR;
-}
+    static inline uint32_t gmac_get_status( Gmac * p_gmac )
+    {
+        return p_gmac->GMAC_NSR;
+    }
 
 /**
  * \brief Get MDIO IN pin status.
@@ -783,10 +892,10 @@ static inline uint32_t gmac_get_status(Gmac* p_gmac)
  *
  * \return MDIO IN pin status.
  */
-static inline uint8_t gmac_get_MDIO(Gmac* p_gmac)
-{
-	return ((p_gmac->GMAC_NSR & GMAC_NSR_MDIO) > 0);
-}
+    static inline uint8_t gmac_get_MDIO( Gmac * p_gmac )
+    {
+        return( ( p_gmac->GMAC_NSR & GMAC_NSR_MDIO ) > 0 );
+    }
 
 /**
  * \brief Check if PHY is idle.
@@ -795,10 +904,10 @@ static inline uint8_t gmac_get_MDIO(Gmac* p_gmac)
  *
  * \return  1 if PHY is idle.
  */
-static inline uint8_t gmac_is_phy_idle(Gmac* p_gmac)
-{
-	return ((p_gmac->GMAC_NSR & GMAC_NSR_IDLE) > 0);
-}
+    static inline uint8_t gmac_is_phy_idle( Gmac * p_gmac )
+    {
+        return( ( p_gmac->GMAC_NSR & GMAC_NSR_IDLE ) > 0 );
+    }
 
 /**
  * \brief Return transmit status.
@@ -807,10 +916,10 @@ static inline uint8_t gmac_is_phy_idle(Gmac* p_gmac)
  *
  * \return  Transmit status.
  */
-static inline uint32_t gmac_get_tx_status(Gmac* p_gmac)
-{
-	return p_gmac->GMAC_TSR;
-}
+    static inline uint32_t gmac_get_tx_status( Gmac * p_gmac )
+    {
+        return p_gmac->GMAC_TSR;
+    }
 
 /**
  * \brief Clear transmit status.
@@ -818,20 +927,21 @@ static inline uint32_t gmac_get_tx_status(Gmac* p_gmac)
  * \param p_gmac   Pointer to the GMAC instance.
  * \param ul_status   Transmit status.
  */
-static inline void gmac_clear_tx_status(Gmac* p_gmac, uint32_t ul_status)
-{
-	p_gmac->GMAC_TSR = ul_status;
-}
+    static inline void gmac_clear_tx_status( Gmac * p_gmac,
+                                             uint32_t ul_status )
+    {
+        p_gmac->GMAC_TSR = ul_status;
+    }
 
 /**
  * \brief Return receive status.
  *
  * \param p_gmac   Pointer to the GMAC instance.
  */
-static inline uint32_t gmac_get_rx_status(Gmac* p_gmac)
-{
-	return p_gmac->GMAC_RSR;
-}
+    static inline uint32_t gmac_get_rx_status( Gmac * p_gmac )
+    {
+        return p_gmac->GMAC_RSR;
+    }
 
 /**
  * \brief Clear receive status.
@@ -839,10 +949,11 @@ static inline uint32_t gmac_get_rx_status(Gmac* p_gmac)
  * \param p_gmac   Pointer to the GMAC instance.
  * \param ul_status   Receive status.
  */
-static inline void gmac_clear_rx_status(Gmac* p_gmac, uint32_t ul_status)
-{
-	p_gmac->GMAC_RSR = ul_status;
-}
+    static inline void gmac_clear_rx_status( Gmac * p_gmac,
+                                             uint32_t ul_status )
+    {
+        p_gmac->GMAC_RSR = ul_status;
+    }
 
 /**
  * \brief Set Rx Queue.
@@ -850,10 +961,11 @@ static inline void gmac_clear_rx_status(Gmac* p_gmac, uint32_t ul_status)
  * \param p_gmac   Pointer to the GMAC instance.
  * \param ul_addr   Rx queue address.
  */
-static inline void gmac_set_rx_queue(Gmac* p_gmac, uint32_t ul_addr)
-{
-	p_gmac->GMAC_RBQB = GMAC_RBQB_ADDR_Msk & ul_addr;
-}
+    static inline void gmac_set_rx_queue( Gmac * p_gmac,
+                                          uint32_t ul_addr )
+    {
+        p_gmac->GMAC_RBQB = GMAC_RBQB_ADDR_Msk & ul_addr;
+    }
 
 /**
  * \brief Get Rx Queue Address.
@@ -862,10 +974,10 @@ static inline void gmac_set_rx_queue(Gmac* p_gmac, uint32_t ul_addr)
  *
  * \return  Rx queue address.
  */
-static inline uint32_t gmac_get_rx_queue(Gmac* p_gmac)
-{
-	return p_gmac->GMAC_RBQB;
-}
+    static inline uint32_t gmac_get_rx_queue( Gmac * p_gmac )
+    {
+        return p_gmac->GMAC_RBQB;
+    }
 
 /**
  * \brief Set Tx Queue.
@@ -873,10 +985,11 @@ static inline uint32_t gmac_get_rx_queue(Gmac* p_gmac)
  * \param p_gmac   Pointer to the GMAC instance.
  * \param ul_addr  Tx queue address.
  */
-static inline void gmac_set_tx_queue(Gmac* p_gmac, uint32_t ul_addr)
-{
-	p_gmac->GMAC_TBQB = GMAC_TBQB_ADDR_Msk & ul_addr;
-}
+    static inline void gmac_set_tx_queue( Gmac * p_gmac,
+                                          uint32_t ul_addr )
+    {
+        p_gmac->GMAC_TBQB = GMAC_TBQB_ADDR_Msk & ul_addr;
+    }
 
 /**
  * \brief Get Tx Queue.
@@ -885,10 +998,10 @@ static inline void gmac_set_tx_queue(Gmac* p_gmac, uint32_t ul_addr)
  *
  * \return  Rx queue address.
  */
-static inline uint32_t gmac_get_tx_queue(Gmac* p_gmac)
-{
-	return p_gmac->GMAC_TBQB;
-}
+    static inline uint32_t gmac_get_tx_queue( Gmac * p_gmac )
+    {
+        return p_gmac->GMAC_TBQB;
+    }
 
 /**
  * \brief Enable interrupt(s).
@@ -896,10 +1009,11 @@ static inline uint32_t gmac_get_tx_queue(Gmac* p_gmac)
  * \param p_gmac   Pointer to the GMAC instance.
  * \param ul_source   Interrupt source(s) to be enabled.
  */
-static inline void gmac_enable_interrupt(Gmac* p_gmac, uint32_t ul_source)
-{
-	p_gmac->GMAC_IER = ul_source;
-}
+    static inline void gmac_enable_interrupt( Gmac * p_gmac,
+                                              uint32_t ul_source )
+    {
+        p_gmac->GMAC_IER = ul_source;
+    }
 
 /**
  * \brief Disable interrupt(s).
@@ -907,10 +1021,11 @@ static inline void gmac_enable_interrupt(Gmac* p_gmac, uint32_t ul_source)
  * \param p_gmac   Pointer to the GMAC instance.
  * \param ul_source   Interrupt source(s) to be disabled.
  */
-static inline void gmac_disable_interrupt(Gmac* p_gmac, uint32_t ul_source)
-{
-	p_gmac->GMAC_IDR = ul_source;
-}
+    static inline void gmac_disable_interrupt( Gmac * p_gmac,
+                                               uint32_t ul_source )
+    {
+        p_gmac->GMAC_IDR = ul_source;
+    }
 
 /**
  * \brief Return interrupt status.
@@ -919,10 +1034,10 @@ static inline void gmac_disable_interrupt(Gmac* p_gmac, uint32_t ul_source)
  *
  * \return Interrupt status.
  */
-static inline uint32_t gmac_get_interrupt_status(Gmac* p_gmac)
-{
-	return p_gmac->GMAC_ISR;
-}
+    static inline uint32_t gmac_get_interrupt_status( Gmac * p_gmac )
+    {
+        return p_gmac->GMAC_ISR;
+    }
 
 /**
  * \brief Return interrupt mask.
@@ -931,10 +1046,10 @@ static inline uint32_t gmac_get_interrupt_status(Gmac* p_gmac)
  *
  * \return Interrupt mask.
  */
-static inline uint32_t gmac_get_interrupt_mask(Gmac* p_gmac)
-{
-	return p_gmac->GMAC_IMR;
-}
+    static inline uint32_t gmac_get_interrupt_mask( Gmac * p_gmac )
+    {
+        return p_gmac->GMAC_IMR;
+    }
 
 /**
  * \brief Execute PHY maintenance command.
@@ -945,20 +1060,25 @@ static inline uint32_t gmac_get_interrupt_mask(Gmac* p_gmac)
  * \param uc_rw   1 to Read, 0 to write.
  * \param us_data   Data to be performed, write only.
  */
-static inline void gmac_maintain_phy(Gmac* p_gmac,
-		uint8_t uc_phy_addr, uint8_t uc_reg_addr, uint8_t uc_rw,
-		uint16_t us_data)
-{
-	/* Wait until bus idle */
-	while ((p_gmac->GMAC_NSR & GMAC_NSR_IDLE) == 0);
-	/* Write maintain register */
-	p_gmac->GMAC_MAN = GMAC_MAN_WTN(GMAC_MAN_CODE_VALUE)
-			| GMAC_MAN_CLTTO 
-			| GMAC_MAN_PHYA(uc_phy_addr)
-			| GMAC_MAN_REGA(uc_reg_addr)
-			| GMAC_MAN_OP((uc_rw ? GMAC_MAN_RW_TYPE : GMAC_MAN_READ_ONLY))
-			| GMAC_MAN_DATA(us_data);
-}
+    static inline void gmac_maintain_phy( Gmac * p_gmac,
+                                          uint8_t uc_phy_addr,
+                                          uint8_t uc_reg_addr,
+                                          uint8_t uc_rw,
+                                          uint16_t us_data )
+    {
+        /* Wait until bus idle */
+        while( ( p_gmac->GMAC_NSR & GMAC_NSR_IDLE ) == 0 )
+        {
+        }
+
+        /* Write maintain register */
+        p_gmac->GMAC_MAN = GMAC_MAN_WTN( GMAC_MAN_CODE_VALUE )
+                           | GMAC_MAN_CLTTO
+                           | GMAC_MAN_PHYA( uc_phy_addr )
+                           | GMAC_MAN_REGA( uc_reg_addr )
+                           | GMAC_MAN_OP( ( uc_rw ? GMAC_MAN_RW_TYPE : GMAC_MAN_READ_ONLY ) )
+                           | GMAC_MAN_DATA( us_data );
+    }
 
 /**
  * \brief Get PHY maintenance data returned.
@@ -967,13 +1087,16 @@ static inline void gmac_maintain_phy(Gmac* p_gmac,
  *
  * \return Get PHY data.
  */
-static inline uint16_t gmac_get_phy_data(Gmac* p_gmac)
-{
-	/* Wait until bus idle */
-	while ((p_gmac->GMAC_NSR & GMAC_NSR_IDLE) == 0);
-	/* Return data */
-	return (uint16_t) (p_gmac->GMAC_MAN & GMAC_MAN_DATA_Msk);
-}
+    static inline uint16_t gmac_get_phy_data( Gmac * p_gmac )
+    {
+        /* Wait until bus idle */
+        while( ( p_gmac->GMAC_NSR & GMAC_NSR_IDLE ) == 0 )
+        {
+        }
+
+        /* Return data */
+        return ( uint16_t ) ( p_gmac->GMAC_MAN & GMAC_MAN_DATA_Msk );
+    }
 
 /**
  * \brief Set Hash.
@@ -982,12 +1105,13 @@ static inline uint16_t gmac_get_phy_data(Gmac* p_gmac)
  * \param ul_hash_top   Hash top.
  * \param ul_hash_bottom   Hash bottom.
  */
-static inline void gmac_set_hash(Gmac* p_gmac, uint32_t ul_hash_top,
-		uint32_t ul_hash_bottom)
-{
-	p_gmac->GMAC_HRB = ul_hash_bottom;
-	p_gmac->GMAC_HRT = ul_hash_top;
-}
+    static inline void gmac_set_hash( Gmac * p_gmac,
+                                      uint32_t ul_hash_top,
+                                      uint32_t ul_hash_bottom )
+    {
+        p_gmac->GMAC_HRB = ul_hash_bottom;
+        p_gmac->GMAC_HRT = ul_hash_top;
+    }
 
 /**
  * \brief Set 64 bits Hash.
@@ -995,11 +1119,12 @@ static inline void gmac_set_hash(Gmac* p_gmac, uint32_t ul_hash_top,
  * \param p_gmac   Pointer to the GMAC instance.
  * \param ull_hash   64 bits hash value.
  */
-static inline void gmac_set_hash64(Gmac* p_gmac, uint64_t ull_hash)
-{
-	p_gmac->GMAC_HRB = (uint32_t) ull_hash;
-	p_gmac->GMAC_HRT = (uint32_t) (ull_hash >> 32);
-}
+    static inline void gmac_set_hash64( Gmac * p_gmac,
+                                        uint64_t ull_hash )
+    {
+        p_gmac->GMAC_HRB = ( uint32_t ) ull_hash;
+        p_gmac->GMAC_HRT = ( uint32_t ) ( ull_hash >> 32 );
+    }
 
 /**
  * \brief Set MAC Address.
@@ -1008,31 +1133,34 @@ static inline void gmac_set_hash64(Gmac* p_gmac, uint64_t ull_hash)
  * \param uc_index  GMAC specific address register index.
  * \param p_mac_addr  GMAC address.
  */
-static inline void gmac_set_address(Gmac* p_gmac, uint8_t uc_index,
-		uint8_t* p_mac_addr)
-{
-	p_gmac->GMAC_SA[uc_index].GMAC_SAB = (p_mac_addr[3] << 24)
-			| (p_mac_addr[2] << 16)
-			| (p_mac_addr[1] << 8)
-			| (p_mac_addr[0]);
-	p_gmac->GMAC_SA[uc_index].GMAC_SAT = (p_mac_addr[5] << 8)
-			| (p_mac_addr[4]);
-}
+    static inline void gmac_set_address( Gmac * p_gmac,
+                                         uint8_t uc_index,
+                                         uint8_t * p_mac_addr )
+    {
+        p_gmac->GMAC_SA[ uc_index ].GMAC_SAB = ( p_mac_addr[ 3 ] << 24 )
+                                               | ( p_mac_addr[ 2 ] << 16 )
+                                               | ( p_mac_addr[ 1 ] << 8 )
+                                               | ( p_mac_addr[ 0 ] );
+        p_gmac->GMAC_SA[ uc_index ].GMAC_SAT = ( p_mac_addr[ 5 ] << 8 )
+                                               | ( p_mac_addr[ 4 ] );
+    }
 
 /**
  * \brief Set MAC Address via 2 dword.
-  *
+ *
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_index  GMAC specific address register index.
  * \param ul_mac_top  GMAC top address.
  * \param ul_mac_bottom  GMAC bottom address.
  */
-static inline void gmac_set_address32(Gmac* p_gmac, uint8_t uc_index,
-		uint32_t ul_mac_top, uint32_t ul_mac_bottom)
-{
-	p_gmac->GMAC_SA[uc_index].GMAC_SAB = ul_mac_bottom;
-	p_gmac->GMAC_SA[uc_index].GMAC_SAT = ul_mac_top;
-}
+    static inline void gmac_set_address32( Gmac * p_gmac,
+                                           uint8_t uc_index,
+                                           uint32_t ul_mac_top,
+                                           uint32_t ul_mac_bottom )
+    {
+        p_gmac->GMAC_SA[ uc_index ].GMAC_SAB = ul_mac_bottom;
+        p_gmac->GMAC_SA[ uc_index ].GMAC_SAT = ul_mac_top;
+    }
 
 /**
  * \brief Set MAC Address via int64.
@@ -1041,12 +1169,13 @@ static inline void gmac_set_address32(Gmac* p_gmac, uint8_t uc_index,
  * \param uc_index  GMAC specific address register index.
  * \param ull_mac  64-bit GMAC address.
  */
-static inline void gmac_set_address64(Gmac* p_gmac, uint8_t uc_index,
-		uint64_t ull_mac)
-{
-	p_gmac->GMAC_SA[uc_index].GMAC_SAB = (uint32_t) ull_mac;
-	p_gmac->GMAC_SA[uc_index].GMAC_SAT = (uint32_t) (ull_mac >> 32);
-}
+    static inline void gmac_set_address64( Gmac * p_gmac,
+                                           uint8_t uc_index,
+                                           uint64_t ull_mac )
+    {
+        p_gmac->GMAC_SA[ uc_index ].GMAC_SAB = ( uint32_t ) ull_mac;
+        p_gmac->GMAC_SA[ uc_index ].GMAC_SAT = ( uint32_t ) ( ull_mac >> 32 );
+    }
 
 /**
  * \brief Select media independent interface mode.
@@ -1054,45 +1183,57 @@ static inline void gmac_set_address64(Gmac* p_gmac, uint8_t uc_index,
  * \param p_gmac   Pointer to the GMAC instance.
  * \param mode   Media independent interface mode.
  */
-static inline void gmac_select_mii_mode(Gmac* p_gmac, gmac_mii_mode_t mode)
-{
-	switch (mode) {
-		case GMAC_PHY_MII:
-		case GMAC_PHY_RMII:
-			p_gmac->GMAC_UR |= GMAC_UR_RMIIMII;
-		break;
+    static inline void gmac_select_mii_mode( Gmac * p_gmac,
+                                             gmac_mii_mode_t mode )
+    {
+        switch( mode )
+        {
+            case GMAC_PHY_MII:
+            case GMAC_PHY_RMII:
+                p_gmac->GMAC_UR |= GMAC_UR_RMIIMII;
+                break;
 
-		default:
-			p_gmac->GMAC_UR &= ~GMAC_UR_RMIIMII;
-		break;
-	}
-}
+            default:
+                p_gmac->GMAC_UR &= ~GMAC_UR_RMIIMII;
+                break;
+        }
+    }
 
-uint8_t gmac_phy_read(Gmac* p_gmac, uint8_t uc_phy_address, uint8_t uc_address,
-		uint32_t* p_value);
-uint8_t gmac_phy_write(Gmac* p_gmac, uint8_t uc_phy_address,
-		uint8_t uc_address, uint32_t ul_value);
-void gmac_dev_init(Gmac* p_gmac, gmac_device_t* p_gmac_dev,
-		gmac_options_t* p_opt);
-uint32_t gmac_dev_read(gmac_device_t* p_gmac_dev, uint8_t* p_frame,
-		uint32_t ul_frame_size, uint32_t* p_rcv_size);
-uint32_t gmac_dev_write(gmac_device_t* p_gmac_dev, void *p_buffer,
-		uint32_t ul_size, gmac_dev_tx_cb_t func_tx_cb);
-uint32_t gmac_dev_get_tx_load(gmac_device_t* p_gmac_dev);
-void gmac_dev_set_rx_callback(gmac_device_t* p_gmac_dev,
-		gmac_dev_tx_cb_t func_rx_cb);
-uint8_t gmac_dev_set_tx_wakeup_callback(gmac_device_t* p_gmac_dev,
-		gmac_dev_wakeup_cb_t func_wakeup, uint8_t uc_threshold);
-void gmac_dev_reset(gmac_device_t* p_gmac_dev);
-void gmac_handler(gmac_device_t* p_gmac_dev);
+    uint8_t gmac_phy_read( Gmac * p_gmac,
+                           uint8_t uc_phy_address,
+                           uint8_t uc_address,
+                           uint32_t * p_value );
+    uint8_t gmac_phy_write( Gmac * p_gmac,
+                            uint8_t uc_phy_address,
+                            uint8_t uc_address,
+                            uint32_t ul_value );
+    void gmac_dev_init( Gmac * p_gmac,
+                        gmac_device_t * p_gmac_dev,
+                        gmac_options_t * p_opt );
+    uint32_t gmac_dev_read( gmac_device_t * p_gmac_dev,
+                            uint8_t * p_frame,
+                            uint32_t ul_frame_size,
+                            uint32_t * p_rcv_size );
+    uint32_t gmac_dev_write( gmac_device_t * p_gmac_dev,
+                             void * p_buffer,
+                             uint32_t ul_size,
+                             gmac_dev_tx_cb_t func_tx_cb );
+    uint32_t gmac_dev_get_tx_load( gmac_device_t * p_gmac_dev );
+    void gmac_dev_set_rx_callback( gmac_device_t * p_gmac_dev,
+                                   gmac_dev_tx_cb_t func_rx_cb );
+    uint8_t gmac_dev_set_tx_wakeup_callback( gmac_device_t * p_gmac_dev,
+                                             gmac_dev_wakeup_cb_t func_wakeup,
+                                             uint8_t uc_threshold );
+    void gmac_dev_reset( gmac_device_t * p_gmac_dev );
+    void gmac_handler( gmac_device_t * p_gmac_dev );
 
-/// @cond 0
+/*/ @cond 0 */
 /**INDENT-OFF**/
-#ifdef __cplusplus
-}
-#endif
+    #ifdef __cplusplus
+        }
+    #endif
 /**INDENT-ON**/
-/// @endcond
+/*/ @endcond */
 
 /**
  * \page gmac_quickstart Quickstart guide for GMAC driver.
@@ -1184,7 +1325,7 @@ void gmac_handler(gmac_device_t* p_gmac_dev);
  *       NVIC_EnableIRQ(GMAC_IRQn);
  *
  *       ethernet_phy_init(GMAC, BOARD_GMAC_PHY_ADDR, sysclk_get_cpu_hz());
- * 
+ *
  *       ethernet_phy_auto_negotiate(GMAC, BOARD_GMAC_PHY_ADDR);
  *
  *       ethernet_phy_set_link(GMAC, BOARD_GMAC_PHY_ADDR, 1);
@@ -1198,7 +1339,7 @@ void gmac_handler(gmac_device_t* p_gmac_dev);
  * The buffer size used for RX is GMAC_RX_BUFFERS * 128.
  * If it was supposed receiving a large number of frame, the
  * GMAC_RX_BUFFERS should be set higher. E.g., the application wants to accept
- * a ping echo test of 2048, the GMAC_RX_BUFFERS should be set at least 
+ * a ping echo test of 2048, the GMAC_RX_BUFFERS should be set at least
  * (2048/128)=16, and as there are additional frames coming, a preferred
  * number is 24 depending on a normal Ethernet throughput.
  *   - \code
@@ -1268,7 +1409,7 @@ void gmac_handler(gmac_device_t* p_gmac_dev);
  *   - \code
  *         ethernet_phy_init(GMAC, BOARD_GMAC_PHY_ADDR, sysclk_get_cpu_hz());
  * \endcode
-  * -# The link will be established based on auto negotiation.
+ * -# The link will be established based on auto negotiation.
  *   - \code
  *         ethernet_phy_auto_negotiate(GMAC, BOARD_GMAC_PHY_ADDR);
  * \endcode
@@ -1289,58 +1430,60 @@ void gmac_handler(gmac_device_t* p_gmac_dev);
  *   - \code gmac_dev_read(&gs_gmac_dev, (uint8_t *) gs_uc_eth_buffer, sizeof(gs_uc_eth_buffer), &ul_frm_size)); \endcode
  */
 
-#	define GMAC_STATS 0
+    #define GMAC_STATS    0
 
-#if( GMAC_STATS != 0 )
+    #if ( GMAC_STATS != 0 )
 
-	/* Here below some code to study the types and
-	frequencies of 	GMAC interrupts. */
-	#define GMAC_IDX_RXUBR 0
-	#define GMAC_IDX_TUR   1
-	#define GMAC_IDX_RLEX  2
-	#define GMAC_IDX_TFC   3
-	#define GMAC_IDX_RCOMP 4
-	#define GMAC_IDX_TCOMP 5
-	#define GMAC_IDX_ROVR  6
-	#define GMAC_IDX_HRESP 7
-	#define GMAC_IDX_PFNZ  8
-	#define GMAC_IDX_PTZ   9
+        /* Here below some code to study the types and
+         * frequencies of   GMAC interrupts. */
+        #define GMAC_IDX_RXUBR    0
+        #define GMAC_IDX_TUR      1
+        #define GMAC_IDX_RLEX     2
+        #define GMAC_IDX_TFC      3
+        #define GMAC_IDX_RCOMP    4
+        #define GMAC_IDX_TCOMP    5
+        #define GMAC_IDX_ROVR     6
+        #define GMAC_IDX_HRESP    7
+        #define GMAC_IDX_PFNZ     8
+        #define GMAC_IDX_PTZ      9
 
-	struct SGmacStats {
-		unsigned recvCount;
-		unsigned rovrCount;
-		unsigned bnaCount;
-		unsigned sendCount;
-		unsigned sovrCount;
-		unsigned incompCount;
-		unsigned truncCount;
+        struct SGmacStats
+        {
+            unsigned recvCount;
+            unsigned rovrCount;
+            unsigned bnaCount;
+            unsigned sendCount;
+            unsigned sovrCount;
+            unsigned incompCount;
+            unsigned truncCount;
 
-		unsigned intStatus[10];
-	};
-	extern struct SGmacStats gmacStats;
+            unsigned intStatus[ 10 ];
+        };
+        extern struct SGmacStats gmacStats;
 
-	struct SIntPair {
-		const char *name;
-		unsigned mask;
-		int index;
-	};
+        struct SIntPair
+        {
+            const char * name;
+            unsigned mask;
+            int index;
+        };
 
-	#define MK_PAIR( NAME )   #NAME, GMAC_IER_##NAME, GMAC_IDX_##NAME
-	static const struct SIntPair intPairs[] = {
-		{ MK_PAIR( RXUBR ) }, /* Enable receive used bit read interrupt. */
-		{ MK_PAIR( TUR   ) }, /* Enable transmit underrun interrupt. */
-		{ MK_PAIR( RLEX  ) }, /* Enable retry limit  exceeded interrupt. */
-		{ MK_PAIR( TFC   ) }, /* Enable transmit buffers exhausted in mid-frame interrupt. */
-		{ MK_PAIR( RCOMP ) }, /* Receive complete */
-		{ MK_PAIR( TCOMP ) }, /* Enable transmit complete interrupt. */
-		{ MK_PAIR( ROVR  ) }, /* Enable receive overrun interrupt. */
-		{ MK_PAIR( HRESP ) }, /* Enable Hresp not OK interrupt. */
-		{ MK_PAIR( PFNZ  ) }, /* Enable pause frame received interrupt. */
-		{ MK_PAIR( PTZ   ) }  /* Enable pause time zero interrupt. */
-	};
+        #define MK_PAIR( NAME )    # NAME, GMAC_IER_ ## NAME, GMAC_IDX_ ## NAME
+        static const struct SIntPair intPairs[] = {
+            { MK_PAIR( RXUBR ) }, /* Enable receive used bit read interrupt. */
+            { MK_PAIR( TUR )   }, /* Enable transmit underrun interrupt. */
+            { MK_PAIR( RLEX )  }, /* Enable retry limit  exceeded interrupt. */
+            { MK_PAIR( TFC )   }, /* Enable transmit buffers exhausted in mid-frame interrupt. */
+            { MK_PAIR( RCOMP ) }, /* Receive complete */
+            { MK_PAIR( TCOMP ) }, /* Enable transmit complete interrupt. */
+            { MK_PAIR( ROVR )  }, /* Enable receive overrun interrupt. */
+            { MK_PAIR( HRESP ) }, /* Enable Hresp not OK interrupt. */
+            { MK_PAIR( PFNZ )  }, /* Enable pause frame received interrupt. */
+            { MK_PAIR( PTZ )   } /* Enable pause time zero interrupt. */
+        };
 
-	void gmac_show_irq_counts ();
+        void gmac_show_irq_counts();
 
-#endif
+    #endif /* if ( GMAC_STATS != 0 ) */
 
 #endif /* GMAC_H_INCLUDED */

--- a/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/portable/NetworkInterface/ATSAM4E/instance/gmac.h
+++ b/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/portable/NetworkInterface/ATSAM4E/instance/gmac.h
@@ -1,4 +1,4 @@
- /**
+/**
  * \file
  *
  * \brief GMAC (Ethernet MAC) driver for SAM.
@@ -42,237 +42,250 @@
  */
 
 #ifndef GMAC_H_INCLUDED
-#define GMAC_H_INCLUDED
+    #define GMAC_H_INCLUDED
 
-#include "compiler.h"
-#include "component/gmac.h"
+    #include "compiler.h"
+    #include "component/gmac.h"
 
-/// @cond 0
+/*/ @cond 0 */
 /**INDENT-OFF**/
-#ifdef __cplusplus
-extern "C" {
-#endif
+    #ifdef __cplusplus
+        extern "C" {
+    #endif
 /**INDENT-ON**/
-/// @endcond
+/*/ @endcond */
 
 /** The buffer addresses written into the descriptors must be aligned, so the
-    last few bits are zero.  These bits have special meaning for the GMAC
-    peripheral and cannot be used as part of the address. */
-#define GMAC_RXD_ADDR_MASK      0xFFFFFFFC
-#define GMAC_RXD_WRAP         (1ul << 1)  /**< Wrap bit */
-#define GMAC_RXD_OWNERSHIP    (1ul << 0)  /**< Ownership bit */
+ *  last few bits are zero.  These bits have special meaning for the GMAC
+ *  peripheral and cannot be used as part of the address. */
+    #define GMAC_RXD_ADDR_MASK         0xFFFFFFFC
+    #define GMAC_RXD_WRAP              ( 1ul << 1 )  /**< Wrap bit */
+    #define GMAC_RXD_OWNERSHIP         ( 1ul << 0 )  /**< Ownership bit */
 
-#define GMAC_RXD_BROADCAST    (1ul << 31) /**< Broadcast detected */
-#define GMAC_RXD_MULTIHASH    (1ul << 30) /**< Multicast hash match */
-#define GMAC_RXD_UNIHASH      (1ul << 29) /**< Unicast hash match */
-#define GMAC_RXD_ADDR_FOUND      (1ul << 27) /**< Specific address match found */
-#define GMAC_RXD_ADDR        (3ul << 25) /**< Address match */
-#define GMAC_RXD_RXCOEN        (1ul << 24) /**< RXCOEN related function */
-#define GMAC_RXD_TYPE         (3ul << 22) /**< Type ID match */
-#define GMAC_RXD_VLAN         (1ul << 21) /**< VLAN tag detected */
-#define GMAC_RXD_PRIORITY     (1ul << 20) /**< Priority tag detected */
-#define GMAC_RXD_PRIORITY_MASK  (3ul << 17) /**< VLAN priority */
-#define GMAC_RXD_CFI          (1ul << 16) /**< Concatenation Format Indicator only if bit 21 is set */
-#define GMAC_RXD_EOF          (1ul << 15) /**< End of frame */
-#define GMAC_RXD_SOF          (1ul << 14) /**< Start of frame */
-#define GMAC_RXD_FCS          (1ul << 13) /**< Frame check sequence */
-#define GMAC_RXD_OFFSET_MASK                /**< Receive buffer offset */
-#define GMAC_RXD_LEN_MASK       (0xFFF)     /**< Length of frame including FCS (if selected) */
-#define GMAC_RXD_LENJUMBO_MASK  (0x3FFF)    /**< Jumbo frame length */
+    #define GMAC_RXD_BROADCAST         ( 1ul << 31 ) /**< Broadcast detected */
+    #define GMAC_RXD_MULTIHASH         ( 1ul << 30 ) /**< Multicast hash match */
+    #define GMAC_RXD_UNIHASH           ( 1ul << 29 ) /**< Unicast hash match */
+    #define GMAC_RXD_ADDR_FOUND        ( 1ul << 27 ) /**< Specific address match found */
+    #define GMAC_RXD_ADDR              ( 3ul << 25 ) /**< Address match */
+    #define GMAC_RXD_RXCOEN            ( 1ul << 24 ) /**< RXCOEN related function */
+    #define GMAC_RXD_TYPE              ( 3ul << 22 ) /**< Type ID match */
+    #define GMAC_RXD_VLAN              ( 1ul << 21 ) /**< VLAN tag detected */
+    #define GMAC_RXD_PRIORITY          ( 1ul << 20 ) /**< Priority tag detected */
+    #define GMAC_RXD_PRIORITY_MASK     ( 3ul << 17 ) /**< VLAN priority */
+    #define GMAC_RXD_CFI               ( 1ul << 16 ) /**< Concatenation Format Indicator only if bit 21 is set */
+    #define GMAC_RXD_EOF               ( 1ul << 15 ) /**< End of frame */
+    #define GMAC_RXD_SOF               ( 1ul << 14 ) /**< Start of frame */
+    #define GMAC_RXD_FCS               ( 1ul << 13 ) /**< Frame check sequence */
+    #define GMAC_RXD_OFFSET_MASK                     /**< Receive buffer offset */
+    #define GMAC_RXD_LEN_MASK          ( 0xFFF )     /**< Length of frame including FCS (if selected) */
+    #define GMAC_RXD_LENJUMBO_MASK     ( 0x3FFF )    /**< Jumbo frame length */
 
-#define GMAC_TXD_USED         (1ul << 31) /**< Frame is transmitted */
-#define GMAC_TXD_WRAP         (1ul << 30) /**< Last descriptor */
-#define GMAC_TXD_ERROR        (1ul << 29) /**< Retry limit exceeded, error */
-#define GMAC_TXD_UNDERRUN     (1ul << 28) /**< Transmit underrun */
-#define GMAC_TXD_EXHAUSTED    (1ul << 27) /**< Buffer exhausted */
-#define GMAC_TXD_LATE    (1ul << 26) /**< Late collision,transmit  error  */
-#define GMAC_TXD_CHECKSUM_ERROR   (7ul << 20) /**< Checksum error */
-#define GMAC_TXD_NOCRC        (1ul << 16) /**< No CRC */
-#define GMAC_TXD_LAST         (1ul << 15) /**< Last buffer in frame */
-#define GMAC_TXD_LEN_MASK       (0x1FFF)     /**< Length of buffer */
+    #define GMAC_TXD_USED              ( 1ul << 31 ) /**< Frame is transmitted */
+    #define GMAC_TXD_WRAP              ( 1ul << 30 ) /**< Last descriptor */
+    #define GMAC_TXD_ERROR             ( 1ul << 29 ) /**< Retry limit exceeded, error */
+    #define GMAC_TXD_UNDERRUN          ( 1ul << 28 ) /**< Transmit underrun */
+    #define GMAC_TXD_EXHAUSTED         ( 1ul << 27 ) /**< Buffer exhausted */
+    #define GMAC_TXD_LATE              ( 1ul << 26 ) /**< Late collision,transmit  error  */
+    #define GMAC_TXD_CHECKSUM_ERROR    ( 7ul << 20 ) /**< Checksum error */
+    #define GMAC_TXD_NOCRC             ( 1ul << 16 ) /**< No CRC */
+    #define GMAC_TXD_LAST              ( 1ul << 15 ) /**< Last buffer in frame */
+    #define GMAC_TXD_LEN_MASK          ( 0x1FFF )    /**< Length of buffer */
 
 /** The MAC can support frame lengths up to 1536 bytes */
-#define GMAC_FRAME_LENTGH_MAX       1536
+    #define GMAC_FRAME_LENTGH_MAX      1536
 
-#define GMAC_RX_UNITSIZE            128     /**< Fixed size for RX buffer  */
-#define GMAC_TX_UNITSIZE            1518    /**< Size for ETH frame length */
+    #define GMAC_RX_UNITSIZE           128  /**< Fixed size for RX buffer  */
+    #define GMAC_TX_UNITSIZE           1518 /**< Size for ETH frame length */
 
 /** GMAC clock speed */
-#define GMAC_MCK_SPEED_240MHZ        (240*1000*1000)
-#define GMAC_MCK_SPEED_160MHZ        (160*1000*1000)
-#define GMAC_MCK_SPEED_120MHZ        (120*1000*1000)
-#define GMAC_MCK_SPEED_80MHZ          (80*1000*1000)
-#define GMAC_MCK_SPEED_40MHZ          (40*1000*1000)
-#define GMAC_MCK_SPEED_20MHZ          (20*1000*1000)
+    #define GMAC_MCK_SPEED_240MHZ      ( 240 * 1000 * 1000 )
+    #define GMAC_MCK_SPEED_160MHZ      ( 160 * 1000 * 1000 )
+    #define GMAC_MCK_SPEED_120MHZ      ( 120 * 1000 * 1000 )
+    #define GMAC_MCK_SPEED_80MHZ       ( 80 * 1000 * 1000 )
+    #define GMAC_MCK_SPEED_40MHZ       ( 40 * 1000 * 1000 )
+    #define GMAC_MCK_SPEED_20MHZ       ( 20 * 1000 * 1000 )
 
 /** GMAC maintain code default value*/
-#define GMAC_MAN_CODE_VALUE    (10)
+    #define GMAC_MAN_CODE_VALUE        ( 10 )
 
 /** GMAC maintain start of frame default value*/
-#define GMAC_MAN_SOF_VALUE     (1)
+    #define GMAC_MAN_SOF_VALUE         ( 1 )
 
 /** GMAC maintain read/write*/
-#define GMAC_MAN_RW_TYPE       (2)
+    #define GMAC_MAN_RW_TYPE           ( 2 )
 
 /** GMAC maintain read only*/
-#define GMAC_MAN_READ_ONLY     (1)
+    #define GMAC_MAN_READ_ONLY         ( 1 )
 
 /** GMAC address length */
-#define GMAC_ADDR_LENGTH       (6)
+    #define GMAC_ADDR_LENGTH           ( 6 )
 
 
-#define GMAC_DUPLEX_HALF 0
-#define GMAC_DUPLEX_FULL 1
+    #define GMAC_DUPLEX_HALF           0
+    #define GMAC_DUPLEX_FULL           1
 
-#define GMAC_SPEED_10M      0
-#define GMAC_SPEED_100M     1
+    #define GMAC_SPEED_10M             0
+    #define GMAC_SPEED_100M            1
 
 /**
  * \brief Return codes for GMAC APIs.
  */
-typedef enum {
-	GMAC_OK = 0,         /** 0  Operation OK */
-	GMAC_TIMEOUT = 1,    /** 1  GMAC operation timeout */
-	GMAC_TX_BUSY,        /** 2  TX in progress */
-	GMAC_RX_NULL,        /** 3  No data received */
-	GMAC_SIZE_TOO_SMALL, /** 4  Buffer size not enough */
-	GMAC_PARAM,          /** 5  Parameter error, TX packet invalid or RX size too small */
-	GMAC_INVALID = 0xFF, /* Invalid */
-} gmac_status_t;
+    typedef enum
+    {
+        GMAC_OK = 0,         /** 0  Operation OK */
+        GMAC_TIMEOUT = 1,    /** 1  GMAC operation timeout */
+        GMAC_TX_BUSY,        /** 2  TX in progress */
+        GMAC_RX_NULL,        /** 3  No data received */
+        GMAC_SIZE_TOO_SMALL, /** 4  Buffer size not enough */
+        GMAC_PARAM,          /** 5  Parameter error, TX packet invalid or RX size too small */
+        GMAC_INVALID = 0xFF, /* Invalid */
+    } gmac_status_t;
 
 /**
  * \brief Media Independent Interface (MII) type.
  */
-typedef enum {
-	GMAC_PHY_MII = 0,         /** MII mode */
-	GMAC_PHY_RMII = 1,    /** Reduced MII mode */
-	GMAC_PHY_INVALID = 0xFF, /* Invalid mode*/
-} gmac_mii_mode_t;
+    typedef enum
+    {
+        GMAC_PHY_MII = 0,        /** MII mode */
+        GMAC_PHY_RMII = 1,       /** Reduced MII mode */
+        GMAC_PHY_INVALID = 0xFF, /* Invalid mode*/
+    } gmac_mii_mode_t;
 
 /** Receive buffer descriptor struct */
-COMPILER_PACK_SET(8)
-typedef struct gmac_rx_descriptor {
-	union gmac_rx_addr {
-		uint32_t val;
-		struct gmac_rx_addr_bm {
-			uint32_t b_ownership:1, /**< User clear, GMAC sets this to 1 once it has successfully written a frame to memory */
-			b_wrap:1,   /**< Marks last descriptor in receive buffer */
-			addr_dw:30; /**< Address in number of DW */
-		} bm;
-	} addr; /**< Address, Wrap & Ownership */
-	union gmac_rx_status {
-		uint32_t val;
-		struct gmac_rx_status_bm {
-			uint32_t len:13,       /**  0..12  Length of frame including FCS */
-			b_fcs:1,               /**  13     Receive buffer offset,  bits 13:12 of frame length for jumbo frame */
-			b_sof:1,               /**  14     Start of frame */
-			b_eof:1,               /**  15     End of frame */
-			b_cfi:1,               /**  16     Concatenation Format Indicator */
-			vlan_priority:3,       /**  17..19 VLAN priority (if VLAN detected) */
-			b_priority_detected:1, /**  20     Priority tag detected */
-			b_vlan_detected:1,     /**  21     VLAN tag detected */
-			b_type_id_match:2,     /**  22..23 Type ID match */
-			b_checksumoffload:1,   /**  24     Checksum offload specific function */
-			b_addrmatch:2,         /**  25..26 Address register match */
-			b_ext_addr_match:1,    /**  27     External address match found */
-			reserved:1,            /**  28     */
-			b_uni_hash_match:1,    /**  29     Unicast hash match */
-			b_multi_hash_match:1,  /**  30     Multicast hash match */
-			b_boardcast_detect:1;  /**  31     Global broadcast address detected */
-		} bm;
-	} status;
-} gmac_rx_descriptor_t;
+    COMPILER_PACK_SET( 8 )
+    typedef struct gmac_rx_descriptor
+    {
+        union gmac_rx_addr
+        {
+            uint32_t val;
+            struct gmac_rx_addr_bm
+            {
+                uint32_t b_ownership : 1, /**< User clear, GMAC sets this to 1 once it has successfully written a frame to memory */
+                         b_wrap : 1,      /**< Marks last descriptor in receive buffer */
+                         addr_dw : 30;    /**< Address in number of DW */
+            } bm;
+        } addr;                           /**< Address, Wrap & Ownership */
+        union gmac_rx_status
+        {
+            uint32_t val;
+            struct gmac_rx_status_bm
+            {
+                uint32_t len : 13,                /**  0..12  Length of frame including FCS */
+                         b_fcs : 1,               /**  13     Receive buffer offset,  bits 13:12 of frame length for jumbo frame */
+                         b_sof : 1,               /**  14     Start of frame */
+                         b_eof : 1,               /**  15     End of frame */
+                         b_cfi : 1,               /**  16     Concatenation Format Indicator */
+                         vlan_priority : 3,       /**  17..19 VLAN priority (if VLAN detected) */
+                         b_priority_detected : 1, /**  20     Priority tag detected */
+                         b_vlan_detected : 1,     /**  21     VLAN tag detected */
+                         b_type_id_match : 2,     /**  22..23 Type ID match */
+                         b_checksumoffload : 1,   /**  24     Checksum offload specific function */
+                         b_addrmatch : 2,         /**  25..26 Address register match */
+                         b_ext_addr_match : 1,    /**  27     External address match found */
+                         reserved : 1,            /**  28     */
+                         b_uni_hash_match : 1,    /**  29     Unicast hash match */
+                         b_multi_hash_match : 1,  /**  30     Multicast hash match */
+                         b_boardcast_detect : 1;  /**  31     Global broadcast address detected */
+            } bm;
+        } status;
+    } gmac_rx_descriptor_t;
 
 /** Transmit buffer descriptor struct */
-COMPILER_PACK_SET(8)
-typedef struct gmac_tx_descriptor {
-	uint32_t addr;
-	union gmac_tx_status {
-		uint32_t val;
-		struct gmac_tx_status_bm {
-			uint32_t len:14,     /**  0..13 Length of buffer */
-			reserved:1,          /** 14            */
-			b_last_buffer:1,     /** 15     Last buffer (in the current frame) */
-			b_no_crc:1,          /** 16     No CRC */
-			reserved1:3,         /** 17..19        */
-			b_checksumoffload:3, /** 20..22 Transmit checksum generation offload errors */
-			reserved2:3,         /** 23..25        */
-			b_lco:1,             /** 26     Late collision, transmit error detected */
-			b_exhausted:1,       /** 27     Buffer exhausted in mid frame */
-			b_underrun:1,        /** 28     Transmit underrun */
-			b_error:1,           /** 29     Retry limit exceeded, error detected */
-			b_wrap:1,            /** 30     Marks last descriptor in TD list */
-			b_used:1;            /** 31     User clear, GMAC sets this to 1 once a frame has been successfully transmitted */
-		} bm;
-	} status;
-} gmac_tx_descriptor_t;
+    COMPILER_PACK_SET( 8 )
+    typedef struct gmac_tx_descriptor
+    {
+        uint32_t addr;
+        union gmac_tx_status
+        {
+            uint32_t val;
+            struct gmac_tx_status_bm
+            {
+                uint32_t len : 14,              /**  0..13 Length of buffer */
+                         reserved : 1,          /** 14            */
+                         b_last_buffer : 1,     /** 15     Last buffer (in the current frame) */
+                         b_no_crc : 1,          /** 16     No CRC */
+                         reserved1 : 3,         /** 17..19        */
+                         b_checksumoffload : 3, /** 20..22 Transmit checksum generation offload errors */
+                         reserved2 : 3,         /** 23..25        */
+                         b_lco : 1,             /** 26     Late collision, transmit error detected */
+                         b_exhausted : 1,       /** 27     Buffer exhausted in mid frame */
+                         b_underrun : 1,        /** 28     Transmit underrun */
+                         b_error : 1,           /** 29     Retry limit exceeded, error detected */
+                         b_wrap : 1,            /** 30     Marks last descriptor in TD list */
+                         b_used : 1;            /** 31     User clear, GMAC sets this to 1 once a frame has been successfully transmitted */
+            } bm;
+        } status;
+    } gmac_tx_descriptor_t;
 
-COMPILER_PACK_RESET()
+    COMPILER_PACK_RESET()
 
 /**
  * \brief Input parameters when initializing the gmac module mode.
  */
-typedef struct gmac_options {
-	/*  Enable/Disable CopyAllFrame */
-	uint8_t uc_copy_all_frame;
-	/* Enable/Disable NoBroadCast */
-	uint8_t uc_no_boardcast;
-	/* MAC address */
-	uint8_t uc_mac_addr[GMAC_ADDR_LENGTH];
-} gmac_options_t;
+    typedef struct gmac_options
+    {
+        /*  Enable/Disable CopyAllFrame */
+        uint8_t uc_copy_all_frame;
+        /* Enable/Disable NoBroadCast */
+        uint8_t uc_no_boardcast;
+        /* MAC address */
+        uint8_t uc_mac_addr[ GMAC_ADDR_LENGTH ];
+    } gmac_options_t;
 
 /** TX callback */
-typedef void (*gmac_dev_tx_cb_t) (uint32_t ul_status, uint8_t *puc_buffer);
+    typedef void (* gmac_dev_tx_cb_t) ( uint32_t ul_status,
+                                        uint8_t * puc_buffer );
 /** RX callback */
-typedef void (*gmac_dev_rx_cb_t) (uint32_t ul_status);
+    typedef void (* gmac_dev_rx_cb_t) ( uint32_t ul_status );
 /** Wakeup callback */
-typedef void (*gmac_dev_wakeup_cb_t) (void);
+    typedef void (* gmac_dev_wakeup_cb_t) ( void );
 
 /**
  * GMAC driver structure.
  */
-typedef struct gmac_device {
+    typedef struct gmac_device
+    {
+        /** Pointer to HW register base */
+        Gmac * p_hw;
 
-	/** Pointer to HW register base */
-	Gmac *p_hw;
-	/**
-	 * Pointer to allocated TX buffer.
-	 * Section 3.6 of AMBA 2.0 spec states that burst should not cross
-	 * 1K Boundaries.
-	 * Receive buffer manager writes are burst of 2 words => 3 lsb bits
-	 * of the address shall be set to 0.
-	 */
-	uint8_t *p_tx_buffer;
-	/** Pointer to allocated RX buffer */
-	uint8_t *p_rx_buffer;
-	/** Pointer to Rx TDs (must be 8-byte aligned) */
-	gmac_rx_descriptor_t *p_rx_dscr;
-	/** Pointer to Tx TDs (must be 8-byte aligned) */
-	gmac_tx_descriptor_t *p_tx_dscr;
-	/** Optional callback to be invoked once a frame has been received */
-	gmac_dev_rx_cb_t func_rx_cb;
-#if( GMAC_USES_WAKEUP_CALLBACK )
-	/** Optional callback to be invoked once several TDs have been released */
-	gmac_dev_wakeup_cb_t func_wakeup_cb;
-#endif
-#if( GMAC_USES_TX_CALLBACK != 0 )
-	/** Optional callback list to be invoked once TD has been processed */
-	gmac_dev_tx_cb_t *func_tx_cb_list;
-#endif
-	/** RX TD list size */
-	uint32_t ul_rx_list_size;
-	/** RX index for current processing TD */
-	uint32_t ul_rx_idx;
-	/** TX TD list size */
-	uint32_t ul_tx_list_size;
-	/** Circular buffer head pointer by upper layer (buffer to be sent) */
-	int32_t l_tx_head;
-	/** Circular buffer tail pointer incremented by handlers (buffer sent) */
-	int32_t l_tx_tail;
+        /**
+         * Pointer to allocated TX buffer.
+         * Section 3.6 of AMBA 2.0 spec states that burst should not cross
+         * 1K Boundaries.
+         * Receive buffer manager writes are burst of 2 words => 3 lsb bits
+         * of the address shall be set to 0.
+         */
+        uint8_t * p_tx_buffer;
+        /** Pointer to allocated RX buffer */
+        uint8_t * p_rx_buffer;
+        /** Pointer to Rx TDs (must be 8-byte aligned) */
+        gmac_rx_descriptor_t * p_rx_dscr;
+        /** Pointer to Tx TDs (must be 8-byte aligned) */
+        gmac_tx_descriptor_t * p_tx_dscr;
+        /** Optional callback to be invoked once a frame has been received */
+        gmac_dev_rx_cb_t func_rx_cb;
+        #if ( GMAC_USES_WAKEUP_CALLBACK )
+            /** Optional callback to be invoked once several TDs have been released */
+            gmac_dev_wakeup_cb_t func_wakeup_cb;
+        #endif
+        #if ( GMAC_USES_TX_CALLBACK != 0 )
+            /** Optional callback list to be invoked once TD has been processed */
+            gmac_dev_tx_cb_t * func_tx_cb_list;
+        #endif
+        /** RX TD list size */
+        uint32_t ul_rx_list_size;
+        /** RX index for current processing TD */
+        uint32_t ul_rx_idx;
+        /** TX TD list size */
+        uint32_t ul_tx_list_size;
+        /** Circular buffer head pointer by upper layer (buffer to be sent) */
+        int32_t l_tx_head;
+        /** Circular buffer tail pointer incremented by handlers (buffer sent) */
+        int32_t l_tx_tail;
 
-	/** Number of free TD before wakeup callback is invoked */
-	uint32_t uc_wakeup_threshold;
-} gmac_device_t;
+        /** Number of free TD before wakeup callback is invoked */
+        uint32_t uc_wakeup_threshold;
+    } gmac_device_t;
 
 /**
  * \brief Write network control value.
@@ -280,10 +293,11 @@ typedef struct gmac_device {
  * \param p_gmac   Pointer to the GMAC instance.
  * \param ul_ncr   Network control value.
  */
-static inline void gmac_network_control(Gmac* p_gmac, uint32_t ul_ncr)
-{
-	p_gmac->GMAC_NCR = ul_ncr;
-}
+    static inline void gmac_network_control( Gmac * p_gmac,
+                                             uint32_t ul_ncr )
+    {
+        p_gmac->GMAC_NCR = ul_ncr;
+    }
 
 /**
  * \brief Get network control value.
@@ -291,10 +305,10 @@ static inline void gmac_network_control(Gmac* p_gmac, uint32_t ul_ncr)
  * \param p_gmac   Pointer to the GMAC instance.
  */
 
-static inline uint32_t gmac_get_network_control(Gmac* p_gmac)
-{
-	return p_gmac->GMAC_NCR;
-}
+    static inline uint32_t gmac_get_network_control( Gmac * p_gmac )
+    {
+        return p_gmac->GMAC_NCR;
+    }
 
 /**
  * \brief Enable/Disable GMAC receive.
@@ -302,14 +316,18 @@ static inline uint32_t gmac_get_network_control(Gmac* p_gmac)
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable GMAC receiver, else to enable it.
  */
-static inline void gmac_enable_receive(Gmac* p_gmac, uint8_t uc_enable)
-{
-	if (uc_enable) {
-		p_gmac->GMAC_NCR |= GMAC_NCR_RXEN;
-	} else {
-		p_gmac->GMAC_NCR &= ~GMAC_NCR_RXEN;
-	}
-}
+    static inline void gmac_enable_receive( Gmac * p_gmac,
+                                            uint8_t uc_enable )
+    {
+        if( uc_enable )
+        {
+            p_gmac->GMAC_NCR |= GMAC_NCR_RXEN;
+        }
+        else
+        {
+            p_gmac->GMAC_NCR &= ~GMAC_NCR_RXEN;
+        }
+    }
 
 /**
  * \brief Enable/Disable GMAC transmit.
@@ -317,14 +335,18 @@ static inline void gmac_enable_receive(Gmac* p_gmac, uint8_t uc_enable)
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable GMAC transmit, else to enable it.
  */
-static inline void gmac_enable_transmit(Gmac* p_gmac, uint8_t uc_enable)
-{
-	if (uc_enable) {
-		p_gmac->GMAC_NCR |= GMAC_NCR_TXEN;
-	} else {
-		p_gmac->GMAC_NCR &= ~GMAC_NCR_TXEN;
-	}
-}
+    static inline void gmac_enable_transmit( Gmac * p_gmac,
+                                             uint8_t uc_enable )
+    {
+        if( uc_enable )
+        {
+            p_gmac->GMAC_NCR |= GMAC_NCR_TXEN;
+        }
+        else
+        {
+            p_gmac->GMAC_NCR &= ~GMAC_NCR_TXEN;
+        }
+    }
 
 /**
  * \brief Enable/Disable GMAC management.
@@ -332,34 +354,38 @@ static inline void gmac_enable_transmit(Gmac* p_gmac, uint8_t uc_enable)
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable GMAC management, else to enable it.
  */
-static inline void gmac_enable_management(Gmac* p_gmac, uint8_t uc_enable)
-{
-	if (uc_enable) {
-		p_gmac->GMAC_NCR |= GMAC_NCR_MPE;
-	} else {
-		p_gmac->GMAC_NCR &= ~GMAC_NCR_MPE;
-	}
-}
+    static inline void gmac_enable_management( Gmac * p_gmac,
+                                               uint8_t uc_enable )
+    {
+        if( uc_enable )
+        {
+            p_gmac->GMAC_NCR |= GMAC_NCR_MPE;
+        }
+        else
+        {
+            p_gmac->GMAC_NCR &= ~GMAC_NCR_MPE;
+        }
+    }
 
 /**
  * \brief Clear all statistics registers.
  *
  * \param p_gmac   Pointer to the GMAC instance.
  */
-static inline void gmac_clear_statistics(Gmac* p_gmac)
-{
-	p_gmac->GMAC_NCR |= GMAC_NCR_CLRSTAT;
-}
+    static inline void gmac_clear_statistics( Gmac * p_gmac )
+    {
+        p_gmac->GMAC_NCR |= GMAC_NCR_CLRSTAT;
+    }
 
 /**
  * \brief Increase all statistics registers.
  *
  * \param p_gmac   Pointer to the GMAC instance.
  */
-static inline void gmac_increase_statistics(Gmac* p_gmac)
-{
-	p_gmac->GMAC_NCR |= GMAC_NCR_INCSTAT;
-}
+    static inline void gmac_increase_statistics( Gmac * p_gmac )
+    {
+        p_gmac->GMAC_NCR |= GMAC_NCR_INCSTAT;
+    }
 
 /**
  * \brief Enable/Disable statistics registers writing.
@@ -367,15 +393,18 @@ static inline void gmac_increase_statistics(Gmac* p_gmac)
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable the statistics registers writing, else to enable it.
  */
-static inline void gmac_enable_statistics_write(Gmac* p_gmac,
-		uint8_t uc_enable)
-{
-	if (uc_enable) {
-		p_gmac->GMAC_NCR |= GMAC_NCR_WESTAT;
-	} else {
-		p_gmac->GMAC_NCR &= ~GMAC_NCR_WESTAT;
-	}
-}
+    static inline void gmac_enable_statistics_write( Gmac * p_gmac,
+                                                     uint8_t uc_enable )
+    {
+        if( uc_enable )
+        {
+            p_gmac->GMAC_NCR |= GMAC_NCR_WESTAT;
+        }
+        else
+        {
+            p_gmac->GMAC_NCR &= ~GMAC_NCR_WESTAT;
+        }
+    }
 
 /**
  * \brief In half-duplex mode, forces collisions on all received frames.
@@ -383,64 +412,68 @@ static inline void gmac_enable_statistics_write(Gmac* p_gmac,
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable the back pressure, else to enable it.
  */
-static inline void gmac_enable_back_pressure(Gmac* p_gmac, uint8_t uc_enable)
-{
-	if (uc_enable) {
-		p_gmac->GMAC_NCR |= GMAC_NCR_BP;
-	} else {
-		p_gmac->GMAC_NCR &= ~GMAC_NCR_BP;
-	}
-}
+    static inline void gmac_enable_back_pressure( Gmac * p_gmac,
+                                                  uint8_t uc_enable )
+    {
+        if( uc_enable )
+        {
+            p_gmac->GMAC_NCR |= GMAC_NCR_BP;
+        }
+        else
+        {
+            p_gmac->GMAC_NCR &= ~GMAC_NCR_BP;
+        }
+    }
 
 /**
  * \brief Start transmission.
  *
  * \param p_gmac   Pointer to the GMAC instance.
  */
-static inline void gmac_start_transmission(Gmac* p_gmac)
-{
-	p_gmac->GMAC_NCR |= GMAC_NCR_TSTART;
-}
+    static inline void gmac_start_transmission( Gmac * p_gmac )
+    {
+        p_gmac->GMAC_NCR |= GMAC_NCR_TSTART;
+    }
 
 /**
  * \brief Halt transmission.
  *
  * \param p_gmac   Pointer to the GMAC instance.
  */
-static inline void gmac_halt_transmission(Gmac* p_gmac)
-{
-	p_gmac->GMAC_NCR |= GMAC_NCR_THALT;
-}
+    static inline void gmac_halt_transmission( Gmac * p_gmac )
+    {
+        p_gmac->GMAC_NCR |= GMAC_NCR_THALT;
+    }
 
 /**
  * \brief Transmit pause frame.
  *
  * \param p_gmac   Pointer to the GMAC instance.
  */
-static inline void gmac_tx_pause_frame(Gmac* p_gmac)
-{
-	p_gmac->GMAC_NCR |= GMAC_NCR_TXPF;
-}
+    static inline void gmac_tx_pause_frame( Gmac * p_gmac )
+    {
+        p_gmac->GMAC_NCR |= GMAC_NCR_TXPF;
+    }
 
 /**
  * \brief Transmit zero quantum pause frame.
  *
  * \param p_gmac   Pointer to the GMAC instance.
  */
-static inline void gmac_tx_pause_zero_quantum_frame(Gmac* p_gmac)
-{
-	p_gmac->GMAC_NCR |= GMAC_NCR_TXZQPF;
-}
+    static inline void gmac_tx_pause_zero_quantum_frame( Gmac * p_gmac )
+    {
+        p_gmac->GMAC_NCR |= GMAC_NCR_TXZQPF;
+    }
 
 /**
  * \brief Read snapshot.
  *
  * \param p_gmac   Pointer to the GMAC instance.
  */
-static inline void gmac_read_snapshot(Gmac* p_gmac)
-{
-	p_gmac->GMAC_NCR |= GMAC_NCR_RDS;
-}
+    static inline void gmac_read_snapshot( Gmac * p_gmac )
+    {
+        p_gmac->GMAC_NCR |= GMAC_NCR_RDS;
+    }
 
 /**
  * \brief Store receivetime stamp to memory.
@@ -448,14 +481,18 @@ static inline void gmac_read_snapshot(Gmac* p_gmac)
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to normal operation, else to enable the store.
  */
-static inline void gmac_store_rx_time_stamp(Gmac* p_gmac, uint8_t uc_enable)
-{
-	if (uc_enable) {
-		p_gmac->GMAC_NCR |= GMAC_NCR_SRTSM;
-	} else {
-		p_gmac->GMAC_NCR &= ~GMAC_NCR_SRTSM;
-	}
-}
+    static inline void gmac_store_rx_time_stamp( Gmac * p_gmac,
+                                                 uint8_t uc_enable )
+    {
+        if( uc_enable )
+        {
+            p_gmac->GMAC_NCR |= GMAC_NCR_SRTSM;
+        }
+        else
+        {
+            p_gmac->GMAC_NCR &= ~GMAC_NCR_SRTSM;
+        }
+    }
 
 /**
  * \brief Enable PFC priority-based pause reception.
@@ -463,45 +500,50 @@ static inline void gmac_store_rx_time_stamp(Gmac* p_gmac, uint8_t uc_enable)
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   1 to set the reception, 0 to disable.
  */
-static inline void gmac_enable_pfc_pause_frame(Gmac* p_gmac, uint8_t uc_enable)
-{
-	if (uc_enable) {
-		p_gmac->GMAC_NCR |= GMAC_NCR_ENPBPR;
-	} else {
-		p_gmac->GMAC_NCR &= ~GMAC_NCR_ENPBPR;
-	}
-}
+    static inline void gmac_enable_pfc_pause_frame( Gmac * p_gmac,
+                                                    uint8_t uc_enable )
+    {
+        if( uc_enable )
+        {
+            p_gmac->GMAC_NCR |= GMAC_NCR_ENPBPR;
+        }
+        else
+        {
+            p_gmac->GMAC_NCR &= ~GMAC_NCR_ENPBPR;
+        }
+    }
 
 /**
  * \brief Transmit PFC priority-based pause reception.
  *
  * \param p_gmac   Pointer to the GMAC instance.
  */
-static inline void gmac_transmit_pfc_pause_frame(Gmac* p_gmac)
-{
-		p_gmac->GMAC_NCR |= GMAC_NCR_TXPBPF;
-}
+    static inline void gmac_transmit_pfc_pause_frame( Gmac * p_gmac )
+    {
+        p_gmac->GMAC_NCR |= GMAC_NCR_TXPBPF;
+    }
 
 /**
  * \brief Flush next packet.
  *
  * \param p_gmac   Pointer to the GMAC instance.
  */
-static inline void gmac_flush_next_packet(Gmac* p_gmac)
-{
-		p_gmac->GMAC_NCR |= GMAC_NCR_FNP;
-}
+    static inline void gmac_flush_next_packet( Gmac * p_gmac )
+    {
+        p_gmac->GMAC_NCR |= GMAC_NCR_FNP;
+    }
 
 /**
  * \brief Set up network configuration register.
  *
  * \param p_gmac   Pointer to the GMAC instance.
-  * \param ul_cfg   Network configuration value.
+ * \param ul_cfg   Network configuration value.
  */
-static inline void gmac_set_configure(Gmac* p_gmac, uint32_t ul_cfg)
-{
-	p_gmac->GMAC_NCFGR = ul_cfg;
-}
+    static inline void gmac_set_configure( Gmac * p_gmac,
+                                           uint32_t ul_cfg )
+    {
+        p_gmac->GMAC_NCFGR = ul_cfg;
+    }
 
 /**
  * \brief Get network configuration.
@@ -510,22 +552,23 @@ static inline void gmac_set_configure(Gmac* p_gmac, uint32_t ul_cfg)
  *
  * \return Network configuration.
  */
-static inline uint32_t gmac_get_configure(Gmac* p_gmac)
-{
-	return p_gmac->GMAC_NCFGR;
-}
+    static inline uint32_t gmac_get_configure( Gmac * p_gmac )
+    {
+        return p_gmac->GMAC_NCFGR;
+    }
 
 
 /* Get and set DMA Configuration Register */
-static inline void gmac_set_dma(Gmac* p_gmac, uint32_t ul_cfg)
-{
-	p_gmac->GMAC_DCFGR = ul_cfg;
-}
+    static inline void gmac_set_dma( Gmac * p_gmac,
+                                     uint32_t ul_cfg )
+    {
+        p_gmac->GMAC_DCFGR = ul_cfg;
+    }
 
-static inline uint32_t gmac_get_dma(Gmac* p_gmac)
-{
-	return p_gmac->GMAC_DCFGR;
-}
+    static inline uint32_t gmac_get_dma( Gmac * p_gmac )
+    {
+        return p_gmac->GMAC_DCFGR;
+    }
 
 /**
  * \brief Set speed.
@@ -533,14 +576,18 @@ static inline uint32_t gmac_get_dma(Gmac* p_gmac)
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_speed 1 to indicate 100Mbps, 0 to 10Mbps.
  */
-static inline void gmac_set_speed(Gmac* p_gmac, uint8_t uc_speed)
-{
-	if (uc_speed) {
-		p_gmac->GMAC_NCFGR |= GMAC_NCFGR_SPD;
-	} else {
-		p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_SPD;
-	}
-}
+    static inline void gmac_set_speed( Gmac * p_gmac,
+                                       uint8_t uc_speed )
+    {
+        if( uc_speed )
+        {
+            p_gmac->GMAC_NCFGR |= GMAC_NCFGR_SPD;
+        }
+        else
+        {
+            p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_SPD;
+        }
+    }
 
 /**
  * \brief Enable/Disable Full-Duplex mode.
@@ -548,14 +595,18 @@ static inline void gmac_set_speed(Gmac* p_gmac, uint8_t uc_speed)
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable the Full-Duplex mode, else to enable it.
  */
-static inline void gmac_enable_full_duplex(Gmac* p_gmac, uint8_t uc_enable)
-{
-	if (uc_enable) {
-		p_gmac->GMAC_NCFGR |= GMAC_NCFGR_FD;
-	} else {
-		p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_FD;
-	}
-}
+    static inline void gmac_enable_full_duplex( Gmac * p_gmac,
+                                                uint8_t uc_enable )
+    {
+        if( uc_enable )
+        {
+            p_gmac->GMAC_NCFGR |= GMAC_NCFGR_FD;
+        }
+        else
+        {
+            p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_FD;
+        }
+    }
 
 /**
  * \brief Enable/Disable Copy(Receive) All Valid Frames.
@@ -563,14 +614,18 @@ static inline void gmac_enable_full_duplex(Gmac* p_gmac, uint8_t uc_enable)
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable copying all valid frames, else to enable it.
  */
-static inline void gmac_enable_copy_all(Gmac* p_gmac, uint8_t uc_enable)
-{
-	if (uc_enable) {
-		p_gmac->GMAC_NCFGR |= GMAC_NCFGR_CAF;
-	} else {
-		p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_CAF;
-	}
-}
+    static inline void gmac_enable_copy_all( Gmac * p_gmac,
+                                             uint8_t uc_enable )
+    {
+        if( uc_enable )
+        {
+            p_gmac->GMAC_NCFGR |= GMAC_NCFGR_CAF;
+        }
+        else
+        {
+            p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_CAF;
+        }
+    }
 
 /**
  * \brief Enable/Disable jumbo frames (up to 10240 bytes).
@@ -578,14 +633,18 @@ static inline void gmac_enable_copy_all(Gmac* p_gmac, uint8_t uc_enable)
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable the jumbo frames, else to enable it.
  */
-static inline void gmac_enable_jumbo_frames(Gmac* p_gmac, uint8_t uc_enable)
-{
-	if (uc_enable) {
-		p_gmac->GMAC_NCFGR |= GMAC_NCFGR_JFRAME;
-	} else {
-		p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_JFRAME;
-	}
-}
+    static inline void gmac_enable_jumbo_frames( Gmac * p_gmac,
+                                                 uint8_t uc_enable )
+    {
+        if( uc_enable )
+        {
+            p_gmac->GMAC_NCFGR |= GMAC_NCFGR_JFRAME;
+        }
+        else
+        {
+            p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_JFRAME;
+        }
+    }
 
 /**
  * \brief Disable/Enable broadcast receiving.
@@ -593,14 +652,18 @@ static inline void gmac_enable_jumbo_frames(Gmac* p_gmac, uint8_t uc_enable)
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   1 to disable the broadcast, else to enable it.
  */
-static inline void gmac_disable_broadcast(Gmac* p_gmac, uint8_t uc_enable)
-{
-	if (uc_enable) {
-		p_gmac->GMAC_NCFGR |= GMAC_NCFGR_NBC;
-	} else {
-		p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_NBC;
-	}
-}
+    static inline void gmac_disable_broadcast( Gmac * p_gmac,
+                                               uint8_t uc_enable )
+    {
+        if( uc_enable )
+        {
+            p_gmac->GMAC_NCFGR |= GMAC_NCFGR_NBC;
+        }
+        else
+        {
+            p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_NBC;
+        }
+    }
 
 /**
  * \brief Enable/Disable multicast hash.
@@ -608,14 +671,18 @@ static inline void gmac_disable_broadcast(Gmac* p_gmac, uint8_t uc_enable)
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable the multicast hash, else to enable it.
  */
-static inline void gmac_enable_multicast_hash(Gmac* p_gmac, uint8_t uc_enable)
-{
-	if (uc_enable) {
-		p_gmac->GMAC_NCFGR |= GMAC_NCFGR_UNIHEN;
-	} else {
-		p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_UNIHEN;
-	}
-}
+    static inline void gmac_enable_multicast_hash( Gmac * p_gmac,
+                                                   uint8_t uc_enable )
+    {
+        if( uc_enable )
+        {
+            p_gmac->GMAC_NCFGR |= GMAC_NCFGR_UNIHEN;
+        }
+        else
+        {
+            p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_UNIHEN;
+        }
+    }
 
 /**
  * \brief Enable/Disable big frames (over 1518, up to 1536).
@@ -623,14 +690,18 @@ static inline void gmac_enable_multicast_hash(Gmac* p_gmac, uint8_t uc_enable)
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable big frames else to enable it.
  */
-static inline void gmac_enable_big_frame(Gmac* p_gmac, uint8_t uc_enable)
-{
-	if (uc_enable) {
-		p_gmac->GMAC_NCFGR |= GMAC_NCFGR_MAXFS;
-	} else {
-		p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_MAXFS;
-	}
-}
+    static inline void gmac_enable_big_frame( Gmac * p_gmac,
+                                              uint8_t uc_enable )
+    {
+        if( uc_enable )
+        {
+            p_gmac->GMAC_NCFGR |= GMAC_NCFGR_MAXFS;
+        }
+        else
+        {
+            p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_MAXFS;
+        }
+    }
 
 /**
  * \brief Set MDC clock divider.
@@ -640,29 +711,43 @@ static inline void gmac_enable_big_frame(Gmac* p_gmac, uint8_t uc_enable)
  *
  * \return GMAC_OK if successfully.
  */
-static inline uint8_t gmac_set_mdc_clock(Gmac* p_gmac, uint32_t ul_mck)
-{
-	uint32_t ul_clk;
+    static inline uint8_t gmac_set_mdc_clock( Gmac * p_gmac,
+                                              uint32_t ul_mck )
+    {
+        uint32_t ul_clk;
 
-	if (ul_mck > GMAC_MCK_SPEED_240MHZ) {
-		return GMAC_INVALID;
-	} else if (ul_mck > GMAC_MCK_SPEED_160MHZ) {
-		ul_clk = GMAC_NCFGR_CLK_MCK_96;
-	} else if (ul_mck > GMAC_MCK_SPEED_120MHZ) {
-		ul_clk = GMAC_NCFGR_CLK_MCK_64;
-	} else if (ul_mck > GMAC_MCK_SPEED_80MHZ) {
-		ul_clk = GMAC_NCFGR_CLK_MCK_48;
-	} else if (ul_mck > GMAC_MCK_SPEED_40MHZ) {
-		ul_clk = GMAC_NCFGR_CLK_MCK_32;
-	} else if (ul_mck > GMAC_MCK_SPEED_20MHZ) {
-		ul_clk = GMAC_NCFGR_CLK_MCK_16;
-	} else {
-		ul_clk = GMAC_NCFGR_CLK_MCK_8;
-	}
-	;
-	p_gmac->GMAC_NCFGR = (p_gmac->GMAC_NCFGR & ~GMAC_NCFGR_CLK_Msk) | ul_clk;
-	return GMAC_OK;
-}
+        if( ul_mck > GMAC_MCK_SPEED_240MHZ )
+        {
+            return GMAC_INVALID;
+        }
+        else if( ul_mck > GMAC_MCK_SPEED_160MHZ )
+        {
+            ul_clk = GMAC_NCFGR_CLK_MCK_96;
+        }
+        else if( ul_mck > GMAC_MCK_SPEED_120MHZ )
+        {
+            ul_clk = GMAC_NCFGR_CLK_MCK_64;
+        }
+        else if( ul_mck > GMAC_MCK_SPEED_80MHZ )
+        {
+            ul_clk = GMAC_NCFGR_CLK_MCK_48;
+        }
+        else if( ul_mck > GMAC_MCK_SPEED_40MHZ )
+        {
+            ul_clk = GMAC_NCFGR_CLK_MCK_32;
+        }
+        else if( ul_mck > GMAC_MCK_SPEED_20MHZ )
+        {
+            ul_clk = GMAC_NCFGR_CLK_MCK_16;
+        }
+        else
+        {
+            ul_clk = GMAC_NCFGR_CLK_MCK_8;
+        }
+
+        p_gmac->GMAC_NCFGR = ( p_gmac->GMAC_NCFGR & ~GMAC_NCFGR_CLK_Msk ) | ul_clk;
+        return GMAC_OK;
+    }
 
 /**
  * \brief Enable/Disable retry test.
@@ -670,14 +755,18 @@ static inline uint8_t gmac_set_mdc_clock(Gmac* p_gmac, uint32_t ul_mck)
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable the GMAC receiver, else to enable it.
  */
-static inline void gmac_enable_retry_test(Gmac* p_gmac, uint8_t uc_enable)
-{
-	if (uc_enable) {
-		p_gmac->GMAC_NCFGR |= GMAC_NCFGR_RTY;
-	} else {
-		p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_RTY;
-	}
-}
+    static inline void gmac_enable_retry_test( Gmac * p_gmac,
+                                               uint8_t uc_enable )
+    {
+        if( uc_enable )
+        {
+            p_gmac->GMAC_NCFGR |= GMAC_NCFGR_RTY;
+        }
+        else
+        {
+            p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_RTY;
+        }
+    }
 
 /**
  * \brief Enable/Disable pause (when a valid pause frame is received).
@@ -685,25 +774,30 @@ static inline void gmac_enable_retry_test(Gmac* p_gmac, uint8_t uc_enable)
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable pause frame, else to enable it.
  */
-static inline void gmac_enable_pause_frame(Gmac* p_gmac, uint8_t uc_enable)
-{
-	if (uc_enable) {
-		p_gmac->GMAC_NCFGR |= GMAC_NCFGR_PEN;
-	} else {
-		p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_PEN;
-	}
-}
+    static inline void gmac_enable_pause_frame( Gmac * p_gmac,
+                                                uint8_t uc_enable )
+    {
+        if( uc_enable )
+        {
+            p_gmac->GMAC_NCFGR |= GMAC_NCFGR_PEN;
+        }
+        else
+        {
+            p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_PEN;
+        }
+    }
 
 /**
  * \brief Set receive buffer offset to 0 ~ 3.
  *
  * \param p_gmac   Pointer to the GMAC instance.
  */
-static inline void gmac_set_rx_buffer_offset(Gmac* p_gmac, uint8_t uc_offset)
-{
-	p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_RXBUFO_Msk;
-	p_gmac->GMAC_NCFGR |= GMAC_NCFGR_RXBUFO(uc_offset);
-}
+    static inline void gmac_set_rx_buffer_offset( Gmac * p_gmac,
+                                                  uint8_t uc_offset )
+    {
+        p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_RXBUFO_Msk;
+        p_gmac->GMAC_NCFGR |= GMAC_NCFGR_RXBUFO( uc_offset );
+    }
 
 /**
  * \brief Enable/Disable receive length field checking.
@@ -711,14 +805,18 @@ static inline void gmac_set_rx_buffer_offset(Gmac* p_gmac, uint8_t uc_offset)
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable receive length field checking, else to enable it.
  */
-static inline void gmac_enable_rx_length_check(Gmac* p_gmac, uint8_t uc_enable)
-{
-	if (uc_enable) {
-		p_gmac->GMAC_NCFGR |= GMAC_NCFGR_LFERD;
-	} else {
-		p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_LFERD;
-	}
-}
+    static inline void gmac_enable_rx_length_check( Gmac * p_gmac,
+                                                    uint8_t uc_enable )
+    {
+        if( uc_enable )
+        {
+            p_gmac->GMAC_NCFGR |= GMAC_NCFGR_LFERD;
+        }
+        else
+        {
+            p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_LFERD;
+        }
+    }
 
 /**
  * \brief Enable/Disable discarding FCS field of received frames.
@@ -726,14 +824,18 @@ static inline void gmac_enable_rx_length_check(Gmac* p_gmac, uint8_t uc_enable)
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable discarding FCS field of received frames, else to enable it.
  */
-static inline void gmac_enable_discard_fcs(Gmac* p_gmac, uint8_t uc_enable)
-{
-	if (uc_enable) {
-		p_gmac->GMAC_NCFGR |= GMAC_NCFGR_RFCS;
-	} else {
-		p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_RFCS;
-	}
-}
+    static inline void gmac_enable_discard_fcs( Gmac * p_gmac,
+                                                uint8_t uc_enable )
+    {
+        if( uc_enable )
+        {
+            p_gmac->GMAC_NCFGR |= GMAC_NCFGR_RFCS;
+        }
+        else
+        {
+            p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_RFCS;
+        }
+    }
 
 
 /**
@@ -743,14 +845,18 @@ static inline void gmac_enable_discard_fcs(Gmac* p_gmac, uint8_t uc_enable)
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable the received in half-duplex mode, else to enable it.
  */
-static inline void gmac_enable_efrhd(Gmac* p_gmac, uint8_t uc_enable)
-{
-	if (uc_enable) {
-		p_gmac->GMAC_NCFGR |= GMAC_NCFGR_EFRHD;
-	} else {
-		p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_EFRHD;
-	}
-}
+    static inline void gmac_enable_efrhd( Gmac * p_gmac,
+                                          uint8_t uc_enable )
+    {
+        if( uc_enable )
+        {
+            p_gmac->GMAC_NCFGR |= GMAC_NCFGR_EFRHD;
+        }
+        else
+        {
+            p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_EFRHD;
+        }
+    }
 
 /**
  * \brief Enable/Disable ignore RX FCS.
@@ -758,14 +864,18 @@ static inline void gmac_enable_efrhd(Gmac* p_gmac, uint8_t uc_enable)
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable ignore RX FCS, else to enable it.
  */
-static inline void gmac_enable_ignore_rx_fcs(Gmac* p_gmac, uint8_t uc_enable)
-{
-	if (uc_enable) {
-		p_gmac->GMAC_NCFGR |= GMAC_NCFGR_IRXFCS;
-	} else {
-		p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_IRXFCS;
-	}
-}
+    static inline void gmac_enable_ignore_rx_fcs( Gmac * p_gmac,
+                                                  uint8_t uc_enable )
+    {
+        if( uc_enable )
+        {
+            p_gmac->GMAC_NCFGR |= GMAC_NCFGR_IRXFCS;
+        }
+        else
+        {
+            p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_IRXFCS;
+        }
+    }
 
 /**
  * \brief Get Network Status.
@@ -774,10 +884,10 @@ static inline void gmac_enable_ignore_rx_fcs(Gmac* p_gmac, uint8_t uc_enable)
  *
  * \return Network status.
  */
-static inline uint32_t gmac_get_status(Gmac* p_gmac)
-{
-	return p_gmac->GMAC_NSR;
-}
+    static inline uint32_t gmac_get_status( Gmac * p_gmac )
+    {
+        return p_gmac->GMAC_NSR;
+    }
 
 /**
  * \brief Get MDIO IN pin status.
@@ -786,10 +896,10 @@ static inline uint32_t gmac_get_status(Gmac* p_gmac)
  *
  * \return MDIO IN pin status.
  */
-static inline uint8_t gmac_get_MDIO(Gmac* p_gmac)
-{
-	return ((p_gmac->GMAC_NSR & GMAC_NSR_MDIO) > 0);
-}
+    static inline uint8_t gmac_get_MDIO( Gmac * p_gmac )
+    {
+        return( ( p_gmac->GMAC_NSR & GMAC_NSR_MDIO ) > 0 );
+    }
 
 /**
  * \brief Check if PHY is idle.
@@ -798,10 +908,10 @@ static inline uint8_t gmac_get_MDIO(Gmac* p_gmac)
  *
  * \return  1 if PHY is idle.
  */
-static inline uint8_t gmac_is_phy_idle(Gmac* p_gmac)
-{
-	return ((p_gmac->GMAC_NSR & GMAC_NSR_IDLE) > 0);
-}
+    static inline uint8_t gmac_is_phy_idle( Gmac * p_gmac )
+    {
+        return( ( p_gmac->GMAC_NSR & GMAC_NSR_IDLE ) > 0 );
+    }
 
 /**
  * \brief Return transmit status.
@@ -810,10 +920,10 @@ static inline uint8_t gmac_is_phy_idle(Gmac* p_gmac)
  *
  * \return  Transmit status.
  */
-static inline uint32_t gmac_get_tx_status(Gmac* p_gmac)
-{
-	return p_gmac->GMAC_TSR;
-}
+    static inline uint32_t gmac_get_tx_status( Gmac * p_gmac )
+    {
+        return p_gmac->GMAC_TSR;
+    }
 
 /**
  * \brief Clear transmit status.
@@ -821,20 +931,21 @@ static inline uint32_t gmac_get_tx_status(Gmac* p_gmac)
  * \param p_gmac   Pointer to the GMAC instance.
  * \param ul_status   Transmit status.
  */
-static inline void gmac_clear_tx_status(Gmac* p_gmac, uint32_t ul_status)
-{
-	p_gmac->GMAC_TSR = ul_status;
-}
+    static inline void gmac_clear_tx_status( Gmac * p_gmac,
+                                             uint32_t ul_status )
+    {
+        p_gmac->GMAC_TSR = ul_status;
+    }
 
 /**
  * \brief Return receive status.
  *
  * \param p_gmac   Pointer to the GMAC instance.
  */
-static inline uint32_t gmac_get_rx_status(Gmac* p_gmac)
-{
-	return p_gmac->GMAC_RSR;
-}
+    static inline uint32_t gmac_get_rx_status( Gmac * p_gmac )
+    {
+        return p_gmac->GMAC_RSR;
+    }
 
 /**
  * \brief Clear receive status.
@@ -842,10 +953,11 @@ static inline uint32_t gmac_get_rx_status(Gmac* p_gmac)
  * \param p_gmac   Pointer to the GMAC instance.
  * \param ul_status   Receive status.
  */
-static inline void gmac_clear_rx_status(Gmac* p_gmac, uint32_t ul_status)
-{
-	p_gmac->GMAC_RSR = ul_status;
-}
+    static inline void gmac_clear_rx_status( Gmac * p_gmac,
+                                             uint32_t ul_status )
+    {
+        p_gmac->GMAC_RSR = ul_status;
+    }
 
 /**
  * \brief Set Rx Queue.
@@ -853,10 +965,11 @@ static inline void gmac_clear_rx_status(Gmac* p_gmac, uint32_t ul_status)
  * \param p_gmac   Pointer to the GMAC instance.
  * \param ul_addr   Rx queue address.
  */
-static inline void gmac_set_rx_queue(Gmac* p_gmac, uint32_t ul_addr)
-{
-	p_gmac->GMAC_RBQB = GMAC_RBQB_ADDR_Msk & ul_addr;
-}
+    static inline void gmac_set_rx_queue( Gmac * p_gmac,
+                                          uint32_t ul_addr )
+    {
+        p_gmac->GMAC_RBQB = GMAC_RBQB_ADDR_Msk & ul_addr;
+    }
 
 /**
  * \brief Get Rx Queue Address.
@@ -865,10 +978,10 @@ static inline void gmac_set_rx_queue(Gmac* p_gmac, uint32_t ul_addr)
  *
  * \return  Rx queue address.
  */
-static inline uint32_t gmac_get_rx_queue(Gmac* p_gmac)
-{
-	return p_gmac->GMAC_RBQB;
-}
+    static inline uint32_t gmac_get_rx_queue( Gmac * p_gmac )
+    {
+        return p_gmac->GMAC_RBQB;
+    }
 
 /**
  * \brief Set Tx Queue.
@@ -876,10 +989,11 @@ static inline uint32_t gmac_get_rx_queue(Gmac* p_gmac)
  * \param p_gmac   Pointer to the GMAC instance.
  * \param ul_addr  Tx queue address.
  */
-static inline void gmac_set_tx_queue(Gmac* p_gmac, uint32_t ul_addr)
-{
-	p_gmac->GMAC_TBQB = GMAC_TBQB_ADDR_Msk & ul_addr;
-}
+    static inline void gmac_set_tx_queue( Gmac * p_gmac,
+                                          uint32_t ul_addr )
+    {
+        p_gmac->GMAC_TBQB = GMAC_TBQB_ADDR_Msk & ul_addr;
+    }
 
 /**
  * \brief Get Tx Queue.
@@ -888,10 +1002,10 @@ static inline void gmac_set_tx_queue(Gmac* p_gmac, uint32_t ul_addr)
  *
  * \return  Rx queue address.
  */
-static inline uint32_t gmac_get_tx_queue(Gmac* p_gmac)
-{
-	return p_gmac->GMAC_TBQB;
-}
+    static inline uint32_t gmac_get_tx_queue( Gmac * p_gmac )
+    {
+        return p_gmac->GMAC_TBQB;
+    }
 
 /**
  * \brief Enable interrupt(s).
@@ -899,10 +1013,11 @@ static inline uint32_t gmac_get_tx_queue(Gmac* p_gmac)
  * \param p_gmac   Pointer to the GMAC instance.
  * \param ul_source   Interrupt source(s) to be enabled.
  */
-static inline void gmac_enable_interrupt(Gmac* p_gmac, uint32_t ul_source)
-{
-	p_gmac->GMAC_IER = ul_source;
-}
+    static inline void gmac_enable_interrupt( Gmac * p_gmac,
+                                              uint32_t ul_source )
+    {
+        p_gmac->GMAC_IER = ul_source;
+    }
 
 /**
  * \brief Disable interrupt(s).
@@ -910,10 +1025,11 @@ static inline void gmac_enable_interrupt(Gmac* p_gmac, uint32_t ul_source)
  * \param p_gmac   Pointer to the GMAC instance.
  * \param ul_source   Interrupt source(s) to be disabled.
  */
-static inline void gmac_disable_interrupt(Gmac* p_gmac, uint32_t ul_source)
-{
-	p_gmac->GMAC_IDR = ul_source;
-}
+    static inline void gmac_disable_interrupt( Gmac * p_gmac,
+                                               uint32_t ul_source )
+    {
+        p_gmac->GMAC_IDR = ul_source;
+    }
 
 /**
  * \brief Return interrupt status.
@@ -922,10 +1038,10 @@ static inline void gmac_disable_interrupt(Gmac* p_gmac, uint32_t ul_source)
  *
  * \return Interrupt status.
  */
-static inline uint32_t gmac_get_interrupt_status(Gmac* p_gmac)
-{
-	return p_gmac->GMAC_ISR;
-}
+    static inline uint32_t gmac_get_interrupt_status( Gmac * p_gmac )
+    {
+        return p_gmac->GMAC_ISR;
+    }
 
 /**
  * \brief Return interrupt mask.
@@ -934,10 +1050,10 @@ static inline uint32_t gmac_get_interrupt_status(Gmac* p_gmac)
  *
  * \return Interrupt mask.
  */
-static inline uint32_t gmac_get_interrupt_mask(Gmac* p_gmac)
-{
-	return p_gmac->GMAC_IMR;
-}
+    static inline uint32_t gmac_get_interrupt_mask( Gmac * p_gmac )
+    {
+        return p_gmac->GMAC_IMR;
+    }
 
 /**
  * \brief Execute PHY maintenance command.
@@ -948,20 +1064,25 @@ static inline uint32_t gmac_get_interrupt_mask(Gmac* p_gmac)
  * \param uc_rw   1 to Read, 0 to write.
  * \param us_data   Data to be performed, write only.
  */
-static inline void gmac_maintain_phy(Gmac* p_gmac,
-		uint8_t uc_phy_addr, uint8_t uc_reg_addr, uint8_t uc_rw,
-		uint16_t us_data)
-{
-	/* Wait until bus idle */
-	while ((p_gmac->GMAC_NSR & GMAC_NSR_IDLE) == 0);
-	/* Write maintain register */
-	p_gmac->GMAC_MAN = GMAC_MAN_WTN(GMAC_MAN_CODE_VALUE)
-			| GMAC_MAN_CLTTO
-			| GMAC_MAN_PHYA(uc_phy_addr)
-			| GMAC_MAN_REGA(uc_reg_addr)
-			| GMAC_MAN_OP((uc_rw ? GMAC_MAN_RW_TYPE : GMAC_MAN_READ_ONLY))
-			| GMAC_MAN_DATA(us_data);
-}
+    static inline void gmac_maintain_phy( Gmac * p_gmac,
+                                          uint8_t uc_phy_addr,
+                                          uint8_t uc_reg_addr,
+                                          uint8_t uc_rw,
+                                          uint16_t us_data )
+    {
+        /* Wait until bus idle */
+        while( ( p_gmac->GMAC_NSR & GMAC_NSR_IDLE ) == 0 )
+        {
+        }
+
+        /* Write maintain register */
+        p_gmac->GMAC_MAN = GMAC_MAN_WTN( GMAC_MAN_CODE_VALUE )
+                           | GMAC_MAN_CLTTO
+                           | GMAC_MAN_PHYA( uc_phy_addr )
+                           | GMAC_MAN_REGA( uc_reg_addr )
+                           | GMAC_MAN_OP( ( uc_rw ? GMAC_MAN_RW_TYPE : GMAC_MAN_READ_ONLY ) )
+                           | GMAC_MAN_DATA( us_data );
+    }
 
 /**
  * \brief Get PHY maintenance data returned.
@@ -970,13 +1091,16 @@ static inline void gmac_maintain_phy(Gmac* p_gmac,
  *
  * \return Get PHY data.
  */
-static inline uint16_t gmac_get_phy_data(Gmac* p_gmac)
-{
-	/* Wait until bus idle */
-	while ((p_gmac->GMAC_NSR & GMAC_NSR_IDLE) == 0);
-	/* Return data */
-	return (uint16_t) (p_gmac->GMAC_MAN & GMAC_MAN_DATA_Msk);
-}
+    static inline uint16_t gmac_get_phy_data( Gmac * p_gmac )
+    {
+        /* Wait until bus idle */
+        while( ( p_gmac->GMAC_NSR & GMAC_NSR_IDLE ) == 0 )
+        {
+        }
+
+        /* Return data */
+        return ( uint16_t ) ( p_gmac->GMAC_MAN & GMAC_MAN_DATA_Msk );
+    }
 
 /**
  * \brief Set Hash.
@@ -985,12 +1109,13 @@ static inline uint16_t gmac_get_phy_data(Gmac* p_gmac)
  * \param ul_hash_top   Hash top.
  * \param ul_hash_bottom   Hash bottom.
  */
-static inline void gmac_set_hash(Gmac* p_gmac, uint32_t ul_hash_top,
-		uint32_t ul_hash_bottom)
-{
-	p_gmac->GMAC_HRB = ul_hash_bottom;
-	p_gmac->GMAC_HRT = ul_hash_top;
-}
+    static inline void gmac_set_hash( Gmac * p_gmac,
+                                      uint32_t ul_hash_top,
+                                      uint32_t ul_hash_bottom )
+    {
+        p_gmac->GMAC_HRB = ul_hash_bottom;
+        p_gmac->GMAC_HRT = ul_hash_top;
+    }
 
 /**
  * \brief Set 64 bits Hash.
@@ -998,11 +1123,12 @@ static inline void gmac_set_hash(Gmac* p_gmac, uint32_t ul_hash_top,
  * \param p_gmac   Pointer to the GMAC instance.
  * \param ull_hash   64 bits hash value.
  */
-static inline void gmac_set_hash64(Gmac* p_gmac, uint64_t ull_hash)
-{
-	p_gmac->GMAC_HRB = (uint32_t) ull_hash;
-	p_gmac->GMAC_HRT = (uint32_t) (ull_hash >> 32);
-}
+    static inline void gmac_set_hash64( Gmac * p_gmac,
+                                        uint64_t ull_hash )
+    {
+        p_gmac->GMAC_HRB = ( uint32_t ) ull_hash;
+        p_gmac->GMAC_HRT = ( uint32_t ) ( ull_hash >> 32 );
+    }
 
 /**
  * \brief Set MAC Address.
@@ -1011,31 +1137,34 @@ static inline void gmac_set_hash64(Gmac* p_gmac, uint64_t ull_hash)
  * \param uc_index  GMAC specific address register index.
  * \param p_mac_addr  GMAC address.
  */
-static inline void gmac_set_address(Gmac* p_gmac, uint8_t uc_index,
-		uint8_t* p_mac_addr)
-{
-	p_gmac->GMAC_SA[uc_index].GMAC_SAB = (p_mac_addr[3] << 24)
-			| (p_mac_addr[2] << 16)
-			| (p_mac_addr[1] << 8)
-			| (p_mac_addr[0]);
-	p_gmac->GMAC_SA[uc_index].GMAC_SAT = (p_mac_addr[5] << 8)
-			| (p_mac_addr[4]);
-}
+    static inline void gmac_set_address( Gmac * p_gmac,
+                                         uint8_t uc_index,
+                                         uint8_t * p_mac_addr )
+    {
+        p_gmac->GMAC_SA[ uc_index ].GMAC_SAB = ( p_mac_addr[ 3 ] << 24 )
+                                               | ( p_mac_addr[ 2 ] << 16 )
+                                               | ( p_mac_addr[ 1 ] << 8 )
+                                               | ( p_mac_addr[ 0 ] );
+        p_gmac->GMAC_SA[ uc_index ].GMAC_SAT = ( p_mac_addr[ 5 ] << 8 )
+                                               | ( p_mac_addr[ 4 ] );
+    }
 
 /**
  * \brief Set MAC Address via 2 dword.
-  *
+ *
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_index  GMAC specific address register index.
  * \param ul_mac_top  GMAC top address.
  * \param ul_mac_bottom  GMAC bottom address.
  */
-static inline void gmac_set_address32(Gmac* p_gmac, uint8_t uc_index,
-		uint32_t ul_mac_top, uint32_t ul_mac_bottom)
-{
-	p_gmac->GMAC_SA[uc_index].GMAC_SAB = ul_mac_bottom;
-	p_gmac->GMAC_SA[uc_index].GMAC_SAT = ul_mac_top;
-}
+    static inline void gmac_set_address32( Gmac * p_gmac,
+                                           uint8_t uc_index,
+                                           uint32_t ul_mac_top,
+                                           uint32_t ul_mac_bottom )
+    {
+        p_gmac->GMAC_SA[ uc_index ].GMAC_SAB = ul_mac_bottom;
+        p_gmac->GMAC_SA[ uc_index ].GMAC_SAT = ul_mac_top;
+    }
 
 /**
  * \brief Set MAC Address via int64.
@@ -1044,12 +1173,13 @@ static inline void gmac_set_address32(Gmac* p_gmac, uint8_t uc_index,
  * \param uc_index  GMAC specific address register index.
  * \param ull_mac  64-bit GMAC address.
  */
-static inline void gmac_set_address64(Gmac* p_gmac, uint8_t uc_index,
-		uint64_t ull_mac)
-{
-	p_gmac->GMAC_SA[uc_index].GMAC_SAB = (uint32_t) ull_mac;
-	p_gmac->GMAC_SA[uc_index].GMAC_SAT = (uint32_t) (ull_mac >> 32);
-}
+    static inline void gmac_set_address64( Gmac * p_gmac,
+                                           uint8_t uc_index,
+                                           uint64_t ull_mac )
+    {
+        p_gmac->GMAC_SA[ uc_index ].GMAC_SAB = ( uint32_t ) ull_mac;
+        p_gmac->GMAC_SA[ uc_index ].GMAC_SAT = ( uint32_t ) ( ull_mac >> 32 );
+    }
 
 /**
  * \brief Select media independent interface mode.
@@ -1057,45 +1187,57 @@ static inline void gmac_set_address64(Gmac* p_gmac, uint8_t uc_index,
  * \param p_gmac   Pointer to the GMAC instance.
  * \param mode   Media independent interface mode.
  */
-static inline void gmac_select_mii_mode(Gmac* p_gmac, gmac_mii_mode_t mode)
-{
-	switch (mode) {
-		case GMAC_PHY_MII:
-		case GMAC_PHY_RMII:
-			p_gmac->GMAC_UR |= GMAC_UR_RMIIMII;
-		break;
+    static inline void gmac_select_mii_mode( Gmac * p_gmac,
+                                             gmac_mii_mode_t mode )
+    {
+        switch( mode )
+        {
+            case GMAC_PHY_MII:
+            case GMAC_PHY_RMII:
+                p_gmac->GMAC_UR |= GMAC_UR_RMIIMII;
+                break;
 
-		default:
-			p_gmac->GMAC_UR &= ~GMAC_UR_RMIIMII;
-		break;
-	}
-}
+            default:
+                p_gmac->GMAC_UR &= ~GMAC_UR_RMIIMII;
+                break;
+        }
+    }
 
-uint8_t gmac_phy_read(Gmac* p_gmac, uint8_t uc_phy_address, uint8_t uc_address,
-		uint32_t* p_value);
-uint8_t gmac_phy_write(Gmac* p_gmac, uint8_t uc_phy_address,
-		uint8_t uc_address, uint32_t ul_value);
-void gmac_dev_init(Gmac* p_gmac, gmac_device_t* p_gmac_dev,
-		gmac_options_t* p_opt);
-uint32_t gmac_dev_read(gmac_device_t* p_gmac_dev, uint8_t* p_frame,
-		uint32_t ul_frame_size, uint32_t* p_rcv_size);
-uint32_t gmac_dev_write(gmac_device_t* p_gmac_dev, void *p_buffer,
-		uint32_t ul_size, gmac_dev_tx_cb_t func_tx_cb);
-uint32_t gmac_dev_get_tx_load(gmac_device_t* p_gmac_dev);
-void gmac_dev_set_rx_callback(gmac_device_t* p_gmac_dev,
-		gmac_dev_rx_cb_t func_rx_cb);
-uint8_t gmac_dev_set_tx_wakeup_callback(gmac_device_t* p_gmac_dev,
-		gmac_dev_wakeup_cb_t func_wakeup, uint8_t uc_threshold);
-void gmac_dev_reset(gmac_device_t* p_gmac_dev);
-void gmac_handler(gmac_device_t* p_gmac_dev);
+    uint8_t gmac_phy_read( Gmac * p_gmac,
+                           uint8_t uc_phy_address,
+                           uint8_t uc_address,
+                           uint32_t * p_value );
+    uint8_t gmac_phy_write( Gmac * p_gmac,
+                            uint8_t uc_phy_address,
+                            uint8_t uc_address,
+                            uint32_t ul_value );
+    void gmac_dev_init( Gmac * p_gmac,
+                        gmac_device_t * p_gmac_dev,
+                        gmac_options_t * p_opt );
+    uint32_t gmac_dev_read( gmac_device_t * p_gmac_dev,
+                            uint8_t * p_frame,
+                            uint32_t ul_frame_size,
+                            uint32_t * p_rcv_size );
+    uint32_t gmac_dev_write( gmac_device_t * p_gmac_dev,
+                             void * p_buffer,
+                             uint32_t ul_size,
+                             gmac_dev_tx_cb_t func_tx_cb );
+    uint32_t gmac_dev_get_tx_load( gmac_device_t * p_gmac_dev );
+    void gmac_dev_set_rx_callback( gmac_device_t * p_gmac_dev,
+                                   gmac_dev_rx_cb_t func_rx_cb );
+    uint8_t gmac_dev_set_tx_wakeup_callback( gmac_device_t * p_gmac_dev,
+                                             gmac_dev_wakeup_cb_t func_wakeup,
+                                             uint8_t uc_threshold );
+    void gmac_dev_reset( gmac_device_t * p_gmac_dev );
+    void gmac_handler( gmac_device_t * p_gmac_dev );
 
-/// @cond 0
+/*/ @cond 0 */
 /**INDENT-OFF**/
-#ifdef __cplusplus
-}
-#endif
+    #ifdef __cplusplus
+        }
+    #endif
 /**INDENT-ON**/
-/// @endcond
+/*/ @endcond */
 
 /**
  * \page gmac_quickstart Quickstart guide for GMAC driver.
@@ -1271,7 +1413,7 @@ void gmac_handler(gmac_device_t* p_gmac_dev);
  *   - \code
  *         ethernet_phy_init(GMAC, BOARD_GMAC_PHY_ADDR, sysclk_get_cpu_hz());
  * \endcode
-  * -# The link will be established based on auto negotiation.
+ * -# The link will be established based on auto negotiation.
  *   - \code
  *         ethernet_phy_auto_negotiate(GMAC, BOARD_GMAC_PHY_ADDR);
  * \endcode
@@ -1292,58 +1434,60 @@ void gmac_handler(gmac_device_t* p_gmac_dev);
  *   - \code gmac_dev_read(&gs_gmac_dev, (uint8_t *) gs_uc_eth_buffer, sizeof(gs_uc_eth_buffer), &ul_frm_size)); \endcode
  */
 
-#	define GMAC_STATS 0
+    #define GMAC_STATS    0
 
-#if( GMAC_STATS != 0 )
+    #if ( GMAC_STATS != 0 )
 
-	/* Here below some code to study the types and
-	frequencies of 	GMAC interrupts. */
-	#define GMAC_IDX_RXUBR 0
-	#define GMAC_IDX_TUR   1
-	#define GMAC_IDX_RLEX  2
-	#define GMAC_IDX_TFC   3
-	#define GMAC_IDX_RCOMP 4
-	#define GMAC_IDX_TCOMP 5
-	#define GMAC_IDX_ROVR  6
-	#define GMAC_IDX_HRESP 7
-	#define GMAC_IDX_PFNZ  8
-	#define GMAC_IDX_PTZ   9
+        /* Here below some code to study the types and
+         * frequencies of   GMAC interrupts. */
+        #define GMAC_IDX_RXUBR    0
+        #define GMAC_IDX_TUR      1
+        #define GMAC_IDX_RLEX     2
+        #define GMAC_IDX_TFC      3
+        #define GMAC_IDX_RCOMP    4
+        #define GMAC_IDX_TCOMP    5
+        #define GMAC_IDX_ROVR     6
+        #define GMAC_IDX_HRESP    7
+        #define GMAC_IDX_PFNZ     8
+        #define GMAC_IDX_PTZ      9
 
-	struct SGmacStats {
-		unsigned recvCount;
-		unsigned rovrCount;
-		unsigned bnaCount;
-		unsigned sendCount;
-		unsigned sovrCount;
-		unsigned incompCount;
-		unsigned truncCount;
+        struct SGmacStats
+        {
+            unsigned recvCount;
+            unsigned rovrCount;
+            unsigned bnaCount;
+            unsigned sendCount;
+            unsigned sovrCount;
+            unsigned incompCount;
+            unsigned truncCount;
 
-		unsigned intStatus[10];
-	};
-	extern struct SGmacStats gmacStats;
+            unsigned intStatus[ 10 ];
+        };
+        extern struct SGmacStats gmacStats;
 
-	struct SIntPair {
-		const char *name;
-		unsigned mask;
-		int index;
-	};
+        struct SIntPair
+        {
+            const char * name;
+            unsigned mask;
+            int index;
+        };
 
-	#define MK_PAIR( NAME )   #NAME, GMAC_IER_##NAME, GMAC_IDX_##NAME
-	static const struct SIntPair intPairs[] = {
-		{ MK_PAIR( RXUBR ) }, /* Enable receive used bit read interrupt. */
-		{ MK_PAIR( TUR   ) }, /* Enable transmit underrun interrupt. */
-		{ MK_PAIR( RLEX  ) }, /* Enable retry limit  exceeded interrupt. */
-		{ MK_PAIR( TFC   ) }, /* Enable transmit buffers exhausted in mid-frame interrupt. */
-		{ MK_PAIR( RCOMP ) }, /* Receive complete */
-		{ MK_PAIR( TCOMP ) }, /* Enable transmit complete interrupt. */
-		{ MK_PAIR( ROVR  ) }, /* Enable receive overrun interrupt. */
-		{ MK_PAIR( HRESP ) }, /* Enable Hresp not OK interrupt. */
-		{ MK_PAIR( PFNZ  ) }, /* Enable pause frame received interrupt. */
-		{ MK_PAIR( PTZ   ) }  /* Enable pause time zero interrupt. */
-	};
+        #define MK_PAIR( NAME )    # NAME, GMAC_IER_ ## NAME, GMAC_IDX_ ## NAME
+        static const struct SIntPair intPairs[] = {
+            { MK_PAIR( RXUBR ) }, /* Enable receive used bit read interrupt. */
+            { MK_PAIR( TUR )   }, /* Enable transmit underrun interrupt. */
+            { MK_PAIR( RLEX )  }, /* Enable retry limit  exceeded interrupt. */
+            { MK_PAIR( TFC )   }, /* Enable transmit buffers exhausted in mid-frame interrupt. */
+            { MK_PAIR( RCOMP ) }, /* Receive complete */
+            { MK_PAIR( TCOMP ) }, /* Enable transmit complete interrupt. */
+            { MK_PAIR( ROVR )  }, /* Enable receive overrun interrupt. */
+            { MK_PAIR( HRESP ) }, /* Enable Hresp not OK interrupt. */
+            { MK_PAIR( PFNZ )  }, /* Enable pause frame received interrupt. */
+            { MK_PAIR( PTZ )   } /* Enable pause time zero interrupt. */
+        };
 
-	void gmac_show_irq_counts ();
+        void gmac_show_irq_counts();
 
-#endif
+    #endif /* if ( GMAC_STATS != 0 ) */
 
 #endif /* GMAC_H_INCLUDED */

--- a/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/portable/NetworkInterface/Common/phyHandling.c
+++ b/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/portable/NetworkInterface/Common/phyHandling.c
@@ -4,7 +4,7 @@
  * a Media-Independent Interface (MII), or a Reduced Media-Independent Interface (RMII).
  * The EMAC can poll for PHY ports on 32 different addresses. Each of the PHY ports
  * shall be treated independently.
- * 
+ *
  */
 
 /* Standard includes. */
@@ -24,698 +24,743 @@
 
 #include "phyHandling.h"
 
-#define phyMIN_PHY_ADDRESS		0
-#define phyMAX_PHY_ADDRESS		31
+#define phyMIN_PHY_ADDRESS    0
+#define phyMAX_PHY_ADDRESS    31
 
 #if defined( PHY_LS_HIGH_CHECK_TIME_MS ) || defined( PHY_LS_LOW_CHECK_TIME_MS )
-	#warning please use the new defines with 'ipconfig' prefix
+    #warning please use the new defines with 'ipconfig' prefix
 #endif
 
-#ifndef	ipconfigPHY_LS_HIGH_CHECK_TIME_MS
-	/* Check if the LinkStatus in the PHY is still high after 15 seconds of not
-	receiving packets. */
-	#define ipconfigPHY_LS_HIGH_CHECK_TIME_MS	15000UL
+#ifndef ipconfigPHY_LS_HIGH_CHECK_TIME_MS
+
+    /* Check if the LinkStatus in the PHY is still high after 15 seconds of not
+     * receiving packets. */
+    #define ipconfigPHY_LS_HIGH_CHECK_TIME_MS    15000UL
 #endif
 
-#ifndef	ipconfigPHY_LS_LOW_CHECK_TIME_MS
-	/* Check if the LinkStatus in the PHY is still low every second. */
-	#define ipconfigPHY_LS_LOW_CHECK_TIME_MS	1000UL
+#ifndef ipconfigPHY_LS_LOW_CHECK_TIME_MS
+    /* Check if the LinkStatus in the PHY is still low every second. */
+    #define ipconfigPHY_LS_LOW_CHECK_TIME_MS    1000UL
 #endif
 
 /* As the following 3 macro's are OK in most situations, and so they're not
-included in 'FreeRTOSIPConfigDefaults.h'.
-Users can change their values in the project's 'FreeRTOSIPConfig.h'. */
+ * included in 'FreeRTOSIPConfigDefaults.h'.
+ * Users can change their values in the project's 'FreeRTOSIPConfig.h'. */
 #ifndef phyPHY_MAX_RESET_TIME_MS
-	#define phyPHY_MAX_RESET_TIME_MS			1000UL
+    #define phyPHY_MAX_RESET_TIME_MS    1000UL
 #endif
 
 #ifndef phyPHY_MAX_NEGOTIATE_TIME_MS
-	#define phyPHY_MAX_NEGOTIATE_TIME_MS		3000UL
+    #define phyPHY_MAX_NEGOTIATE_TIME_MS    3000UL
 #endif
 
 #ifndef phySHORT_DELAY_MS
-	#define phySHORT_DELAY_MS					50UL
+    #define phySHORT_DELAY_MS    50UL
 #endif
 
 /* Naming and numbering of basic PHY registers. */
-#define phyREG_00_BMCR				0x00U	/* Basic Mode Control Register. */
-#define phyREG_01_BMSR				0x01U	/* Basic Mode Status Register. */
-#define phyREG_02_PHYSID1			0x02U	/* PHYS ID 1 */
-#define phyREG_03_PHYSID2			0x03U	/* PHYS ID 2 */
-#define phyREG_04_ADVERTISE			0x04U	/* Advertisement control reg */
+#define phyREG_00_BMCR             0x00U    /* Basic Mode Control Register. */
+#define phyREG_01_BMSR             0x01U    /* Basic Mode Status Register. */
+#define phyREG_02_PHYSID1          0x02U    /* PHYS ID 1 */
+#define phyREG_03_PHYSID2          0x03U    /* PHYS ID 2 */
+#define phyREG_04_ADVERTISE        0x04U    /* Advertisement control reg */
 
 /* Naming and numbering of extended PHY registers. */
-#define PHYREG_10_PHYSTS			0x10U	/* 16 PHY status register Offset */
-#define	phyREG_19_PHYCR				0x19U	/* 25 RW PHY Control Register */
-#define	phyREG_1F_PHYSPCS			0x1FU	/* 31 RW PHY Special Control Status */
+#define PHYREG_10_PHYSTS           0x10U    /* 16 PHY status register Offset */
+#define phyREG_19_PHYCR            0x19U    /* 25 RW PHY Control Register */
+#define phyREG_1F_PHYSPCS          0x1FU    /* 31 RW PHY Special Control Status */
 
 /* Bit fields for 'phyREG_00_BMCR', the 'Basic Mode Control Register'. */
-#define phyBMCR_FULL_DUPLEX			0x0100U	/* Full duplex. */
-#define phyBMCR_AN_RESTART			0x0200U	/* Auto negotiation restart. */
-#define phyBMCR_ISOLATE				0x0400U /* 1 = Isolates 0 = Normal operation. */
-#define phyBMCR_AN_ENABLE			0x1000U	/* Enable auto negotiation. */
-#define phyBMCR_SPEED_100			0x2000U	/* Select 100Mbps. */
-#define phyBMCR_RESET				0x8000U	/* Reset the PHY. */
+#define phyBMCR_FULL_DUPLEX        0x0100U  /* Full duplex. */
+#define phyBMCR_AN_RESTART         0x0200U  /* Auto negotiation restart. */
+#define phyBMCR_ISOLATE            0x0400U  /* 1 = Isolates 0 = Normal operation. */
+#define phyBMCR_AN_ENABLE          0x1000U  /* Enable auto negotiation. */
+#define phyBMCR_SPEED_100          0x2000U  /* Select 100Mbps. */
+#define phyBMCR_RESET              0x8000U  /* Reset the PHY. */
 
 /* Bit fields for 'phyREG_19_PHYCR', the 'PHY Control Register'. */
-#define PHYCR_MDIX_EN				0x8000U	/* Enable Auto MDIX. */
-#define PHYCR_MDIX_FORCE			0x4000U	/* Force MDIX crossed. */
+#define PHYCR_MDIX_EN              0x8000U  /* Enable Auto MDIX. */
+#define PHYCR_MDIX_FORCE           0x4000U  /* Force MDIX crossed. */
 
-#define phyBMSR_AN_COMPLETE			0x0020U	/* Auto-Negotiation process completed */
+#define phyBMSR_AN_COMPLETE        0x0020U  /* Auto-Negotiation process completed */
 
-#define phyBMSR_LINK_STATUS			0x0004U
+#define phyBMSR_LINK_STATUS        0x0004U
 
-#define phyPHYSTS_LINK_STATUS		0x0001U	/* PHY Link mask */
-#define phyPHYSTS_SPEED_STATUS		0x0002U	/* PHY Speed mask */
-#define phyPHYSTS_DUPLEX_STATUS		0x0004U	/* PHY Duplex mask */
+#define phyPHYSTS_LINK_STATUS      0x0001U  /* PHY Link mask */
+#define phyPHYSTS_SPEED_STATUS     0x0002U  /* PHY Speed mask */
+#define phyPHYSTS_DUPLEX_STATUS    0x0004U  /* PHY Duplex mask */
 
 /* Bit fields for 'phyREG_1F_PHYSPCS
-	001 = 10BASE-T half-duplex
-	101 = 10BASE-T full-duplex
-	010 = 100BASE-TX half-duplex
-	110 = 100BASE-TX full-duplex
-*/
-#define phyPHYSPCS_SPEED_MASK		0x000CU
-#define phyPHYSPCS_SPEED_10			0x0004U
-#define phyPHYSPCS_FULL_DUPLEX		0x0010U
+ *  001 = 10BASE-T half-duplex
+ *  101 = 10BASE-T full-duplex
+ *  010 = 100BASE-TX half-duplex
+ *  110 = 100BASE-TX full-duplex
+ */
+#define phyPHYSPCS_SPEED_MASK      0x000CU
+#define phyPHYSPCS_SPEED_10        0x0004U
+#define phyPHYSPCS_FULL_DUPLEX     0x0010U
 
 /*
  * Description of all capabilities that can be advertised to
  * the peer (usually a switch or router).
  */
 
-#define phyADVERTISE_CSMA			0x0001U	/* Supports IEEE 802.3u: Fast Ethernet at 100 Mbit/s */
-#define phyADVERTISE_10HALF			0x0020U	/* Try for 10mbps half-duplex. */
-#define phyADVERTISE_10FULL			0x0040U	/* Try for 10mbps full-duplex. */
-#define phyADVERTISE_100HALF		0x0080U	/* Try for 100mbps half-duplex. */
-#define phyADVERTISE_100FULL		0x0100U	/* Try for 100mbps full-duplex. */
+#define phyADVERTISE_CSMA       0x0001U     /* Supports IEEE 802.3u: Fast Ethernet at 100 Mbit/s */
+#define phyADVERTISE_10HALF     0x0020U     /* Try for 10mbps half-duplex. */
+#define phyADVERTISE_10FULL     0x0040U     /* Try for 10mbps full-duplex. */
+#define phyADVERTISE_100HALF    0x0080U     /* Try for 100mbps half-duplex. */
+#define phyADVERTISE_100FULL    0x0100U     /* Try for 100mbps full-duplex. */
 
-#define phyADVERTISE_ALL			( phyADVERTISE_10HALF | phyADVERTISE_10FULL | \
-									  phyADVERTISE_100HALF | phyADVERTISE_100FULL | \
-									  phyADVERTISE_CSMA )
+#define phyADVERTISE_ALL                            \
+    ( phyADVERTISE_10HALF | phyADVERTISE_10FULL |   \
+      phyADVERTISE_100HALF | phyADVERTISE_100FULL | \
+      phyADVERTISE_CSMA )
 
 /* Send a reset command to a set of PHY-ports. */
-static uint32_t xPhyReset( EthernetPhy_t *pxPhyObject, uint32_t ulPhyMask );
+static uint32_t xPhyReset( EthernetPhy_t * pxPhyObject,
+                           uint32_t ulPhyMask );
 
 static BaseType_t xHas_1F_PHYSPCS( uint32_t ulPhyID )
 {
-BaseType_t xResult;
+    BaseType_t xResult;
 
-	switch( ulPhyID )
-	{
-		case PHY_ID_LAN8720:
-		case PHY_ID_LAN8742A:
-		case PHY_ID_KSZ8041:
+    switch( ulPhyID )
+    {
+        case PHY_ID_LAN8720:
+        case PHY_ID_LAN8742A:
+        case PHY_ID_KSZ8041:
 /*
-		case PHY_ID_KSZ8051: // same ID as 8041
-		case PHY_ID_KSZ8081: // same ID as 8041
-*/
-		case PHY_ID_KSZ8081MNXIA:
+ *      case PHY_ID_KSZ8051: // same ID as 8041
+ *      case PHY_ID_KSZ8081: // same ID as 8041
+ */
+        case PHY_ID_KSZ8081MNXIA:
 
-		case PHY_ID_KSZ8863:
-		default:
-			/* Most PHY's have a 1F_PHYSPCS */
-			xResult = pdTRUE;
-			break;
-		case PHY_ID_DP83848I:
-			xResult = pdFALSE;
-			break;
-	}
-	return xResult;
+        case PHY_ID_KSZ8863:
+        default:
+            /* Most PHY's have a 1F_PHYSPCS */
+            xResult = pdTRUE;
+            break;
+
+        case PHY_ID_DP83848I:
+            xResult = pdFALSE;
+            break;
+    }
+
+    return xResult;
 }
 /*-----------------------------------------------------------*/
 
 static BaseType_t xHas_19_PHYCR( uint32_t ulPhyID )
 {
-BaseType_t xResult;
+    BaseType_t xResult;
 
-	switch( ulPhyID )
-	{
-		case PHY_ID_LAN8742A:
-		case PHY_ID_DP83848I:
-			xResult = pdTRUE;
-			break;
-		default:
-			/* Most PHY's do not have a 19_PHYCR */
-			xResult = pdFALSE;
-			break;
-	}
-	return xResult;
+    switch( ulPhyID )
+    {
+        case PHY_ID_LAN8742A:
+        case PHY_ID_DP83848I:
+            xResult = pdTRUE;
+            break;
+
+        default:
+            /* Most PHY's do not have a 19_PHYCR */
+            xResult = pdFALSE;
+            break;
+    }
+
+    return xResult;
 }
 /*-----------------------------------------------------------*/
 
 /* Initialise the struct and assign a PHY-read and -write function. */
-void vPhyInitialise( EthernetPhy_t *pxPhyObject, xApplicationPhyReadHook_t fnPhyRead, xApplicationPhyWriteHook_t fnPhyWrite )
+void vPhyInitialise( EthernetPhy_t * pxPhyObject,
+                     xApplicationPhyReadHook_t fnPhyRead,
+                     xApplicationPhyWriteHook_t fnPhyWrite )
 {
-	memset( ( void * )pxPhyObject, 0, sizeof( *pxPhyObject ) );
+    memset( ( void * ) pxPhyObject, 0, sizeof( *pxPhyObject ) );
 
-	pxPhyObject->fnPhyRead = fnPhyRead;
-	pxPhyObject->fnPhyWrite = fnPhyWrite;
+    pxPhyObject->fnPhyRead = fnPhyRead;
+    pxPhyObject->fnPhyWrite = fnPhyWrite;
 }
 /*-----------------------------------------------------------*/
 
 /* Discover all PHY's connected by polling 32 indexes ( zero-based ) */
-BaseType_t xPhyDiscover( EthernetPhy_t *pxPhyObject )
+BaseType_t xPhyDiscover( EthernetPhy_t * pxPhyObject )
 {
-BaseType_t xPhyAddress;
+    BaseType_t xPhyAddress;
 
-	pxPhyObject->xPortCount = 0;
+    pxPhyObject->xPortCount = 0;
 
-	for( xPhyAddress = phyMIN_PHY_ADDRESS; xPhyAddress <= phyMAX_PHY_ADDRESS; xPhyAddress++ )
-	{
-	uint32_t ulLowerID;
+    for( xPhyAddress = phyMIN_PHY_ADDRESS; xPhyAddress <= phyMAX_PHY_ADDRESS; xPhyAddress++ )
+    {
+        uint32_t ulLowerID;
 
-		pxPhyObject->fnPhyRead( xPhyAddress, phyREG_03_PHYSID2, &ulLowerID );
-		/* A valid PHY id can not be all zeros or all ones. */
-		if( ( ulLowerID != ( uint16_t ) ~0U )  && ( ulLowerID != ( uint16_t ) 0U ) )
-		{
-		uint32_t ulUpperID;
-		uint32_t ulPhyID;
+        pxPhyObject->fnPhyRead( xPhyAddress, phyREG_03_PHYSID2, &ulLowerID );
 
-			pxPhyObject->fnPhyRead( xPhyAddress, phyREG_02_PHYSID1, &ulUpperID );
-			ulPhyID = ( ( ( uint32_t ) ulUpperID ) << 16 ) | ( ulLowerID & 0xFFF0 );
+        /* A valid PHY id can not be all zeros or all ones. */
+        if( ( ulLowerID != ( uint16_t ) ~0U ) && ( ulLowerID != ( uint16_t ) 0U ) )
+        {
+            uint32_t ulUpperID;
+            uint32_t ulPhyID;
 
-			pxPhyObject->ucPhyIndexes[ pxPhyObject->xPortCount ] = xPhyAddress;
-			pxPhyObject->ulPhyIDs[ pxPhyObject->xPortCount ] = ulPhyID;
+            pxPhyObject->fnPhyRead( xPhyAddress, phyREG_02_PHYSID1, &ulUpperID );
+            ulPhyID = ( ( ( uint32_t ) ulUpperID ) << 16 ) | ( ulLowerID & 0xFFF0 );
 
-			pxPhyObject->xPortCount++;
+            pxPhyObject->ucPhyIndexes[ pxPhyObject->xPortCount ] = xPhyAddress;
+            pxPhyObject->ulPhyIDs[ pxPhyObject->xPortCount ] = ulPhyID;
 
-			/* See if there is more storage space. */
-			if( pxPhyObject->xPortCount == ipconfigPHY_MAX_PORTS )
-			{
-				break;
-			}
-		}
-	}
-	if( pxPhyObject->xPortCount > 0 )
-	{
-		FreeRTOS_printf( ( "PHY ID %lX\n", pxPhyObject->ulPhyIDs[ 0 ] ) );
-	}
+            pxPhyObject->xPortCount++;
 
-	return pxPhyObject->xPortCount;
+            /* See if there is more storage space. */
+            if( pxPhyObject->xPortCount == ipconfigPHY_MAX_PORTS )
+            {
+                break;
+            }
+        }
+    }
+
+    if( pxPhyObject->xPortCount > 0 )
+    {
+        FreeRTOS_printf( ( "PHY ID %lX\n", pxPhyObject->ulPhyIDs[ 0 ] ) );
+    }
+
+    return pxPhyObject->xPortCount;
 }
 /*-----------------------------------------------------------*/
 
 /* Send a reset command to a set of PHY-ports. */
-static uint32_t xPhyReset( EthernetPhy_t *pxPhyObject, uint32_t ulPhyMask )
+static uint32_t xPhyReset( EthernetPhy_t * pxPhyObject,
+                           uint32_t ulPhyMask )
 {
-uint32_t ulDoneMask, ulConfig;
-TickType_t xRemainingTime;
-TimeOut_t xTimer;
-BaseType_t xPhyIndex;
+    uint32_t ulDoneMask, ulConfig;
+    TickType_t xRemainingTime;
+    TimeOut_t xTimer;
+    BaseType_t xPhyIndex;
 
-	/* A bit-mask of PHY ports that are ready. */
-	ulDoneMask = 0UL;
+    /* A bit-mask of PHY ports that are ready. */
+    ulDoneMask = 0UL;
 
-	/* Set the RESET bits high. */
-	for( xPhyIndex = 0; xPhyIndex < pxPhyObject->xPortCount; xPhyIndex++ )
-	{
-	BaseType_t xPhyAddress = pxPhyObject->ucPhyIndexes[ xPhyIndex ];
+    /* Set the RESET bits high. */
+    for( xPhyIndex = 0; xPhyIndex < pxPhyObject->xPortCount; xPhyIndex++ )
+    {
+        BaseType_t xPhyAddress = pxPhyObject->ucPhyIndexes[ xPhyIndex ];
 
-		/* Read Control register. */
-		pxPhyObject->fnPhyRead( xPhyAddress, phyREG_00_BMCR, &ulConfig );
-		pxPhyObject->fnPhyWrite( xPhyAddress, phyREG_00_BMCR, ulConfig | phyBMCR_RESET );
-	}
+        /* Read Control register. */
+        pxPhyObject->fnPhyRead( xPhyAddress, phyREG_00_BMCR, &ulConfig );
+        pxPhyObject->fnPhyWrite( xPhyAddress, phyREG_00_BMCR, ulConfig | phyBMCR_RESET );
+    }
 
-	xRemainingTime = ( TickType_t ) pdMS_TO_TICKS( phyPHY_MAX_RESET_TIME_MS );
-	vTaskSetTimeOutState( &xTimer );
+    xRemainingTime = ( TickType_t ) pdMS_TO_TICKS( phyPHY_MAX_RESET_TIME_MS );
+    vTaskSetTimeOutState( &xTimer );
 
-	/* The reset should last less than a second. */
-	for( ;; )
-	{
-		for( xPhyIndex = 0; xPhyIndex < pxPhyObject->xPortCount; xPhyIndex++ )
-		{
-		BaseType_t xPhyAddress = pxPhyObject->ucPhyIndexes[ xPhyIndex ];
+    /* The reset should last less than a second. */
+    for( ; ; )
+    {
+        for( xPhyIndex = 0; xPhyIndex < pxPhyObject->xPortCount; xPhyIndex++ )
+        {
+            BaseType_t xPhyAddress = pxPhyObject->ucPhyIndexes[ xPhyIndex ];
 
-			pxPhyObject->fnPhyRead( xPhyAddress, phyREG_00_BMCR, &ulConfig );
-			if( ( ulConfig & phyBMCR_RESET ) == 0 )
-			{
-				FreeRTOS_printf( ( "xPhyReset: phyBMCR_RESET %d ready\n", (int)xPhyIndex ) );
-				ulDoneMask |= ( 1UL << xPhyIndex );
-			}
-		}
-		if( ulDoneMask == ulPhyMask )
-		{
-			break;
-		}
-		if( xTaskCheckForTimeOut( &xTimer, &xRemainingTime ) != pdFALSE )
-		{
-			FreeRTOS_printf( ( "xPhyReset: phyBMCR_RESET timed out ( done 0x%02lX )\n", ulDoneMask ) );
-			break;
-		}
-		/* Block for a while */
-		vTaskDelay( pdMS_TO_TICKS( phySHORT_DELAY_MS ) );
-	}
+            pxPhyObject->fnPhyRead( xPhyAddress, phyREG_00_BMCR, &ulConfig );
 
-	/* Clear the reset bits. */
-	for( xPhyIndex = 0; xPhyIndex < pxPhyObject->xPortCount; xPhyIndex++ )
-	{
-		if( ( ulDoneMask & ( 1UL << xPhyIndex ) ) == 0UL )
-		{
-		BaseType_t xPhyAddress = pxPhyObject->ucPhyIndexes[ xPhyIndex ];
+            if( ( ulConfig & phyBMCR_RESET ) == 0 )
+            {
+                FreeRTOS_printf( ( "xPhyReset: phyBMCR_RESET %d ready\n", ( int ) xPhyIndex ) );
+                ulDoneMask |= ( 1UL << xPhyIndex );
+            }
+        }
 
-			/* The reset operation timed out, clear the bit manually. */
-			pxPhyObject->fnPhyRead( xPhyAddress, phyREG_00_BMCR, &ulConfig );
-			pxPhyObject->fnPhyWrite( xPhyAddress, phyREG_00_BMCR, ulConfig & ~phyBMCR_RESET );
-		}
-	}
+        if( ulDoneMask == ulPhyMask )
+        {
+            break;
+        }
 
-	vTaskDelay( pdMS_TO_TICKS( phySHORT_DELAY_MS ) );
+        if( xTaskCheckForTimeOut( &xTimer, &xRemainingTime ) != pdFALSE )
+        {
+            FreeRTOS_printf( ( "xPhyReset: phyBMCR_RESET timed out ( done 0x%02lX )\n", ulDoneMask ) );
+            break;
+        }
 
-	return ulDoneMask;
+        /* Block for a while */
+        vTaskDelay( pdMS_TO_TICKS( phySHORT_DELAY_MS ) );
+    }
+
+    /* Clear the reset bits. */
+    for( xPhyIndex = 0; xPhyIndex < pxPhyObject->xPortCount; xPhyIndex++ )
+    {
+        if( ( ulDoneMask & ( 1UL << xPhyIndex ) ) == 0UL )
+        {
+            BaseType_t xPhyAddress = pxPhyObject->ucPhyIndexes[ xPhyIndex ];
+
+            /* The reset operation timed out, clear the bit manually. */
+            pxPhyObject->fnPhyRead( xPhyAddress, phyREG_00_BMCR, &ulConfig );
+            pxPhyObject->fnPhyWrite( xPhyAddress, phyREG_00_BMCR, ulConfig & ~phyBMCR_RESET );
+        }
+    }
+
+    vTaskDelay( pdMS_TO_TICKS( phySHORT_DELAY_MS ) );
+
+    return ulDoneMask;
 }
 /*-----------------------------------------------------------*/
 
-BaseType_t xPhyConfigure( EthernetPhy_t *pxPhyObject, const PhyProperties_t *pxPhyProperties )
+BaseType_t xPhyConfigure( EthernetPhy_t * pxPhyObject,
+                          const PhyProperties_t * pxPhyProperties )
 {
-uint32_t ulConfig, ulAdvertise;
-BaseType_t xPhyIndex;
+    uint32_t ulConfig, ulAdvertise;
+    BaseType_t xPhyIndex;
 
-	if( pxPhyObject->xPortCount < 1 )
-	{
-		FreeRTOS_printf( ( "xPhyConfigure: No PHY's detected.\n" ) );
-		return -1;
-	}
+    if( pxPhyObject->xPortCount < 1 )
+    {
+        FreeRTOS_printf( ( "xPhyConfigure: No PHY's detected.\n" ) );
+        return -1;
+    }
 
-	/* The expected ID for the 'LAN8742A'  is 0x0007c130. */
-	/* The expected ID for the 'LAN8720'   is 0x0007c0f0. */
-	/* The expected ID for the 'DP83848I'  is 0x20005C90. */
+    /* The expected ID for the 'LAN8742A'  is 0x0007c130. */
+    /* The expected ID for the 'LAN8720'   is 0x0007c0f0. */
+    /* The expected ID for the 'DP83848I'  is 0x20005C90. */
 
     /* Set advertise register. */
-	if( ( pxPhyProperties->ucSpeed == ( uint8_t )PHY_SPEED_AUTO ) && ( pxPhyProperties->ucDuplex == ( uint8_t )PHY_DUPLEX_AUTO ) )
-	{
-		ulAdvertise = phyADVERTISE_ALL;
-		/* Reset auto-negotiation capability. */
-	}
-	else
-	{
-		/* Always select protocol 802.3u. */
-		ulAdvertise = phyADVERTISE_CSMA;
+    if( ( pxPhyProperties->ucSpeed == ( uint8_t ) PHY_SPEED_AUTO ) && ( pxPhyProperties->ucDuplex == ( uint8_t ) PHY_DUPLEX_AUTO ) )
+    {
+        ulAdvertise = phyADVERTISE_ALL;
+        /* Reset auto-negotiation capability. */
+    }
+    else
+    {
+        /* Always select protocol 802.3u. */
+        ulAdvertise = phyADVERTISE_CSMA;
 
-		if( pxPhyProperties->ucSpeed == ( uint8_t )PHY_SPEED_AUTO )
-		{
-			if( pxPhyProperties->ucDuplex == ( uint8_t )PHY_DUPLEX_FULL )
-			{
-				ulAdvertise |= phyADVERTISE_10FULL | phyADVERTISE_100FULL;
-			}
-			else
-			{
-				ulAdvertise |= phyADVERTISE_10HALF | phyADVERTISE_100HALF;
-			}
-		}
-		else if( pxPhyProperties->ucDuplex == ( uint8_t )PHY_DUPLEX_AUTO )
-		{
-			if( pxPhyProperties->ucSpeed == ( uint8_t )PHY_SPEED_10 )
-			{
-				ulAdvertise |= phyADVERTISE_10FULL | phyADVERTISE_10HALF;
-			}
-			else
-			{
-				ulAdvertise |= phyADVERTISE_100FULL | phyADVERTISE_100HALF;
-			}
-		}
-		else if( pxPhyProperties->ucSpeed == ( uint8_t )PHY_SPEED_100 )
-		{
-			if( pxPhyProperties->ucDuplex == ( uint8_t )PHY_DUPLEX_FULL )
-			{
-				ulAdvertise |= phyADVERTISE_100FULL;
-			}
-			else
-			{
-				ulAdvertise |= phyADVERTISE_100HALF;
-			}
-		}
-		else
-		{
-			if( pxPhyProperties->ucDuplex == ( uint8_t )PHY_DUPLEX_FULL )
-			{
-				ulAdvertise |= phyADVERTISE_10FULL;
-			}
-			else
-			{
-				ulAdvertise |= phyADVERTISE_10HALF;
-			}
-		}
-	}
+        if( pxPhyProperties->ucSpeed == ( uint8_t ) PHY_SPEED_AUTO )
+        {
+            if( pxPhyProperties->ucDuplex == ( uint8_t ) PHY_DUPLEX_FULL )
+            {
+                ulAdvertise |= phyADVERTISE_10FULL | phyADVERTISE_100FULL;
+            }
+            else
+            {
+                ulAdvertise |= phyADVERTISE_10HALF | phyADVERTISE_100HALF;
+            }
+        }
+        else if( pxPhyProperties->ucDuplex == ( uint8_t ) PHY_DUPLEX_AUTO )
+        {
+            if( pxPhyProperties->ucSpeed == ( uint8_t ) PHY_SPEED_10 )
+            {
+                ulAdvertise |= phyADVERTISE_10FULL | phyADVERTISE_10HALF;
+            }
+            else
+            {
+                ulAdvertise |= phyADVERTISE_100FULL | phyADVERTISE_100HALF;
+            }
+        }
+        else if( pxPhyProperties->ucSpeed == ( uint8_t ) PHY_SPEED_100 )
+        {
+            if( pxPhyProperties->ucDuplex == ( uint8_t ) PHY_DUPLEX_FULL )
+            {
+                ulAdvertise |= phyADVERTISE_100FULL;
+            }
+            else
+            {
+                ulAdvertise |= phyADVERTISE_100HALF;
+            }
+        }
+        else
+        {
+            if( pxPhyProperties->ucDuplex == ( uint8_t ) PHY_DUPLEX_FULL )
+            {
+                ulAdvertise |= phyADVERTISE_10FULL;
+            }
+            else
+            {
+                ulAdvertise |= phyADVERTISE_10HALF;
+            }
+        }
+    }
 
-	/* Send a reset command to a set of PHY-ports. */
-	xPhyReset( pxPhyObject, xPhyGetMask( pxPhyObject ) );
+    /* Send a reset command to a set of PHY-ports. */
+    xPhyReset( pxPhyObject, xPhyGetMask( pxPhyObject ) );
 
-	for( xPhyIndex = 0; xPhyIndex < pxPhyObject->xPortCount; xPhyIndex++ )
-	{
-	BaseType_t xPhyAddress = pxPhyObject->ucPhyIndexes[ xPhyIndex ];
-	uint32_t ulPhyID = pxPhyObject->ulPhyIDs[ xPhyIndex ];
+    for( xPhyIndex = 0; xPhyIndex < pxPhyObject->xPortCount; xPhyIndex++ )
+    {
+        BaseType_t xPhyAddress = pxPhyObject->ucPhyIndexes[ xPhyIndex ];
+        uint32_t ulPhyID = pxPhyObject->ulPhyIDs[ xPhyIndex ];
 
-		/* Write advertise register. */
-		pxPhyObject->fnPhyWrite( xPhyAddress, phyREG_04_ADVERTISE, ulAdvertise );
+        /* Write advertise register. */
+        pxPhyObject->fnPhyWrite( xPhyAddress, phyREG_04_ADVERTISE, ulAdvertise );
 
-		/*
-				AN_EN        AN1         AN0       Forced Mode
-				  0           0           0        10BASE-T, Half-Duplex
-				  0           0           1        10BASE-T, Full-Duplex
-				  0           1           0        100BASE-TX, Half-Duplex
-				  0           1           1        100BASE-TX, Full-Duplex
-				AN_EN        AN1         AN0       Advertised Mode
-				  1           0           0        10BASE-T, Half/Full-Duplex
-				  1           0           1        100BASE-TX, Half/Full-Duplex
-				  1           1           0        10BASE-T Half-Duplex
-												   100BASE-TX, Half-Duplex
-				  1           1           1        10BASE-T, Half/Full-Duplex
-												   100BASE-TX, Half/Full-Duplex
-		*/
+        /*
+         *      AN_EN        AN1         AN0       Forced Mode
+         *        0           0           0        10BASE-T, Half-Duplex
+         *        0           0           1        10BASE-T, Full-Duplex
+         *        0           1           0        100BASE-TX, Half-Duplex
+         *        0           1           1        100BASE-TX, Full-Duplex
+         *      AN_EN        AN1         AN0       Advertised Mode
+         *        1           0           0        10BASE-T, Half/Full-Duplex
+         *        1           0           1        100BASE-TX, Half/Full-Duplex
+         *        1           1           0        10BASE-T Half-Duplex
+         *                                         100BASE-TX, Half-Duplex
+         *        1           1           1        10BASE-T, Half/Full-Duplex
+         *                                         100BASE-TX, Half/Full-Duplex
+         */
 
-		/* Read Control register. */
-		pxPhyObject->fnPhyRead( xPhyAddress, phyREG_00_BMCR, &ulConfig );
+        /* Read Control register. */
+        pxPhyObject->fnPhyRead( xPhyAddress, phyREG_00_BMCR, &ulConfig );
 
-		ulConfig &= ~( phyBMCR_SPEED_100 | phyBMCR_FULL_DUPLEX );
+        ulConfig &= ~( phyBMCR_SPEED_100 | phyBMCR_FULL_DUPLEX );
 
-		ulConfig |= phyBMCR_AN_ENABLE;
+        ulConfig |= phyBMCR_AN_ENABLE;
 
-		if( ( pxPhyProperties->ucSpeed == ( uint8_t )PHY_SPEED_100 ) || ( pxPhyProperties->ucSpeed == ( uint8_t )PHY_SPEED_AUTO ) )
-		{
-			ulConfig |= phyBMCR_SPEED_100;
-		}
-		else if( pxPhyProperties->ucSpeed == ( uint8_t )PHY_SPEED_10 )
-		{
-			ulConfig &= ~phyBMCR_SPEED_100;
-		}
+        if( ( pxPhyProperties->ucSpeed == ( uint8_t ) PHY_SPEED_100 ) || ( pxPhyProperties->ucSpeed == ( uint8_t ) PHY_SPEED_AUTO ) )
+        {
+            ulConfig |= phyBMCR_SPEED_100;
+        }
+        else if( pxPhyProperties->ucSpeed == ( uint8_t ) PHY_SPEED_10 )
+        {
+            ulConfig &= ~phyBMCR_SPEED_100;
+        }
 
-		if( ( pxPhyProperties->ucDuplex == ( uint8_t )PHY_DUPLEX_FULL ) || ( pxPhyProperties->ucDuplex == ( uint8_t )PHY_DUPLEX_AUTO ) )
-		{
-			ulConfig |= phyBMCR_FULL_DUPLEX;
-		}
-		else if( pxPhyProperties->ucDuplex == ( uint8_t )PHY_DUPLEX_HALF )
-		{
-			ulConfig &= ~phyBMCR_FULL_DUPLEX;
-		}
+        if( ( pxPhyProperties->ucDuplex == ( uint8_t ) PHY_DUPLEX_FULL ) || ( pxPhyProperties->ucDuplex == ( uint8_t ) PHY_DUPLEX_AUTO ) )
+        {
+            ulConfig |= phyBMCR_FULL_DUPLEX;
+        }
+        else if( pxPhyProperties->ucDuplex == ( uint8_t ) PHY_DUPLEX_HALF )
+        {
+            ulConfig &= ~phyBMCR_FULL_DUPLEX;
+        }
 
-		if( xHas_19_PHYCR( ulPhyID ) )
-		{
-		uint32_t ulPhyControl;
-			/* Read PHY Control register. */
-			pxPhyObject->fnPhyRead( xPhyAddress, phyREG_19_PHYCR, &ulPhyControl );
+        if( xHas_19_PHYCR( ulPhyID ) )
+        {
+            uint32_t ulPhyControl;
+            /* Read PHY Control register. */
+            pxPhyObject->fnPhyRead( xPhyAddress, phyREG_19_PHYCR, &ulPhyControl );
 
-			/* Clear bits which might get set: */
-			ulPhyControl &= ~( PHYCR_MDIX_EN|PHYCR_MDIX_FORCE );
+            /* Clear bits which might get set: */
+            ulPhyControl &= ~( PHYCR_MDIX_EN | PHYCR_MDIX_FORCE );
 
-			if( pxPhyProperties->ucMDI_X == PHY_MDIX_AUTO )
-			{
-				ulPhyControl |= PHYCR_MDIX_EN;
-			}
-			else if( pxPhyProperties->ucMDI_X == PHY_MDIX_CROSSED )
-			{
-				/* Force direct link = Use crossed RJ45 cable. */
-				ulPhyControl &= ~PHYCR_MDIX_FORCE;
-			}
-			else
-			{
-				/* Force crossed link = Use direct RJ45 cable. */
-				ulPhyControl |= PHYCR_MDIX_FORCE;
-			}
-			/* update PHY Control Register. */
-			pxPhyObject->fnPhyWrite( xPhyAddress, phyREG_19_PHYCR, ulPhyControl );
-		}
+            if( pxPhyProperties->ucMDI_X == PHY_MDIX_AUTO )
+            {
+                ulPhyControl |= PHYCR_MDIX_EN;
+            }
+            else if( pxPhyProperties->ucMDI_X == PHY_MDIX_CROSSED )
+            {
+                /* Force direct link = Use crossed RJ45 cable. */
+                ulPhyControl &= ~PHYCR_MDIX_FORCE;
+            }
+            else
+            {
+                /* Force crossed link = Use direct RJ45 cable. */
+                ulPhyControl |= PHYCR_MDIX_FORCE;
+            }
 
-		FreeRTOS_printf( ( "+TCP: advertise: %04lX config %04lX\n", ulAdvertise, ulConfig ) );
-	}
+            /* update PHY Control Register. */
+            pxPhyObject->fnPhyWrite( xPhyAddress, phyREG_19_PHYCR, ulPhyControl );
+        }
 
-	/* Keep these values for later use. */
-	pxPhyObject->ulBCRValue = ulConfig & ~phyBMCR_ISOLATE;
-	pxPhyObject->ulACRValue = ulAdvertise;
+        FreeRTOS_printf( ( "+TCP: advertise: %04lX config %04lX\n", ulAdvertise, ulConfig ) );
+    }
 
-	return 0;
+    /* Keep these values for later use. */
+    pxPhyObject->ulBCRValue = ulConfig & ~phyBMCR_ISOLATE;
+    pxPhyObject->ulACRValue = ulAdvertise;
+
+    return 0;
 }
 /*-----------------------------------------------------------*/
 
 /* xPhyFixedValue(): this function is called in case auto-negotiation is disabled.
-The caller has set the values in 'xPhyPreferences' (ucDuplex and ucSpeed).
-The PHY register phyREG_00_BMCR will be set for every connected PHY that matches
-with ulPhyMask. */
-BaseType_t xPhyFixedValue( EthernetPhy_t *pxPhyObject, uint32_t ulPhyMask )
+ * The caller has set the values in 'xPhyPreferences' (ucDuplex and ucSpeed).
+ * The PHY register phyREG_00_BMCR will be set for every connected PHY that matches
+ * with ulPhyMask. */
+BaseType_t xPhyFixedValue( EthernetPhy_t * pxPhyObject,
+                           uint32_t ulPhyMask )
 {
-BaseType_t xPhyIndex;
-uint32_t ulValue, ulBitMask = ( uint32_t )1U;
+    BaseType_t xPhyIndex;
+    uint32_t ulValue, ulBitMask = ( uint32_t ) 1U;
 
-	ulValue = ( uint32_t ) 0U;
+    ulValue = ( uint32_t ) 0U;
 
-	if( pxPhyObject->xPhyPreferences.ucDuplex == PHY_DUPLEX_FULL )
-	{
-		ulValue |= phyBMCR_FULL_DUPLEX;
-	}
-	if( pxPhyObject->xPhyPreferences.ucSpeed == PHY_SPEED_100 )
-	{
-		ulValue |= phyBMCR_SPEED_100;
-	}
+    if( pxPhyObject->xPhyPreferences.ucDuplex == PHY_DUPLEX_FULL )
+    {
+        ulValue |= phyBMCR_FULL_DUPLEX;
+    }
 
-	for( xPhyIndex = 0; xPhyIndex < pxPhyObject->xPortCount; xPhyIndex++, ulBitMask <<= 1 )
-	{
-		if( ( ulPhyMask & ulBitMask ) != 0lu )
-		{
-		BaseType_t xPhyAddress = pxPhyObject->ucPhyIndexes[ xPhyIndex ];
+    if( pxPhyObject->xPhyPreferences.ucSpeed == PHY_SPEED_100 )
+    {
+        ulValue |= phyBMCR_SPEED_100;
+    }
 
-			/* Enable Auto-Negotiation. */
-			pxPhyObject->fnPhyWrite( xPhyAddress, phyREG_00_BMCR, ulValue );
-		}
-	}
-	return 0;
+    for( xPhyIndex = 0; xPhyIndex < pxPhyObject->xPortCount; xPhyIndex++, ulBitMask <<= 1 )
+    {
+        if( ( ulPhyMask & ulBitMask ) != 0lu )
+        {
+            BaseType_t xPhyAddress = pxPhyObject->ucPhyIndexes[ xPhyIndex ];
+
+            /* Enable Auto-Negotiation. */
+            pxPhyObject->fnPhyWrite( xPhyAddress, phyREG_00_BMCR, ulValue );
+        }
+    }
+
+    return 0;
 }
 /*-----------------------------------------------------------*/
 
 /* xPhyStartAutoNegotiation() is the alternative xPhyFixedValue():
-It sets the BMCR_AN_RESTART bit and waits for the auto-negotiation completion
-( phyBMSR_AN_COMPLETE ). */
-BaseType_t xPhyStartAutoNegotiation( EthernetPhy_t *pxPhyObject, uint32_t ulPhyMask )
+ * It sets the BMCR_AN_RESTART bit and waits for the auto-negotiation completion
+ * ( phyBMSR_AN_COMPLETE ). */
+BaseType_t xPhyStartAutoNegotiation( EthernetPhy_t * pxPhyObject,
+                                     uint32_t ulPhyMask )
 {
-uint32_t xPhyIndex, ulDoneMask, ulBitMask;
-uint32_t ulPHYLinkStatus, ulRegValue;
-TickType_t xRemainingTime;
-TimeOut_t xTimer;
+    uint32_t xPhyIndex, ulDoneMask, ulBitMask;
+    uint32_t ulPHYLinkStatus, ulRegValue;
+    TickType_t xRemainingTime;
+    TimeOut_t xTimer;
 
-	if( ulPhyMask == ( uint32_t ) 0U )
-	{
-		return 0;
-	}
-	for( xPhyIndex = 0; xPhyIndex < ( uint32_t ) pxPhyObject->xPortCount; xPhyIndex++ )
-	{
-		if( ( ulPhyMask & ( 1lu << xPhyIndex ) ) != 0lu )
-		{
-		BaseType_t xPhyAddress = pxPhyObject->ucPhyIndexes[ xPhyIndex ];
+    if( ulPhyMask == ( uint32_t ) 0U )
+    {
+        return 0;
+    }
 
-			/* Enable Auto-Negotiation. */
-			pxPhyObject->fnPhyWrite( xPhyAddress, phyREG_04_ADVERTISE, pxPhyObject->ulACRValue);
-			pxPhyObject->fnPhyWrite( xPhyAddress, phyREG_00_BMCR, pxPhyObject->ulBCRValue | phyBMCR_AN_RESTART );
-		}
-	}
-	xRemainingTime = ( TickType_t ) pdMS_TO_TICKS( phyPHY_MAX_NEGOTIATE_TIME_MS );
-	vTaskSetTimeOutState( &xTimer );
-	ulDoneMask = 0;
-	/* Wait until the auto-negotiation will be completed */
-	for( ;; )
-	{
-		ulBitMask = ( uint32_t ) 1U;
-		for( xPhyIndex = 0; xPhyIndex < ( uint32_t ) pxPhyObject->xPortCount; xPhyIndex++, ulBitMask <<= 1 )
-		{
-			if( ( ulPhyMask & ulBitMask ) != 0lu )
-			{
-				if( ( ulDoneMask & ulBitMask ) == 0lu )
-				{
-				BaseType_t xPhyAddress = pxPhyObject->ucPhyIndexes[ xPhyIndex ];
+    for( xPhyIndex = 0; xPhyIndex < ( uint32_t ) pxPhyObject->xPortCount; xPhyIndex++ )
+    {
+        if( ( ulPhyMask & ( 1lu << xPhyIndex ) ) != 0lu )
+        {
+            BaseType_t xPhyAddress = pxPhyObject->ucPhyIndexes[ xPhyIndex ];
 
-					pxPhyObject->fnPhyRead( xPhyAddress, phyREG_01_BMSR, &ulRegValue );
-					if( ( ulRegValue & phyBMSR_AN_COMPLETE ) != 0 )
-					{
-						ulDoneMask |= ulBitMask;
-					}
-				}
-			}
-		}
-		if( ulPhyMask == ulDoneMask )
-		{
-			break;
-		}
-		if( xTaskCheckForTimeOut( &xTimer, &xRemainingTime ) != pdFALSE )
-		{
-			FreeRTOS_printf( ( "xPhyStartAutoNegotiation: phyBMCR_RESET timed out ( done 0x%02lX )\n", ulDoneMask ) );
-			break;
-		}
-		vTaskDelay( pdMS_TO_TICKS( phySHORT_DELAY_MS ) );
-	}
+            /* Enable Auto-Negotiation. */
+            pxPhyObject->fnPhyWrite( xPhyAddress, phyREG_04_ADVERTISE, pxPhyObject->ulACRValue );
+            pxPhyObject->fnPhyWrite( xPhyAddress, phyREG_00_BMCR, pxPhyObject->ulBCRValue | phyBMCR_AN_RESTART );
+        }
+    }
 
-	if( ulDoneMask != ( uint32_t) 0U )
-	{
-		ulBitMask = ( uint32_t ) 1U;
-		pxPhyObject->ulLinkStatusMask &= ~( ulDoneMask );
-		for( xPhyIndex = 0; xPhyIndex < ( uint32_t ) pxPhyObject->xPortCount; xPhyIndex++, ulBitMask <<= 1 )
-		{
-		BaseType_t xPhyAddress = pxPhyObject->ucPhyIndexes[ xPhyIndex ];
-		uint32_t ulPhyID = pxPhyObject->ulPhyIDs[ xPhyIndex ];
+    xRemainingTime = ( TickType_t ) pdMS_TO_TICKS( phyPHY_MAX_NEGOTIATE_TIME_MS );
+    vTaskSetTimeOutState( &xTimer );
+    ulDoneMask = 0;
 
-			if( ( ulDoneMask & ulBitMask ) == ( uint32_t ) 0U )
-			{
-				continue;
-			}
+    /* Wait until the auto-negotiation will be completed */
+    for( ; ; )
+    {
+        ulBitMask = ( uint32_t ) 1U;
 
-			/* Clear the 'phyBMCR_AN_RESTART'  bit. */
-			pxPhyObject->fnPhyWrite( xPhyAddress, phyREG_00_BMCR, pxPhyObject->ulBCRValue );
+        for( xPhyIndex = 0; xPhyIndex < ( uint32_t ) pxPhyObject->xPortCount; xPhyIndex++, ulBitMask <<= 1 )
+        {
+            if( ( ulPhyMask & ulBitMask ) != 0lu )
+            {
+                if( ( ulDoneMask & ulBitMask ) == 0lu )
+                {
+                    BaseType_t xPhyAddress = pxPhyObject->ucPhyIndexes[ xPhyIndex ];
 
-			pxPhyObject->fnPhyRead( xPhyAddress, phyREG_01_BMSR, &ulRegValue);
-			if( ( ulRegValue & phyBMSR_LINK_STATUS ) != 0 )
-			{
-				ulPHYLinkStatus |= phyBMSR_LINK_STATUS;
-				pxPhyObject->ulLinkStatusMask |= ulBitMask;
-			}
-			else
-			{
-				ulPHYLinkStatus &= ~( phyBMSR_LINK_STATUS );
-			}
+                    pxPhyObject->fnPhyRead( xPhyAddress, phyREG_01_BMSR, &ulRegValue );
 
-			if( ulPhyID == PHY_ID_KSZ8081MNXIA )
-			{
-			uint32_t ulControlStatus;
+                    if( ( ulRegValue & phyBMSR_AN_COMPLETE ) != 0 )
+                    {
+                        ulDoneMask |= ulBitMask;
+                    }
+                }
+            }
+        }
 
-				pxPhyObject->fnPhyRead( xPhyAddress, 0x1E, &ulControlStatus);
-				switch( ulControlStatus & 0x07 )
-				{
-				case 0x01:
-				case 0x05:
-//	[001] = 10BASE-T half-duplex
-//	[101] = 10BASE-T full-duplex
-					/* 10 Mbps. */
-					ulRegValue |= phyPHYSTS_SPEED_STATUS;
-					break;
-				case 0x02:
-				case 0x06:
-//	[010] = 100BASE-TX half-duplex
-//	[110] = 100BASE-TX full-duplex
-					break;
-				}
-				switch( ulControlStatus & 0x07 )
-				{
-				case 0x05:
-				case 0x06:
-//	[101] = 10BASE-T full-duplex
-//	[110] = 100BASE-TX full-duplex
-					/* Full duplex. */
-					ulRegValue |= phyPHYSTS_DUPLEX_STATUS;
-					break;
-				case 0x01:
-				case 0x02:
-//	[001] = 10BASE-T half-duplex
-//	[010] = 100BASE-TX half-duplex
-					break;
-				}
-			}
-			else if( xHas_1F_PHYSPCS( ulPhyID ) )
-			{
-			/* 31 RW PHY Special Control Status */
-			uint32_t ulControlStatus;
+        if( ulPhyMask == ulDoneMask )
+        {
+            break;
+        }
 
-				pxPhyObject->fnPhyRead( xPhyAddress, phyREG_1F_PHYSPCS, &ulControlStatus);
-				ulRegValue = 0;
-				if( ( ulControlStatus & phyPHYSPCS_FULL_DUPLEX ) != 0 )
-				{
-					ulRegValue |= phyPHYSTS_DUPLEX_STATUS;
-				}
-				if( ( ulControlStatus & phyPHYSPCS_SPEED_MASK ) == phyPHYSPCS_SPEED_10 )
-				{
-					ulRegValue |= phyPHYSTS_SPEED_STATUS;
-				}
-			}
-			else
-			{
-				/* Read the result of the auto-negotiation. */
-				pxPhyObject->fnPhyRead( xPhyAddress, PHYREG_10_PHYSTS, &ulRegValue);
-			}
+        if( xTaskCheckForTimeOut( &xTimer, &xRemainingTime ) != pdFALSE )
+        {
+            FreeRTOS_printf( ( "xPhyStartAutoNegotiation: phyBMCR_RESET timed out ( done 0x%02lX )\n", ulDoneMask ) );
+            break;
+        }
 
-			FreeRTOS_printf( ( "Autonego ready: %08lx: %s duplex %u mbit %s status\n",
-				ulRegValue,
-				( ulRegValue & phyPHYSTS_DUPLEX_STATUS ) ? "full" : "half",
-				( ulRegValue & phyPHYSTS_SPEED_STATUS ) ? 10 : 100,
-				( ( ulPHYLinkStatus |= phyBMSR_LINK_STATUS ) != 0) ? "high" : "low" ) );
-			if( ( ulRegValue & phyPHYSTS_DUPLEX_STATUS ) != ( uint32_t ) 0U )
-			{
-				pxPhyObject->xPhyProperties.ucDuplex = PHY_DUPLEX_FULL;
-			}
-			else
-			{
-				pxPhyObject->xPhyProperties.ucDuplex = PHY_DUPLEX_HALF;
-			}
+        vTaskDelay( pdMS_TO_TICKS( phySHORT_DELAY_MS ) );
+    }
 
-			if( ( ulRegValue & phyPHYSTS_SPEED_STATUS ) != 0 )
-			{
-				pxPhyObject->xPhyProperties.ucSpeed = PHY_SPEED_10;
-			}
-			else
-			{
-				pxPhyObject->xPhyProperties.ucSpeed = PHY_SPEED_100;
-			}
-		}
-	}	/* if( ulDoneMask != ( uint32_t) 0U ) */
+    if( ulDoneMask != ( uint32_t ) 0U )
+    {
+        ulBitMask = ( uint32_t ) 1U;
+        pxPhyObject->ulLinkStatusMask &= ~( ulDoneMask );
 
-	return 0;
+        for( xPhyIndex = 0; xPhyIndex < ( uint32_t ) pxPhyObject->xPortCount; xPhyIndex++, ulBitMask <<= 1 )
+        {
+            BaseType_t xPhyAddress = pxPhyObject->ucPhyIndexes[ xPhyIndex ];
+            uint32_t ulPhyID = pxPhyObject->ulPhyIDs[ xPhyIndex ];
+
+            if( ( ulDoneMask & ulBitMask ) == ( uint32_t ) 0U )
+            {
+                continue;
+            }
+
+            /* Clear the 'phyBMCR_AN_RESTART'  bit. */
+            pxPhyObject->fnPhyWrite( xPhyAddress, phyREG_00_BMCR, pxPhyObject->ulBCRValue );
+
+            pxPhyObject->fnPhyRead( xPhyAddress, phyREG_01_BMSR, &ulRegValue );
+
+            if( ( ulRegValue & phyBMSR_LINK_STATUS ) != 0 )
+            {
+                ulPHYLinkStatus |= phyBMSR_LINK_STATUS;
+                pxPhyObject->ulLinkStatusMask |= ulBitMask;
+            }
+            else
+            {
+                ulPHYLinkStatus &= ~( phyBMSR_LINK_STATUS );
+            }
+
+            if( ulPhyID == PHY_ID_KSZ8081MNXIA )
+            {
+                uint32_t ulControlStatus;
+
+                pxPhyObject->fnPhyRead( xPhyAddress, 0x1E, &ulControlStatus );
+
+                switch( ulControlStatus & 0x07 )
+                {
+                    case 0x01:
+                    case 0x05:
+/*	[001] = 10BASE-T half-duplex */
+/*	[101] = 10BASE-T full-duplex */
+                        /* 10 Mbps. */
+                        ulRegValue |= phyPHYSTS_SPEED_STATUS;
+                        break;
+
+                    case 0x02:
+                    case 0x06:
+/*	[010] = 100BASE-TX half-duplex */
+/*	[110] = 100BASE-TX full-duplex */
+                        break;
+                }
+
+                switch( ulControlStatus & 0x07 )
+                {
+                    case 0x05:
+                    case 0x06:
+/*	[101] = 10BASE-T full-duplex */
+/*	[110] = 100BASE-TX full-duplex */
+                        /* Full duplex. */
+                        ulRegValue |= phyPHYSTS_DUPLEX_STATUS;
+                        break;
+
+                    case 0x01:
+                    case 0x02:
+/*	[001] = 10BASE-T half-duplex */
+/*	[010] = 100BASE-TX half-duplex */
+                        break;
+                }
+            }
+            else if( xHas_1F_PHYSPCS( ulPhyID ) )
+            {
+                /* 31 RW PHY Special Control Status */
+                uint32_t ulControlStatus;
+
+                pxPhyObject->fnPhyRead( xPhyAddress, phyREG_1F_PHYSPCS, &ulControlStatus );
+                ulRegValue = 0;
+
+                if( ( ulControlStatus & phyPHYSPCS_FULL_DUPLEX ) != 0 )
+                {
+                    ulRegValue |= phyPHYSTS_DUPLEX_STATUS;
+                }
+
+                if( ( ulControlStatus & phyPHYSPCS_SPEED_MASK ) == phyPHYSPCS_SPEED_10 )
+                {
+                    ulRegValue |= phyPHYSTS_SPEED_STATUS;
+                }
+            }
+            else
+            {
+                /* Read the result of the auto-negotiation. */
+                pxPhyObject->fnPhyRead( xPhyAddress, PHYREG_10_PHYSTS, &ulRegValue );
+            }
+
+            FreeRTOS_printf( ( "Autonego ready: %08lx: %s duplex %u mbit %s status\n",
+                               ulRegValue,
+                               ( ulRegValue & phyPHYSTS_DUPLEX_STATUS ) ? "full" : "half",
+                               ( ulRegValue & phyPHYSTS_SPEED_STATUS ) ? 10 : 100,
+                               ( ( ulPHYLinkStatus |= phyBMSR_LINK_STATUS ) != 0 ) ? "high" : "low" ) );
+
+            if( ( ulRegValue & phyPHYSTS_DUPLEX_STATUS ) != ( uint32_t ) 0U )
+            {
+                pxPhyObject->xPhyProperties.ucDuplex = PHY_DUPLEX_FULL;
+            }
+            else
+            {
+                pxPhyObject->xPhyProperties.ucDuplex = PHY_DUPLEX_HALF;
+            }
+
+            if( ( ulRegValue & phyPHYSTS_SPEED_STATUS ) != 0 )
+            {
+                pxPhyObject->xPhyProperties.ucSpeed = PHY_SPEED_10;
+            }
+            else
+            {
+                pxPhyObject->xPhyProperties.ucSpeed = PHY_SPEED_100;
+            }
+        }
+    } /* if( ulDoneMask != ( uint32_t) 0U ) */
+
+    return 0;
 }
 /*-----------------------------------------------------------*/
 
-BaseType_t xPhyCheckLinkStatus( EthernetPhy_t *pxPhyObject, BaseType_t xHadReception )
+BaseType_t xPhyCheckLinkStatus( EthernetPhy_t * pxPhyObject,
+                                BaseType_t xHadReception )
 {
-uint32_t ulStatus, ulBitMask = 1U;
-BaseType_t xPhyIndex;
-BaseType_t xNeedCheck = pdFALSE;
+    uint32_t ulStatus, ulBitMask = 1U;
+    BaseType_t xPhyIndex;
+    BaseType_t xNeedCheck = pdFALSE;
 
-	if( xHadReception > 0 )
-	{
-		/* A packet was received. No need to check for the PHY status now,
-		but set a timer to check it later on. */
-		vTaskSetTimeOutState( &( pxPhyObject->xLinkStatusTimer ) );
-		pxPhyObject->xLinkStatusRemaining = pdMS_TO_TICKS( ipconfigPHY_LS_HIGH_CHECK_TIME_MS );
-		for( xPhyIndex = 0; xPhyIndex < pxPhyObject->xPortCount; xPhyIndex++, ulBitMask <<= 1 )
-		{
-			if( ( pxPhyObject->ulLinkStatusMask & ulBitMask ) == 0UL )
-			{
-				pxPhyObject->ulLinkStatusMask |= ulBitMask;
-				FreeRTOS_printf( ( "xPhyCheckLinkStatus: PHY LS now %02lX\n", pxPhyObject->ulLinkStatusMask ) );
-				xNeedCheck = pdTRUE;
-			}
-		}
-	}
-	else if( xTaskCheckForTimeOut( &( pxPhyObject->xLinkStatusTimer ), &( pxPhyObject->xLinkStatusRemaining ) ) != pdFALSE )
-	{
-		/* Frequent checking the PHY Link Status can affect for the performance of Ethernet controller.
-		As long as packets are received, no polling is needed.
-		Otherwise, polling will be done when the 'xLinkStatusTimer' expires. */
-		for( xPhyIndex = 0; xPhyIndex < pxPhyObject->xPortCount; xPhyIndex++, ulBitMask <<= 1 )
-		{
-		BaseType_t xPhyAddress = pxPhyObject->ucPhyIndexes[ xPhyIndex ];
+    if( xHadReception > 0 )
+    {
+        /* A packet was received. No need to check for the PHY status now,
+         * but set a timer to check it later on. */
+        vTaskSetTimeOutState( &( pxPhyObject->xLinkStatusTimer ) );
+        pxPhyObject->xLinkStatusRemaining = pdMS_TO_TICKS( ipconfigPHY_LS_HIGH_CHECK_TIME_MS );
 
-			if( pxPhyObject->fnPhyRead( xPhyAddress, phyREG_01_BMSR, &ulStatus ) == 0 )
-			{
-				if( !!( pxPhyObject->ulLinkStatusMask & ulBitMask ) != !!( ulStatus & phyBMSR_LINK_STATUS ) )
-				{
-					if( ( ulStatus & phyBMSR_LINK_STATUS ) != 0 )
-					{
-						pxPhyObject->ulLinkStatusMask |= ulBitMask;
-					}
-					else
-					{
-						pxPhyObject->ulLinkStatusMask &= ~( ulBitMask );
-					}
-					FreeRTOS_printf( ( "xPhyCheckLinkStatus: PHY LS now %02lX\n", pxPhyObject->ulLinkStatusMask ) );
-					xNeedCheck = pdTRUE;
-				}
-			}
-		}
-		vTaskSetTimeOutState( &( pxPhyObject->xLinkStatusTimer ) );
-		if( ( pxPhyObject->ulLinkStatusMask & ( ulBitMask >> 1 ) ) != 0 )
-		{
-			/* The link status is high, so don't poll the PHY too often. */
-			pxPhyObject->xLinkStatusRemaining = pdMS_TO_TICKS( ipconfigPHY_LS_HIGH_CHECK_TIME_MS );
-		}
-		else
-		{
-			/* The link status is low, polling may be done more frequently. */
-			pxPhyObject->xLinkStatusRemaining = pdMS_TO_TICKS( ipconfigPHY_LS_LOW_CHECK_TIME_MS );
-		}
-	}
-	return xNeedCheck;
+        for( xPhyIndex = 0; xPhyIndex < pxPhyObject->xPortCount; xPhyIndex++, ulBitMask <<= 1 )
+        {
+            if( ( pxPhyObject->ulLinkStatusMask & ulBitMask ) == 0UL )
+            {
+                pxPhyObject->ulLinkStatusMask |= ulBitMask;
+                FreeRTOS_printf( ( "xPhyCheckLinkStatus: PHY LS now %02lX\n", pxPhyObject->ulLinkStatusMask ) );
+                xNeedCheck = pdTRUE;
+            }
+        }
+    }
+    else if( xTaskCheckForTimeOut( &( pxPhyObject->xLinkStatusTimer ), &( pxPhyObject->xLinkStatusRemaining ) ) != pdFALSE )
+    {
+        /* Frequent checking the PHY Link Status can affect for the performance of Ethernet controller.
+         * As long as packets are received, no polling is needed.
+         * Otherwise, polling will be done when the 'xLinkStatusTimer' expires. */
+        for( xPhyIndex = 0; xPhyIndex < pxPhyObject->xPortCount; xPhyIndex++, ulBitMask <<= 1 )
+        {
+            BaseType_t xPhyAddress = pxPhyObject->ucPhyIndexes[ xPhyIndex ];
+
+            if( pxPhyObject->fnPhyRead( xPhyAddress, phyREG_01_BMSR, &ulStatus ) == 0 )
+            {
+                if( !!( pxPhyObject->ulLinkStatusMask & ulBitMask ) != !!( ulStatus & phyBMSR_LINK_STATUS ) )
+                {
+                    if( ( ulStatus & phyBMSR_LINK_STATUS ) != 0 )
+                    {
+                        pxPhyObject->ulLinkStatusMask |= ulBitMask;
+                    }
+                    else
+                    {
+                        pxPhyObject->ulLinkStatusMask &= ~( ulBitMask );
+                    }
+
+                    FreeRTOS_printf( ( "xPhyCheckLinkStatus: PHY LS now %02lX\n", pxPhyObject->ulLinkStatusMask ) );
+                    xNeedCheck = pdTRUE;
+                }
+            }
+        }
+
+        vTaskSetTimeOutState( &( pxPhyObject->xLinkStatusTimer ) );
+
+        if( ( pxPhyObject->ulLinkStatusMask & ( ulBitMask >> 1 ) ) != 0 )
+        {
+            /* The link status is high, so don't poll the PHY too often. */
+            pxPhyObject->xLinkStatusRemaining = pdMS_TO_TICKS( ipconfigPHY_LS_HIGH_CHECK_TIME_MS );
+        }
+        else
+        {
+            /* The link status is low, polling may be done more frequently. */
+            pxPhyObject->xLinkStatusRemaining = pdMS_TO_TICKS( ipconfigPHY_LS_LOW_CHECK_TIME_MS );
+        }
+    }
+
+    return xNeedCheck;
 }
 /*-----------------------------------------------------------*/

--- a/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/portable/NetworkInterface/LPC17xx/NetworkInterface.c
+++ b/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/portable/NetworkInterface/LPC17xx/NetworkInterface.c
@@ -1,27 +1,27 @@
 /*
-FreeRTOS+TCP V2.2.1
-Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of
-this software and associated documentation files (the "Software"), to deal in
-the Software without restriction, including without limitation the rights to
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
-the Software, and to permit persons to whom the Software is furnished to do so,
-subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
-COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
-IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
- http://aws.amazon.com/freertos
- http://www.FreeRTOS.org
-*/
+ * FreeRTOS+TCP V2.2.1
+ * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
 
 /* Standard includes. */
 #include <stdint.h>
@@ -48,28 +48,28 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "NetworkInterface.h"
 
 #if ipconfigETHERNET_DRIVER_FILTERS_FRAME_TYPES != 1
-	#define ipCONSIDER_FRAME_FOR_PROCESSING( pucEthernetBuffer ) eProcessBuffer
+    #define ipCONSIDER_FRAME_FOR_PROCESSING( pucEthernetBuffer )    eProcessBuffer
 #else
-	#define ipCONSIDER_FRAME_FOR_PROCESSING( pucEthernetBuffer ) eConsiderFrameForProcessing( ( pucEthernetBuffer ) )
+    #define ipCONSIDER_FRAME_FOR_PROCESSING( pucEthernetBuffer )    eConsiderFrameForProcessing( ( pucEthernetBuffer ) )
 #endif
 
 /* When a packet is ready to be sent, if it cannot be sent immediately then the
-task performing the transmit will block for niTX_BUFFER_FREE_WAIT
-milliseconds.  It will do this a maximum of niMAX_TX_ATTEMPTS before giving
-up. */
-#define niTX_BUFFER_FREE_WAIT	( pdMS_TO_TICKS( 2UL ) )
-#define niMAX_TX_ATTEMPTS		( 5 )
+ * task performing the transmit will block for niTX_BUFFER_FREE_WAIT
+ * milliseconds.  It will do this a maximum of niMAX_TX_ATTEMPTS before giving
+ * up. */
+#define niTX_BUFFER_FREE_WAIT       ( pdMS_TO_TICKS( 2UL ) )
+#define niMAX_TX_ATTEMPTS           ( 5 )
 
 /* The length of the queue used to send interrupt status words from the
-interrupt handler to the deferred handler task. */
-#define niINTERRUPT_QUEUE_LENGTH	( 10 )
+ * interrupt handler to the deferred handler task. */
+#define niINTERRUPT_QUEUE_LENGTH    ( 10 )
 
 /*-----------------------------------------------------------*/
 
 /*
  * A deferred interrupt handler task that processes
  */
-static void prvEMACHandlerTask( void *pvParameters );
+static void prvEMACHandlerTask( void * pvParameters );
 
 /*-----------------------------------------------------------*/
 
@@ -77,191 +77,193 @@ static void prvEMACHandlerTask( void *pvParameters );
 extern QueueHandle_t xNetworkEventQueue;
 
 /* The semaphore used to wake the deferred interrupt handler task when an Rx
-interrupt is received. */
+ * interrupt is received. */
 static SemaphoreHandle_t xEMACRxEventSemaphore = NULL;
 /*-----------------------------------------------------------*/
 
 BaseType_t xNetworkInterfaceInitialise( void )
 {
-EMAC_CFG_Type Emac_Config;
-PINSEL_CFG_Type xPinConfig;
-BaseType_t xStatus, xReturn;
-extern uint8_t ucMACAddress[ 6 ];
+    EMAC_CFG_Type Emac_Config;
+    PINSEL_CFG_Type xPinConfig;
+    BaseType_t xStatus, xReturn;
+    extern uint8_t ucMACAddress[ 6 ];
 
-	/* Enable Ethernet Pins */
-	boardCONFIGURE_ENET_PINS( xPinConfig );
+    /* Enable Ethernet Pins */
+    boardCONFIGURE_ENET_PINS( xPinConfig );
 
-	Emac_Config.Mode = EMAC_MODE_AUTO;
-	Emac_Config.pbEMAC_Addr = ucMACAddress;
-	xStatus = EMAC_Init( &Emac_Config );
+    Emac_Config.Mode = EMAC_MODE_AUTO;
+    Emac_Config.pbEMAC_Addr = ucMACAddress;
+    xStatus = EMAC_Init( &Emac_Config );
 
-	LPC_EMAC->IntEnable &= ~( EMAC_INT_TX_DONE );
+    LPC_EMAC->IntEnable &= ~( EMAC_INT_TX_DONE );
 
-	if( xStatus != ERROR )
-	{
-		vSemaphoreCreateBinary( xEMACRxEventSemaphore );
-		configASSERT( xEMACRxEventSemaphore != NULL );
+    if( xStatus != ERROR )
+    {
+        vSemaphoreCreateBinary( xEMACRxEventSemaphore );
+        configASSERT( xEMACRxEventSemaphore != NULL );
 
-		/* The handler task is created at the highest possible priority to
-		ensure the interrupt handler can return directly to it. */
-		xTaskCreate( prvEMACHandlerTask, "EMAC", configMINIMAL_STACK_SIZE, NULL, configMAX_PRIORITIES - 1, NULL );
+        /* The handler task is created at the highest possible priority to
+         * ensure the interrupt handler can return directly to it. */
+        xTaskCreate( prvEMACHandlerTask, "EMAC", configMINIMAL_STACK_SIZE, NULL, configMAX_PRIORITIES - 1, NULL );
 
-		/* Enable the interrupt and set its priority to the minimum
-		interrupt priority.  */
-		NVIC_SetPriority( ENET_IRQn, configMAC_INTERRUPT_PRIORITY );
-		NVIC_EnableIRQ( ENET_IRQn );
+        /* Enable the interrupt and set its priority to the minimum
+         * interrupt priority.  */
+        NVIC_SetPriority( ENET_IRQn, configMAC_INTERRUPT_PRIORITY );
+        NVIC_EnableIRQ( ENET_IRQn );
 
-		xReturn = pdPASS;
-	}
-	else
-	{
-		xReturn = pdFAIL;
-	}
+        xReturn = pdPASS;
+    }
+    else
+    {
+        xReturn = pdFAIL;
+    }
 
-	configASSERT( xStatus != ERROR );
+    configASSERT( xStatus != ERROR );
 
-	return xReturn;
+    return xReturn;
 }
 /*-----------------------------------------------------------*/
 
 BaseType_t xNetworkInterfaceOutput( NetworkBufferDescriptor_t * const pxNetworkBuffer )
 {
-BaseType_t xReturn = pdFAIL;
-int32_t x;
-extern void EMAC_StartTransmitNextBuffer( uint32_t ulLength );
-extern void EMAC_SetNextPacketToSend( uint8_t * pucBuffer );
+    BaseType_t xReturn = pdFAIL;
+    int32_t x;
+    extern void EMAC_StartTransmitNextBuffer( uint32_t ulLength );
+    extern void EMAC_SetNextPacketToSend( uint8_t * pucBuffer );
 
 
-	/* Attempt to obtain access to a Tx buffer. */
-	for( x = 0; x < niMAX_TX_ATTEMPTS; x++ )
-	{
-		if( EMAC_CheckTransmitIndex() == TRUE )
-		{
-			/* Will the data fit in the Tx buffer? */
-			if( pxNetworkBuffer->xDataLength < EMAC_ETH_MAX_FLEN ) /*_RB_ The size needs to come from FreeRTOSIPConfig.h. */
-			{
-				/* Assign the buffer to the Tx descriptor that is now known to
-				be free. */
-				EMAC_SetNextPacketToSend( pxNetworkBuffer->pucBuffer );
+    /* Attempt to obtain access to a Tx buffer. */
+    for( x = 0; x < niMAX_TX_ATTEMPTS; x++ )
+    {
+        if( EMAC_CheckTransmitIndex() == TRUE )
+        {
+            /* Will the data fit in the Tx buffer? */
+            if( pxNetworkBuffer->xDataLength < EMAC_ETH_MAX_FLEN ) /*_RB_ The size needs to come from FreeRTOSIPConfig.h. */
+            {
+                /* Assign the buffer to the Tx descriptor that is now known to
+                 * be free. */
+                EMAC_SetNextPacketToSend( pxNetworkBuffer->pucBuffer );
 
-				/* The EMAC now owns the buffer. */
-				pxNetworkBuffer->pucBuffer = NULL;
+                /* The EMAC now owns the buffer. */
+                pxNetworkBuffer->pucBuffer = NULL;
 
-				/* Initiate the Tx. */
-				EMAC_StartTransmitNextBuffer( pxNetworkBuffer->xDataLength );
-				iptraceNETWORK_INTERFACE_TRANSMIT();
+                /* Initiate the Tx. */
+                EMAC_StartTransmitNextBuffer( pxNetworkBuffer->xDataLength );
+                iptraceNETWORK_INTERFACE_TRANSMIT();
 
-				/* The Tx has been initiated. */
-				xReturn = pdPASS;
-			}
-			break;
-		}
-		else
-		{
-			vTaskDelay( niTX_BUFFER_FREE_WAIT );
-		}
-	}
+                /* The Tx has been initiated. */
+                xReturn = pdPASS;
+            }
 
-	/* Finished with the network buffer. */
-	vReleaseNetworkBufferAndDescriptor( pxNetworkBuffer );
+            break;
+        }
+        else
+        {
+            vTaskDelay( niTX_BUFFER_FREE_WAIT );
+        }
+    }
 
-	return xReturn;
+    /* Finished with the network buffer. */
+    vReleaseNetworkBufferAndDescriptor( pxNetworkBuffer );
+
+    return xReturn;
 }
 /*-----------------------------------------------------------*/
 
 void ENET_IRQHandler( void )
 {
-uint32_t ulInterruptCause;
+    uint32_t ulInterruptCause;
 
-	while( ( ulInterruptCause = LPC_EMAC->IntStatus ) != 0 )
-	{
-		/* Clear the interrupt. */
-		LPC_EMAC->IntClear = ulInterruptCause;
+    while( ( ulInterruptCause = LPC_EMAC->IntStatus ) != 0 )
+    {
+        /* Clear the interrupt. */
+        LPC_EMAC->IntClear = ulInterruptCause;
 
-		/* Clear fatal error conditions.  NOTE:  The driver does not clear all
-		errors, only those actually experienced.  For future reference, range
-		errors are not actually errors so can be ignored. */
-		if( ( ulInterruptCause & EMAC_INT_TX_UNDERRUN ) != 0U )
-		{
-			LPC_EMAC->Command |= EMAC_CR_TX_RES;
-		}
+        /* Clear fatal error conditions.  NOTE:  The driver does not clear all
+         * errors, only those actually experienced.  For future reference, range
+         * errors are not actually errors so can be ignored. */
+        if( ( ulInterruptCause & EMAC_INT_TX_UNDERRUN ) != 0U )
+        {
+            LPC_EMAC->Command |= EMAC_CR_TX_RES;
+        }
 
-		/* Unblock the deferred interrupt handler task if the event was an
-		Rx. */
-		if( ( ulInterruptCause & EMAC_INT_RX_DONE ) != 0UL )
-		{
-			xSemaphoreGiveFromISR( xEMACRxEventSemaphore, NULL );
-		}
-	}
+        /* Unblock the deferred interrupt handler task if the event was an
+         * Rx. */
+        if( ( ulInterruptCause & EMAC_INT_RX_DONE ) != 0UL )
+        {
+            xSemaphoreGiveFromISR( xEMACRxEventSemaphore, NULL );
+        }
+    }
 
-	/* ulInterruptCause is used for convenience here.  A context switch is
-	wanted, but coding portEND_SWITCHING_ISR( 1 ) would likely result in a
-	compiler warning. */
-	portEND_SWITCHING_ISR( ulInterruptCause );
+    /* ulInterruptCause is used for convenience here.  A context switch is
+     * wanted, but coding portEND_SWITCHING_ISR( 1 ) would likely result in a
+     * compiler warning. */
+    portEND_SWITCHING_ISR( ulInterruptCause );
 }
 /*-----------------------------------------------------------*/
 
-static void prvEMACHandlerTask( void *pvParameters )
+static void prvEMACHandlerTask( void * pvParameters )
 {
-size_t xDataLength;
-const uint16_t usCRCLength = 4;
-NetworkBufferDescriptor_t *pxNetworkBuffer;
-IPStackEvent_t xRxEvent = { eNetworkRxEvent, NULL };
+    size_t xDataLength;
+    const uint16_t usCRCLength = 4;
+    NetworkBufferDescriptor_t * pxNetworkBuffer;
+    IPStackEvent_t xRxEvent = { eNetworkRxEvent, NULL };
 
 /* This is not included in the header file for some reason. */
-extern uint8_t *EMAC_NextPacketToRead( void );
+    extern uint8_t * EMAC_NextPacketToRead( void );
 
-	( void ) pvParameters;
-	configASSERT( xEMACRxEventSemaphore != NULL );
+    ( void ) pvParameters;
+    configASSERT( xEMACRxEventSemaphore != NULL );
 
-	for( ;; )
-	{
-		/* Wait for the EMAC interrupt to indicate that another packet has been
-		received.  The while() loop is only needed if INCLUDE_vTaskSuspend is
-		set to 0 in FreeRTOSConfig.h. */
-		while( xSemaphoreTake( xEMACRxEventSemaphore, portMAX_DELAY ) == pdFALSE );
+    for( ; ; )
+    {
+        /* Wait for the EMAC interrupt to indicate that another packet has been
+         * received.  The while() loop is only needed if INCLUDE_vTaskSuspend is
+         * set to 0 in FreeRTOSConfig.h. */
+        while( xSemaphoreTake( xEMACRxEventSemaphore, portMAX_DELAY ) == pdFALSE )
+        {
+        }
 
-		/* At least one packet has been received. */
-		while( EMAC_CheckReceiveIndex() != FALSE )
-		{
-			/* Obtain the length, minus the CRC.  The CRC is four bytes
-			but the length is already minus 1. */
-			xDataLength = ( size_t ) EMAC_GetReceiveDataSize() - ( usCRCLength - 1U );
+        /* At least one packet has been received. */
+        while( EMAC_CheckReceiveIndex() != FALSE )
+        {
+            /* Obtain the length, minus the CRC.  The CRC is four bytes
+             * but the length is already minus 1. */
+            xDataLength = ( size_t ) EMAC_GetReceiveDataSize() - ( usCRCLength - 1U );
 
-			if( xDataLength > 0U )
-			{
-				/* Obtain a network buffer to pass this data into the
-				stack.  No storage is required as the network buffer
-				will point directly to the buffer that already holds
-				the	received data. */
-				pxNetworkBuffer = pxGetNetworkBufferWithDescriptor( 0, ( TickType_t ) 0 );
+            if( xDataLength > 0U )
+            {
+                /* Obtain a network buffer to pass this data into the
+                 * stack.  No storage is required as the network buffer
+                 * will point directly to the buffer that already holds
+                 * the	received data. */
+                pxNetworkBuffer = pxGetNetworkBufferWithDescriptor( 0, ( TickType_t ) 0 );
 
-				if( pxNetworkBuffer != NULL )
-				{
-					pxNetworkBuffer->pucBuffer = EMAC_NextPacketToRead();
-					pxNetworkBuffer->xDataLength = xDataLength;
-					xRxEvent.pvData = ( void * ) pxNetworkBuffer;
+                if( pxNetworkBuffer != NULL )
+                {
+                    pxNetworkBuffer->pucBuffer = EMAC_NextPacketToRead();
+                    pxNetworkBuffer->xDataLength = xDataLength;
+                    xRxEvent.pvData = ( void * ) pxNetworkBuffer;
 
-					/* Data was received and stored.  Send a message to the IP
-					task to let it know. */
-					if( xSendEventStructToIPTask( &xRxEvent, ( TickType_t ) 0 ) == pdFAIL )
-					{
-						vReleaseNetworkBufferAndDescriptor( pxNetworkBuffer );
-						iptraceETHERNET_RX_EVENT_LOST();
-					}
-				}
-				else
-				{
-					iptraceETHERNET_RX_EVENT_LOST();
-				}
+                    /* Data was received and stored.  Send a message to the IP
+                     * task to let it know. */
+                    if( xSendEventStructToIPTask( &xRxEvent, ( TickType_t ) 0 ) == pdFAIL )
+                    {
+                        vReleaseNetworkBufferAndDescriptor( pxNetworkBuffer );
+                        iptraceETHERNET_RX_EVENT_LOST();
+                    }
+                }
+                else
+                {
+                    iptraceETHERNET_RX_EVENT_LOST();
+                }
 
-				iptraceNETWORK_INTERFACE_RECEIVE();
-			}
+                iptraceNETWORK_INTERFACE_RECEIVE();
+            }
 
-			/* Release the frame. */
-			EMAC_UpdateRxConsumeIndex();
-		}
-	}
+            /* Release the frame. */
+            EMAC_UpdateRxConsumeIndex();
+        }
+    }
 }
 /*-----------------------------------------------------------*/
-

--- a/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/portable/NetworkInterface/LPC18xx/NetworkInterface.c
+++ b/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/portable/NetworkInterface/LPC18xx/NetworkInterface.c
@@ -1,27 +1,27 @@
 /*
-FreeRTOS+TCP V2.2.1
-Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of
-this software and associated documentation files (the "Software"), to deal in
-the Software without restriction, including without limitation the rights to
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
-the Software, and to permit persons to whom the Software is furnished to do so,
-subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
-COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
-IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
- http://aws.amazon.com/freertos
- http://www.FreeRTOS.org
-*/
+ * FreeRTOS+TCP V2.2.1
+ * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
 
 /* Standard includes. */
 #include <stdint.h>
@@ -46,97 +46,99 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "lpc_phy.h"
 
 /* The size of the stack allocated to the task that handles Rx packets. */
-#define nwRX_TASK_STACK_SIZE	140
+#define nwRX_TASK_STACK_SIZE    140
 
-#ifndef	PHY_LS_HIGH_CHECK_TIME_MS
-	/* Check if the LinkSStatus in the PHY is still high after 15 seconds of not
-	receiving packets. */
-	#define PHY_LS_HIGH_CHECK_TIME_MS	15000
+#ifndef PHY_LS_HIGH_CHECK_TIME_MS
+
+    /* Check if the LinkSStatus in the PHY is still high after 15 seconds of not
+     * receiving packets. */
+    #define PHY_LS_HIGH_CHECK_TIME_MS    15000
 #endif
 
-#ifndef	PHY_LS_LOW_CHECK_TIME_MS
-	/* Check if the LinkSStatus in the PHY is still low every second. */
-	#define PHY_LS_LOW_CHECK_TIME_MS	1000
+#ifndef PHY_LS_LOW_CHECK_TIME_MS
+    /* Check if the LinkSStatus in the PHY is still low every second. */
+    #define PHY_LS_LOW_CHECK_TIME_MS    1000
 #endif
 
 #ifndef configUSE_RMII
-	#define configUSE_RMII 1
+    #define configUSE_RMII    1
 #endif
 
 #ifndef configNUM_RX_DESCRIPTORS
-	#error please define configNUM_RX_DESCRIPTORS in your FreeRTOSIPConfig.h
+    #error please define configNUM_RX_DESCRIPTORS in your FreeRTOSIPConfig.h
 #endif
 
 #ifndef configNUM_TX_DESCRIPTORS
-	#error please define configNUM_TX_DESCRIPTORS in your FreeRTOSIPConfig.h
+    #error please define configNUM_TX_DESCRIPTORS in your FreeRTOSIPConfig.h
 #endif
 
 #ifndef NETWORK_IRQHandler
-	#error NETWORK_IRQHandler must be defined to the name of the function that is installed in the interrupt vector table to handle Ethernet interrupts.
+    #error NETWORK_IRQHandler must be defined to the name of the function that is installed in the interrupt vector table to handle Ethernet interrupts.
 #endif
 
 #if !defined( MAC_FF_HMC )
-	/* Hash for multicast. */
-	#define MAC_FF_HMC     ( 1UL << 2UL )
+    /* Hash for multicast. */
+    #define MAC_FF_HMC    ( 1UL << 2UL )
 #endif
 
 #ifndef iptraceEMAC_TASK_STARTING
-	#define iptraceEMAC_TASK_STARTING()	do { } while( ipFALSE_BOOL )
+    #define iptraceEMAC_TASK_STARTING()    do {} while( ipFALSE_BOOL )
 #endif
 
 /* Define the bits of .STATUS that indicate a reception error. */
-#define nwRX_STATUS_ERROR_BITS \
-	( RDES_CE  /* CRC Error */                        | \
-	  RDES_RE  /* Receive Error */                    | \
-	  RDES_DE  /* Descriptor Error */                 | \
-	  RDES_RWT /* Receive Watchdog Timeout */         | \
-	  RDES_LC  /* Late Collision */                   | \
-	  RDES_OE  /* Overflow Error */                   | \
-	  RDES_SAF /* Source Address Filter Fail */       | \
-	  RDES_AFM /* Destination Address Filter Fail */  | \
-	  RDES_LE  /* Length Error */                     )
+#define nwRX_STATUS_ERROR_BITS                         \
+    ( RDES_CE /* CRC Error */ |                        \
+      RDES_RE /* Receive Error */ |                    \
+      RDES_DE /* Descriptor Error */ |                 \
+      RDES_RWT /* Receive Watchdog Timeout */ |        \
+      RDES_LC /* Late Collision */ |                   \
+      RDES_OE /* Overflow Error */ |                   \
+      RDES_SAF /* Source Address Filter Fail */ |      \
+      RDES_AFM /* Destination Address Filter Fail */ | \
+      RDES_LE /* Length Error */ )
 
 /* Define the EMAC status bits that should trigger an interrupt. */
-#define nwDMA_INTERRUPT_MASK \
-	( DMA_IE_TIE  /* Transmit interrupt enable */         | \
-	  DMA_IE_TSE  /* Transmit stopped enable */           | \
-	  DMA_IE_OVE  /* Overflow interrupt enable */         | \
-	  DMA_IE_RIE  /* Receive interrupt enable */          | \
-	  DMA_IE_NIE  /* Normal interrupt summary enable */   | \
-	  DMA_IE_AIE  /* Abnormal interrupt summary enable */ | \
-	  DMA_IE_RUE  /* Receive buffer unavailable enable */ | \
-	  DMA_IE_UNE  /* Underflow interrupt enable. */       | \
-	  DMA_IE_TJE  /* Transmit jabber timeout enable */    | \
-	  DMA_IE_RSE  /* Received stopped enable */           | \
-	  DMA_IE_RWE  /* Receive watchdog timeout enable */   | \
-	  DMA_IE_FBE )/* Fatal bus error enable */
+#define nwDMA_INTERRUPT_MASK                               \
+    ( DMA_IE_TIE /* Transmit interrupt enable */ |         \
+      DMA_IE_TSE /* Transmit stopped enable */ |           \
+      DMA_IE_OVE /* Overflow interrupt enable */ |         \
+      DMA_IE_RIE /* Receive interrupt enable */ |          \
+      DMA_IE_NIE /* Normal interrupt summary enable */ |   \
+      DMA_IE_AIE /* Abnormal interrupt summary enable */ | \
+      DMA_IE_RUE /* Receive buffer unavailable enable */ | \
+      DMA_IE_UNE /* Underflow interrupt enable. */ |       \
+      DMA_IE_TJE /* Transmit jabber timeout enable */ |    \
+      DMA_IE_RSE /* Received stopped enable */ |           \
+      DMA_IE_RWE /* Receive watchdog timeout enable */ |   \
+      DMA_IE_FBE ) /* Fatal bus error enable */
 
 /* Interrupt events to process.  Currently only the RX/TX events are processed
-although code for other events is included to allow for possible future
-expansion. */
-#define EMAC_IF_RX_EVENT        1UL
-#define EMAC_IF_TX_EVENT        2UL
-#define EMAC_IF_ERR_EVENT       4UL
-#define EMAC_IF_ALL_EVENT       ( EMAC_IF_RX_EVENT | EMAC_IF_TX_EVENT | EMAC_IF_ERR_EVENT )
+ * although code for other events is included to allow for possible future
+ * expansion. */
+#define EMAC_IF_RX_EVENT     1UL
+#define EMAC_IF_TX_EVENT     2UL
+#define EMAC_IF_ERR_EVENT    4UL
+#define EMAC_IF_ALL_EVENT    ( EMAC_IF_RX_EVENT | EMAC_IF_TX_EVENT | EMAC_IF_ERR_EVENT )
 
- /* If ipconfigETHERNET_DRIVER_FILTERS_FRAME_TYPES is set to 1, then the Ethernet
- driver will filter incoming packets and only pass the stack those packets it
- considers need processing. */
- #if( ipconfigETHERNET_DRIVER_FILTERS_FRAME_TYPES == 0 )
- 	#define ipCONSIDER_FRAME_FOR_PROCESSING( pucEthernetBuffer ) eProcessBuffer
- #else
- 	#define ipCONSIDER_FRAME_FOR_PROCESSING( pucEthernetBuffer ) eConsiderFrameForProcessing( ( pucEthernetBuffer ) )
- #endif
+/* If ipconfigETHERNET_DRIVER_FILTERS_FRAME_TYPES is set to 1, then the Ethernet
+ * driver will filter incoming packets and only pass the stack those packets it
+ * considers need processing. */
+#if ( ipconfigETHERNET_DRIVER_FILTERS_FRAME_TYPES == 0 )
+    #define ipCONSIDER_FRAME_FOR_PROCESSING( pucEthernetBuffer )    eProcessBuffer
+#else
+    #define ipCONSIDER_FRAME_FOR_PROCESSING( pucEthernetBuffer )    eConsiderFrameForProcessing( ( pucEthernetBuffer ) )
+#endif
 
-#if( ipconfigZERO_COPY_RX_DRIVER == 0 ) || ( ipconfigZERO_COPY_TX_DRIVER == 0 )
-	#warning It is adviced to enable both macros
+#if ( ipconfigZERO_COPY_RX_DRIVER == 0 ) || ( ipconfigZERO_COPY_TX_DRIVER == 0 )
+    #warning It is adviced to enable both macros
 #endif
 
 #ifndef configPLACE_IN_SECTION_RAM
-	#define configPLACE_IN_SECTION_RAM
+    #define configPLACE_IN_SECTION_RAM
+
 /*
-	#define configPLACE_IN_SECTION_RAM	__attribute__ ((section(".ramfunc")))
-*/
+ #define configPLACE_IN_SECTION_RAM	__attribute__ ((section(".ramfunc")))
+ */
 #endif
 
 /*-----------------------------------------------------------*/
@@ -156,7 +158,7 @@ static void prvSetupRxDescriptors( void );
 /*
  * A task that processes received frames.
  */
-static void prvEMACHandlerTask( void *pvParameters );
+static void prvEMACHandlerTask( void * pvParameters );
 
 /*
  * Sets up the MAC with the results of an auto-negotiation.
@@ -166,30 +168,30 @@ static BaseType_t prvSetLinkSpeed( void );
 /*
  * Generates a CRC for a MAC address that is then used to generate a hash index.
  */
-static uint32_t prvGenerateCRC32( const uint8_t *ucAddress );
+static uint32_t prvGenerateCRC32( const uint8_t * ucAddress );
 
 /*
  * Generates a hash index when setting a filter to permit a MAC address.
  */
-static uint32_t prvGetHashIndex( const uint8_t *ucAddress );
+static uint32_t prvGetHashIndex( const uint8_t * ucAddress );
 
 /*
  * Update the hash table to allow a MAC address.
  */
-static void prvAddMACAddress( const uint8_t* ucMacAddress );
+static void prvAddMACAddress( const uint8_t * ucMacAddress );
 
 /*
  * Sometimes the DMA will report received data as being longer than the actual
  * received from length.  This function checks the reported length and corrects
  * if if necessary.
  */
-static void prvRemoveTrailingBytes( NetworkBufferDescriptor_t *pxDescriptor );
+static void prvRemoveTrailingBytes( NetworkBufferDescriptor_t * pxDescriptor );
 
 /*-----------------------------------------------------------*/
 
 /* Bit map of outstanding ETH interrupt events for processing.  Currently only
-the Rx and Tx interrupt is handled, although code is included for other events
-to enable future expansion. */
+ * the Rx and Tx interrupt is handled, although code is included for other events
+ * to enable future expansion. */
 static volatile uint32_t ulISREvents;
 
 /* A copy of PHY register 1: 'PHY_REG_01_BMSR' */
@@ -199,7 +201,7 @@ static uint32_t ulPHYLinkStatus = 0;
 static ENET_ENHTXDESC_T xDMATxDescriptors[ configNUM_TX_DESCRIPTORS ];
 
 /* ulNextFreeTxDescriptor is declared volatile, because it is accessed from
-to different tasks. */
+ * to different tasks. */
 static volatile uint32_t ulNextFreeTxDescriptor;
 static uint32_t ulTxDescriptorToClear;
 
@@ -211,16 +213,16 @@ static uint32_t ulNextRxDescriptorToProcess;
 extern uint8_t ucMACAddress[ 6 ];
 
 /* The handle of the task that processes Rx packets.  The handle is required so
-the task can be notified when new packets arrive. */
+ * the task can be notified when new packets arrive. */
 static TaskHandle_t xRxHanderTask = NULL;
 
-#if( ipconfigUSE_LLMNR == 1 )
-	static const uint8_t xLLMNR_MACAddress[] = { '\x01', '\x00', '\x5E', '\x00', '\x00', '\xFC' };
-#endif	/* ipconfigUSE_LLMNR == 1 */
+#if ( ipconfigUSE_LLMNR == 1 )
+    static const uint8_t xLLMNR_MACAddress[] = { '\x01', '\x00', '\x5E', '\x00', '\x00', '\xFC' };
+#endif /* ipconfigUSE_LLMNR == 1 */
 
 /* xTXDescriptorSemaphore is a counting semaphore with
-a maximum count of ETH_TXBUFNB, which is the number of
-DMA TX descriptors. */
+ * a maximum count of ETH_TXBUFNB, which is the number of
+ * DMA TX descriptors. */
 static SemaphoreHandle_t xTXDescriptorSemaphore = NULL;
 
 /*-----------------------------------------------------------*/
@@ -228,425 +230,431 @@ static SemaphoreHandle_t xTXDescriptorSemaphore = NULL;
 
 BaseType_t xNetworkInterfaceInitialise( void )
 {
-BaseType_t xReturn = pdPASS;
+    BaseType_t xReturn = pdPASS;
 
-	/* The interrupt will be turned on when a link is established. */
-	NVIC_DisableIRQ( ETHERNET_IRQn );
+    /* The interrupt will be turned on when a link is established. */
+    NVIC_DisableIRQ( ETHERNET_IRQn );
 
-	/* Disable receive and transmit DMA processes. */
-	LPC_ETHERNET->DMA_OP_MODE &= ~( DMA_OM_ST | DMA_OM_SR );
+    /* Disable receive and transmit DMA processes. */
+    LPC_ETHERNET->DMA_OP_MODE &= ~( DMA_OM_ST | DMA_OM_SR );
 
-	/* Disable packet reception. */
-	LPC_ETHERNET->MAC_CONFIG &= ~( MAC_CFG_RE | MAC_CFG_TE );
+    /* Disable packet reception. */
+    LPC_ETHERNET->MAC_CONFIG &= ~( MAC_CFG_RE | MAC_CFG_TE );
 
-	/* Call the LPCOpen function to initialise the hardware. */
-	Chip_ENET_Init( LPC_ETHERNET );
+    /* Call the LPCOpen function to initialise the hardware. */
+    Chip_ENET_Init( LPC_ETHERNET );
 
-	/* Save MAC address. */
-	Chip_ENET_SetADDR( LPC_ETHERNET, ucMACAddress );
+    /* Save MAC address. */
+    Chip_ENET_SetADDR( LPC_ETHERNET, ucMACAddress );
 
-	/* Clear all MAC address hash entries. */
-	LPC_ETHERNET->MAC_HASHTABLE_HIGH = 0;
-	LPC_ETHERNET->MAC_HASHTABLE_LOW = 0;
+    /* Clear all MAC address hash entries. */
+    LPC_ETHERNET->MAC_HASHTABLE_HIGH = 0;
+    LPC_ETHERNET->MAC_HASHTABLE_LOW = 0;
 
-	#if( ipconfigUSE_LLMNR == 1 )
-	{
-		prvAddMACAddress( xLLMNR_MACAddress );
-	}
-	#endif /* ipconfigUSE_LLMNR == 1 */
+    #if ( ipconfigUSE_LLMNR == 1 )
+        {
+            prvAddMACAddress( xLLMNR_MACAddress );
+        }
+    #endif /* ipconfigUSE_LLMNR == 1 */
 
-	/* Promiscuous flag (PR) and Receive All flag (RA) set to zero.  The
-	registers MAC_HASHTABLE_[LOW|HIGH] will be loaded to allow certain
-	multi-cast addresses. */
-	LPC_ETHERNET->MAC_FRAME_FILTER = MAC_FF_HMC;
+    /* Promiscuous flag (PR) and Receive All flag (RA) set to zero.  The
+     * registers MAC_HASHTABLE_[LOW|HIGH] will be loaded to allow certain
+     * multi-cast addresses. */
+    LPC_ETHERNET->MAC_FRAME_FILTER = MAC_FF_HMC;
 
-	#if( configUSE_RMII == 1 )
-	{
-		if( lpc_phy_init( pdTRUE, prvDelay ) != SUCCESS )
-		{
-			xReturn = pdFAIL;
-		}
-	}
-	#else
-	{
-		#warning This path has not been tested.
-		if( lpc_phy_init( pdFALSE, prvDelay ) != SUCCESS )
-		{
-			xReturn = pdFAIL;
-		}
-	}
-	#endif
+    #if ( configUSE_RMII == 1 )
+        {
+            if( lpc_phy_init( pdTRUE, prvDelay ) != SUCCESS )
+            {
+                xReturn = pdFAIL;
+            }
+        }
+    #else
+        {
+            #warning This path has not been tested.
 
-	if( xReturn == pdPASS )
-	{
-		/* Guard against the task being created more than once and the
-		descriptors being initialised more than once. */
-		if( xRxHanderTask == NULL )
-		{
-			xReturn = xTaskCreate( prvEMACHandlerTask, "EMAC", nwRX_TASK_STACK_SIZE, NULL, configMAX_PRIORITIES - 1, &xRxHanderTask );
-			configASSERT( xReturn != NULL );
-		}
+            if( lpc_phy_init( pdFALSE, prvDelay ) != SUCCESS )
+            {
+                xReturn = pdFAIL;
+            }
+        }
+    #endif /* if ( configUSE_RMII == 1 ) */
 
-		if( xTXDescriptorSemaphore == NULL )
-		{
-			/* Create a counting semaphore, with a value of 'configNUM_TX_DESCRIPTORS'
-			and a maximum of 'configNUM_TX_DESCRIPTORS'. */
-			xTXDescriptorSemaphore = xSemaphoreCreateCounting( ( UBaseType_t ) configNUM_TX_DESCRIPTORS, ( UBaseType_t ) configNUM_TX_DESCRIPTORS );
-			configASSERT( xTXDescriptorSemaphore != NULL );
-		}
+    if( xReturn == pdPASS )
+    {
+        /* Guard against the task being created more than once and the
+         * descriptors being initialised more than once. */
+        if( xRxHanderTask == NULL )
+        {
+            xReturn = xTaskCreate( prvEMACHandlerTask, "EMAC", nwRX_TASK_STACK_SIZE, NULL, configMAX_PRIORITIES - 1, &xRxHanderTask );
+            configASSERT( xReturn != NULL );
+        }
 
-		/* Enable MAC interrupts. */
-		LPC_ETHERNET->DMA_INT_EN = nwDMA_INTERRUPT_MASK;
-	}
+        if( xTXDescriptorSemaphore == NULL )
+        {
+            /* Create a counting semaphore, with a value of 'configNUM_TX_DESCRIPTORS'
+             * and a maximum of 'configNUM_TX_DESCRIPTORS'. */
+            xTXDescriptorSemaphore = xSemaphoreCreateCounting( ( UBaseType_t ) configNUM_TX_DESCRIPTORS, ( UBaseType_t ) configNUM_TX_DESCRIPTORS );
+            configASSERT( xTXDescriptorSemaphore != NULL );
+        }
 
-	if( xReturn != pdFAIL )
-	{
-		/* Auto-negotiate was already started.  Wait for it to complete. */
-		xReturn = prvSetLinkSpeed();
+        /* Enable MAC interrupts. */
+        LPC_ETHERNET->DMA_INT_EN = nwDMA_INTERRUPT_MASK;
+    }
 
-		if( xReturn == pdPASS )
-		{
-       		/* Initialise the descriptors. */
-			prvSetupTxDescriptors();
-			prvSetupRxDescriptors();
+    if( xReturn != pdFAIL )
+    {
+        /* Auto-negotiate was already started.  Wait for it to complete. */
+        xReturn = prvSetLinkSpeed();
 
-			/* Clear all interrupts. */
-			LPC_ETHERNET->DMA_STAT = DMA_ST_ALL;
+        if( xReturn == pdPASS )
+        {
+            /* Initialise the descriptors. */
+            prvSetupTxDescriptors();
+            prvSetupRxDescriptors();
 
-			/* Enable receive and transmit DMA processes. */
-			LPC_ETHERNET->DMA_OP_MODE |= DMA_OM_ST | DMA_OM_SR;
+            /* Clear all interrupts. */
+            LPC_ETHERNET->DMA_STAT = DMA_ST_ALL;
 
-			/* Set Receiver / Transmitter Enable. */
-			LPC_ETHERNET->MAC_CONFIG |= MAC_CFG_RE | MAC_CFG_TE;
+            /* Enable receive and transmit DMA processes. */
+            LPC_ETHERNET->DMA_OP_MODE |= DMA_OM_ST | DMA_OM_SR;
 
-			/* Start receive polling. */
-			LPC_ETHERNET->DMA_REC_POLL_DEMAND = 1;
+            /* Set Receiver / Transmitter Enable. */
+            LPC_ETHERNET->MAC_CONFIG |= MAC_CFG_RE | MAC_CFG_TE;
 
-			/* Enable interrupts in the NVIC. */
-			NVIC_SetPriority( ETHERNET_IRQn, configMAC_INTERRUPT_PRIORITY );
-			NVIC_EnableIRQ( ETHERNET_IRQn );
-		}
-	}
+            /* Start receive polling. */
+            LPC_ETHERNET->DMA_REC_POLL_DEMAND = 1;
 
-	return xReturn;
+            /* Enable interrupts in the NVIC. */
+            NVIC_SetPriority( ETHERNET_IRQn, configMAC_INTERRUPT_PRIORITY );
+            NVIC_EnableIRQ( ETHERNET_IRQn );
+        }
+    }
+
+    return xReturn;
 }
 /*-----------------------------------------------------------*/
 
-#define niBUFFER_1_PACKET_SIZE		1536
+#define niBUFFER_1_PACKET_SIZE    1536
 
-static __attribute__ ((section("._ramAHB32"))) uint8_t ucNetworkPackets[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS * niBUFFER_1_PACKET_SIZE ] __attribute__ ( ( aligned( 32 ) ) );
+static __attribute__( ( section( "._ramAHB32" ) ) ) uint8_t ucNetworkPackets[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS * niBUFFER_1_PACKET_SIZE ] __attribute__( ( aligned( 32 ) ) );
 
 void vNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
 {
+    uint8_t * ucRAMBuffer = ucNetworkPackets;
+    uint32_t ul;
 
-uint8_t *ucRAMBuffer = ucNetworkPackets;
-uint32_t ul;
-
-	for( ul = 0; ul < ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS; ul++ )
-	{
-		pxNetworkBuffers[ ul ].pucEthernetBuffer = ucRAMBuffer + ipBUFFER_PADDING;
-		*( ( unsigned * ) ucRAMBuffer ) = ( unsigned ) ( &( pxNetworkBuffers[ ul ] ) );
-		ucRAMBuffer += niBUFFER_1_PACKET_SIZE;
-	}
+    for( ul = 0; ul < ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS; ul++ )
+    {
+        pxNetworkBuffers[ ul ].pucEthernetBuffer = ucRAMBuffer + ipBUFFER_PADDING;
+        *( ( unsigned * ) ucRAMBuffer ) = ( unsigned ) ( &( pxNetworkBuffers[ ul ] ) );
+        ucRAMBuffer += niBUFFER_1_PACKET_SIZE;
+    }
 }
 /*-----------------------------------------------------------*/
 
 configPLACE_IN_SECTION_RAM
 static void vClearTXBuffers()
 {
-uint32_t ulLastDescriptor = ulNextFreeTxDescriptor;
-size_t uxCount = ( ( size_t ) configNUM_TX_DESCRIPTORS ) - uxSemaphoreGetCount( xTXDescriptorSemaphore );
-#if( ipconfigZERO_COPY_TX_DRIVER != 0 )
-	NetworkBufferDescriptor_t *pxNetworkBuffer;
-	uint8_t *ucPayLoad;
-#endif
+    uint32_t ulLastDescriptor = ulNextFreeTxDescriptor;
+    size_t uxCount = ( ( size_t ) configNUM_TX_DESCRIPTORS ) - uxSemaphoreGetCount( xTXDescriptorSemaphore );
 
-	/* This function is called after a TX-completion interrupt.
-	It will release each Network Buffer used in xNetworkInterfaceOutput().
-	'uxCount' represents the number of descriptors given to DMA for transmission.
-	After sending a packet, the DMA will clear the 'TDES_OWN' bit. */
-	while( ( uxCount > ( size_t ) 0u ) && ( ( xDMATxDescriptors[ ulTxDescriptorToClear ].CTRLSTAT & TDES_OWN ) == 0 ) )
-	{
-		if( ( ulTxDescriptorToClear == ulLastDescriptor ) && ( uxCount != ( size_t ) configNUM_TX_DESCRIPTORS ) )
-		{
-			break;
-		}
+    #if ( ipconfigZERO_COPY_TX_DRIVER != 0 )
+        NetworkBufferDescriptor_t * pxNetworkBuffer;
+        uint8_t * ucPayLoad;
+    #endif
 
+    /* This function is called after a TX-completion interrupt.
+     * It will release each Network Buffer used in xNetworkInterfaceOutput().
+     * 'uxCount' represents the number of descriptors given to DMA for transmission.
+     * After sending a packet, the DMA will clear the 'TDES_OWN' bit. */
+    while( ( uxCount > ( size_t ) 0u ) && ( ( xDMATxDescriptors[ ulTxDescriptorToClear ].CTRLSTAT & TDES_OWN ) == 0 ) )
+    {
+        if( ( ulTxDescriptorToClear == ulLastDescriptor ) && ( uxCount != ( size_t ) configNUM_TX_DESCRIPTORS ) )
+        {
+            break;
+        }
 
-		#if( ipconfigZERO_COPY_TX_DRIVER != 0 )
-		{
-			ucPayLoad = ( uint8_t * )xDMATxDescriptors[ ulTxDescriptorToClear ].B1ADD;
-			if( ucPayLoad != NULL )
-			{
-				/* B1ADD points to a pucEthernetBuffer of a Network Buffer descriptor. */
-				pxNetworkBuffer = pxPacketBuffer_to_NetworkBuffer( ucPayLoad );
+        #if ( ipconfigZERO_COPY_TX_DRIVER != 0 )
+            {
+                ucPayLoad = ( uint8_t * ) xDMATxDescriptors[ ulTxDescriptorToClear ].B1ADD;
 
-				configASSERT( pxNetworkBuffer != NULL );
+                if( ucPayLoad != NULL )
+                {
+                    /* B1ADD points to a pucEthernetBuffer of a Network Buffer descriptor. */
+                    pxNetworkBuffer = pxPacketBuffer_to_NetworkBuffer( ucPayLoad );
 
-				vReleaseNetworkBufferAndDescriptor( pxNetworkBuffer ) ;
-				xDMATxDescriptors[ ulTxDescriptorToClear ].B1ADD = ( uint32_t )0u;
-			}
-		}
-		#endif /* ipconfigZERO_COPY_TX_DRIVER */
+                    configASSERT( pxNetworkBuffer != NULL );
 
-		/* Move onto the next descriptor, wrapping if necessary. */
-		ulTxDescriptorToClear++;
-		if( ulTxDescriptorToClear >= configNUM_TX_DESCRIPTORS )
-		{
-			ulTxDescriptorToClear = 0;
-		}
+                    vReleaseNetworkBufferAndDescriptor( pxNetworkBuffer );
+                    xDMATxDescriptors[ ulTxDescriptorToClear ].B1ADD = ( uint32_t ) 0u;
+                }
+            }
+        #endif /* ipconfigZERO_COPY_TX_DRIVER */
 
-		uxCount--;
-		/* Tell the counting semaphore that one more TX descriptor is available. */
-		xSemaphoreGive( xTXDescriptorSemaphore );
-	}
+        /* Move onto the next descriptor, wrapping if necessary. */
+        ulTxDescriptorToClear++;
+
+        if( ulTxDescriptorToClear >= configNUM_TX_DESCRIPTORS )
+        {
+            ulTxDescriptorToClear = 0;
+        }
+
+        uxCount--;
+        /* Tell the counting semaphore that one more TX descriptor is available. */
+        xSemaphoreGive( xTXDescriptorSemaphore );
+    }
 }
 
 /*-----------------------------------------------------------*/
 
 configPLACE_IN_SECTION_RAM
-BaseType_t xNetworkInterfaceOutput( NetworkBufferDescriptor_t * const pxDescriptor, BaseType_t bReleaseAfterSend )
+BaseType_t xNetworkInterfaceOutput( NetworkBufferDescriptor_t * const pxDescriptor,
+                                    BaseType_t bReleaseAfterSend )
 {
-BaseType_t xReturn = pdFAIL;
-const TickType_t xBlockTimeTicks = pdMS_TO_TICKS( 50 );
+    BaseType_t xReturn = pdFAIL;
+    const TickType_t xBlockTimeTicks = pdMS_TO_TICKS( 50 );
 
-	/* Attempt to obtain access to a Tx descriptor. */
-	do
-	{
-		if( xTXDescriptorSemaphore == NULL )
-		{
-			break;
-		}
-		if( xSemaphoreTake( xTXDescriptorSemaphore, xBlockTimeTicks ) != pdPASS )
-		{
-			/* Time-out waiting for a free TX descriptor. */
-			break;
-		}
+    /* Attempt to obtain access to a Tx descriptor. */
+    do
+    {
+        if( xTXDescriptorSemaphore == NULL )
+        {
+            break;
+        }
 
-		/* If the descriptor is still owned by the DMA it can't be used. */
-		if( ( xDMATxDescriptors[ ulNextFreeTxDescriptor ].CTRLSTAT & TDES_OWN ) != 0 )
-		{
-			/* The semaphore was taken, the TX DMA-descriptor is still not available.
-			Actually that should not occur, the 'TDES_OWN' was already confirmed low in vClearTXBuffers(). */
-			xSemaphoreGive( xTXDescriptorSemaphore );
-		}
-		else
-		{
-			#if( ipconfigZERO_COPY_TX_DRIVER != 0 )
-			{
-				/* bReleaseAfterSend should always be set when using the zero
-				copy driver. */
-				configASSERT( bReleaseAfterSend != pdFALSE );
+        if( xSemaphoreTake( xTXDescriptorSemaphore, xBlockTimeTicks ) != pdPASS )
+        {
+            /* Time-out waiting for a free TX descriptor. */
+            break;
+        }
 
-				/* The DMA's descriptor to point directly to the data in the
-				network buffer descriptor.  The data is not copied. */
-				xDMATxDescriptors[ ulNextFreeTxDescriptor ].B1ADD = ( uint32_t ) pxDescriptor->pucEthernetBuffer;
+        /* If the descriptor is still owned by the DMA it can't be used. */
+        if( ( xDMATxDescriptors[ ulNextFreeTxDescriptor ].CTRLSTAT & TDES_OWN ) != 0 )
+        {
+            /* The semaphore was taken, the TX DMA-descriptor is still not available.
+             * Actually that should not occur, the 'TDES_OWN' was already confirmed low in vClearTXBuffers(). */
+            xSemaphoreGive( xTXDescriptorSemaphore );
+        }
+        else
+        {
+            #if ( ipconfigZERO_COPY_TX_DRIVER != 0 )
+                {
+                    /* bReleaseAfterSend should always be set when using the zero
+                     * copy driver. */
+                    configASSERT( bReleaseAfterSend != pdFALSE );
 
-				/* The DMA descriptor will 'own' this Network Buffer,
-				until it has been sent.  So don't release it now. */
-				bReleaseAfterSend = false;
-			}
-			#else
-			{
-				/* The data is copied from the network buffer descriptor into
-				the DMA's descriptor. */
-				memcpy( ( void * ) xDMATxDescriptors[ ulNextFreeTxDescriptor ].B1ADD, ( void * ) pxDescriptor->pucEthernetBuffer, pxDescriptor->xDataLength );
-			}
-			#endif
+                    /* The DMA's descriptor to point directly to the data in the
+                     * network buffer descriptor.  The data is not copied. */
+                    xDMATxDescriptors[ ulNextFreeTxDescriptor ].B1ADD = ( uint32_t ) pxDescriptor->pucEthernetBuffer;
 
-			xDMATxDescriptors[ ulNextFreeTxDescriptor ].BSIZE = ( uint32_t ) TDES_ENH_BS1( pxDescriptor->xDataLength );
+                    /* The DMA descriptor will 'own' this Network Buffer,
+                     * until it has been sent.  So don't release it now. */
+                    bReleaseAfterSend = false;
+                }
+            #else /* if ( ipconfigZERO_COPY_TX_DRIVER != 0 ) */
+                {
+                    /* The data is copied from the network buffer descriptor into
+                     * the DMA's descriptor. */
+                    memcpy( ( void * ) xDMATxDescriptors[ ulNextFreeTxDescriptor ].B1ADD, ( void * ) pxDescriptor->pucEthernetBuffer, pxDescriptor->xDataLength );
+                }
+            #endif /* if ( ipconfigZERO_COPY_TX_DRIVER != 0 ) */
 
-			/* This descriptor is given back to the DMA. */
-			xDMATxDescriptors[ ulNextFreeTxDescriptor ].CTRLSTAT |= TDES_OWN;
+            xDMATxDescriptors[ ulNextFreeTxDescriptor ].BSIZE = ( uint32_t ) TDES_ENH_BS1( pxDescriptor->xDataLength );
 
-			/* Ensure the DMA is polling Tx descriptors. */
-			LPC_ETHERNET->DMA_TRANS_POLL_DEMAND = 1;
+            /* This descriptor is given back to the DMA. */
+            xDMATxDescriptors[ ulNextFreeTxDescriptor ].CTRLSTAT |= TDES_OWN;
+
+            /* Ensure the DMA is polling Tx descriptors. */
+            LPC_ETHERNET->DMA_TRANS_POLL_DEMAND = 1;
 
             iptraceNETWORK_INTERFACE_TRANSMIT();
 
-			/* Move onto the next descriptor, wrapping if necessary. */
-			ulNextFreeTxDescriptor++;
-			if( ulNextFreeTxDescriptor >= configNUM_TX_DESCRIPTORS )
-			{
-				ulNextFreeTxDescriptor = 0;
-			}
+            /* Move onto the next descriptor, wrapping if necessary. */
+            ulNextFreeTxDescriptor++;
 
-			/* The Tx has been initiated. */
-			xReturn = pdPASS;
-		}
-	} while( 0 );
+            if( ulNextFreeTxDescriptor >= configNUM_TX_DESCRIPTORS )
+            {
+                ulNextFreeTxDescriptor = 0;
+            }
 
-	/* The buffer has been sent so can be released. */
-	if( bReleaseAfterSend != pdFALSE )
-	{
-		vReleaseNetworkBufferAndDescriptor( pxDescriptor );
-	}
+            /* The Tx has been initiated. */
+            xReturn = pdPASS;
+        }
+    } while( 0 );
 
-	return xReturn;
+    /* The buffer has been sent so can be released. */
+    if( bReleaseAfterSend != pdFALSE )
+    {
+        vReleaseNetworkBufferAndDescriptor( pxDescriptor );
+    }
+
+    return xReturn;
 }
 /*-----------------------------------------------------------*/
 
 static void prvDelay( uint32_t ulMilliSeconds )
 {
-	/* Ensure the scheduler was started before attempting to use the scheduler to
-	create a delay. */
-	configASSERT( xTaskGetSchedulerState() == taskSCHEDULER_RUNNING );
+    /* Ensure the scheduler was started before attempting to use the scheduler to
+     * create a delay. */
+    configASSERT( xTaskGetSchedulerState() == taskSCHEDULER_RUNNING );
 
-	vTaskDelay( pdMS_TO_TICKS( ulMilliSeconds ) );
+    vTaskDelay( pdMS_TO_TICKS( ulMilliSeconds ) );
 }
 /*-----------------------------------------------------------*/
 
 static void prvSetupTxDescriptors( void )
 {
-BaseType_t x;
+    BaseType_t x;
 
-	/* Start with Tx descriptors clear. */
-	memset( ( void * ) xDMATxDescriptors, 0, sizeof( xDMATxDescriptors ) );
+    /* Start with Tx descriptors clear. */
+    memset( ( void * ) xDMATxDescriptors, 0, sizeof( xDMATxDescriptors ) );
 
-	/* Index to the next Tx descriptor to use. */
-	ulNextFreeTxDescriptor = 0ul;
+    /* Index to the next Tx descriptor to use. */
+    ulNextFreeTxDescriptor = 0ul;
 
-	/* Index to the next Tx descriptor to clear ( after transmission ). */
-	ulTxDescriptorToClear = 0ul;
+    /* Index to the next Tx descriptor to clear ( after transmission ). */
+    ulTxDescriptorToClear = 0ul;
 
-	for( x = 0; x < configNUM_TX_DESCRIPTORS; x++ )
-	{
-		#if( ipconfigZERO_COPY_TX_DRIVER != 0 )
-		{
-			/* Nothing to do, B1ADD will be set when data is ready to transmit.
-			Currently the memset above will have set it to NULL. */
-		}
-		#else
-		{
-			/* Allocate a buffer to the Tx descriptor.  This is the most basic
-			way of creating a driver as the data is then copied into the
-			buffer. */
-			xDMATxDescriptors[ x ].B1ADD = ( uint32_t ) pvPortMalloc( ipTOTAL_ETHERNET_FRAME_SIZE );
+    for( x = 0; x < configNUM_TX_DESCRIPTORS; x++ )
+    {
+        #if ( ipconfigZERO_COPY_TX_DRIVER != 0 )
+            {
+                /* Nothing to do, B1ADD will be set when data is ready to transmit.
+                 * Currently the memset above will have set it to NULL. */
+            }
+        #else
+            {
+                /* Allocate a buffer to the Tx descriptor.  This is the most basic
+                 * way of creating a driver as the data is then copied into the
+                 * buffer. */
+                xDMATxDescriptors[ x ].B1ADD = ( uint32_t ) pvPortMalloc( ipTOTAL_ETHERNET_FRAME_SIZE );
 
-			/* Use an assert to check the allocation as +TCP applications will
-			often not use a malloc() failed hook as the TCP stack will recover
-			from allocation failures. */
-			configASSERT( xDMATxDescriptors[ x ].B1ADD != 0U );
-		}
-		#endif
+                /* Use an assert to check the allocation as +TCP applications will
+                 * often not use a malloc() failed hook as the TCP stack will recover
+                 * from allocation failures. */
+                configASSERT( xDMATxDescriptors[ x ].B1ADD != 0U );
+            }
+        #endif /* if ( ipconfigZERO_COPY_TX_DRIVER != 0 ) */
 
-		/* Buffers hold an entire frame so all buffers are both the start and
-		end of a frame. */
-		/* TDES_ENH_TCH     Second Address Chained. */
-		/* TDES_ENH_CIC(n)  Checksum Insertion Control, tried but it does not work for the LPC18xx... */
-		/* TDES_ENH_FS      First Segment. */
-		/* TDES_ENH_LS      Last Segment. */
-		/* TDES_ENH_IC      Interrupt on Completion. */
-		xDMATxDescriptors[ x ].CTRLSTAT = TDES_ENH_TCH | TDES_ENH_CIC( 3 ) | TDES_ENH_FS | TDES_ENH_LS | TDES_ENH_IC;
-		xDMATxDescriptors[ x ].B2ADD = ( uint32_t ) &xDMATxDescriptors[ x + 1 ];
-	}
+        /* Buffers hold an entire frame so all buffers are both the start and
+         * end of a frame. */
+        /* TDES_ENH_TCH     Second Address Chained. */
+        /* TDES_ENH_CIC(n)  Checksum Insertion Control, tried but it does not work for the LPC18xx... */
+        /* TDES_ENH_FS      First Segment. */
+        /* TDES_ENH_LS      Last Segment. */
+        /* TDES_ENH_IC      Interrupt on Completion. */
+        xDMATxDescriptors[ x ].CTRLSTAT = TDES_ENH_TCH | TDES_ENH_CIC( 3 ) | TDES_ENH_FS | TDES_ENH_LS | TDES_ENH_IC;
+        xDMATxDescriptors[ x ].B2ADD = ( uint32_t ) &xDMATxDescriptors[ x + 1 ];
+    }
 
-	xDMATxDescriptors[ configNUM_TX_DESCRIPTORS - 1 ].CTRLSTAT |= TDES_ENH_TER;
-	xDMATxDescriptors[ configNUM_TX_DESCRIPTORS - 1 ].B2ADD = ( uint32_t ) &xDMATxDescriptors[ 0 ];
+    xDMATxDescriptors[ configNUM_TX_DESCRIPTORS - 1 ].CTRLSTAT |= TDES_ENH_TER;
+    xDMATxDescriptors[ configNUM_TX_DESCRIPTORS - 1 ].B2ADD = ( uint32_t ) &xDMATxDescriptors[ 0 ];
 
-	/* Point the DMA to the base of the descriptor list. */
-	LPC_ETHERNET->DMA_TRANS_DES_ADDR = ( uint32_t ) xDMATxDescriptors;
+    /* Point the DMA to the base of the descriptor list. */
+    LPC_ETHERNET->DMA_TRANS_DES_ADDR = ( uint32_t ) xDMATxDescriptors;
 }
 /*-----------------------------------------------------------*/
 
 static void prvSetupRxDescriptors( void )
 {
-BaseType_t x;
-#if( ipconfigZERO_COPY_RX_DRIVER != 0 )
-	NetworkBufferDescriptor_t *pxNetworkBuffer;
-#endif
+    BaseType_t x;
 
-	/* Index to the next Rx descriptor to use. */
-	ulNextRxDescriptorToProcess = 0;
+    #if ( ipconfigZERO_COPY_RX_DRIVER != 0 )
+        NetworkBufferDescriptor_t * pxNetworkBuffer;
+    #endif
 
-	/* Clear RX descriptor list. */
-	memset( ( void * )  xDMARxDescriptors, 0, sizeof( xDMARxDescriptors ) );
+    /* Index to the next Rx descriptor to use. */
+    ulNextRxDescriptorToProcess = 0;
 
-	for( x = 0; x < configNUM_RX_DESCRIPTORS; x++ )
-	{
-		/* Allocate a buffer of the largest	possible frame size as it is not
-		known what size received frames will be. */
+    /* Clear RX descriptor list. */
+    memset( ( void * ) xDMARxDescriptors, 0, sizeof( xDMARxDescriptors ) );
 
-		#if( ipconfigZERO_COPY_RX_DRIVER != 0 )
-		{
-			pxNetworkBuffer = pxGetNetworkBufferWithDescriptor( ipTOTAL_ETHERNET_FRAME_SIZE, 0 );
+    for( x = 0; x < configNUM_RX_DESCRIPTORS; x++ )
+    {
+        /* Allocate a buffer of the largest	possible frame size as it is not
+         * known what size received frames will be. */
 
-			/* During start-up there should be enough Network Buffers available,
-			so it is safe to use configASSERT().
-			In case this assert fails, please check: configNUM_RX_DESCRIPTORS,
-			ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS, and in case BufferAllocation_2.c
-			is included, check the amount of available heap. */
-			configASSERT( pxNetworkBuffer != NULL );
+        #if ( ipconfigZERO_COPY_RX_DRIVER != 0 )
+            {
+                pxNetworkBuffer = pxGetNetworkBufferWithDescriptor( ipTOTAL_ETHERNET_FRAME_SIZE, 0 );
 
-			/* Pass the actual buffer to DMA. */
-			xDMARxDescriptors[ x ].B1ADD = ( uint32_t ) pxNetworkBuffer->pucEthernetBuffer;
-		}
-		#else
-		{
-			/* All DMA descriptors are populated with permanent memory blocks.
-			Their contents will be copy to Network Buffers. */
-			xDMARxDescriptors[ x ].B1ADD = ( uint32_t ) pvPortMalloc( ipTOTAL_ETHERNET_FRAME_SIZE );
-		}
-		#endif /* ipconfigZERO_COPY_RX_DRIVER */
+                /* During start-up there should be enough Network Buffers available,
+                 * so it is safe to use configASSERT().
+                 * In case this assert fails, please check: configNUM_RX_DESCRIPTORS,
+                 * ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS, and in case BufferAllocation_2.c
+                 * is included, check the amount of available heap. */
+                configASSERT( pxNetworkBuffer != NULL );
 
-		/* Use an assert to check the allocation as +TCP applications will often
-		not use a malloc failed hook as the TCP stack will recover from
-		allocation failures. */
-		configASSERT( xDMARxDescriptors[ x ].B1ADD != 0U );
+                /* Pass the actual buffer to DMA. */
+                xDMARxDescriptors[ x ].B1ADD = ( uint32_t ) pxNetworkBuffer->pucEthernetBuffer;
+            }
+        #else
+            {
+                /* All DMA descriptors are populated with permanent memory blocks.
+                 * Their contents will be copy to Network Buffers. */
+                xDMARxDescriptors[ x ].B1ADD = ( uint32_t ) pvPortMalloc( ipTOTAL_ETHERNET_FRAME_SIZE );
+            }
+        #endif /* ipconfigZERO_COPY_RX_DRIVER */
 
-		xDMARxDescriptors[ x ].B2ADD = ( uint32_t ) &( xDMARxDescriptors[ x + 1 ] );
-		xDMARxDescriptors[ x ].CTRL = ( uint32_t ) RDES_ENH_BS1( ipTOTAL_ETHERNET_FRAME_SIZE ) | RDES_ENH_RCH;
+        /* Use an assert to check the allocation as +TCP applications will often
+         * not use a malloc failed hook as the TCP stack will recover from
+         * allocation failures. */
+        configASSERT( xDMARxDescriptors[ x ].B1ADD != 0U );
 
-		/* The descriptor is available for use by the DMA. */
-		xDMARxDescriptors[ x ].STATUS = RDES_OWN;
-	}
+        xDMARxDescriptors[ x ].B2ADD = ( uint32_t ) &( xDMARxDescriptors[ x + 1 ] );
+        xDMARxDescriptors[ x ].CTRL = ( uint32_t ) RDES_ENH_BS1( ipTOTAL_ETHERNET_FRAME_SIZE ) | RDES_ENH_RCH;
 
-	/* RDES_ENH_RER  Receive End of Ring. */
-	xDMARxDescriptors[ ( configNUM_RX_DESCRIPTORS - 1 ) ].CTRL |= RDES_ENH_RER;
-	xDMARxDescriptors[ configNUM_RX_DESCRIPTORS - 1 ].B2ADD = ( uint32_t ) &( xDMARxDescriptors[ 0 ] );
+        /* The descriptor is available for use by the DMA. */
+        xDMARxDescriptors[ x ].STATUS = RDES_OWN;
+    }
 
-	/* Point the DMA to the base of the descriptor list. */
-	LPC_ETHERNET->DMA_REC_DES_ADDR = ( uint32_t ) xDMARxDescriptors;
+    /* RDES_ENH_RER  Receive End of Ring. */
+    xDMARxDescriptors[ ( configNUM_RX_DESCRIPTORS - 1 ) ].CTRL |= RDES_ENH_RER;
+    xDMARxDescriptors[ configNUM_RX_DESCRIPTORS - 1 ].B2ADD = ( uint32_t ) &( xDMARxDescriptors[ 0 ] );
+
+    /* Point the DMA to the base of the descriptor list. */
+    LPC_ETHERNET->DMA_REC_DES_ADDR = ( uint32_t ) xDMARxDescriptors;
 }
 /*-----------------------------------------------------------*/
 configPLACE_IN_SECTION_RAM
-static void prvRemoveTrailingBytes( NetworkBufferDescriptor_t *pxDescriptor )
+static void prvRemoveTrailingBytes( NetworkBufferDescriptor_t * pxDescriptor )
 {
-size_t xExpectedLength;
-IPPacket_t *pxIPPacket;
+    size_t xExpectedLength;
+    IPPacket_t * pxIPPacket;
 
-	pxIPPacket = ( IPPacket_t * ) pxDescriptor->pucEthernetBuffer;
-	/* Look at the actual length of the packet, translate it to a host-endial notation. */
-	xExpectedLength = sizeof( EthernetHeader_t ) + ( size_t ) FreeRTOS_htons( pxIPPacket->xIPHeader.usLength );
+    pxIPPacket = ( IPPacket_t * ) pxDescriptor->pucEthernetBuffer;
+    /* Look at the actual length of the packet, translate it to a host-endial notation. */
+    xExpectedLength = sizeof( EthernetHeader_t ) + ( size_t ) FreeRTOS_htons( pxIPPacket->xIPHeader.usLength );
 
-	if( xExpectedLength == ( pxDescriptor->xDataLength + 4 ) )
-	{
-		pxDescriptor->xDataLength -= 4;
-	}
-	else
-	{
-		if( pxDescriptor->xDataLength > xExpectedLength )
-		{
-			pxDescriptor->xDataLength = ( size_t ) xExpectedLength;
-		}
-	}
+    if( xExpectedLength == ( pxDescriptor->xDataLength + 4 ) )
+    {
+        pxDescriptor->xDataLength -= 4;
+    }
+    else
+    {
+        if( pxDescriptor->xDataLength > xExpectedLength )
+        {
+            pxDescriptor->xDataLength = ( size_t ) xExpectedLength;
+        }
+    }
 }
 /*-----------------------------------------------------------*/
 configPLACE_IN_SECTION_RAM
 BaseType_t xGetPhyLinkStatus( void )
 {
-BaseType_t xReturn;
+    BaseType_t xReturn;
 
-	if( ( ulPHYLinkStatus & PHY_LINK_CONNECTED ) == 0 )
-	{
-		xReturn = pdFALSE;
-	}
-	else
-	{
-		xReturn = pdTRUE;
-	}
+    if( ( ulPHYLinkStatus & PHY_LINK_CONNECTED ) == 0 )
+    {
+        xReturn = pdFALSE;
+    }
+    else
+    {
+        xReturn = pdTRUE;
+    }
 
-	return xReturn;
+    return xReturn;
 }
 /*-----------------------------------------------------------*/
 
@@ -655,266 +663,278 @@ uint32_t ulDataAvailable;
 configPLACE_IN_SECTION_RAM
 static BaseType_t prvNetworkInterfaceInput()
 {
-BaseType_t xResult = pdFALSE;
-uint32_t ulStatus;
-eFrameProcessingResult_t eResult;
-const TickType_t xDescriptorWaitTime = pdMS_TO_TICKS( 250 );
-const UBaseType_t uxMinimumBuffersRemaining = 3UL;
-uint16_t usLength;
-NetworkBufferDescriptor_t *pxDescriptor;
-#if( ipconfigZERO_COPY_RX_DRIVER != 0 )
-	NetworkBufferDescriptor_t *pxNewDescriptor;
-#endif /* ipconfigZERO_COPY_RX_DRIVER */
-#if( ipconfigUSE_LINKED_RX_MESSAGES == 0 )
-	IPStackEvent_t xRxEvent = { eNetworkRxEvent, NULL };
-#endif
+    BaseType_t xResult = pdFALSE;
+    uint32_t ulStatus;
+    eFrameProcessingResult_t eResult;
+    const TickType_t xDescriptorWaitTime = pdMS_TO_TICKS( 250 );
+    const UBaseType_t uxMinimumBuffersRemaining = 3UL;
+    uint16_t usLength;
+    NetworkBufferDescriptor_t * pxDescriptor;
 
-	/* Process each descriptor that is not still in use by the DMA. */
-	ulStatus = xDMARxDescriptors[ ulNextRxDescriptorToProcess ].STATUS;
-	if( ( ulStatus & RDES_OWN ) == 0 )
-	{
-		/* Check packet for errors */
-		if( ( ulStatus & nwRX_STATUS_ERROR_BITS ) != 0 )
-		{
-			/* There is some reception error. */
-			intCount[ 3 ]++;
-			/* Clear error bits. */
-			ulStatus &= ~( ( uint32_t )nwRX_STATUS_ERROR_BITS );
-		}
-		else
-		{
-			xResult++;
+    #if ( ipconfigZERO_COPY_RX_DRIVER != 0 )
+        NetworkBufferDescriptor_t * pxNewDescriptor;
+    #endif /* ipconfigZERO_COPY_RX_DRIVER */
+    #if ( ipconfigUSE_LINKED_RX_MESSAGES == 0 )
+        IPStackEvent_t xRxEvent = { eNetworkRxEvent, NULL };
+    #endif
 
-			eResult = ipCONSIDER_FRAME_FOR_PROCESSING( ( const uint8_t * const ) ( xDMARxDescriptors[ ulNextRxDescriptorToProcess ].B1ADD ) );
-			if( eResult == eProcessBuffer )
-			{
-				if( ( ulPHYLinkStatus & PHY_LINK_CONNECTED ) == 0 )
-				{
-					ulPHYLinkStatus |= PHY_LINK_CONNECTED;
-					FreeRTOS_printf( ( "prvEMACHandlerTask: PHY LS now %d (message received)\n", ( ulPHYLinkStatus & PHY_LINK_CONNECTED ) != 0 ) );
-				}
+    /* Process each descriptor that is not still in use by the DMA. */
+    ulStatus = xDMARxDescriptors[ ulNextRxDescriptorToProcess ].STATUS;
 
-			#if( ipconfigZERO_COPY_RX_DRIVER != 0 )
-				if( uxGetNumberOfFreeNetworkBuffers() > uxMinimumBuffersRemaining )
-				{
-					pxNewDescriptor = pxGetNetworkBufferWithDescriptor( ipTOTAL_ETHERNET_FRAME_SIZE, xDescriptorWaitTime );
-				}
-				else
-				{
-					/* Too risky to allocate a new Network Buffer. */
-					pxNewDescriptor = NULL;
-				}
-				if( pxNewDescriptor != NULL )
-			#else
-				if( uxGetNumberOfFreeNetworkBuffers() > uxMinimumBuffersRemaining )
-			#endif /* ipconfigZERO_COPY_RX_DRIVER */
-				{
-			#if( ipconfigZERO_COPY_RX_DRIVER != 0 )
-				const uint8_t *pucBuffer;
-			#endif
+    if( ( ulStatus & RDES_OWN ) == 0 )
+    {
+        /* Check packet for errors */
+        if( ( ulStatus & nwRX_STATUS_ERROR_BITS ) != 0 )
+        {
+            /* There is some reception error. */
+            intCount[ 3 ]++;
+            /* Clear error bits. */
+            ulStatus &= ~( ( uint32_t ) nwRX_STATUS_ERROR_BITS );
+        }
+        else
+        {
+            xResult++;
 
-					/* Get the actual length. */
-					usLength = RDES_FLMSK( ulStatus );
+            eResult = ipCONSIDER_FRAME_FOR_PROCESSING( ( const uint8_t * const ) ( xDMARxDescriptors[ ulNextRxDescriptorToProcess ].B1ADD ) );
 
-					#if( ipconfigZERO_COPY_RX_DRIVER != 0 )
-					{
-						/* Replace the character buffer 'B1ADD'. */
-						pucBuffer = ( const uint8_t * const ) ( xDMARxDescriptors[ ulNextRxDescriptorToProcess ].B1ADD );
-						xDMARxDescriptors[ ulNextRxDescriptorToProcess ].B1ADD = ( uint32_t ) pxNewDescriptor->pucEthernetBuffer;
+            if( eResult == eProcessBuffer )
+            {
+                if( ( ulPHYLinkStatus & PHY_LINK_CONNECTED ) == 0 )
+                {
+                    ulPHYLinkStatus |= PHY_LINK_CONNECTED;
+                    FreeRTOS_printf( ( "prvEMACHandlerTask: PHY LS now %d (message received)\n", ( ulPHYLinkStatus & PHY_LINK_CONNECTED ) != 0 ) );
+                }
 
-						/* 'B1ADD' contained the address of a 'pucEthernetBuffer' that
-						belongs to a Network Buffer.  Find the original Network Buffer. */
-						pxDescriptor = pxPacketBuffer_to_NetworkBuffer( pucBuffer );
-						/* This zero-copy driver makes sure that every 'xDMARxDescriptors' contains
-						a reference to a Network Buffer at any time.
-						In case it runs out of Network Buffers, a DMA buffer won't be replaced,
-						and the received messages is dropped. */
-						configASSERT( pxDescriptor != NULL );
-					}
-					#else
-					{
-						/* Create a buffer of exactly the required length. */
-						pxDescriptor = pxGetNetworkBufferWithDescriptor( usLength, xDescriptorWaitTime );
-					}
-					#endif /* ipconfigZERO_COPY_RX_DRIVER */
+                #if ( ipconfigZERO_COPY_RX_DRIVER != 0 )
+                    if( uxGetNumberOfFreeNetworkBuffers() > uxMinimumBuffersRemaining )
+                    {
+                        pxNewDescriptor = pxGetNetworkBufferWithDescriptor( ipTOTAL_ETHERNET_FRAME_SIZE, xDescriptorWaitTime );
+                    }
+                    else
+                    {
+                        /* Too risky to allocate a new Network Buffer. */
+                        pxNewDescriptor = NULL;
+                    }
 
-					if( pxDescriptor != NULL )
-					{
-						pxDescriptor->xDataLength = ( size_t ) usLength;
-						#if( ipconfigZERO_COPY_RX_DRIVER == 0 )
-						{
-							/* Copy the data into the allocated buffer. */
-							memcpy( ( void * ) pxDescriptor->pucEthernetBuffer, ( void * ) xDMARxDescriptors[ ulNextRxDescriptorToProcess ].B1ADD, usLength );
-						}
-						#endif /* ipconfigZERO_COPY_RX_DRIVER */
-						/* It is possible that more data was copied than
-						actually makes up the frame.  If this is the case
-						adjust the length to remove any trailing bytes. */
-						prvRemoveTrailingBytes( pxDescriptor );
+                    if( pxNewDescriptor != NULL )
+                #else /* if ( ipconfigZERO_COPY_RX_DRIVER != 0 ) */
+                    if( uxGetNumberOfFreeNetworkBuffers() > uxMinimumBuffersRemaining )
+                #endif /* ipconfigZERO_COPY_RX_DRIVER */
+                {
+                    #if ( ipconfigZERO_COPY_RX_DRIVER != 0 )
+                        const uint8_t * pucBuffer;
+                    #endif
 
-						/* Pass the data to the TCP/IP task for processing. */
-						xRxEvent.pvData = ( void * ) pxDescriptor;
-						if( xSendEventStructToIPTask( &xRxEvent, xDescriptorWaitTime ) == pdFALSE )
-						{
-							/* Could not send the descriptor into the TCP/IP
-							stack, it must be released. */
-							vReleaseNetworkBufferAndDescriptor( pxDescriptor );
-						}
-						else
-						{
-							iptraceNETWORK_INTERFACE_RECEIVE();
+                    /* Get the actual length. */
+                    usLength = RDES_FLMSK( ulStatus );
 
-							/* The data that was available at the top of this
-							loop has been sent, so is no longer available. */
-							ulDataAvailable = pdFALSE;
-						}
-					}
-				}
-			}
-			else
-			{
-				/* The packet is discarded as uninteresting. */
-				ulDataAvailable = pdFALSE;
-			}
-			/* Got here because received data was sent to the IP task or the
-			data contained an error and was discarded.  Give the descriptor
-			back to the DMA. */
-			xDMARxDescriptors[ ulNextRxDescriptorToProcess ].STATUS = ulStatus | RDES_OWN;
+                    #if ( ipconfigZERO_COPY_RX_DRIVER != 0 )
+                        {
+                            /* Replace the character buffer 'B1ADD'. */
+                            pucBuffer = ( const uint8_t * const ) ( xDMARxDescriptors[ ulNextRxDescriptorToProcess ].B1ADD );
+                            xDMARxDescriptors[ ulNextRxDescriptorToProcess ].B1ADD = ( uint32_t ) pxNewDescriptor->pucEthernetBuffer;
 
-			/* Move onto the next descriptor. */
-			ulNextRxDescriptorToProcess++;
-			if( ulNextRxDescriptorToProcess >= configNUM_RX_DESCRIPTORS )
-			{
-				ulNextRxDescriptorToProcess = 0;
-			}
+                            /* 'B1ADD' contained the address of a 'pucEthernetBuffer' that
+                             * belongs to a Network Buffer.  Find the original Network Buffer. */
+                            pxDescriptor = pxPacketBuffer_to_NetworkBuffer( pucBuffer );
 
-			ulStatus = xDMARxDescriptors[ ulNextRxDescriptorToProcess ].STATUS;
-		} /* if( ( ulStatus & nwRX_STATUS_ERROR_BITS ) != 0 ) */
-	} /* if( ( ulStatus & RDES_OWN ) == 0 ) */
+                            /* This zero-copy driver makes sure that every 'xDMARxDescriptors' contains
+                             * a reference to a Network Buffer at any time.
+                             * In case it runs out of Network Buffers, a DMA buffer won't be replaced,
+                             * and the received messages is dropped. */
+                            configASSERT( pxDescriptor != NULL );
+                        }
+                    #else /* if ( ipconfigZERO_COPY_RX_DRIVER != 0 ) */
+                        {
+                            /* Create a buffer of exactly the required length. */
+                            pxDescriptor = pxGetNetworkBufferWithDescriptor( usLength, xDescriptorWaitTime );
+                        }
+                    #endif /* ipconfigZERO_COPY_RX_DRIVER */
 
-	/* Restart receive polling. */
-	LPC_ETHERNET->DMA_REC_POLL_DEMAND = 1;
+                    if( pxDescriptor != NULL )
+                    {
+                        pxDescriptor->xDataLength = ( size_t ) usLength;
+                        #if ( ipconfigZERO_COPY_RX_DRIVER == 0 )
+                            {
+                                /* Copy the data into the allocated buffer. */
+                                memcpy( ( void * ) pxDescriptor->pucEthernetBuffer, ( void * ) xDMARxDescriptors[ ulNextRxDescriptorToProcess ].B1ADD, usLength );
+                            }
+                        #endif /* ipconfigZERO_COPY_RX_DRIVER */
 
-	return xResult;
+                        /* It is possible that more data was copied than
+                         * actually makes up the frame.  If this is the case
+                         * adjust the length to remove any trailing bytes. */
+                        prvRemoveTrailingBytes( pxDescriptor );
+
+                        /* Pass the data to the TCP/IP task for processing. */
+                        xRxEvent.pvData = ( void * ) pxDescriptor;
+
+                        if( xSendEventStructToIPTask( &xRxEvent, xDescriptorWaitTime ) == pdFALSE )
+                        {
+                            /* Could not send the descriptor into the TCP/IP
+                             * stack, it must be released. */
+                            vReleaseNetworkBufferAndDescriptor( pxDescriptor );
+                        }
+                        else
+                        {
+                            iptraceNETWORK_INTERFACE_RECEIVE();
+
+                            /* The data that was available at the top of this
+                             *  loop has been sent, so is no longer available. */
+                            ulDataAvailable = pdFALSE;
+                        }
+                    }
+                }
+            }
+            else
+            {
+                /* The packet is discarded as uninteresting. */
+                ulDataAvailable = pdFALSE;
+            }
+
+            /* Got here because received data was sent to the IP task or the
+             * data contained an error and was discarded.  Give the descriptor
+             * back to the DMA. */
+            xDMARxDescriptors[ ulNextRxDescriptorToProcess ].STATUS = ulStatus | RDES_OWN;
+
+            /* Move onto the next descriptor. */
+            ulNextRxDescriptorToProcess++;
+
+            if( ulNextRxDescriptorToProcess >= configNUM_RX_DESCRIPTORS )
+            {
+                ulNextRxDescriptorToProcess = 0;
+            }
+
+            ulStatus = xDMARxDescriptors[ ulNextRxDescriptorToProcess ].STATUS;
+        } /* if( ( ulStatus & nwRX_STATUS_ERROR_BITS ) != 0 ) */
+    }     /* if( ( ulStatus & RDES_OWN ) == 0 ) */
+
+    /* Restart receive polling. */
+    LPC_ETHERNET->DMA_REC_POLL_DEMAND = 1;
+
+    return xResult;
 }
 /*-----------------------------------------------------------*/
 
 configPLACE_IN_SECTION_RAM
 void NETWORK_IRQHandler( void )
 {
-BaseType_t xHigherPriorityTaskWoken = pdFALSE;
-uint32_t ulDMAStatus;
-const uint32_t ulRxInterruptMask =
-	DMA_ST_RI |		/* Receive interrupt */
-	DMA_ST_RU;		/* Receive buffer unavailable */
-const uint32_t ulTxInterruptMask =
-	DMA_ST_TI |		/* Transmit interrupt */
-	DMA_ST_TPS;		/* Transmit process stopped */
+    BaseType_t xHigherPriorityTaskWoken = pdFALSE;
+    uint32_t ulDMAStatus;
+    const uint32_t ulRxInterruptMask =
+        DMA_ST_RI | /* Receive interrupt */
+        DMA_ST_RU;  /* Receive buffer unavailable */
+    const uint32_t ulTxInterruptMask =
+        DMA_ST_TI | /* Transmit interrupt */
+        DMA_ST_TPS; /* Transmit process stopped */
 
-	configASSERT( xRxHanderTask );
+    configASSERT( xRxHanderTask );
 
-	/* Get pending interrupts. */
-	ulDMAStatus = LPC_ETHERNET->DMA_STAT;
+    /* Get pending interrupts. */
+    ulDMAStatus = LPC_ETHERNET->DMA_STAT;
 
-	/* RX group interrupt(s). */
-	if( ( ulDMAStatus & ulRxInterruptMask ) != 0x00 )
-	{
-		/* Remember that an RX event has happened. */
-		ulISREvents |= EMAC_IF_RX_EVENT;
-		vTaskNotifyGiveFromISR( xRxHanderTask, &xHigherPriorityTaskWoken );
-		intCount[ 0 ]++;
-	}
+    /* RX group interrupt(s). */
+    if( ( ulDMAStatus & ulRxInterruptMask ) != 0x00 )
+    {
+        /* Remember that an RX event has happened. */
+        ulISREvents |= EMAC_IF_RX_EVENT;
+        vTaskNotifyGiveFromISR( xRxHanderTask, &xHigherPriorityTaskWoken );
+        intCount[ 0 ]++;
+    }
 
-	/* TX group interrupt(s). */
-	if( ( ulDMAStatus & ulTxInterruptMask ) != 0x00 )
-	{
-		/* Remember that a TX event has happened. */
-		ulISREvents |= EMAC_IF_TX_EVENT;
-		vTaskNotifyGiveFromISR( xRxHanderTask, &xHigherPriorityTaskWoken );
-		intCount[ 1 ]++;
-	}
+    /* TX group interrupt(s). */
+    if( ( ulDMAStatus & ulTxInterruptMask ) != 0x00 )
+    {
+        /* Remember that a TX event has happened. */
+        ulISREvents |= EMAC_IF_TX_EVENT;
+        vTaskNotifyGiveFromISR( xRxHanderTask, &xHigherPriorityTaskWoken );
+        intCount[ 1 ]++;
+    }
 
-	/* Test for 'Abnormal interrupt summary'. */
-	if( ( ulDMAStatus & DMA_ST_AIE ) != 0x00 )
-	{
-		/* The trace macro must be written such that it can be called from
-		an interrupt. */
-		iptraceETHERNET_RX_EVENT_LOST();
-	}
+    /* Test for 'Abnormal interrupt summary'. */
+    if( ( ulDMAStatus & DMA_ST_AIE ) != 0x00 )
+    {
+        /* The trace macro must be written such that it can be called from
+         * an interrupt. */
+        iptraceETHERNET_RX_EVENT_LOST();
+    }
 
-	/* Clear pending interrupts */
-	LPC_ETHERNET->DMA_STAT = ulDMAStatus;
+    /* Clear pending interrupts */
+    LPC_ETHERNET->DMA_STAT = ulDMAStatus;
 
-	/* Context switch needed? */
-	portYIELD_FROM_ISR( xHigherPriorityTaskWoken );
+    /* Context switch needed? */
+    portYIELD_FROM_ISR( xHigherPriorityTaskWoken );
 }
 /*-----------------------------------------------------------*/
 
 static BaseType_t prvSetLinkSpeed( void )
 {
-BaseType_t xReturn = pdFAIL;
-TickType_t xTimeOnEntering;
-uint32_t ulPhyStatus;
-const TickType_t xAutoNegotiateDelay = pdMS_TO_TICKS( 5000UL );
+    BaseType_t xReturn = pdFAIL;
+    TickType_t xTimeOnEntering;
+    uint32_t ulPhyStatus;
+    const TickType_t xAutoNegotiateDelay = pdMS_TO_TICKS( 5000UL );
 
-	/* Ensure polling does not starve lower priority tasks by temporarily
-	setting the priority of this task to that of the idle task. */
-	vTaskPrioritySet( NULL, tskIDLE_PRIORITY );
+    /* Ensure polling does not starve lower priority tasks by temporarily
+     * setting the priority of this task to that of the idle task. */
+    vTaskPrioritySet( NULL, tskIDLE_PRIORITY );
 
-	xTimeOnEntering = xTaskGetTickCount();
-	do
-	{
-		ulPhyStatus = lpcPHYStsPoll();
-		if( ( ulPhyStatus & PHY_LINK_CONNECTED ) != 0x00 )
-		{
-			/* Set interface speed and duplex. */
-			if( ( ulPhyStatus & PHY_LINK_SPEED100 ) != 0x00 )
-			{
-				Chip_ENET_SetSpeed( LPC_ETHERNET, 1 );
-			}
-			else
-			{
-				Chip_ENET_SetSpeed( LPC_ETHERNET, 0 );
-			}
+    xTimeOnEntering = xTaskGetTickCount();
 
-			if( ( ulPhyStatus & PHY_LINK_FULLDUPLX ) != 0x00 )
-			{
-				Chip_ENET_SetDuplex( LPC_ETHERNET, true );
-			}
-			else
-			{
-				Chip_ENET_SetDuplex( LPC_ETHERNET, false );
-			}
+    do
+    {
+        ulPhyStatus = lpcPHYStsPoll();
 
-			xReturn = pdPASS;
-			break;
-		}
-	} while( ( xTaskGetTickCount() - xTimeOnEntering ) < xAutoNegotiateDelay );
+        if( ( ulPhyStatus & PHY_LINK_CONNECTED ) != 0x00 )
+        {
+            /* Set interface speed and duplex. */
+            if( ( ulPhyStatus & PHY_LINK_SPEED100 ) != 0x00 )
+            {
+                Chip_ENET_SetSpeed( LPC_ETHERNET, 1 );
+            }
+            else
+            {
+                Chip_ENET_SetSpeed( LPC_ETHERNET, 0 );
+            }
 
-	/* Reset the priority of this task back to its original value. */
-	vTaskPrioritySet( NULL, ipconfigIP_TASK_PRIORITY );
+            if( ( ulPhyStatus & PHY_LINK_FULLDUPLX ) != 0x00 )
+            {
+                Chip_ENET_SetDuplex( LPC_ETHERNET, true );
+            }
+            else
+            {
+                Chip_ENET_SetDuplex( LPC_ETHERNET, false );
+            }
 
-	return xReturn;
+            xReturn = pdPASS;
+            break;
+        }
+    } while( ( xTaskGetTickCount() - xTimeOnEntering ) < xAutoNegotiateDelay );
+
+    /* Reset the priority of this task back to its original value. */
+    vTaskPrioritySet( NULL, ipconfigIP_TASK_PRIORITY );
+
+    return xReturn;
 }
 /*-----------------------------------------------------------*/
 
-static uint32_t prvGenerateCRC32( const uint8_t *ucAddress )
+static uint32_t prvGenerateCRC32( const uint8_t * ucAddress )
 {
-unsigned int j;
-const uint32_t Polynomial = 0xEDB88320;
-uint32_t crc = ~0ul;
-const uint8_t *pucCurrent = ( const uint8_t * ) ucAddress;
-const uint8_t *pucLast = pucCurrent + 6;
+    unsigned int j;
+    const uint32_t Polynomial = 0xEDB88320;
+    uint32_t crc = ~0ul;
+    const uint8_t * pucCurrent = ( const uint8_t * ) ucAddress;
+    const uint8_t * pucLast = pucCurrent + 6;
 
     /* Calculate  normal CRC32 */
     while( pucCurrent < pucLast )
     {
         crc ^= *( pucCurrent++ );
+
         for( j = 0; j < 8; j++ )
         {
             if( ( crc & 1 ) != 0 )
             {
-                crc = (crc >> 1) ^ Polynomial;
+                crc = ( crc >> 1 ) ^ Polynomial;
             }
             else
             {
@@ -922,15 +942,16 @@ const uint8_t *pucLast = pucCurrent + 6;
             }
         }
     }
+
     return ~crc;
 }
 /*-----------------------------------------------------------*/
 
-static uint32_t prvGetHashIndex( const uint8_t *ucAddress )
+static uint32_t prvGetHashIndex( const uint8_t * ucAddress )
 {
-uint32_t ulCrc = prvGenerateCRC32( ucAddress );
-uint32_t ulIndex = 0ul;
-BaseType_t xCount = 6;
+    uint32_t ulCrc = prvGenerateCRC32( ucAddress );
+    uint32_t ulIndex = 0ul;
+    BaseType_t xCount = 6;
 
     /* Take the lowest 6 bits of the CRC32 and reverse them */
     while( xCount-- )
@@ -945,11 +966,12 @@ BaseType_t xCount = 6;
 }
 /*-----------------------------------------------------------*/
 
-static void prvAddMACAddress( const uint8_t* ucMacAddress )
+static void prvAddMACAddress( const uint8_t * ucMacAddress )
 {
-BaseType_t xIndex;
+    BaseType_t xIndex;
 
     xIndex = prvGetHashIndex( ucMacAddress );
+
     if( xIndex >= 32 )
     {
         LPC_ETHERNET->MAC_HASHTABLE_HIGH |= ( 1u << ( xIndex - 32 ) );
@@ -962,107 +984,111 @@ BaseType_t xIndex;
 /*-----------------------------------------------------------*/
 
 configPLACE_IN_SECTION_RAM
-static void prvEMACHandlerTask( void *pvParameters )
+static void prvEMACHandlerTask( void * pvParameters )
 {
-TimeOut_t xPhyTime;
-TickType_t xPhyRemTime;
-UBaseType_t uxLastMinBufferCount = 0;
-UBaseType_t uxCurrentCount;
-BaseType_t xResult = 0;
-uint32_t ulStatus;
-const TickType_t xBlockTime = pdMS_TO_TICKS( 5000ul );
+    TimeOut_t xPhyTime;
+    TickType_t xPhyRemTime;
+    UBaseType_t uxLastMinBufferCount = 0;
+    UBaseType_t uxCurrentCount;
+    BaseType_t xResult = 0;
+    uint32_t ulStatus;
+    const TickType_t xBlockTime = pdMS_TO_TICKS( 5000ul );
 
-	/* Remove compiler warning about unused parameter. */
-	( void ) pvParameters;
+    /* Remove compiler warning about unused parameter. */
+    ( void ) pvParameters;
 
-	/* A possibility to set some additional task properties. */
-	iptraceEMAC_TASK_STARTING();
+    /* A possibility to set some additional task properties. */
+    iptraceEMAC_TASK_STARTING();
 
-	vTaskSetTimeOutState( &xPhyTime );
-	xPhyRemTime = pdMS_TO_TICKS( PHY_LS_LOW_CHECK_TIME_MS );
+    vTaskSetTimeOutState( &xPhyTime );
+    xPhyRemTime = pdMS_TO_TICKS( PHY_LS_LOW_CHECK_TIME_MS );
 
-	for( ;; )
-	{
-		uxCurrentCount = uxGetMinimumFreeNetworkBuffers();
-		if( uxLastMinBufferCount != uxCurrentCount )
-		{
-			/* The logging produced below may be helpful
-			while tuning +TCP: see how many buffers are in use. */
-			uxLastMinBufferCount = uxCurrentCount;
-			FreeRTOS_printf( ( "Network buffers: %lu lowest %lu\n",
-				uxGetNumberOfFreeNetworkBuffers(), uxCurrentCount ) );
-		}
+    for( ; ; )
+    {
+        uxCurrentCount = uxGetMinimumFreeNetworkBuffers();
 
-		#if( ipconfigCHECK_IP_QUEUE_SPACE != 0 )
-		{
-		static UBaseType_t uxLastMinQueueSpace = 0;
+        if( uxLastMinBufferCount != uxCurrentCount )
+        {
+            /* The logging produced below may be helpful
+             * while tuning +TCP: see how many buffers are in use. */
+            uxLastMinBufferCount = uxCurrentCount;
+            FreeRTOS_printf( ( "Network buffers: %lu lowest %lu\n",
+                               uxGetNumberOfFreeNetworkBuffers(), uxCurrentCount ) );
+        }
 
-			uxCurrentCount = uxGetMinimumIPQueueSpace();
-			if( uxLastMinQueueSpace != uxCurrentCount )
-			{
-				/* The logging produced below may be helpful
-				while tuning +TCP: see how many buffers are in use. */
-				uxLastMinQueueSpace = uxCurrentCount;
-				FreeRTOS_printf( ( "Queue space: lowest %lu\n", uxCurrentCount ) );
-			}
-		}
-		#endif /* ipconfigCHECK_IP_QUEUE_SPACE */
+        #if ( ipconfigCHECK_IP_QUEUE_SPACE != 0 )
+            {
+                static UBaseType_t uxLastMinQueueSpace = 0;
 
-		ulTaskNotifyTake( pdTRUE, xBlockTime );
+                uxCurrentCount = uxGetMinimumIPQueueSpace();
 
-		xResult = ( BaseType_t ) 0;
+                if( uxLastMinQueueSpace != uxCurrentCount )
+                {
+                    /* The logging produced below may be helpful
+                     * while tuning +TCP: see how many buffers are in use. */
+                    uxLastMinQueueSpace = uxCurrentCount;
+                    FreeRTOS_printf( ( "Queue space: lowest %lu\n", uxCurrentCount ) );
+                }
+            }
+        #endif /* ipconfigCHECK_IP_QUEUE_SPACE */
 
-		if( ( ulISREvents & EMAC_IF_TX_EVENT ) != 0 )
-		{
-			/* Code to release TX buffers if zero-copy is used. */
-			ulISREvents &= ~EMAC_IF_TX_EVENT;
-			{
-				/* Check if DMA packets have been delivered. */
-				vClearTXBuffers();
-			}
-		}
+        ulTaskNotifyTake( pdTRUE, xBlockTime );
 
-		if( ( ulISREvents & EMAC_IF_RX_EVENT ) != 0 )
-		{
-			ulISREvents &= ~EMAC_IF_RX_EVENT;
+        xResult = ( BaseType_t ) 0;
 
-			xResult = prvNetworkInterfaceInput();
-			if( xResult > 0 )
-			{
-			  	while( prvNetworkInterfaceInput() > 0 )
-				{
-				}
-			}
-		}
+        if( ( ulISREvents & EMAC_IF_TX_EVENT ) != 0 )
+        {
+            /* Code to release TX buffers if zero-copy is used. */
+            ulISREvents &= ~EMAC_IF_TX_EVENT;
+            {
+                /* Check if DMA packets have been delivered. */
+                vClearTXBuffers();
+            }
+        }
 
-		if( xResult > 0 )
-		{
-			/* A packet was received. No need to check for the PHY status now,
-			but set a timer to check it later on. */
-			vTaskSetTimeOutState( &xPhyTime );
-			xPhyRemTime = pdMS_TO_TICKS( PHY_LS_HIGH_CHECK_TIME_MS );
-			xResult = 0;
-		}
-		else if( xTaskCheckForTimeOut( &xPhyTime, &xPhyRemTime ) != pdFALSE )
-		{
-			ulStatus = lpcPHYStsPoll();
+        if( ( ulISREvents & EMAC_IF_RX_EVENT ) != 0 )
+        {
+            ulISREvents &= ~EMAC_IF_RX_EVENT;
 
-			if( ( ulPHYLinkStatus & PHY_LINK_CONNECTED ) != ( ulStatus & PHY_LINK_CONNECTED ) )
-			{
-				ulPHYLinkStatus = ulStatus;
-				FreeRTOS_printf( ( "prvEMACHandlerTask: PHY LS now %d (polled PHY)\n", ( ulPHYLinkStatus & PHY_LINK_CONNECTED ) != 0 ) );
-			}
+            xResult = prvNetworkInterfaceInput();
 
-			vTaskSetTimeOutState( &xPhyTime );
-			if( ( ulPHYLinkStatus & PHY_LINK_CONNECTED ) != 0 )
-			{
-				xPhyRemTime = pdMS_TO_TICKS( PHY_LS_HIGH_CHECK_TIME_MS );
-			}
-			else
-			{
-				xPhyRemTime = pdMS_TO_TICKS( PHY_LS_LOW_CHECK_TIME_MS );
-			}
-		}
-	}
+            if( xResult > 0 )
+            {
+                while( prvNetworkInterfaceInput() > 0 )
+                {
+                }
+            }
+        }
+
+        if( xResult > 0 )
+        {
+            /* A packet was received. No need to check for the PHY status now,
+             * but set a timer to check it later on. */
+            vTaskSetTimeOutState( &xPhyTime );
+            xPhyRemTime = pdMS_TO_TICKS( PHY_LS_HIGH_CHECK_TIME_MS );
+            xResult = 0;
+        }
+        else if( xTaskCheckForTimeOut( &xPhyTime, &xPhyRemTime ) != pdFALSE )
+        {
+            ulStatus = lpcPHYStsPoll();
+
+            if( ( ulPHYLinkStatus & PHY_LINK_CONNECTED ) != ( ulStatus & PHY_LINK_CONNECTED ) )
+            {
+                ulPHYLinkStatus = ulStatus;
+                FreeRTOS_printf( ( "prvEMACHandlerTask: PHY LS now %d (polled PHY)\n", ( ulPHYLinkStatus & PHY_LINK_CONNECTED ) != 0 ) );
+            }
+
+            vTaskSetTimeOutState( &xPhyTime );
+
+            if( ( ulPHYLinkStatus & PHY_LINK_CONNECTED ) != 0 )
+            {
+                xPhyRemTime = pdMS_TO_TICKS( PHY_LS_HIGH_CHECK_TIME_MS );
+            }
+            else
+            {
+                xPhyRemTime = pdMS_TO_TICKS( PHY_LS_LOW_CHECK_TIME_MS );
+            }
+        }
+    }
 }
 /*-----------------------------------------------------------*/

--- a/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/portable/NetworkInterface/M487/NetworkInterface.c
+++ b/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/portable/NetworkInterface/M487/NetworkInterface.c
@@ -1,27 +1,27 @@
 /*
-FreeRTOS+TCP V2.2.1
-Copyright (C) 2018 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of
-this software and associated documentation files (the "Software"), to deal in
-the Software without restriction, including without limitation the rights to
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
-the Software, and to permit persons to whom the Software is furnished to do so,
-subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
-COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
-IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
- http://aws.amazon.com/freertos
- http://www.FreeRTOS.org
-*/
+ * FreeRTOS+TCP V2.2.1
+ * Copyright (C) 2018 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
 
 /* FreeRTOS includes. */
 #include "FreeRTOS.h"
@@ -41,139 +41,147 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "m480_eth.h"
 
 /* If ipconfigETHERNET_DRIVER_FILTERS_FRAME_TYPES is set to 1, then the Ethernet
-driver will filter incoming packets and only pass the stack those packets it
-considers need processing. */
-#if( ipconfigETHERNET_DRIVER_FILTERS_FRAME_TYPES == 0 )
-#define ipCONSIDER_FRAME_FOR_PROCESSING( pucEthernetBuffer ) eProcessBuffer
+ * driver will filter incoming packets and only pass the stack those packets it
+ * considers need processing. */
+#if ( ipconfigETHERNET_DRIVER_FILTERS_FRAME_TYPES == 0 )
+    #define ipCONSIDER_FRAME_FOR_PROCESSING( pucEthernetBuffer )    eProcessBuffer
 #else
-#define ipCONSIDER_FRAME_FOR_PROCESSING( pucEthernetBuffer ) eConsiderFrameForProcessing( ( pucEthernetBuffer ) )
+    #define ipCONSIDER_FRAME_FOR_PROCESSING( pucEthernetBuffer )    eConsiderFrameForProcessing( ( pucEthernetBuffer ) )
 #endif
 
 /* Default the size of the stack used by the EMAC deferred handler task to twice
-the size of the stack used by the idle task - but allow this to be overridden in
-FreeRTOSConfig.h as configMINIMAL_STACK_SIZE is a user definable constant. */
+ * the size of the stack used by the idle task - but allow this to be overridden in
+ * FreeRTOSConfig.h as configMINIMAL_STACK_SIZE is a user definable constant. */
 #ifndef configEMAC_TASK_STACK_SIZE
-    #define configEMAC_TASK_STACK_SIZE ( 2 * configMINIMAL_STACK_SIZE )
+    #define configEMAC_TASK_STACK_SIZE    ( 2 * configMINIMAL_STACK_SIZE )
 #endif
 
 
 static SemaphoreHandle_t xTXMutex = NULL;
 
 /* The handle of the task that processes Rx packets.  The handle is required so
-the task can be notified when new packets arrive. */
+ * the task can be notified when new packets arrive. */
 static TaskHandle_t xRxHanderTask = NULL;
 static TimerHandle_t xPhyHandlerTask = NULL;
+
 /*
  * A task that processes received frames.
  */
-static void prvEMACHandlerTask( void *pvParameters );
+static void prvEMACHandlerTask( void * pvParameters );
 static void prvPhyTmrCallback( TimerHandle_t xTimer );
 
 /* The size of each buffer when BufferAllocation_1 is used:
-http://www.freertos.org/FreeRTOS-Plus/FreeRTOS_Plus_TCP/Embedded_Ethernet_Buffer_Management.html */
+ * http://www.freertos.org/FreeRTOS-Plus/FreeRTOS_Plus_TCP/Embedded_Ethernet_Buffer_Management.html */
 
-#define niBUFFER_1_PACKET_SIZE        1536
+#define niBUFFER_1_PACKET_SIZE    1536
 #ifdef __ICCARM__
-#pragma data_alignment=4
-static uint8_t ucNetworkPackets[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS * niBUFFER_1_PACKET_SIZE ]
+    #pragma data_alignment=4
+    static uint8_t ucNetworkPackets[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS * niBUFFER_1_PACKET_SIZE ]
 #else
-static uint8_t ucNetworkPackets[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS * niBUFFER_1_PACKET_SIZE ] __attribute__ ((aligned(4)));
+    static uint8_t ucNetworkPackets[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS * niBUFFER_1_PACKET_SIZE ] __attribute__( ( aligned( 4 ) ) );
 #endif
 
 BaseType_t xNetworkInterfaceInitialise( void )
 {
-    uint8_t hwaddr[6];
+    uint8_t hwaddr[ 6 ];
     BaseType_t xReturn = pdPASS;
 
     /* Init ETH */
-    numaker_mac_address(hwaddr);
-    FreeRTOS_UpdateMACAddress(hwaddr);
-    FreeRTOS_printf( ("mac address %02x-%02x-%02x-%02x-%02x-%02x \r\n", hwaddr[0], hwaddr[1],hwaddr[2],hwaddr[3],hwaddr[4],hwaddr[5]) );
+    numaker_mac_address( hwaddr );
+    FreeRTOS_UpdateMACAddress( hwaddr );
+    FreeRTOS_printf( ( "mac address %02x-%02x-%02x-%02x-%02x-%02x \r\n", hwaddr[ 0 ], hwaddr[ 1 ], hwaddr[ 2 ], hwaddr[ 3 ], hwaddr[ 4 ], hwaddr[ 5 ] ) );
+
     /* Enable clock & set EMAC configuration         */
     /* Enable MAC and DMA transmission and reception */
-    if( numaker_eth_init(hwaddr) < 0)
+    if( numaker_eth_init( hwaddr ) < 0 )
     {
         xReturn = pdFAIL;
-    } else {
+    }
+    else
+    {
         xReturn = pdPASS;
+
         /* Guard against the task being created more than once and the
-        descriptors being initialized more than once. */
+         * descriptors being initialized more than once. */
         /* Timer task to monitor PHY Link status */
         if( xPhyHandlerTask == NULL )
         {
-            xPhyHandlerTask = xTimerCreate( "TimerPhy",  pdMS_TO_TICKS( 1000 ), pdTRUE, 0, prvPhyTmrCallback );
-            configASSERT(xPhyHandlerTask);
-            xReturn = xTimerStart( xPhyHandlerTask, 0 ) ;
+            xPhyHandlerTask = xTimerCreate( "TimerPhy", pdMS_TO_TICKS( 1000 ), pdTRUE, 0, prvPhyTmrCallback );
+            configASSERT( xPhyHandlerTask );
+            xReturn = xTimerStart( xPhyHandlerTask, 0 );
             configASSERT( xReturn );
         }
+
         /* Rx task */
         if( xRxHanderTask == NULL )
         {
             xReturn = xTaskCreate( prvEMACHandlerTask, "EMAC", configEMAC_TASK_STACK_SIZE, NULL, configMAX_PRIORITIES - 1, &xRxHanderTask );
             configASSERT( xReturn );
         }
-        
+
         if( xTXMutex == NULL )
         {
             xTXMutex = xSemaphoreCreateMutex();
             configASSERT( xTXMutex );
-        }        
+        }
     }
 
-        NVIC_SetPriority( EMAC_RX_IRQn, configMAC_INTERRUPT_PRIORITY );
-        NVIC_SetPriority( EMAC_TX_IRQn, configMAC_INTERRUPT_PRIORITY );
+    NVIC_SetPriority( EMAC_RX_IRQn, configMAC_INTERRUPT_PRIORITY );
+    NVIC_SetPriority( EMAC_TX_IRQn, configMAC_INTERRUPT_PRIORITY );
 
-        numaker_eth_enable_interrupts();
+    numaker_eth_enable_interrupts();
 
-        FreeRTOS_printf( ("ETH-RX priority:%d\n",NVIC_GetPriority( EMAC_RX_IRQn)) );
+    FreeRTOS_printf( ( "ETH-RX priority:%d\n", NVIC_GetPriority( EMAC_RX_IRQn ) ) );
 
     return xReturn;
 }
 
-BaseType_t xNetworkInterfaceOutput( NetworkBufferDescriptor_t * const pxDescriptor, BaseType_t xReleaseAfterSend )
+BaseType_t xNetworkInterfaceOutput( NetworkBufferDescriptor_t * const pxDescriptor,
+                                    BaseType_t xReleaseAfterSend )
 {
-    uint8_t *buffer=NULL;
-//    FreeRTOS_printf(("<-- dataLength=%d\n",pxDescriptor->xDataLength));
+    uint8_t * buffer = NULL;
+
+/*    FreeRTOS_printf(("<-- dataLength=%d\n",pxDescriptor->xDataLength)); */
     if( pxDescriptor->xDataLength >= PACKET_BUFFER_SIZE )
     {
-        FreeRTOS_printf(("TX buffer length %d over %d\n", pxDescriptor->xDataLength, PACKET_BUFFER_SIZE));
+        FreeRTOS_printf( ( "TX buffer length %d over %d\n", pxDescriptor->xDataLength, PACKET_BUFFER_SIZE ) );
         return pdFALSE;
     }
-    
+
     buffer = numaker_eth_get_tx_buf();
+
     if( buffer == NULL )
     {
-        NU_DEBUGF(("Eth TX slots are busy\n"));
+        NU_DEBUGF( ( "Eth TX slots are busy\n" ) );
         return pdFALSE;
-    }    
-    
+    }
+
     /* Get exclusive access */
-    xSemaphoreTake(xTXMutex, portMAX_DELAY);
-    NU_DEBUGF(("%s ... buffer=0x%x\r\n",__FUNCTION__, buffer));   
-    //SendData: pt = pxDescriptor->pucBuffer, length = pxDescriptor->xDataLength
-    memcpy(buffer, pxDescriptor->pucEthernetBuffer, pxDescriptor->xDataLength);
-    numaker_eth_trigger_tx(pxDescriptor->xDataLength, NULL);
+    xSemaphoreTake( xTXMutex, portMAX_DELAY );
+    NU_DEBUGF( ( "%s ... buffer=0x%x\r\n", __FUNCTION__, buffer ) );
+    /*SendData: pt = pxDescriptor->pucBuffer, length = pxDescriptor->xDataLength */
+    memcpy( buffer, pxDescriptor->pucEthernetBuffer, pxDescriptor->xDataLength );
+    numaker_eth_trigger_tx( pxDescriptor->xDataLength, NULL );
     /* Call the standard trace macro to log the send event. */
     iptraceNETWORK_INTERFACE_TRANSMIT();
 
     if( xReleaseAfterSend != pdFALSE )
     {
         /* It is assumed SendData() copies the data out of the FreeRTOS+TCP Ethernet
-        buffer.  The Ethernet buffer is therefore no longer needed, and must be
-        freed for re-use. */
+         * buffer.  The Ethernet buffer is therefore no longer needed, and must be
+         * freed for re-use. */
         vReleaseNetworkBufferAndDescriptor( pxDescriptor );
     }
 
-    xSemaphoreGive(xTXMutex);
-    
+    xSemaphoreGive( xTXMutex );
+
     return pdTRUE;
 }
 
 
 void vNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
 {
-
-    uint8_t *ucRAMBuffer = ucNetworkPackets;
+    uint8_t * ucRAMBuffer = ucNetworkPackets;
     uint32_t ul;
 
     for( ul = 0; ul < ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS; ul++ )
@@ -206,21 +214,23 @@ static void prvPhyTmrCallback( TimerHandle_t xTimer )
     IPStackEvent_t xRxEvent;
     static BaseType_t lastLink = pdFAIL;
     BaseType_t currLink = xGetPhyLinkStatus();
+
     if( currLink != lastLink )
     {
-        FreeRTOS_printf(("PHY Link %s\n", (currLink) ? "Up" : "Down"));
+        FreeRTOS_printf( ( "PHY Link %s\n", ( currLink ) ? "Up" : "Down" ) );
+
         if( !currLink )
         {
             xRxEvent.eEventType = eNetworkDownEvent;
             xSendEventStructToIPTask( &xRxEvent, 0 );
         }
+
         lastLink = currLink;
     }
+}
 
-}    
 
-    
-static void prvEMACHandlerTask( void *pvParameters )
+static void prvEMACHandlerTask( void * pvParameters )
 {
     TimeOut_t xPhyTime;
     TickType_t xPhyRemTime;
@@ -229,103 +239,117 @@ static void prvEMACHandlerTask( void *pvParameters )
     BaseType_t xResult = 0;
     uint32_t ulStatus;
     uint16_t dataLength = 0;
-    uint8_t *buffer = NULL;
-    NetworkBufferDescriptor_t *pxBufferDescriptor = NULL;
+    uint8_t * buffer = NULL;
+    NetworkBufferDescriptor_t * pxBufferDescriptor = NULL;
     IPStackEvent_t xRxEvent;
     const TickType_t xBlockTime = pdMS_TO_TICKS( 5000ul );
-    
+
     /* Remove compiler warnings about unused parameters. */
     ( void ) pvParameters;
     /* A possibility to set some additional task properties. */
-    
-    for( ;; )
+
+    for( ; ; )
     {
         uxCurrentCount = uxGetMinimumFreeNetworkBuffers();
+
         if( uxLastMinBufferCount != uxCurrentCount )
         {
             /* The logging produced below may be helpful
-            while tuning +TCP: see how many buffers are in use. */
+             * while tuning +TCP: see how many buffers are in use. */
             uxLastMinBufferCount = uxCurrentCount;
             FreeRTOS_printf( ( "Network buffers: %lu lowest %lu\n",
-                uxGetNumberOfFreeNetworkBuffers(), uxCurrentCount ) );
+                               uxGetNumberOfFreeNetworkBuffers(), uxCurrentCount ) );
         }
-        
+
         /* No events to process now, wait for the next. */
-        ulTaskNotifyTake( pdFALSE, portMAX_DELAY ); 
-        while(1)
-        {    
+        ulTaskNotifyTake( pdFALSE, portMAX_DELAY );
+
+        while( 1 )
+        {
             /* get received frame */
-            if ( numaker_eth_get_rx_buf(&dataLength, &buffer) != 0) {
-            /* The event was lost because a network buffer was not available.
-            Call the standard trace macro to log the occurrence. */
+            if( numaker_eth_get_rx_buf( &dataLength, &buffer ) != 0 )
+            {
+                /* The event was lost because a network buffer was not available.
+                 * Call the standard trace macro to log the occurrence. */
                 iptraceETHERNET_RX_EVENT_LOST();
                 break;
-            }        
+            }
 
             /* Allocate a network buffer descriptor that points to a buffer
-            large enough to hold the received frame.  As this is the simple
-            rather than efficient example the received data will just be copied
-            into this buffer. */
+             * large enough to hold the received frame.  As this is the simple
+             * rather than efficient example the received data will just be copied
+             * into this buffer. */
 
             pxBufferDescriptor = pxGetNetworkBufferWithDescriptor( PACKET_BUFFER_SIZE, 0 );
 
             if( pxBufferDescriptor != NULL )
-            {        
+            {
                 memcpy( pxBufferDescriptor->pucEthernetBuffer, buffer, dataLength );
-//                          FreeRTOS_printf(("--> dataLength=%d\n",dataLength));
-                pxBufferDescriptor->xDataLength = dataLength;            
-            } else {
+/*                          FreeRTOS_printf(("--> dataLength=%d\n",dataLength)); */
+                pxBufferDescriptor->xDataLength = dataLength;
+            }
+            else
+            {
                 numaker_eth_rx_next();
                 iptraceETHERNET_RX_EVENT_LOST();
                 break;
             }
+
             /* The event about to be sent to the TCP/IP is an Rx event. */
             xRxEvent.eEventType = eNetworkRxEvent;
 
             /* pvData is used to point to the network buffer descriptor that
-                now references the received data. */
+             *  now references the received data. */
             xRxEvent.pvData = ( void * ) pxBufferDescriptor;
 
             /* Send the data to the TCP/IP stack. */
             if( xSendEventStructToIPTask( &xRxEvent, 0 ) == pdFALSE )
             {
                 /* The buffer could not be sent to the IP task so the buffer
-                 must be released. */
+                 * must be released. */
                 vReleaseNetworkBufferAndDescriptor( pxBufferDescriptor );
 
                 /* Make a call to the standard trace macro to log the
-                        occurrence. */
+                 *      occurrence. */
 
                 iptraceETHERNET_RX_EVENT_LOST();
-            } else
+            }
+            else
             {
                 /* The message was successfully sent to the TCP/IP stack.
-                Call the standard trace macro to log the occurrence. */
+                * Call the standard trace macro to log the occurrence. */
                 iptraceNETWORK_INTERFACE_RECEIVE();
-            } 
-                numaker_eth_rx_next();
-        }    
+            }
+
+            numaker_eth_rx_next();
+        }
+
         numaker_eth_trigger_rx();
     }
 }
 
-void xNetworkCallback(char event)
+void xNetworkCallback( char event )
 {
     BaseType_t xHigherPriorityTaskWoken = pdFALSE;
-    switch (event)
+
+    switch( event )
     {
-      case 'R': //For RX event
-    /* Wakeup the prvEMACHandlerTask. */
-        if( xRxHanderTask != NULL )
-        {
-            vTaskNotifyGiveFromISR( xRxHanderTask, &xHigherPriorityTaskWoken );
-            portYIELD_FROM_ISR( xHigherPriorityTaskWoken );
-        }
-        break;
-      case 'T': //For TX event
-        // ack of tx done, no-op in this stage
-        break;
-      default:
-        break;
+        case 'R': /*For RX event */
+
+            /* Wakeup the prvEMACHandlerTask. */
+            if( xRxHanderTask != NULL )
+            {
+                vTaskNotifyGiveFromISR( xRxHanderTask, &xHigherPriorityTaskWoken );
+                portYIELD_FROM_ISR( xHigherPriorityTaskWoken );
+            }
+
+            break;
+
+        case 'T': /*For TX event */
+            /* ack of tx done, no-op in this stage */
+            break;
+
+        default:
+            break;
     }
 }

--- a/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/portable/NetworkInterface/M487/m480_eth.c
+++ b/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/portable/NetworkInterface/M487/m480_eth.c
@@ -1,6 +1,6 @@
 /**************************************************************************//**
  * @copyright (C) 2019 Nuvoton Technology Corp. All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without modification,
  * are permitted provided that the following conditions are met:
  *   1. Redistributions of source code must retain the above copyright notice,
@@ -11,7 +11,7 @@
  *   3. Neither the name of Nuvoton Technology Corp. nor the names of its contributors
  *      may be used to endorse or promote products derived from this software
  *      without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -22,177 +22,201 @@
  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*****************************************************************************/
+ *****************************************************************************/
 #include "FreeRTOS.h"
 #include "list.h"
 #include "FreeRTOS_IP.h"
 
 #include "m480_eth.h"
 
-#define ETH_TRIGGER_RX()    do{EMAC->RXST = 0;}while(0)
-#define ETH_TRIGGER_TX()    do{EMAC->TXST = 0;}while(0)
-#define ETH_ENABLE_TX()     do{EMAC->CTL |= EMAC_CTL_TXON;}while(0)
-#define ETH_ENABLE_RX()     do{EMAC->CTL |= EMAC_CTL_RXON;}while(0)
-#define ETH_DISABLE_TX()    do{EMAC->CTL &= ~EMAC_CTL_TXON;}while(0)
-#define ETH_DISABLE_RX()    do{EMAC->CTL &= ~EMAC_CTL_RXON;}while(0)
-    
+#define ETH_TRIGGER_RX()    do{ EMAC->RXST = 0; }while( 0 )
+#define ETH_TRIGGER_TX()    do{ EMAC->TXST = 0; }while( 0 )
+#define ETH_ENABLE_TX()     do{ EMAC->CTL |= EMAC_CTL_TXON; }while( 0 )
+#define ETH_ENABLE_RX()     do{ EMAC->CTL |= EMAC_CTL_RXON; }while( 0 )
+#define ETH_DISABLE_TX()    do{ EMAC->CTL &= ~EMAC_CTL_TXON; }while( 0 )
+#define ETH_DISABLE_RX()    do{ EMAC->CTL &= ~EMAC_CTL_RXON; }while( 0 )
 
-struct eth_descriptor rx_desc[RX_DESCRIPTOR_NUM] __attribute__ ((aligned(4)));
-struct eth_descriptor tx_desc[TX_DESCRIPTOR_NUM] __attribute__ ((aligned(4)));
+
+struct eth_descriptor rx_desc[ RX_DESCRIPTOR_NUM ] __attribute__( ( aligned( 4 ) ) );
+struct eth_descriptor tx_desc[ TX_DESCRIPTOR_NUM ] __attribute__( ( aligned( 4 ) ) );
 #ifdef __ICCARM__
-#pragma data_alignment=4
-struct eth_descriptor rx_desc[RX_DESCRIPTOR_NUM];
-struct eth_descriptor tx_desc[TX_DESCRIPTOR_NUM];
-uint8_t rx_buf[RX_DESCRIPTOR_NUM][PACKET_BUFFER_SIZE];
-uint8_t tx_buf[TX_DESCRIPTOR_NUM][PACKET_BUFFER_SIZE];
+    #pragma data_alignment=4
+    struct eth_descriptor rx_desc[ RX_DESCRIPTOR_NUM ];
+    struct eth_descriptor tx_desc[ TX_DESCRIPTOR_NUM ];
+    uint8_t rx_buf[ RX_DESCRIPTOR_NUM ][ PACKET_BUFFER_SIZE ];
+    uint8_t tx_buf[ TX_DESCRIPTOR_NUM ][ PACKET_BUFFER_SIZE ];
 #else
-struct eth_descriptor rx_desc[RX_DESCRIPTOR_NUM] __attribute__ ((aligned(4)));
-struct eth_descriptor tx_desc[TX_DESCRIPTOR_NUM] __attribute__ ((aligned(4)));
-uint8_t rx_buf[RX_DESCRIPTOR_NUM][PACKET_BUFFER_SIZE]  __attribute__ ((aligned(4)));
-uint8_t tx_buf[TX_DESCRIPTOR_NUM][PACKET_BUFFER_SIZE]  __attribute__ ((aligned(4)));
+    struct eth_descriptor rx_desc[ RX_DESCRIPTOR_NUM ] __attribute__( ( aligned( 4 ) ) );
+    struct eth_descriptor tx_desc[ TX_DESCRIPTOR_NUM ] __attribute__( ( aligned( 4 ) ) );
+    uint8_t rx_buf[ RX_DESCRIPTOR_NUM ][ PACKET_BUFFER_SIZE ]  __attribute__( ( aligned( 4 ) ) );
+    uint8_t tx_buf[ TX_DESCRIPTOR_NUM ][ PACKET_BUFFER_SIZE ]  __attribute__( ( aligned( 4 ) ) );
 #endif
-struct eth_descriptor volatile *cur_tx_desc_ptr, *cur_rx_desc_ptr, *fin_tx_desc_ptr;
+struct eth_descriptor volatile * cur_tx_desc_ptr, * cur_rx_desc_ptr, * fin_tx_desc_ptr;
 
 
-// PTP source clock is 84MHz (Real chip using PLL). Each tick is 11.90ns
-// Assume we want to set each tick to 100ns.
-// Increase register = (100 * 2^31) / (10^9) = 214.71 =~ 215 = 0xD7
-// Addend register = 2^32 * tick_freq / (84MHz), where tick_freq = (2^31 / 215) MHz
-// From above equation, addend register = 2^63 / (84M * 215) ~= 510707200 = 0x1E70C600
+/* PTP source clock is 84MHz (Real chip using PLL). Each tick is 11.90ns */
+/* Assume we want to set each tick to 100ns. */
+/* Increase register = (100 * 2^31) / (10^9) = 214.71 =~ 215 = 0xD7 */
+/* Addend register = 2^32 * tick_freq / (84MHz), where tick_freq = (2^31 / 215) MHz */
+/* From above equation, addend register = 2^63 / (84M * 215) ~= 510707200 = 0x1E70C600 */
 
 
 
-static void mdio_write(uint8_t addr, uint8_t reg, uint16_t val)
+static void mdio_write( uint8_t addr,
+                        uint8_t reg,
+                        uint16_t val )
 {
-
     EMAC->MIIMDAT = val;
-    EMAC->MIIMCTL = (addr << EMAC_MIIMCTL_PHYADDR_Pos) | reg | EMAC_MIIMCTL_BUSY_Msk | EMAC_MIIMCTL_WRITE_Msk | EMAC_MIIMCTL_MDCON_Msk;
+    EMAC->MIIMCTL = ( addr << EMAC_MIIMCTL_PHYADDR_Pos ) | reg | EMAC_MIIMCTL_BUSY_Msk | EMAC_MIIMCTL_WRITE_Msk | EMAC_MIIMCTL_MDCON_Msk;
 
-    while (EMAC->MIIMCTL & EMAC_MIIMCTL_BUSY_Msk);
-
+    while( EMAC->MIIMCTL & EMAC_MIIMCTL_BUSY_Msk )
+    {
+    }
 }
 
 
-static uint16_t mdio_read(uint8_t addr, uint8_t reg)
+static uint16_t mdio_read( uint8_t addr,
+                           uint8_t reg )
 {
-    EMAC->MIIMCTL = (addr << EMAC_MIIMCTL_PHYADDR_Pos) | reg | EMAC_MIIMCTL_BUSY_Msk | EMAC_MIIMCTL_MDCON_Msk;
-    while (EMAC->MIIMCTL & EMAC_MIIMCTL_BUSY_Msk);
+    EMAC->MIIMCTL = ( addr << EMAC_MIIMCTL_PHYADDR_Pos ) | reg | EMAC_MIIMCTL_BUSY_Msk | EMAC_MIIMCTL_MDCON_Msk;
 
-    return(EMAC->MIIMDAT);
+    while( EMAC->MIIMCTL & EMAC_MIIMCTL_BUSY_Msk )
+    {
+    }
+
+    return( EMAC->MIIMDAT );
 }
 
-static int reset_phy(void)
+static int reset_phy( void )
 {
-
     uint16_t reg;
     uint32_t delayCnt;
 
 
-    mdio_write(CONFIG_PHY_ADDR, MII_BMCR, BMCR_RESET);
+    mdio_write( CONFIG_PHY_ADDR, MII_BMCR, BMCR_RESET );
 
     delayCnt = 2000;
-    while(delayCnt-- > 0) {
-        if((mdio_read(CONFIG_PHY_ADDR, MII_BMCR) & BMCR_RESET) == 0)
+
+    while( delayCnt-- > 0 )
+    {
+        if( ( mdio_read( CONFIG_PHY_ADDR, MII_BMCR ) & BMCR_RESET ) == 0 )
+        {
             break;
-
-    }
-
-    if(delayCnt == 0) {
-        NU_DEBUGF(("Reset phy failed\n"));
-        return(-1);
-    }
-
-    mdio_write(CONFIG_PHY_ADDR, MII_ADVERTISE, ADVERTISE_CSMA |
-               ADVERTISE_10HALF |
-               ADVERTISE_10FULL |
-               ADVERTISE_100HALF |
-               ADVERTISE_100FULL);
-
-    reg = mdio_read(CONFIG_PHY_ADDR, MII_BMCR);
-    mdio_write(CONFIG_PHY_ADDR, MII_BMCR, reg | BMCR_ANRESTART);
-
-    delayCnt = 200000;
-    while(delayCnt-- > 0) {
-        if((mdio_read(CONFIG_PHY_ADDR, MII_BMSR) & (BMSR_ANEGCOMPLETE | BMSR_LSTATUS))
-                == (BMSR_ANEGCOMPLETE | BMSR_LSTATUS))
-            break;
-    }
-
-    if(delayCnt == 0) {
-        NU_DEBUGF(("AN failed. Set to 100 FULL\n"));
-        EMAC->CTL |= (EMAC_CTL_OPMODE_Msk | EMAC_CTL_FUDUP_Msk);
-        return(-1);
-    } else {
-        reg = mdio_read(CONFIG_PHY_ADDR, MII_LPA);
-
-        if(reg & ADVERTISE_100FULL) {
-            NU_DEBUGF(("100 full\n"));
-            EMAC->CTL |= (EMAC_CTL_OPMODE_Msk | EMAC_CTL_FUDUP_Msk);
-        } else if(reg & ADVERTISE_100HALF) {
-            NU_DEBUGF(("100 half\n"));
-            EMAC->CTL = (EMAC->CTL & ~EMAC_CTL_FUDUP_Msk) | EMAC_CTL_OPMODE_Msk;
-        } else if(reg & ADVERTISE_10FULL) {
-            NU_DEBUGF(("10 full\n"));
-            EMAC->CTL = (EMAC->CTL & ~EMAC_CTL_OPMODE_Msk) | EMAC_CTL_FUDUP_Msk;
-        } else {
-            NU_DEBUGF(("10 half\n"));
-            EMAC->CTL &= ~(EMAC_CTL_OPMODE_Msk | EMAC_CTL_FUDUP_Msk);
         }
     }
-	FreeRTOS_printf(("PHY ID 1:0x%x\r\n", mdio_read(CONFIG_PHY_ADDR, MII_PHYSID1)));
-	FreeRTOS_printf(("PHY ID 2:0x%x\r\n", mdio_read(CONFIG_PHY_ADDR, MII_PHYSID2)));
 
-    return(0);
+    if( delayCnt == 0 )
+    {
+        NU_DEBUGF( ( "Reset phy failed\n" ) );
+        return( -1 );
+    }
+
+    mdio_write( CONFIG_PHY_ADDR, MII_ADVERTISE, ADVERTISE_CSMA |
+                ADVERTISE_10HALF |
+                ADVERTISE_10FULL |
+                ADVERTISE_100HALF |
+                ADVERTISE_100FULL );
+
+    reg = mdio_read( CONFIG_PHY_ADDR, MII_BMCR );
+    mdio_write( CONFIG_PHY_ADDR, MII_BMCR, reg | BMCR_ANRESTART );
+
+    delayCnt = 200000;
+
+    while( delayCnt-- > 0 )
+    {
+        if( ( mdio_read( CONFIG_PHY_ADDR, MII_BMSR ) & ( BMSR_ANEGCOMPLETE | BMSR_LSTATUS ) )
+            == ( BMSR_ANEGCOMPLETE | BMSR_LSTATUS ) )
+        {
+            break;
+        }
+    }
+
+    if( delayCnt == 0 )
+    {
+        NU_DEBUGF( ( "AN failed. Set to 100 FULL\n" ) );
+        EMAC->CTL |= ( EMAC_CTL_OPMODE_Msk | EMAC_CTL_FUDUP_Msk );
+        return( -1 );
+    }
+    else
+    {
+        reg = mdio_read( CONFIG_PHY_ADDR, MII_LPA );
+
+        if( reg & ADVERTISE_100FULL )
+        {
+            NU_DEBUGF( ( "100 full\n" ) );
+            EMAC->CTL |= ( EMAC_CTL_OPMODE_Msk | EMAC_CTL_FUDUP_Msk );
+        }
+        else if( reg & ADVERTISE_100HALF )
+        {
+            NU_DEBUGF( ( "100 half\n" ) );
+            EMAC->CTL = ( EMAC->CTL & ~EMAC_CTL_FUDUP_Msk ) | EMAC_CTL_OPMODE_Msk;
+        }
+        else if( reg & ADVERTISE_10FULL )
+        {
+            NU_DEBUGF( ( "10 full\n" ) );
+            EMAC->CTL = ( EMAC->CTL & ~EMAC_CTL_OPMODE_Msk ) | EMAC_CTL_FUDUP_Msk;
+        }
+        else
+        {
+            NU_DEBUGF( ( "10 half\n" ) );
+            EMAC->CTL &= ~( EMAC_CTL_OPMODE_Msk | EMAC_CTL_FUDUP_Msk );
+        }
+    }
+
+    FreeRTOS_printf( ( "PHY ID 1:0x%x\r\n", mdio_read( CONFIG_PHY_ADDR, MII_PHYSID1 ) ) );
+    FreeRTOS_printf( ( "PHY ID 2:0x%x\r\n", mdio_read( CONFIG_PHY_ADDR, MII_PHYSID2 ) ) );
+
+    return( 0 );
 }
 
 
-static void init_tx_desc(void)
+static void init_tx_desc( void )
 {
     uint32_t i;
 
 
-    cur_tx_desc_ptr = fin_tx_desc_ptr = &tx_desc[0];
+    cur_tx_desc_ptr = fin_tx_desc_ptr = &tx_desc[ 0 ];
 
-    for(i = 0; i < TX_DESCRIPTOR_NUM; i++) {
-        tx_desc[i].status1 = TXFD_PADEN | TXFD_CRCAPP | TXFD_INTEN;
-        tx_desc[i].buf = &tx_buf[i][0];
-        tx_desc[i].status2 = 0;
-        tx_desc[i].next = &tx_desc[(i + 1) % TX_DESCRIPTOR_NUM];
-
+    for( i = 0; i < TX_DESCRIPTOR_NUM; i++ )
+    {
+        tx_desc[ i ].status1 = TXFD_PADEN | TXFD_CRCAPP | TXFD_INTEN;
+        tx_desc[ i ].buf = &tx_buf[ i ][ 0 ];
+        tx_desc[ i ].status2 = 0;
+        tx_desc[ i ].next = &tx_desc[ ( i + 1 ) % TX_DESCRIPTOR_NUM ];
     }
-    EMAC->TXDSA = (unsigned int)&tx_desc[0];
+
+    EMAC->TXDSA = ( unsigned int ) &tx_desc[ 0 ];
     return;
 }
 
-static void init_rx_desc(void)
+static void init_rx_desc( void )
 {
     uint32_t i;
 
 
-    cur_rx_desc_ptr = &rx_desc[0];
+    cur_rx_desc_ptr = &rx_desc[ 0 ];
 
-    for(i = 0; i < RX_DESCRIPTOR_NUM; i++) {
-        rx_desc[i].status1 = OWNERSHIP_EMAC;
-        rx_desc[i].buf = &rx_buf[i][0];
-        rx_desc[i].status2 = 0;
-        rx_desc[i].next = &rx_desc[(i + 1) % TX_DESCRIPTOR_NUM];
+    for( i = 0; i < RX_DESCRIPTOR_NUM; i++ )
+    {
+        rx_desc[ i ].status1 = OWNERSHIP_EMAC;
+        rx_desc[ i ].buf = &rx_buf[ i ][ 0 ];
+        rx_desc[ i ].status2 = 0;
+        rx_desc[ i ].next = &rx_desc[ ( i + 1 ) % TX_DESCRIPTOR_NUM ];
     }
-    EMAC->RXDSA = (unsigned int)&rx_desc[0];
+
+    EMAC->RXDSA = ( unsigned int ) &rx_desc[ 0 ];
     return;
 }
 
-void numaker_set_mac_addr(uint8_t *addr)
+void numaker_set_mac_addr( uint8_t * addr )
 {
+    EMAC->CAM0M = ( addr[ 0 ] << 24 ) |
+                  ( addr[ 1 ] << 16 ) |
+                  ( addr[ 2 ] << 8 ) |
+                  addr[ 3 ];
 
-    EMAC->CAM0M = (addr[0] << 24) |
-                  (addr[1] << 16) |
-                  (addr[2] << 8) |
-                  addr[3];
-
-    EMAC->CAM0L = (addr[4] << 24) |
-                  (addr[5] << 16);
-
-
+    EMAC->CAM0L = ( addr[ 4 ] << 24 ) |
+                  ( addr[ 5 ] << 16 );
 }
 
 static void __eth_clk_pin_init()
@@ -201,58 +225,60 @@ static void __eth_clk_pin_init()
     SYS_UnlockReg();
 
     /* Enable IP clock */
-    CLK_EnableModuleClock(EMAC_MODULE);
-    
-    // Configure MDC clock rate to HCLK / (127 + 1) = 1.25 MHz if system is running at 160 MH
-    CLK_SetModuleClock(EMAC_MODULE, 0, CLK_CLKDIV3_EMAC(127));
-    
+    CLK_EnableModuleClock( EMAC_MODULE );
+
+    /* Configure MDC clock rate to HCLK / (127 + 1) = 1.25 MHz if system is running at 160 MH */
+    CLK_SetModuleClock( EMAC_MODULE, 0, CLK_CLKDIV3_EMAC( 127 ) );
+
     /* Update System Core Clock */
     SystemCoreClockUpdate();
-    
+
     /*---------------------------------------------------------------------------------------------------------*/
     /* Init I/O Multi-function                                                                                 */
     /*---------------------------------------------------------------------------------------------------------*/
-    // Configure RMII pins
-    SYS->GPA_MFPL &= ~(SYS_GPA_MFPL_PA6MFP_Msk | SYS_GPA_MFPL_PA7MFP_Msk);
+    /* Configure RMII pins */
+    SYS->GPA_MFPL &= ~( SYS_GPA_MFPL_PA6MFP_Msk | SYS_GPA_MFPL_PA7MFP_Msk );
     SYS->GPA_MFPL |= SYS_GPA_MFPL_PA6MFP_EMAC_RMII_RXERR | SYS_GPA_MFPL_PA7MFP_EMAC_RMII_CRSDV;
-    SYS->GPC_MFPL &= ~(SYS_GPC_MFPL_PC6MFP_Msk | SYS_GPC_MFPL_PC7MFP_Msk);
+    SYS->GPC_MFPL &= ~( SYS_GPC_MFPL_PC6MFP_Msk | SYS_GPC_MFPL_PC7MFP_Msk );
     SYS->GPC_MFPL |= SYS_GPC_MFPL_PC6MFP_EMAC_RMII_RXD1 | SYS_GPC_MFPL_PC7MFP_EMAC_RMII_RXD0;
     SYS->GPC_MFPH &= ~SYS_GPC_MFPH_PC8MFP_Msk;
     SYS->GPC_MFPH |= SYS_GPC_MFPH_PC8MFP_EMAC_RMII_REFCLK;
-    SYS->GPE_MFPH &= ~(SYS_GPE_MFPH_PE8MFP_Msk | SYS_GPE_MFPH_PE9MFP_Msk | SYS_GPE_MFPH_PE10MFP_Msk |
-                       SYS_GPE_MFPH_PE11MFP_Msk | SYS_GPE_MFPH_PE12MFP_Msk);
+    SYS->GPE_MFPH &= ~( SYS_GPE_MFPH_PE8MFP_Msk | SYS_GPE_MFPH_PE9MFP_Msk | SYS_GPE_MFPH_PE10MFP_Msk |
+                        SYS_GPE_MFPH_PE11MFP_Msk | SYS_GPE_MFPH_PE12MFP_Msk );
     SYS->GPE_MFPH |= SYS_GPE_MFPH_PE8MFP_EMAC_RMII_MDC |
-                    SYS_GPE_MFPH_PE9MFP_EMAC_RMII_MDIO |
-                    SYS_GPE_MFPH_PE10MFP_EMAC_RMII_TXD0 |
-                    SYS_GPE_MFPH_PE11MFP_EMAC_RMII_TXD1 |
-                    SYS_GPE_MFPH_PE12MFP_EMAC_RMII_TXEN;
+                     SYS_GPE_MFPH_PE9MFP_EMAC_RMII_MDIO |
+                     SYS_GPE_MFPH_PE10MFP_EMAC_RMII_TXD0 |
+                     SYS_GPE_MFPH_PE11MFP_EMAC_RMII_TXD1 |
+                     SYS_GPE_MFPH_PE12MFP_EMAC_RMII_TXEN;
 
-    // Enable high slew rate on all RMII TX output pins
-    PE->SLEWCTL = (GPIO_SLEWCTL_HIGH << GPIO_SLEWCTL_HSREN10_Pos) |
-                  (GPIO_SLEWCTL_HIGH << GPIO_SLEWCTL_HSREN11_Pos) |
-                  (GPIO_SLEWCTL_HIGH << GPIO_SLEWCTL_HSREN12_Pos);
+    /* Enable high slew rate on all RMII TX output pins */
+    PE->SLEWCTL = ( GPIO_SLEWCTL_HIGH << GPIO_SLEWCTL_HSREN10_Pos ) |
+                  ( GPIO_SLEWCTL_HIGH << GPIO_SLEWCTL_HSREN11_Pos ) |
+                  ( GPIO_SLEWCTL_HIGH << GPIO_SLEWCTL_HSREN12_Pos );
 
 
     /* Lock protected registers */
     SYS_LockReg();
-
-
 }
 
-int numaker_eth_init(uint8_t *mac_addr)
+int numaker_eth_init( uint8_t * mac_addr )
 {
     int ret = 0;
-    // init CLK & pins
+
+    /* init CLK & pins */
     __eth_clk_pin_init();
-  
-    // Reset MAC
+
+    /* Reset MAC */
     EMAC->CTL = EMAC_CTL_RST_Msk;
-    while(EMAC->CTL & EMAC_CTL_RST_Msk) {}
+
+    while( EMAC->CTL & EMAC_CTL_RST_Msk )
+    {
+    }
 
     init_tx_desc();
     init_rx_desc();
 
-    numaker_set_mac_addr(mac_addr);  // need to reconfigure hardware address 'cos we just RESET emc...
+    numaker_set_mac_addr( mac_addr ); /* need to reconfigure hardware address 'cos we just RESET emc... */
 
 
     /* Configure the MAC interrupt enable register. */
@@ -270,13 +296,13 @@ int numaker_eth_init(uint8_t *mac_addr)
     EMAC->CTL = EMAC_CTL_STRIPCRC_Msk | EMAC_CTL_RMIIEN_Msk;
 
     /* Accept packets for us and all broadcast and multicast packets */
-    EMAC->CAMCTL =  EMAC_CAMCTL_CMPEN_Msk |
-                    EMAC_CAMCTL_AMP_Msk |
-                    EMAC_CAMCTL_ABP_Msk;
-    EMAC->CAMEN = 1;    // Enable CAM entry 0    
+    EMAC->CAMCTL = EMAC_CAMCTL_CMPEN_Msk |
+                   EMAC_CAMCTL_AMP_Msk |
+                   EMAC_CAMCTL_ABP_Msk;
+    EMAC->CAMEN = 1; /* Enable CAM entry 0 */
 
-    ret= reset_phy();                    
-                    
+    ret = reset_phy();
+
     EMAC_ENABLE_RX();
     EMAC_ENABLE_TX();
     return ret;
@@ -284,138 +310,161 @@ int numaker_eth_init(uint8_t *mac_addr)
 
 
 
-void  ETH_halt(void)
+void ETH_halt( void )
 {
-
-    EMAC->CTL &= ~(EMAC_CTL_RXON_Msk | EMAC_CTL_TXON_Msk);
+    EMAC->CTL &= ~( EMAC_CTL_RXON_Msk | EMAC_CTL_TXON_Msk );
 }
 
 unsigned int m_status;
 
-void EMAC_RX_IRQHandler(void)
+void EMAC_RX_IRQHandler( void )
 {
-//    NU_DEBUGF(("%s ... \r\n", __FUNCTION__));
+/*    NU_DEBUGF(("%s ... \r\n", __FUNCTION__)); */
     m_status = EMAC->INTSTS & 0xFFFF;
     EMAC->INTSTS = m_status;
-    if (m_status & EMAC_INTSTS_RXBEIF_Msk) {
-        // Shouldn't goes here, unless descriptor corrupted
-		NU_DEBUGF(("RX descriptor corrupted \r\n"));
-		//return;
+
+    if( m_status & EMAC_INTSTS_RXBEIF_Msk )
+    {
+        /* Shouldn't goes here, unless descriptor corrupted */
+        NU_DEBUGF( ( "RX descriptor corrupted \r\n" ) );
+        /*return; */
     }
-    // FIX ME: for rx-event, to ack rx_isr into event queue
-        xNetworkCallback('R');
+
+    /* FIX ME: for rx-event, to ack rx_isr into event queue */
+    xNetworkCallback( 'R' );
 }
 
 
-void numaker_eth_trigger_rx(void)
+void numaker_eth_trigger_rx( void )
 {
     ETH_TRIGGER_RX();
 }
 
-int numaker_eth_get_rx_buf(uint16_t *len, uint8_t **buf)
+int numaker_eth_get_rx_buf( uint16_t * len,
+                            uint8_t ** buf )
 {
     unsigned int cur_entry, status;
 
     cur_entry = EMAC->CRXDSA;
-    if ((cur_entry == (uint32_t)cur_rx_desc_ptr) && (!(m_status & EMAC_INTSTS_RDUIF_Msk)))  // cur_entry may equal to cur_rx_desc_ptr if RDU occures
-            return -1;
+
+    if( ( cur_entry == ( uint32_t ) cur_rx_desc_ptr ) && ( !( m_status & EMAC_INTSTS_RDUIF_Msk ) ) ) /* cur_entry may equal to cur_rx_desc_ptr if RDU occures */
+    {
+        return -1;
+    }
+
     status = cur_rx_desc_ptr->status1;
 
-    if(status & OWNERSHIP_EMAC)
-            return -1;
+    if( status & OWNERSHIP_EMAC )
+    {
+        return -1;
+    }
 
-    if (status & RXFD_RXGD) {
+    if( status & RXFD_RXGD )
+    {
         *buf = cur_rx_desc_ptr->buf;
         *len = status & 0xFFFF;
     }
-    return 0;
-}    
 
-void numaker_eth_rx_next(void)
+    return 0;
+}
+
+void numaker_eth_rx_next( void )
 {
     cur_rx_desc_ptr->status1 = OWNERSHIP_EMAC;
-    cur_rx_desc_ptr = cur_rx_desc_ptr->next;    
-}    
+    cur_rx_desc_ptr = cur_rx_desc_ptr->next;
+}
 
-void EMAC_TX_IRQHandler(void)
+void EMAC_TX_IRQHandler( void )
 {
     unsigned int cur_entry, status;
 
     status = EMAC->INTSTS & 0xFFFF0000;
     EMAC->INTSTS = status;
-    if(status & EMAC_INTSTS_TXBEIF_Msk) {
-        // Shouldn't goes here, unless descriptor corrupted
+
+    if( status & EMAC_INTSTS_TXBEIF_Msk )
+    {
+        /* Shouldn't goes here, unless descriptor corrupted */
         return;
     }
 
     cur_entry = EMAC->CTXDSA;
 
-    while (cur_entry != (uint32_t)fin_tx_desc_ptr) {
-
+    while( cur_entry != ( uint32_t ) fin_tx_desc_ptr )
+    {
         fin_tx_desc_ptr = fin_tx_desc_ptr->next;
     }
-    // FIX ME: for tx-event, no-op at this stage
-    xNetworkCallback('T');
+
+    /* FIX ME: for tx-event, no-op at this stage */
+    xNetworkCallback( 'T' );
 }
 
-uint8_t *numaker_eth_get_tx_buf(void)
+uint8_t * numaker_eth_get_tx_buf( void )
 {
-    if(cur_tx_desc_ptr->status1 & OWNERSHIP_EMAC)
-        return(NULL);
+    if( cur_tx_desc_ptr->status1 & OWNERSHIP_EMAC )
+    {
+        return( NULL );
+    }
     else
-        return(cur_tx_desc_ptr->buf);
+    {
+        return( cur_tx_desc_ptr->buf );
+    }
 }
 
-void numaker_eth_trigger_tx(uint16_t length, void *p)
+void numaker_eth_trigger_tx( uint16_t length,
+                             void * p )
 {
-    struct eth_descriptor volatile *desc;
-    cur_tx_desc_ptr->status2 = (unsigned int)length;
-    desc = cur_tx_desc_ptr->next;    // in case TX is transmitting and overwrite next pointer before we can update cur_tx_desc_ptr
+    struct eth_descriptor volatile * desc;
+
+    cur_tx_desc_ptr->status2 = ( unsigned int ) length;
+    desc = cur_tx_desc_ptr->next; /* in case TX is transmitting and overwrite next pointer before we can update cur_tx_desc_ptr */
     cur_tx_desc_ptr->status1 |= OWNERSHIP_EMAC;
     cur_tx_desc_ptr = desc;
 
     ETH_TRIGGER_TX();
-
 }
 
-int numaker_eth_link_ok(void)
+int numaker_eth_link_ok( void )
 {
     /* first, a dummy read to latch */
-    mdio_read(CONFIG_PHY_ADDR, MII_BMSR);
-    if(mdio_read(CONFIG_PHY_ADDR, MII_BMSR) & BMSR_LSTATUS)
-      return 1;
-    return 0;	
+    mdio_read( CONFIG_PHY_ADDR, MII_BMSR );
+
+    if( mdio_read( CONFIG_PHY_ADDR, MII_BMSR ) & BMSR_LSTATUS )
+    {
+        return 1;
+    }
+
+    return 0;
 }
 
-//void numaker_eth_set_cb(eth_callback_t eth_cb, void *userData)
-//{
-//    nu_eth_txrx_cb =  eth_cb;
-//    nu_userData = userData;
-//}
+/*void numaker_eth_set_cb(eth_callback_t eth_cb, void *userData) */
+/*{ */
+/*    nu_eth_txrx_cb =  eth_cb; */
+/*    nu_userData = userData; */
+/*} */
 
-// Provide ethernet devices with a semi-unique MAC address
-void numaker_mac_address(uint8_t *mac)
+/* Provide ethernet devices with a semi-unique MAC address */
+void numaker_mac_address( uint8_t * mac )
 {
     uint32_t uID1;
-    // Fetch word 0
-    uint32_t word0 = *(uint32_t *)0x7F804; // 2KB Data Flash at 0x7F800
-    // Fetch word 1
-    // we only want bottom 16 bits of word1 (MAC bits 32-47)
-    // and bit 9 forced to 1, bit 8 forced to 0
-    // Locally administered MAC, reduced conflicts
-    // http://en.wikipedia.org/wiki/MAC_address
-    uint32_t word1 = *(uint32_t *)0x7F800; // 2KB Data Flash at 0x7F800
+    /* Fetch word 0 */
+    uint32_t word0 = *( uint32_t * ) 0x7F804; /* 2KB Data Flash at 0x7F800 */
+    /* Fetch word 1 */
+    /* we only want bottom 16 bits of word1 (MAC bits 32-47) */
+    /* and bit 9 forced to 1, bit 8 forced to 0 */
+    /* Locally administered MAC, reduced conflicts */
+    /* http://en.wikipedia.org/wiki/MAC_address */
+    uint32_t word1 = *( uint32_t * ) 0x7F800; /* 2KB Data Flash at 0x7F800 */
 
-    if( word0 == 0xFFFFFFFF )		// Not burn any mac address at 1st 2 words of Data Flash
+    if( word0 == 0xFFFFFFFF )                 /* Not burn any mac address at 1st 2 words of Data Flash */
     {
-        // with a semi-unique MAC address from the UUID
+        /* with a semi-unique MAC address from the UUID */
         /* Enable FMC ISP function */
         SYS_UnlockReg();
         FMC_Open();
-        // = FMC_ReadUID(0);
-        uID1 = FMC_ReadUID(1);
-        word1 = (uID1 & 0x003FFFFF) | ((uID1 & 0x030000) << 6) >> 8;
-        word0 = ((FMC_ReadUID(0) >> 4) << 20) | ((uID1 & 0xFF)<<12) | (FMC_ReadUID(2) & 0xFFF);
+        /* = FMC_ReadUID(0); */
+        uID1 = FMC_ReadUID( 1 );
+        word1 = ( uID1 & 0x003FFFFF ) | ( ( uID1 & 0x030000 ) << 6 ) >> 8;
+        word0 = ( ( FMC_ReadUID( 0 ) >> 4 ) << 20 ) | ( ( uID1 & 0xFF ) << 12 ) | ( FMC_ReadUID( 2 ) & 0xFFF );
         /* Disable FMC ISP function */
         FMC_Close();
         /* Lock protected registers */
@@ -425,24 +474,26 @@ void numaker_mac_address(uint8_t *mac)
     word1 |= 0x00000200;
     word1 &= 0x0000FEFF;
 
-    mac[0] = (word1 & 0x0000ff00) >> 8;    
-    mac[1] = (word1 & 0x000000ff);
-    mac[2] = (word0 & 0xff000000) >> 24;
-    mac[3] = (word0 & 0x00ff0000) >> 16;
-    mac[4] = (word0 & 0x0000ff00) >> 8;
-    mac[5] = (word0 & 0x000000ff);
-    
-    NU_DEBUGF(("mac address %02x-%02x-%02x-%02x-%02x-%02x \r\n", mac[0], mac[1],mac[2],mac[3],mac[4],mac[5]));
+    mac[ 0 ] = ( word1 & 0x0000ff00 ) >> 8;
+    mac[ 1 ] = ( word1 & 0x000000ff );
+    mac[ 2 ] = ( word0 & 0xff000000 ) >> 24;
+    mac[ 3 ] = ( word0 & 0x00ff0000 ) >> 16;
+    mac[ 4 ] = ( word0 & 0x0000ff00 ) >> 8;
+    mac[ 5 ] = ( word0 & 0x000000ff );
+
+    NU_DEBUGF( ( "mac address %02x-%02x-%02x-%02x-%02x-%02x \r\n", mac[ 0 ], mac[ 1 ], mac[ 2 ], mac[ 3 ], mac[ 4 ], mac[ 5 ] ) );
 }
 
-void numaker_eth_enable_interrupts(void) {
-  EMAC->INTEN |= EMAC_INTEN_RXIEN_Msk |
-                   EMAC_INTEN_TXIEN_Msk ;
-  NVIC_EnableIRQ(EMAC_RX_IRQn);
-  NVIC_EnableIRQ(EMAC_TX_IRQn);
+void numaker_eth_enable_interrupts( void )
+{
+    EMAC->INTEN |= EMAC_INTEN_RXIEN_Msk |
+                   EMAC_INTEN_TXIEN_Msk;
+    NVIC_EnableIRQ( EMAC_RX_IRQn );
+    NVIC_EnableIRQ( EMAC_TX_IRQn );
 }
 
-void numaker_eth_disable_interrupts(void) {
-  NVIC_DisableIRQ(EMAC_RX_IRQn);
-  NVIC_DisableIRQ(EMAC_TX_IRQn);
+void numaker_eth_disable_interrupts( void )
+{
+    NVIC_DisableIRQ( EMAC_RX_IRQn );
+    NVIC_DisableIRQ( EMAC_TX_IRQn );
 }

--- a/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/portable/NetworkInterface/M487/m480_eth.h
+++ b/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/portable/NetworkInterface/M487/m480_eth.h
@@ -1,6 +1,6 @@
 /**************************************************************************//**
  * @copyright (C) 2019 Nuvoton Technology Corp. All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without modification,
  * are permitted provided that the following conditions are met:
  *   1. Redistributions of source code must retain the above copyright notice,
@@ -11,7 +11,7 @@
  *   3. Neither the name of Nuvoton Technology Corp. nor the names of its contributors
  *      may be used to endorse or promote products derived from this software
  *      without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -22,143 +22,150 @@
  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*****************************************************************************/
+ *****************************************************************************/
 #include "M480.h"
 #ifndef  _M480_ETH_
-#define  _M480_ETH_
+    #define  _M480_ETH_
 
 /* Generic MII registers. */
 
-#define MII_BMCR            0x00        /* Basic mode control register */
-#define MII_BMSR            0x01        /* Basic mode status register  */
-#define MII_PHYSID1         0x02        /* PHYS ID 1                   */
-#define MII_PHYSID2         0x03        /* PHYS ID 2                   */
-#define MII_ADVERTISE       0x04        /* Advertisement control reg   */
-#define MII_LPA             0x05        /* Link partner ability reg    */
-#define MII_EXPANSION       0x06        /* Expansion register          */
-#define MII_DCOUNTER        0x12        /* Disconnect counter          */
-#define MII_FCSCOUNTER      0x13        /* False carrier counter       */
-#define MII_NWAYTEST        0x14        /* N-way auto-neg test reg     */
-#define MII_RERRCOUNTER     0x15        /* Receive error counter       */
-#define MII_SREVISION       0x16        /* Silicon revision            */
-#define MII_RESV1           0x17        /* Reserved...                 */
-#define MII_LBRERROR        0x18        /* Lpback, rx, bypass error    */
-#define MII_PHYADDR         0x19        /* PHY address                 */
-#define MII_RESV2           0x1a        /* Reserved...                 */
-#define MII_TPISTATUS       0x1b        /* TPI status for 10mbps       */
-#define MII_NCONFIG         0x1c        /* Network interface config    */
+    #define MII_BMCR              0x00  /* Basic mode control register */
+    #define MII_BMSR              0x01  /* Basic mode status register  */
+    #define MII_PHYSID1           0x02  /* PHYS ID 1                   */
+    #define MII_PHYSID2           0x03  /* PHYS ID 2                   */
+    #define MII_ADVERTISE         0x04  /* Advertisement control reg   */
+    #define MII_LPA               0x05  /* Link partner ability reg    */
+    #define MII_EXPANSION         0x06  /* Expansion register          */
+    #define MII_DCOUNTER          0x12  /* Disconnect counter          */
+    #define MII_FCSCOUNTER        0x13  /* False carrier counter       */
+    #define MII_NWAYTEST          0x14  /* N-way auto-neg test reg     */
+    #define MII_RERRCOUNTER       0x15  /* Receive error counter       */
+    #define MII_SREVISION         0x16  /* Silicon revision            */
+    #define MII_RESV1             0x17  /* Reserved...                 */
+    #define MII_LBRERROR          0x18  /* Lpback, rx, bypass error    */
+    #define MII_PHYADDR           0x19  /* PHY address                 */
+    #define MII_RESV2             0x1a  /* Reserved...                 */
+    #define MII_TPISTATUS         0x1b  /* TPI status for 10mbps       */
+    #define MII_NCONFIG           0x1c  /* Network interface config    */
 
 /* Basic mode control register. */
-#define BMCR_RESV               0x007f  /* Unused...                   */
-#define BMCR_CTST               0x0080  /* Collision test              */
-#define BMCR_FULLDPLX           0x0100  /* Full duplex                 */
-#define BMCR_ANRESTART          0x0200  /* Auto negotiation restart    */
-#define BMCR_ISOLATE            0x0400  /* Disconnect DP83840 from MII */
-#define BMCR_PDOWN              0x0800  /* Powerdown the DP83840       */
-#define BMCR_ANENABLE           0x1000  /* Enable auto negotiation     */
-#define BMCR_SPEED100           0x2000  /* Select 100Mbps              */
-#define BMCR_LOOPBACK           0x4000  /* TXD loopback bits           */
-#define BMCR_RESET              0x8000  /* Reset the DP83840           */
+    #define BMCR_RESV             0x007f /* Unused...                   */
+    #define BMCR_CTST             0x0080 /* Collision test              */
+    #define BMCR_FULLDPLX         0x0100 /* Full duplex                 */
+    #define BMCR_ANRESTART        0x0200 /* Auto negotiation restart    */
+    #define BMCR_ISOLATE          0x0400 /* Disconnect DP83840 from MII */
+    #define BMCR_PDOWN            0x0800 /* Powerdown the DP83840       */
+    #define BMCR_ANENABLE         0x1000 /* Enable auto negotiation     */
+    #define BMCR_SPEED100         0x2000 /* Select 100Mbps              */
+    #define BMCR_LOOPBACK         0x4000 /* TXD loopback bits           */
+    #define BMCR_RESET            0x8000 /* Reset the DP83840           */
 
 /* Basic mode status register. */
-#define BMSR_ERCAP              0x0001  /* Ext-reg capability          */
-#define BMSR_JCD                0x0002  /* Jabber detected             */
-#define BMSR_LSTATUS            0x0004  /* Link status                 */
-#define BMSR_ANEGCAPABLE        0x0008  /* Able to do auto-negotiation */
-#define BMSR_RFAULT             0x0010  /* Remote fault detected       */
-#define BMSR_ANEGCOMPLETE       0x0020  /* Auto-negotiation complete   */
-#define BMSR_RESV               0x07c0  /* Unused...                   */
-#define BMSR_10HALF             0x0800  /* Can do 10mbps, half-duplex  */
-#define BMSR_10FULL             0x1000  /* Can do 10mbps, full-duplex  */
-#define BMSR_100HALF            0x2000  /* Can do 100mbps, half-duplex */
-#define BMSR_100FULL            0x4000  /* Can do 100mbps, full-duplex */
-#define BMSR_100BASE4           0x8000  /* Can do 100mbps, 4k packets  */
+    #define BMSR_ERCAP            0x0001 /* Ext-reg capability          */
+    #define BMSR_JCD              0x0002 /* Jabber detected             */
+    #define BMSR_LSTATUS          0x0004 /* Link status                 */
+    #define BMSR_ANEGCAPABLE      0x0008 /* Able to do auto-negotiation */
+    #define BMSR_RFAULT           0x0010 /* Remote fault detected       */
+    #define BMSR_ANEGCOMPLETE     0x0020 /* Auto-negotiation complete   */
+    #define BMSR_RESV             0x07c0 /* Unused...                   */
+    #define BMSR_10HALF           0x0800 /* Can do 10mbps, half-duplex  */
+    #define BMSR_10FULL           0x1000 /* Can do 10mbps, full-duplex  */
+    #define BMSR_100HALF          0x2000 /* Can do 100mbps, half-duplex */
+    #define BMSR_100FULL          0x4000 /* Can do 100mbps, full-duplex */
+    #define BMSR_100BASE4         0x8000 /* Can do 100mbps, 4k packets  */
 
 /* Advertisement control register. */
-#define ADVERTISE_SLCT          0x001f  /* Selector bits               */
-#define ADVERTISE_CSMA          0x0001  /* Only selector supported     */
-#define ADVERTISE_10HALF        0x0020  /* Try for 10mbps half-duplex  */
-#define ADVERTISE_10FULL        0x0040  /* Try for 10mbps full-duplex  */
-#define ADVERTISE_100HALF       0x0080  /* Try for 100mbps half-duplex */
-#define ADVERTISE_100FULL       0x0100  /* Try for 100mbps full-duplex */
-#define ADVERTISE_100BASE4      0x0200  /* Try for 100mbps 4k packets  */
-#define ADVERTISE_RESV          0x1c00  /* Unused...                   */
-#define ADVERTISE_RFAULT        0x2000  /* Say we can detect faults    */
-#define ADVERTISE_LPACK         0x4000  /* Ack link partners response  */
-#define ADVERTISE_NPAGE         0x8000  /* Next page bit               */
+    #define ADVERTISE_SLCT        0x001f /* Selector bits               */
+    #define ADVERTISE_CSMA        0x0001 /* Only selector supported     */
+    #define ADVERTISE_10HALF      0x0020 /* Try for 10mbps half-duplex  */
+    #define ADVERTISE_10FULL      0x0040 /* Try for 10mbps full-duplex  */
+    #define ADVERTISE_100HALF     0x0080 /* Try for 100mbps half-duplex */
+    #define ADVERTISE_100FULL     0x0100 /* Try for 100mbps full-duplex */
+    #define ADVERTISE_100BASE4    0x0200 /* Try for 100mbps 4k packets  */
+    #define ADVERTISE_RESV        0x1c00 /* Unused...                   */
+    #define ADVERTISE_RFAULT      0x2000 /* Say we can detect faults    */
+    #define ADVERTISE_LPACK       0x4000 /* Ack link partners response  */
+    #define ADVERTISE_NPAGE       0x8000 /* Next page bit               */
 
-#define RX_DESCRIPTOR_NUM       4 //8    // Max Number of Rx Frame Descriptors
-#define TX_DESCRIPTOR_NUM       2 //4    // Max number of Tx Frame Descriptors
+    #define RX_DESCRIPTOR_NUM     4      /*8    // Max Number of Rx Frame Descriptors */
+    #define TX_DESCRIPTOR_NUM     2      /*4    // Max number of Tx Frame Descriptors */
 
-#define PACKET_BUFFER_SIZE      1520
+    #define PACKET_BUFFER_SIZE    1520
 
-#define CONFIG_PHY_ADDR     1
-
-
-// Frame Descriptor's Owner bit
-#define OWNERSHIP_EMAC 0x80000000  // 1 = EMAC
-//#define OWNERSHIP_CPU 0x7fffffff  // 0 = CPU
+    #define CONFIG_PHY_ADDR       1
 
 
+/* Frame Descriptor's Owner bit */
+    #define OWNERSHIP_EMAC    0x80000000 /* 1 = EMAC */
+/*#define OWNERSHIP_CPU 0x7fffffff  // 0 = CPU */
 
-// Rx Frame Descriptor Status
-#define RXFD_RXGD    0x00100000  // Receiving Good Packet Received
-#define RXFD_RTSAS   0x00800000  // RX Time Stamp Available 
 
 
-// Tx Frame Descriptor's Control bits
-#define TXFD_TTSEN    0x08    // Tx Time Stamp Enable
-#define TXFD_INTEN    0x04    // Interrupt Enable
-#define TXFD_CRCAPP   0x02    // Append CRC
-#define TXFD_PADEN    0x01    // Padding Enable
+/* Rx Frame Descriptor Status */
+    #define RXFD_RXGD     0x00100000 /* Receiving Good Packet Received */
+    #define RXFD_RTSAS    0x00800000 /* RX Time Stamp Available */
 
-// Tx Frame Descriptor Status
-#define TXFD_TXCP    0x00080000  // Transmission Completion
-#define TXFD_TTSAS   0x08000000  // TX Time Stamp Available
 
-// Tx/Rx buffer descriptor structure
-struct eth_descriptor;
-struct eth_descriptor {
-    uint32_t  status1;
-    uint8_t *buf;
-    uint32_t  status2;
-    struct eth_descriptor *next;
-#ifdef TIME_STAMPING
-    uint32_t backup1;
-    uint32_t backup2;
-    uint32_t reserved1;
-    uint32_t reserved2;
-#endif
-};
+/* Tx Frame Descriptor's Control bits */
+    #define TXFD_TTSEN     0x08 /* Tx Time Stamp Enable */
+    #define TXFD_INTEN     0x04 /* Interrupt Enable */
+    #define TXFD_CRCAPP    0x02 /* Append CRC */
+    #define TXFD_PADEN     0x01 /* Padding Enable */
 
-#ifdef TIME_STAMPING
+/* Tx Frame Descriptor Status */
+    #define TXFD_TXCP      0x00080000 /* Transmission Completion */
+    #define TXFD_TTSAS     0x08000000 /* TX Time Stamp Available */
 
-#define ETH_TS_ENABLE() do{EMAC->TSCTL = EMAC_TSCTL_TSEN_Msk;}while(0)
-#define ETH_TS_START() do{EMAC->TSCTL |= (EMAC_TSCTL_TSMODE_Msk | EMAC_TSCTL_TSIEN_Msk);}while(0)
-s32_t ETH_settime(u32_t sec, u32_t nsec);
-s32_t ETH_gettime(u32_t *sec, u32_t *nsec);
-s32_t ETH_updatetime(u32_t neg, u32_t sec, u32_t nsec);
-s32_t ETH_adjtimex(int ppm);
-void ETH_setinc(void);
+/* Tx/Rx buffer descriptor structure */
+    struct eth_descriptor;
+    struct eth_descriptor
+    {
+        uint32_t status1;
+        uint8_t * buf;
+        uint32_t status2;
+        struct eth_descriptor * next;
+        #ifdef TIME_STAMPING
+            uint32_t backup1;
+            uint32_t backup2;
+            uint32_t reserved1;
+            uint32_t reserved2;
+        #endif
+    };
 
-#endif
+    #ifdef TIME_STAMPING
 
-#ifdef NU_TRACE
-#define NU_DEBUGF(x) { printf x; }
-#else
-#define NU_DEBUGF(x)
-#endif
+        #define ETH_TS_ENABLE()    do{ EMAC->TSCTL = EMAC_TSCTL_TSEN_Msk; }while( 0 )
+        #define ETH_TS_START()     do{ EMAC->TSCTL |= ( EMAC_TSCTL_TSMODE_Msk | EMAC_TSCTL_TSIEN_Msk ); }while( 0 )
+        s32_t ETH_settime( u32_t sec,
+                           u32_t nsec );
+        s32_t ETH_gettime( u32_t * sec,
+                           u32_t * nsec );
+        s32_t ETH_updatetime( u32_t neg,
+                              u32_t sec,
+                              u32_t nsec );
+        s32_t ETH_adjtimex( int ppm );
+        void ETH_setinc( void );
 
-void numaker_set_mac_addr(uint8_t *addr);
-int numaker_eth_init(uint8_t *mac_addr);
-uint8_t *numaker_eth_get_tx_buf(void);
-void numaker_eth_trigger_tx(uint16_t length, void *p);
-int numaker_eth_get_rx_buf(uint16_t *len, uint8_t **buf);
-void numaker_eth_rx_next(void);
-void numaker_eth_trigger_rx(void);
-int numaker_eth_link_ok(void);
-void numaker_mac_address(uint8_t *mac);
-void numaker_eth_enable_interrupts(void);
-void numaker_eth_disable_interrupts(void);
+    #endif /* ifdef TIME_STAMPING */
 
-#endif  /* _M480_ETH_ */
+    #ifdef NU_TRACE
+        #define NU_DEBUGF( x )    { printf x; }
+    #else
+        #define NU_DEBUGF( x )
+    #endif
+
+    void numaker_set_mac_addr( uint8_t * addr );
+    int numaker_eth_init( uint8_t * mac_addr );
+    uint8_t * numaker_eth_get_tx_buf( void );
+    void numaker_eth_trigger_tx( uint16_t length,
+                                 void * p );
+    int numaker_eth_get_rx_buf( uint16_t * len,
+                                uint8_t ** buf );
+    void numaker_eth_rx_next( void );
+    void numaker_eth_trigger_rx( void );
+    int numaker_eth_link_ok( void );
+    void numaker_mac_address( uint8_t * mac );
+    void numaker_eth_enable_interrupts( void );
+    void numaker_eth_disable_interrupts( void );
+
+#endif /* _M480_ETH_ */

--- a/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/portable/NetworkInterface/RX/NetworkInterface.c
+++ b/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/portable/NetworkInterface/RX/NetworkInterface.c
@@ -305,15 +305,15 @@ static void prvEMACDeferredInterruptHandlerTask( void * pvParameters )
         if( xBytesReceived < 0 )
         {
             /* This is an error. Logged. */
-        	if( xBytesReceived == ETHER_ERR_LINK )
-        	{
-				/* Auto-negotiation is not completed, and transmission/
-				reception is not enabled. Will be logged elsewhere. */
-        	}
-        	else
-         	{
-        		FreeRTOS_printf( ( "R_ETHER_Read_ZC2: rc = %d not %d\n", xBytesReceived, ETHER_ERR_LINK ) );
-        	}
+            if( xBytesReceived == ETHER_ERR_LINK )
+            {
+                /* Auto-negotiation is not completed, and transmission/
+                 * reception is not enabled. Will be logged elsewhere. */
+            }
+            else
+            {
+                FreeRTOS_printf( ( "R_ETHER_Read_ZC2: rc = %d not %d\n", xBytesReceived, ETHER_ERR_LINK ) );
+            }
         }
         else if( xBytesReceived > 0 )
         {

--- a/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/portable/NetworkInterface/SH2A/NetworkInterface.c
+++ b/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/portable/NetworkInterface/SH2A/NetworkInterface.c
@@ -1,27 +1,27 @@
 /*
-FreeRTOS+TCP V2.2.1
-Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of
-this software and associated documentation files (the "Software"), to deal in
-the Software without restriction, including without limitation the rights to
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
-the Software, and to permit persons to whom the Software is furnished to do so,
-subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
-COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
-IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
- http://aws.amazon.com/freertos
- http://www.FreeRTOS.org
-*/
+ * FreeRTOS+TCP V2.2.1
+ * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
 
 /* Standard includes. */
 #include <stdint.h>
@@ -44,28 +44,28 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "NetworkInterface.h"
 
 #if ipconfigETHERNET_DRIVER_FILTERS_FRAME_TYPES != 1
-	#define ipCONSIDER_FRAME_FOR_PROCESSING( pucEthernetBuffer ) eProcessBuffer
+    #define ipCONSIDER_FRAME_FOR_PROCESSING( pucEthernetBuffer )    eProcessBuffer
 #else
-	#define ipCONSIDER_FRAME_FOR_PROCESSING( pucEthernetBuffer ) eConsiderFrameForProcessing( ( pucEthernetBuffer ) )
+    #define ipCONSIDER_FRAME_FOR_PROCESSING( pucEthernetBuffer )    eConsiderFrameForProcessing( ( pucEthernetBuffer ) )
 #endif
 
 /* When a packet is ready to be sent, if it cannot be sent immediately then the
-task performing the transmit will block for niTX_BUFFER_FREE_WAIT
-milliseconds.  It will do this a maximum of niMAX_TX_ATTEMPTS before giving
-up. */
-#define niTX_BUFFER_FREE_WAIT	( ( TickType_t ) 2UL / portTICK_PERIOD_MS )
-#define niMAX_TX_ATTEMPTS		( 5 )
+ * task performing the transmit will block for niTX_BUFFER_FREE_WAIT
+ * milliseconds.  It will do this a maximum of niMAX_TX_ATTEMPTS before giving
+ * up. */
+#define niTX_BUFFER_FREE_WAIT       ( ( TickType_t ) 2UL / portTICK_PERIOD_MS )
+#define niMAX_TX_ATTEMPTS           ( 5 )
 
 /* The length of the queue used to send interrupt status words from the
-interrupt handler to the deferred handler task. */
-#define niINTERRUPT_QUEUE_LENGTH	( 10 )
+ * interrupt handler to the deferred handler task. */
+#define niINTERRUPT_QUEUE_LENGTH    ( 10 )
 
 /*-----------------------------------------------------------*/
 
 /*
  * A deferred interrupt handler task that processes
  */
-extern void vEMACHandlerTask( void *pvParameters );
+extern void vEMACHandlerTask( void * pvParameters );
 
 /*-----------------------------------------------------------*/
 
@@ -73,46 +73,45 @@ extern void vEMACHandlerTask( void *pvParameters );
 extern QueueHandle_t xNetworkEventQueue;
 
 /* The semaphore used to wake the deferred interrupt handler task when an Rx
-interrupt is received. */
+ * interrupt is received. */
 SemaphoreHandle_t xEMACRxEventSemaphore = NULL;
 /*-----------------------------------------------------------*/
 
 BaseType_t xNetworkInterfaceInitialise( void )
 {
-BaseType_t xStatus, xReturn;
-extern uint8_t ucMACAddress[ 6 ];
+    BaseType_t xStatus, xReturn;
+    extern uint8_t ucMACAddress[ 6 ];
 
-	/* Initialise the MAC. */
-	vInitEmac();
+    /* Initialise the MAC. */
+    vInitEmac();
 
-	while( lEMACWaitForLink() != pdPASS )
+    while( lEMACWaitForLink() != pdPASS )
     {
         vTaskDelay( 20 );
     }
 
-	vSemaphoreCreateBinary( xEMACRxEventSemaphore );
-	configASSERT( xEMACRxEventSemaphore );
+    vSemaphoreCreateBinary( xEMACRxEventSemaphore );
+    configASSERT( xEMACRxEventSemaphore );
 
-	/* The handler task is created at the highest possible priority to
-	ensure the interrupt handler can return directly to it. */
-	xTaskCreate( vEMACHandlerTask, "EMAC", configMINIMAL_STACK_SIZE, NULL, configMAX_PRIORITIES - 1, NULL );
-	xReturn = pdPASS;
+    /* The handler task is created at the highest possible priority to
+     * ensure the interrupt handler can return directly to it. */
+    xTaskCreate( vEMACHandlerTask, "EMAC", configMINIMAL_STACK_SIZE, NULL, configMAX_PRIORITIES - 1, NULL );
+    xReturn = pdPASS;
 
-	return xReturn;
+    return xReturn;
 }
 /*-----------------------------------------------------------*/
 
 BaseType_t xNetworkInterfaceOutput( NetworkBufferDescriptor_t * const pxNetworkBuffer )
 {
-extern void vEMACCopyWrite( uint8_t * pucBuffer, uint16_t usLength );
+    extern void vEMACCopyWrite( uint8_t * pucBuffer,
+                                uint16_t usLength );
 
-	vEMACCopyWrite( pxNetworkBuffer->pucBuffer, pxNetworkBuffer->xDataLength );
+    vEMACCopyWrite( pxNetworkBuffer->pucBuffer, pxNetworkBuffer->xDataLength );
 
-	/* Finished with the network buffer. */
-	vReleaseNetworkBufferAndDescriptor( pxNetworkBuffer );
+    /* Finished with the network buffer. */
+    vReleaseNetworkBufferAndDescriptor( pxNetworkBuffer );
 
-	return pdTRUE;
+    return pdTRUE;
 }
 /*-----------------------------------------------------------*/
-
-

--- a/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/portable/NetworkInterface/STM32Fxx/NetworkInterface.c
+++ b/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/portable/NetworkInterface/STM32Fxx/NetworkInterface.c
@@ -4,29 +4,29 @@
  */
 
 /*
-FreeRTOS+TCP V2.2.1
-Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of
-this software and associated documentation files (the "Software"), to deal in
-the Software without restriction, including without limitation the rights to
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
-the Software, and to permit persons to whom the Software is furnished to do so,
-subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
-COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
-IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
- http://aws.amazon.com/freertos
- http://www.FreeRTOS.org
-*/
+ * FreeRTOS+TCP V2.2.1
+ * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
 
 /* Standard includes. */
 #include <stdint.h>
@@ -51,42 +51,42 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 /* ST includes. */
 #if defined( STM32F7xx )
-	#include "stm32f7xx_hal.h"
+    #include "stm32f7xx_hal.h"
 #elif defined( STM32F4xx )
-	#include "stm32f4xx_hal.h"
+    #include "stm32f4xx_hal.h"
 #elif defined( STM32F2xx )
-	#include "stm32f2xx_hal.h"
-#elif !defined( _lint )	/* Lint does not like an #error */
-	#error What part?
+    #include "stm32f2xx_hal.h"
+#elif !defined( _lint ) /* Lint does not like an #error */
+    #error What part?
 #endif
 
 #include "stm32fxx_hal_eth.h"
 
 /* Interrupt events to process.  Currently only the Rx event is processed
-although code for other events is included to allow for possible future
-expansion. */
-#define EMAC_IF_RX_EVENT        1UL
-#define EMAC_IF_TX_EVENT        2UL
-#define EMAC_IF_ERR_EVENT       4UL
-#define EMAC_IF_ALL_EVENT       ( EMAC_IF_RX_EVENT | EMAC_IF_TX_EVENT | EMAC_IF_ERR_EVENT )
+ * although code for other events is included to allow for possible future
+ * expansion. */
+#define EMAC_IF_RX_EVENT     1UL
+#define EMAC_IF_TX_EVENT     2UL
+#define EMAC_IF_ERR_EVENT    4UL
+#define EMAC_IF_ALL_EVENT    ( EMAC_IF_RX_EVENT | EMAC_IF_TX_EVENT | EMAC_IF_ERR_EVENT )
 
-#define ETH_DMA_ALL_INTS \
-	( ETH_DMA_IT_TST | ETH_DMA_IT_PMT | ETH_DMA_IT_MMC | ETH_DMA_IT_NIS | ETH_DMA_IT_ER | \
-	  ETH_DMA_IT_FBE | ETH_DMA_IT_RWT | ETH_DMA_IT_RPS | ETH_DMA_IT_RBU | ETH_DMA_IT_R | \
-	  ETH_DMA_IT_TU | ETH_DMA_IT_RO | ETH_DMA_IT_TJT | ETH_DMA_IT_TPS | ETH_DMA_IT_T )
+#define ETH_DMA_ALL_INTS                                                                  \
+    ( ETH_DMA_IT_TST | ETH_DMA_IT_PMT | ETH_DMA_IT_MMC | ETH_DMA_IT_NIS | ETH_DMA_IT_ER | \
+      ETH_DMA_IT_FBE | ETH_DMA_IT_RWT | ETH_DMA_IT_RPS | ETH_DMA_IT_RBU | ETH_DMA_IT_R |  \
+      ETH_DMA_IT_TU | ETH_DMA_IT_RO | ETH_DMA_IT_TJT | ETH_DMA_IT_TPS | ETH_DMA_IT_T )
 
 #ifndef niEMAC_HANDLER_TASK_PRIORITY
-	#define niEMAC_HANDLER_TASK_PRIORITY	configMAX_PRIORITIES - 1
+    #define niEMAC_HANDLER_TASK_PRIORITY    configMAX_PRIORITIES - 1
 #endif
 
-#define ipFRAGMENT_OFFSET_BIT_MASK		( ( uint16_t ) 0x0fff ) /* The bits in the two byte IP header field that make up the fragment offset value. */
+#define ipFRAGMENT_OFFSET_BIT_MASK          ( ( uint16_t ) 0x0fff ) /* The bits in the two byte IP header field that make up the fragment offset value. */
 
-#if( ( ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM == 0 ) || ( ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM == 0 ) )
-	#warning Consider enabling checksum offloading
+#if ( ( ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM == 0 ) || ( ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM == 0 ) )
+    #warning Consider enabling checksum offloading
 #endif
 
 #ifndef niDESCRIPTOR_WAIT_TIME_MS
-	#define niDESCRIPTOR_WAIT_TIME_MS		250uL
+    #define niDESCRIPTOR_WAIT_TIME_MS    250uL
 #endif
 
 /*
@@ -97,53 +97,54 @@ expansion. */
  */
 
 #if !defined( ipconfigETHERNET_AN_ENABLE )
-	/* Enable auto-negotiation */
-	#define ipconfigETHERNET_AN_ENABLE				1
+    /* Enable auto-negotiation */
+    #define ipconfigETHERNET_AN_ENABLE    1
 #endif
 
 #if !defined( ipconfigETHERNET_AUTO_CROSS_ENABLE )
-	#define ipconfigETHERNET_AUTO_CROSS_ENABLE		1
+    #define ipconfigETHERNET_AUTO_CROSS_ENABLE    1
 #endif
 
-#if( ipconfigETHERNET_AN_ENABLE == 0 )
-	/*
-	 * The following three defines are only used in case there
-	 * is no auto-negotiation.
-	 */
-	#if !defined( ipconfigETHERNET_CROSSED_LINK )
-		#define	ipconfigETHERNET_CROSSED_LINK			1
-	#endif
+#if ( ipconfigETHERNET_AN_ENABLE == 0 )
 
-	#if !defined( ipconfigETHERNET_USE_100MB )
-		#define ipconfigETHERNET_USE_100MB				1
-	#endif
+    /*
+     * The following three defines are only used in case there
+     * is no auto-negotiation.
+     */
+    #if !defined( ipconfigETHERNET_CROSSED_LINK )
+        #define ipconfigETHERNET_CROSSED_LINK    1
+    #endif
 
-	#if !defined( ipconfigETHERNET_USE_FULL_DUPLEX )
-		#define ipconfigETHERNET_USE_FULL_DUPLEX		1
-	#endif
+    #if !defined( ipconfigETHERNET_USE_100MB )
+        #define ipconfigETHERNET_USE_100MB    1
+    #endif
+
+    #if !defined( ipconfigETHERNET_USE_FULL_DUPLEX )
+        #define ipconfigETHERNET_USE_FULL_DUPLEX    1
+    #endif
 #endif /* ipconfigETHERNET_AN_ENABLE == 0 */
 
 /* Default the size of the stack used by the EMAC deferred handler task to twice
-the size of the stack used by the idle task - but allow this to be overridden in
-FreeRTOSConfig.h as configMINIMAL_STACK_SIZE is a user definable constant. */
+ * the size of the stack used by the idle task - but allow this to be overridden in
+ * FreeRTOSConfig.h as configMINIMAL_STACK_SIZE is a user definable constant. */
 #ifndef configEMAC_TASK_STACK_SIZE
-	#define configEMAC_TASK_STACK_SIZE ( 2 * configMINIMAL_STACK_SIZE )
+    #define configEMAC_TASK_STACK_SIZE    ( 2 * configMINIMAL_STACK_SIZE )
 #endif
 
 /* Two choices must be made: RMII versus MII,
-and the index of the PHY in use ( between 0 and 31 ). */
+ * and the index of the PHY in use ( between 0 and 31 ). */
 #ifndef ipconfigUSE_RMII
-	#ifdef STM32F7xx
-		#define ipconfigUSE_RMII	1
-	#else
-		#define ipconfigUSE_RMII	0
-	#endif /* STM32F7xx */
+    #ifdef STM32F7xx
+        #define ipconfigUSE_RMII    1
+    #else
+        #define ipconfigUSE_RMII    0
+    #endif /* STM32F7xx */
 #endif /* ipconfigUSE_RMII */
 
-#if( ipconfigUSE_RMII != 0 )
-	#warning Using RMII, make sure if this is correct
+#if ( ipconfigUSE_RMII != 0 )
+    #warning Using RMII, make sure if this is correct
 #else
-	#warning Using MII, make sure if this is correct
+    #warning Using MII, make sure if this is correct
 #endif
 
 typedef enum
@@ -160,7 +161,7 @@ static eMAC_INIT_STATUS_TYPE xMacInitStatus = eMACInit;
 /*
  * A deferred interrupt handler task that processes
  */
-static void prvEMACHandlerTask( void *pvParameters );
+static void prvEMACHandlerTask( void * pvParameters );
 
 /*
  * Force a negotiation with the Switch or Router and wait for LS.
@@ -172,18 +173,21 @@ static void prvEthernetUpdateConfig( BaseType_t xForce );
  */
 static BaseType_t prvNetworkInterfaceInput( void );
 
-#if( ipconfigUSE_LLMNR != 0 )
-	/*
-	 * For LLMNR, an extra MAC-address must be configured to
-	 * be able to receive the multicast messages.
-	 */
-	static void prvMACAddressConfig(ETH_HandleTypeDef *heth, uint32_t ulIndex, uint8_t *Addr);
+#if ( ipconfigUSE_LLMNR != 0 )
+
+    /*
+     * For LLMNR, an extra MAC-address must be configured to
+     * be able to receive the multicast messages.
+     */
+    static void prvMACAddressConfig( ETH_HandleTypeDef * heth,
+                                     uint32_t ulIndex,
+                                     uint8_t * Addr );
 #endif
 
 /*
  * Check if a given packet should be accepted.
  */
-static BaseType_t xMayAcceptPacket( uint8_t *pcBuffer );
+static BaseType_t xMayAcceptPacket( uint8_t * pcBuffer );
 
 /*
  * Initialise the TX descriptors.
@@ -196,18 +200,18 @@ static void prvDMATxDescListInit( void );
 static void prvDMARxDescListInit( void );
 
 /* After packets have been sent, the network
-buffers will be released. */
+ * buffers will be released. */
 static void vClearTXBuffers( void );
 
 /*-----------------------------------------------------------*/
 
 /* Bit map of outstanding ETH interrupt events for processing.  Currently only
-the Rx interrupt is handled, although code is included for other events to
-enable future expansion. */
+ * the Rx interrupt is handled, although code is included for other events to
+ * enable future expansion. */
 static volatile uint32_t ulISREvents;
 
-#if( ipconfigUSE_LLMNR == 1 )
-	static const uint8_t xLLMNR_MACAddress[] = { 0x01, 0x00, 0x5E, 0x00, 0x00, 0xFC };
+#if ( ipconfigUSE_LLMNR == 1 )
+    static const uint8_t xLLMNR_MACAddress[] = { 0x01, 0x00, 0x5E, 0x00, 0x00, 0xFC };
 #endif
 
 static EthernetPhy_t xPhyObject;
@@ -216,8 +220,8 @@ static EthernetPhy_t xPhyObject;
 static ETH_HandleTypeDef xETH;
 
 /* xTXDescriptorSemaphore is a counting semaphore with
-a maximum count of ETH_TXBUFNB, which is the number of
-DMA TX descriptors. */
+ * a maximum count of ETH_TXBUFNB, which is the number of
+ * DMA TX descriptors. */
 static SemaphoreHandle_t xTXDescriptorSemaphore = NULL;
 
 /*
@@ -235,941 +239,973 @@ static SemaphoreHandle_t xTXDescriptorSemaphore = NULL;
 /* MAC buffers: ---------------------------------------------------------*/
 
 /* Put the DMA descriptors in '.first_data'.
-This is important for STM32F7, which has an L1 data cache.
-The first 64KB of the SRAM is not cached.
-See README.TXT in this folder. */
+ * This is important for STM32F7, which has an L1 data cache.
+ * The first 64KB of the SRAM is not cached.
+ * See README.TXT in this folder. */
 
 /* Ethernet Rx MA Descriptor */
-__attribute__ ((aligned (32)))
-#if defined(STM32F7xx)
-	__attribute__ ((section(".first_data")))
+__attribute__( ( aligned( 32 ) ) )
+#if defined( STM32F7xx )
+    __attribute__( ( section( ".first_data" ) ) )
 #endif
-	ETH_DMADescTypeDef  DMARxDscrTab[ ETH_RXBUFNB ];
+ETH_DMADescTypeDef DMARxDscrTab[ ETH_RXBUFNB ];
 
-#if( ipconfigZERO_COPY_RX_DRIVER == 0 )
-	/* Ethernet Receive Buffer */
-	__ALIGN_BEGIN uint8_t Rx_Buff[ ETH_RXBUFNB ][ ETH_RX_BUF_SIZE ] __ALIGN_END;
+#if ( ipconfigZERO_COPY_RX_DRIVER == 0 )
+    /* Ethernet Receive Buffer */
+    __ALIGN_BEGIN uint8_t Rx_Buff[ ETH_RXBUFNB ][ ETH_RX_BUF_SIZE ] __ALIGN_END;
 #endif
 
 /* Ethernet Tx DMA Descriptor */
-__attribute__ ((aligned (32)))
-#if defined(STM32F7xx)
-	__attribute__ ((section(".first_data")))
+__attribute__( ( aligned( 32 ) ) )
+#if defined( STM32F7xx )
+    __attribute__( ( section( ".first_data" ) ) )
 #endif
-	ETH_DMADescTypeDef  DMATxDscrTab[ ETH_TXBUFNB ];
+ETH_DMADescTypeDef DMATxDscrTab[ ETH_TXBUFNB ];
 
-#if( ipconfigZERO_COPY_TX_DRIVER == 0 )
-	/* Ethernet Transmit Buffer */
-	__ALIGN_BEGIN uint8_t Tx_Buff[ ETH_TXBUFNB ][ ETH_TX_BUF_SIZE ] __ALIGN_END;
+#if ( ipconfigZERO_COPY_TX_DRIVER == 0 )
+    /* Ethernet Transmit Buffer */
+    __ALIGN_BEGIN uint8_t Tx_Buff[ ETH_TXBUFNB ][ ETH_TX_BUF_SIZE ] __ALIGN_END;
 #endif
 
 /* DMATxDescToClear points to the next TX DMA descriptor
-that must be cleared by vClearTXBuffers(). */
-static __IO ETH_DMADescTypeDef  *DMATxDescToClear;
+ * that must be cleared by vClearTXBuffers(). */
+static __IO ETH_DMADescTypeDef * DMATxDescToClear;
 
 /* Holds the handle of the task used as a deferred interrupt processor.  The
-handle is used so direct notifications can be sent to the task for all EMAC/DMA
-related interrupts. */
+ * handle is used so direct notifications can be sent to the task for all EMAC/DMA
+ * related interrupts. */
 static TaskHandle_t xEMACTaskHandle = NULL;
 
 /* For local use only: describe the PHY's properties: */
 const PhyProperties_t xPHYProperties =
 {
-	#if( ipconfigETHERNET_AN_ENABLE != 0 )
-		.ucSpeed = PHY_SPEED_AUTO,
-		.ucDuplex = PHY_DUPLEX_AUTO,
-	#else
-		#if( ipconfigETHERNET_USE_100MB != 0 )
-			.ucSpeed = PHY_SPEED_100,
-		#else
-			.ucSpeed = PHY_SPEED_10,
-		#endif
+    #if ( ipconfigETHERNET_AN_ENABLE != 0 )
+        .ucSpeed      = PHY_SPEED_AUTO,
+        .ucDuplex     = PHY_DUPLEX_AUTO,
+    #else
+        #if ( ipconfigETHERNET_USE_100MB != 0 )
+            .ucSpeed  = PHY_SPEED_100,
+        #else
+            .ucSpeed  = PHY_SPEED_10,
+        #endif
 
-		#if( ipconfigETHERNET_USE_FULL_DUPLEX != 0 )
-			.ucDuplex = PHY_DUPLEX_FULL,
-		#else
-			.ucDuplex = PHY_DUPLEX_HALF,
-		#endif
-	#endif
+        #if ( ipconfigETHERNET_USE_FULL_DUPLEX != 0 )
+            .ucDuplex = PHY_DUPLEX_FULL,
+        #else
+            .ucDuplex = PHY_DUPLEX_HALF,
+        #endif
+    #endif /* if ( ipconfigETHERNET_AN_ENABLE != 0 ) */
 
-	#if( ipconfigETHERNET_AN_ENABLE != 0 ) && ( ipconfigETHERNET_AUTO_CROSS_ENABLE != 0 )
-		.ucMDI_X = PHY_MDIX_AUTO,
-	#elif( ipconfigETHERNET_CROSSED_LINK != 0 )
-		.ucMDI_X = PHY_MDIX_CROSSED,
-	#else
-		.ucMDI_X = PHY_MDIX_DIRECT,
-	#endif
+    #if ( ipconfigETHERNET_AN_ENABLE != 0 ) && ( ipconfigETHERNET_AUTO_CROSS_ENABLE != 0 )
+        .ucMDI_X      = PHY_MDIX_AUTO,
+    #elif ( ipconfigETHERNET_CROSSED_LINK != 0 )
+        .ucMDI_X      = PHY_MDIX_CROSSED,
+    #else
+        .ucMDI_X      = PHY_MDIX_DIRECT,
+    #endif
 };
 
 /*-----------------------------------------------------------*/
 
-void HAL_ETH_RxCpltCallback( ETH_HandleTypeDef *heth )
+void HAL_ETH_RxCpltCallback( ETH_HandleTypeDef * heth )
 {
-BaseType_t xHigherPriorityTaskWoken = pdFALSE;
+    BaseType_t xHigherPriorityTaskWoken = pdFALSE;
 
-	( void ) heth;
+    ( void ) heth;
 
-	/* Ethernet RX-Complete callback function, elsewhere declared as weak. */
+    /* Ethernet RX-Complete callback function, elsewhere declared as weak. */
     ulISREvents |= EMAC_IF_RX_EVENT;
-	/* Wakeup the prvEMACHandlerTask. */
-	if( xEMACTaskHandle != NULL )
-	{
-		vTaskNotifyGiveFromISR( xEMACTaskHandle, &xHigherPriorityTaskWoken );
-		portYIELD_FROM_ISR( xHigherPriorityTaskWoken );
-	}
+
+    /* Wakeup the prvEMACHandlerTask. */
+    if( xEMACTaskHandle != NULL )
+    {
+        vTaskNotifyGiveFromISR( xEMACTaskHandle, &xHigherPriorityTaskWoken );
+        portYIELD_FROM_ISR( xHigherPriorityTaskWoken );
+    }
 }
 /*-----------------------------------------------------------*/
 
-void HAL_ETH_TxCpltCallback( ETH_HandleTypeDef *heth )
+void HAL_ETH_TxCpltCallback( ETH_HandleTypeDef * heth )
 {
-BaseType_t xHigherPriorityTaskWoken = pdFALSE;
+    BaseType_t xHigherPriorityTaskWoken = pdFALSE;
 
-	( void ) heth;
+    ( void ) heth;
 
-	/* This call-back is only useful in case packets are being sent
-	zero-copy.  Once they're sent, the buffers will be released
-	by the function vClearTXBuffers(). */
-	ulISREvents |= EMAC_IF_TX_EVENT;
-	/* Wakeup the prvEMACHandlerTask. */
-	if( xEMACTaskHandle != NULL )
-	{
-		vTaskNotifyGiveFromISR( xEMACTaskHandle, &xHigherPriorityTaskWoken );
-		portYIELD_FROM_ISR( xHigherPriorityTaskWoken );
-	}
+    /* This call-back is only useful in case packets are being sent
+     * zero-copy.  Once they're sent, the buffers will be released
+     * by the function vClearTXBuffers(). */
+    ulISREvents |= EMAC_IF_TX_EVENT;
+
+    /* Wakeup the prvEMACHandlerTask. */
+    if( xEMACTaskHandle != NULL )
+    {
+        vTaskNotifyGiveFromISR( xEMACTaskHandle, &xHigherPriorityTaskWoken );
+        portYIELD_FROM_ISR( xHigherPriorityTaskWoken );
+    }
 }
 /*-----------------------------------------------------------*/
 
 static void vClearTXBuffers()
 {
-__IO ETH_DMADescTypeDef  *txLastDescriptor = xETH.TxDesc;
-size_t uxCount = ( ( UBaseType_t ) ETH_TXBUFNB ) - uxSemaphoreGetCount( xTXDescriptorSemaphore );
-#if( ipconfigZERO_COPY_TX_DRIVER != 0 )
-	NetworkBufferDescriptor_t *pxNetworkBuffer;
-	uint8_t *ucPayLoad;
-#endif
+    __IO ETH_DMADescTypeDef * txLastDescriptor = xETH.TxDesc;
+    size_t uxCount = ( ( UBaseType_t ) ETH_TXBUFNB ) - uxSemaphoreGetCount( xTXDescriptorSemaphore );
 
-	/* This function is called after a TX-completion interrupt.
-	It will release each Network Buffer used in xNetworkInterfaceOutput().
-	'uxCount' represents the number of descriptors given to DMA for transmission.
-	After sending a packet, the DMA will clear the 'ETH_DMATXDESC_OWN' bit. */
-	while( ( uxCount > 0 ) && ( ( DMATxDescToClear->Status & ETH_DMATXDESC_OWN ) == 0 ) )
-	{
-		if( ( DMATxDescToClear == txLastDescriptor ) && ( uxCount != ETH_TXBUFNB ) )
-		{
-			break;
-		}
-		#if( ipconfigZERO_COPY_TX_DRIVER != 0 )
-		{
-			ucPayLoad = ( uint8_t * )DMATxDescToClear->Buffer1Addr;
+    #if ( ipconfigZERO_COPY_TX_DRIVER != 0 )
+        NetworkBufferDescriptor_t * pxNetworkBuffer;
+        uint8_t * ucPayLoad;
+    #endif
 
-			if( ucPayLoad != NULL )
-			{
-				pxNetworkBuffer = pxPacketBuffer_to_NetworkBuffer( ucPayLoad );
-				if( pxNetworkBuffer != NULL )
-				{
-					vReleaseNetworkBufferAndDescriptor( pxNetworkBuffer ) ;
-				}
-				DMATxDescToClear->Buffer1Addr = ( uint32_t )0u;
-			}
-		}
-		#endif /* ipconfigZERO_COPY_TX_DRIVER */
+    /* This function is called after a TX-completion interrupt.
+     * It will release each Network Buffer used in xNetworkInterfaceOutput().
+     * 'uxCount' represents the number of descriptors given to DMA for transmission.
+     * After sending a packet, the DMA will clear the 'ETH_DMATXDESC_OWN' bit. */
+    while( ( uxCount > 0 ) && ( ( DMATxDescToClear->Status & ETH_DMATXDESC_OWN ) == 0 ) )
+    {
+        if( ( DMATxDescToClear == txLastDescriptor ) && ( uxCount != ETH_TXBUFNB ) )
+        {
+            break;
+        }
 
-		DMATxDescToClear = ( ETH_DMADescTypeDef * )( DMATxDescToClear->Buffer2NextDescAddr );
+        #if ( ipconfigZERO_COPY_TX_DRIVER != 0 )
+            {
+                ucPayLoad = ( uint8_t * ) DMATxDescToClear->Buffer1Addr;
 
-		uxCount--;
-		/* Tell the counting semaphore that one more TX descriptor is available. */
-		xSemaphoreGive( xTXDescriptorSemaphore );
-	}
+                if( ucPayLoad != NULL )
+                {
+                    pxNetworkBuffer = pxPacketBuffer_to_NetworkBuffer( ucPayLoad );
+
+                    if( pxNetworkBuffer != NULL )
+                    {
+                        vReleaseNetworkBufferAndDescriptor( pxNetworkBuffer );
+                    }
+
+                    DMATxDescToClear->Buffer1Addr = ( uint32_t ) 0u;
+                }
+            }
+        #endif /* ipconfigZERO_COPY_TX_DRIVER */
+
+        DMATxDescToClear = ( ETH_DMADescTypeDef * ) ( DMATxDescToClear->Buffer2NextDescAddr );
+
+        uxCount--;
+        /* Tell the counting semaphore that one more TX descriptor is available. */
+        xSemaphoreGive( xTXDescriptorSemaphore );
+    }
 }
 /*-----------------------------------------------------------*/
 
 BaseType_t xNetworkInterfaceInitialise( void )
 {
-HAL_StatusTypeDef hal_eth_init_status;
-BaseType_t xResult;
+    HAL_StatusTypeDef hal_eth_init_status;
+    BaseType_t xResult;
 
     if( xMacInitStatus == eMACInit )
-	{
-		xTXDescriptorSemaphore = xSemaphoreCreateCounting( ( UBaseType_t ) ETH_TXBUFNB, ( UBaseType_t ) ETH_TXBUFNB );
-		if( xTXDescriptorSemaphore == NULL )
-		{
-			xMacInitStatus = eMACFailed;
-		}
-		else
-		{
-			/* Initialise ETH */
+    {
+        xTXDescriptorSemaphore = xSemaphoreCreateCounting( ( UBaseType_t ) ETH_TXBUFNB, ( UBaseType_t ) ETH_TXBUFNB );
 
-			xETH.Instance = ETH;
-			xETH.Init.AutoNegotiation = ETH_AUTONEGOTIATION_ENABLE;
-			xETH.Init.Speed = ETH_SPEED_100M;
-			xETH.Init.DuplexMode = ETH_MODE_FULLDUPLEX;
-			/* Value of PhyAddress doesn't matter, will be probed for. */
-			xETH.Init.PhyAddress = 0;
+        if( xTXDescriptorSemaphore == NULL )
+        {
+            xMacInitStatus = eMACFailed;
+        }
+        else
+        {
+            /* Initialise ETH */
 
-			xETH.Init.MACAddr = ( uint8_t * ) FreeRTOS_GetMACAddress();
-			xETH.Init.RxMode = ETH_RXINTERRUPT_MODE;
+            xETH.Instance = ETH;
+            xETH.Init.AutoNegotiation = ETH_AUTONEGOTIATION_ENABLE;
+            xETH.Init.Speed = ETH_SPEED_100M;
+            xETH.Init.DuplexMode = ETH_MODE_FULLDUPLEX;
+            /* Value of PhyAddress doesn't matter, will be probed for. */
+            xETH.Init.PhyAddress = 0;
 
-			#if( ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM != 0 )
-			{
-				/* using the ETH_CHECKSUM_BY_HARDWARE option:
-				both the IP and the protocol checksums will be calculated
-				by the peripheral. */
-				xETH.Init.ChecksumMode = ETH_CHECKSUM_BY_HARDWARE;
-			}
-			#else
-			{
-				xETH.Init.ChecksumMode = ETH_CHECKSUM_BY_SOFTWARE;
-			}
-			#endif
+            xETH.Init.MACAddr = ( uint8_t * ) FreeRTOS_GetMACAddress();
+            xETH.Init.RxMode = ETH_RXINTERRUPT_MODE;
 
-			#if( ipconfigUSE_RMII != 0 )
-			{
-				xETH.Init.MediaInterface = ETH_MEDIA_INTERFACE_RMII;
-			}
-			#else
-			{
-				xETH.Init.MediaInterface = ETH_MEDIA_INTERFACE_MII;
-			}
-			#endif /* ipconfigUSE_RMII */
+            #if ( ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM != 0 )
+                {
+                    /* using the ETH_CHECKSUM_BY_HARDWARE option:
+                     * both the IP and the protocol checksums will be calculated
+                     * by the peripheral. */
+                    xETH.Init.ChecksumMode = ETH_CHECKSUM_BY_HARDWARE;
+                }
+            #else
+                {
+                    xETH.Init.ChecksumMode = ETH_CHECKSUM_BY_SOFTWARE;
+                }
+            #endif
 
-			hal_eth_init_status = HAL_ETH_Init( &xETH );
+            #if ( ipconfigUSE_RMII != 0 )
+                {
+                    xETH.Init.MediaInterface = ETH_MEDIA_INTERFACE_RMII;
+                }
+            #else
+                {
+                    xETH.Init.MediaInterface = ETH_MEDIA_INTERFACE_MII;
+                }
+            #endif /* ipconfigUSE_RMII */
 
-			/* Only for inspection by debugger. */
-			( void ) hal_eth_init_status;
+            hal_eth_init_status = HAL_ETH_Init( &xETH );
 
-			/* Set the TxDesc and RxDesc pointers. */
-			xETH.TxDesc = DMATxDscrTab;
-			xETH.RxDesc = DMARxDscrTab;
+            /* Only for inspection by debugger. */
+            ( void ) hal_eth_init_status;
 
-			/* Make sure that all unused fields are cleared. */
-			memset( &DMATxDscrTab, '\0', sizeof( DMATxDscrTab ) );
-			memset( &DMARxDscrTab, '\0', sizeof( DMARxDscrTab ) );
+            /* Set the TxDesc and RxDesc pointers. */
+            xETH.TxDesc = DMATxDscrTab;
+            xETH.RxDesc = DMARxDscrTab;
 
-			/* Initialize Tx Descriptors list: Chain Mode */
-			DMATxDescToClear = DMATxDscrTab;
+            /* Make sure that all unused fields are cleared. */
+            memset( &DMATxDscrTab, '\0', sizeof( DMATxDscrTab ) );
+            memset( &DMARxDscrTab, '\0', sizeof( DMARxDscrTab ) );
 
-			/* Initialise TX-descriptors. */
-			prvDMATxDescListInit();
+            /* Initialize Tx Descriptors list: Chain Mode */
+            DMATxDescToClear = DMATxDscrTab;
 
-			/* Initialise RX-descriptors. */
-			prvDMARxDescListInit();
+            /* Initialise TX-descriptors. */
+            prvDMATxDescListInit();
 
-			#if( ipconfigUSE_LLMNR != 0 )
-			{
-				/* Program the LLMNR address at index 1. */
-				prvMACAddressConfig( &xETH, ETH_MAC_ADDRESS1, ( uint8_t *) xLLMNR_MACAddress );
-			}
-			#endif
+            /* Initialise RX-descriptors. */
+            prvDMARxDescListInit();
 
-			/* Force a negotiation with the Switch or Router and wait for LS. */
-			prvEthernetUpdateConfig( pdTRUE );
+            #if ( ipconfigUSE_LLMNR != 0 )
+                {
+                    /* Program the LLMNR address at index 1. */
+                    prvMACAddressConfig( &xETH, ETH_MAC_ADDRESS1, ( uint8_t * ) xLLMNR_MACAddress );
+                }
+            #endif
 
-			/* The deferred interrupt handler task is created at the highest
-			possible priority to ensure the interrupt handler can return directly
-			to it.  The task's handle is stored in xEMACTaskHandle so interrupts can
-			notify the task when there is something to process. */
-			if( xTaskCreate( prvEMACHandlerTask, "EMAC", configEMAC_TASK_STACK_SIZE, NULL, niEMAC_HANDLER_TASK_PRIORITY, &xEMACTaskHandle ) == pdPASS )
-			{
-				/* The xTXDescriptorSemaphore and the task are created successfully. */
-				xMacInitStatus = eMACPass;
-			}
-			else
-			{
-				xMacInitStatus = eMACFailed;
-			}
-		}
-	} /* if( xEMACTaskHandle == NULL ) */
+            /* Force a negotiation with the Switch or Router and wait for LS. */
+            prvEthernetUpdateConfig( pdTRUE );
 
-	if( xMacInitStatus != eMACPass )
-	{
-		/* EMAC initialisation failed, return pdFAIL. */
-		xResult = pdFAIL;
-	}
-	else
-	{
-		if( xPhyObject.ulLinkStatusMask != 0uL )
-		{
-			xETH.Instance->DMAIER |= ETH_DMA_ALL_INTS;
-			xResult = pdPASS;
-			FreeRTOS_printf( ( "Link Status is high\n" ) ) ;
-		}
-		else
-		{
-			/* For now pdFAIL will be returned. But prvEMACHandlerTask() is running
-			and it will keep on checking the PHY and set 'ulLinkStatusMask' when necessary. */
-			xResult = pdFAIL;
-		}
-	}
-	/* When returning non-zero, the stack will become active and
-    start DHCP (in configured) */
-	return xResult;
+            /* The deferred interrupt handler task is created at the highest
+             * possible priority to ensure the interrupt handler can return directly
+             * to it.  The task's handle is stored in xEMACTaskHandle so interrupts can
+             * notify the task when there is something to process. */
+            if( xTaskCreate( prvEMACHandlerTask, "EMAC", configEMAC_TASK_STACK_SIZE, NULL, niEMAC_HANDLER_TASK_PRIORITY, &xEMACTaskHandle ) == pdPASS )
+            {
+                /* The xTXDescriptorSemaphore and the task are created successfully. */
+                xMacInitStatus = eMACPass;
+            }
+            else
+            {
+                xMacInitStatus = eMACFailed;
+            }
+        }
+    } /* if( xEMACTaskHandle == NULL ) */
+
+    if( xMacInitStatus != eMACPass )
+    {
+        /* EMAC initialisation failed, return pdFAIL. */
+        xResult = pdFAIL;
+    }
+    else
+    {
+        if( xPhyObject.ulLinkStatusMask != 0uL )
+        {
+            xETH.Instance->DMAIER |= ETH_DMA_ALL_INTS;
+            xResult = pdPASS;
+            FreeRTOS_printf( ( "Link Status is high\n" ) );
+        }
+        else
+        {
+            /* For now pdFAIL will be returned. But prvEMACHandlerTask() is running
+             * and it will keep on checking the PHY and set 'ulLinkStatusMask' when necessary. */
+            xResult = pdFAIL;
+        }
+    }
+
+    /* When returning non-zero, the stack will become active and
+     * start DHCP (in configured) */
+    return xResult;
 }
 /*-----------------------------------------------------------*/
 
 static void prvDMATxDescListInit()
 {
-ETH_DMADescTypeDef *pxDMADescriptor;
-BaseType_t xIndex;
+    ETH_DMADescTypeDef * pxDMADescriptor;
+    BaseType_t xIndex;
 
-	/* Get the pointer on the first member of the descriptor list */
-	pxDMADescriptor = DMATxDscrTab;
+    /* Get the pointer on the first member of the descriptor list */
+    pxDMADescriptor = DMATxDscrTab;
 
-	/* Fill each DMA descriptor with the right values */
-	for( xIndex = 0; xIndex < ETH_TXBUFNB; xIndex++, pxDMADescriptor++ )
-	{
-		/* Set Second Address Chained bit */
-		pxDMADescriptor->Status = ETH_DMATXDESC_TCH;
+    /* Fill each DMA descriptor with the right values */
+    for( xIndex = 0; xIndex < ETH_TXBUFNB; xIndex++, pxDMADescriptor++ )
+    {
+        /* Set Second Address Chained bit */
+        pxDMADescriptor->Status = ETH_DMATXDESC_TCH;
 
-		#if( ipconfigZERO_COPY_TX_DRIVER == 0 )
-		{
-			/* Set Buffer1 address pointer */
-			pxDMADescriptor->Buffer1Addr = ( uint32_t )( Tx_Buff[ xIndex ] );
-		}
-		#endif
+        #if ( ipconfigZERO_COPY_TX_DRIVER == 0 )
+            {
+                /* Set Buffer1 address pointer */
+                pxDMADescriptor->Buffer1Addr = ( uint32_t ) ( Tx_Buff[ xIndex ] );
+            }
+        #endif
 
-		if( xETH.Init.ChecksumMode == ETH_CHECKSUM_BY_HARDWARE )
-		{
-			/* Set the DMA Tx descriptors checksum insertion for TCP, UDP, and ICMP */
-			pxDMADescriptor->Status |= ETH_DMATXDESC_CHECKSUMTCPUDPICMPFULL;
-		}
-		else
-		{
-			pxDMADescriptor->Status &= ~( ( uint32_t ) ETH_DMATXDESC_CHECKSUMTCPUDPICMPFULL );
-		}
+        if( xETH.Init.ChecksumMode == ETH_CHECKSUM_BY_HARDWARE )
+        {
+            /* Set the DMA Tx descriptors checksum insertion for TCP, UDP, and ICMP */
+            pxDMADescriptor->Status |= ETH_DMATXDESC_CHECKSUMTCPUDPICMPFULL;
+        }
+        else
+        {
+            pxDMADescriptor->Status &= ~( ( uint32_t ) ETH_DMATXDESC_CHECKSUMTCPUDPICMPFULL );
+        }
 
-		/* Initialize the next descriptor with the Next Descriptor Polling Enable */
-		if( xIndex < ETH_TXBUFNB - 1 )
-		{
-			/* Set next descriptor address register with next descriptor base address */
-			pxDMADescriptor->Buffer2NextDescAddr = ( uint32_t ) ( pxDMADescriptor + 1 );
-		}
-		else
-		{
-			/* For last descriptor, set next descriptor address register equal to the first descriptor base address */
-			pxDMADescriptor->Buffer2NextDescAddr = ( uint32_t ) DMATxDscrTab;
-		}
-	}
+        /* Initialize the next descriptor with the Next Descriptor Polling Enable */
+        if( xIndex < ETH_TXBUFNB - 1 )
+        {
+            /* Set next descriptor address register with next descriptor base address */
+            pxDMADescriptor->Buffer2NextDescAddr = ( uint32_t ) ( pxDMADescriptor + 1 );
+        }
+        else
+        {
+            /* For last descriptor, set next descriptor address register equal to the first descriptor base address */
+            pxDMADescriptor->Buffer2NextDescAddr = ( uint32_t ) DMATxDscrTab;
+        }
+    }
 
-	/* Set Transmit Descriptor List Address Register */
-	xETH.Instance->DMATDLAR = ( uint32_t ) DMATxDscrTab;
+    /* Set Transmit Descriptor List Address Register */
+    xETH.Instance->DMATDLAR = ( uint32_t ) DMATxDscrTab;
 }
 /*-----------------------------------------------------------*/
 
 static void prvDMARxDescListInit()
 {
-ETH_DMADescTypeDef *pxDMADescriptor;
-BaseType_t xIndex;
-	/*
-	 * RX-descriptors.
-	 */
+    ETH_DMADescTypeDef * pxDMADescriptor;
+    BaseType_t xIndex;
 
-	/* Get the pointer on the first member of the descriptor list */
-	pxDMADescriptor = DMARxDscrTab;
+    /*
+     * RX-descriptors.
+     */
 
-	/* Fill each DMA descriptor with the right values */
-	for( xIndex = 0; xIndex < ETH_RXBUFNB; xIndex++, pxDMADescriptor++ )
-	{
+    /* Get the pointer on the first member of the descriptor list */
+    pxDMADescriptor = DMARxDscrTab;
 
-		/* Set Buffer1 size and Second Address Chained bit */
-		pxDMADescriptor->ControlBufferSize = ETH_DMARXDESC_RCH | (uint32_t)ETH_RX_BUF_SIZE;  
+    /* Fill each DMA descriptor with the right values */
+    for( xIndex = 0; xIndex < ETH_RXBUFNB; xIndex++, pxDMADescriptor++ )
+    {
+        /* Set Buffer1 size and Second Address Chained bit */
+        pxDMADescriptor->ControlBufferSize = ETH_DMARXDESC_RCH | ( uint32_t ) ETH_RX_BUF_SIZE;
 
-		#if( ipconfigZERO_COPY_RX_DRIVER != 0 )
-		{
-		/* Set Buffer1 address pointer */
-		NetworkBufferDescriptor_t *pxBuffer;
+        #if ( ipconfigZERO_COPY_RX_DRIVER != 0 )
+            {
+                /* Set Buffer1 address pointer */
+                NetworkBufferDescriptor_t * pxBuffer;
 
-			pxBuffer = pxGetNetworkBufferWithDescriptor( ETH_RX_BUF_SIZE, 100ul );
-			/* If the assert below fails, make sure that there are at least 'ETH_RXBUFNB'
-			Network Buffers available during start-up ( ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ) */
-			configASSERT( pxBuffer != NULL );
-			if( pxBuffer != NULL )
-			{
-				pxDMADescriptor->Buffer1Addr = (uint32_t)pxBuffer->pucEthernetBuffer;
-				pxDMADescriptor->Status = ETH_DMARXDESC_OWN;
-			}
-		}
-		#else
-		{
-			/* Set Buffer1 address pointer */
-			pxDMADescriptor->Buffer1Addr = ( uint32_t )( Rx_Buff[ xIndex ] );
-			/* Set Own bit of the Rx descriptor Status */
-			pxDMADescriptor->Status = ETH_DMARXDESC_OWN;
-		}
-		#endif
+                pxBuffer = pxGetNetworkBufferWithDescriptor( ETH_RX_BUF_SIZE, 100ul );
 
-		/* Initialize the next descriptor with the Next Descriptor Polling Enable */
-		if( xIndex < ETH_RXBUFNB - 1 )
-		{
-			/* Set next descriptor address register with next descriptor base address */
-			pxDMADescriptor->Buffer2NextDescAddr = ( uint32_t )( pxDMADescriptor + 1 );
-		}
-		else
-		{
-			/* For last descriptor, set next descriptor address register equal to the first descriptor base address */
-			pxDMADescriptor->Buffer2NextDescAddr = ( uint32_t ) DMARxDscrTab;
-		}
+                /* If the assert below fails, make sure that there are at least 'ETH_RXBUFNB'
+                 * Network Buffers available during start-up ( ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ) */
+                configASSERT( pxBuffer != NULL );
 
-	}
-	/* Set Receive Descriptor List Address Register */
-	xETH.Instance->DMARDLAR = ( uint32_t ) DMARxDscrTab;
+                if( pxBuffer != NULL )
+                {
+                    pxDMADescriptor->Buffer1Addr = ( uint32_t ) pxBuffer->pucEthernetBuffer;
+                    pxDMADescriptor->Status = ETH_DMARXDESC_OWN;
+                }
+            }
+        #else /* if ( ipconfigZERO_COPY_RX_DRIVER != 0 ) */
+            {
+                /* Set Buffer1 address pointer */
+                pxDMADescriptor->Buffer1Addr = ( uint32_t ) ( Rx_Buff[ xIndex ] );
+                /* Set Own bit of the Rx descriptor Status */
+                pxDMADescriptor->Status = ETH_DMARXDESC_OWN;
+            }
+        #endif /* if ( ipconfigZERO_COPY_RX_DRIVER != 0 ) */
+
+        /* Initialize the next descriptor with the Next Descriptor Polling Enable */
+        if( xIndex < ETH_RXBUFNB - 1 )
+        {
+            /* Set next descriptor address register with next descriptor base address */
+            pxDMADescriptor->Buffer2NextDescAddr = ( uint32_t ) ( pxDMADescriptor + 1 );
+        }
+        else
+        {
+            /* For last descriptor, set next descriptor address register equal to the first descriptor base address */
+            pxDMADescriptor->Buffer2NextDescAddr = ( uint32_t ) DMARxDscrTab;
+        }
+    }
+
+    /* Set Receive Descriptor List Address Register */
+    xETH.Instance->DMARDLAR = ( uint32_t ) DMARxDscrTab;
 }
 /*-----------------------------------------------------------*/
 
-static void prvMACAddressConfig(ETH_HandleTypeDef *heth, uint32_t ulIndex, uint8_t *Addr)
+static void prvMACAddressConfig( ETH_HandleTypeDef * heth,
+                                 uint32_t ulIndex,
+                                 uint8_t * Addr )
 {
-uint32_t ulTempReg;
+    uint32_t ulTempReg;
 
-	( void ) heth;
+    ( void ) heth;
 
-	/* Calculate the selected MAC address high register. */
-	ulTempReg = 0x80000000ul | ( ( uint32_t ) Addr[ 5 ] << 8 ) | ( uint32_t ) Addr[ 4 ];
+    /* Calculate the selected MAC address high register. */
+    ulTempReg = 0x80000000ul | ( ( uint32_t ) Addr[ 5 ] << 8 ) | ( uint32_t ) Addr[ 4 ];
 
-	/* Load the selected MAC address high register. */
-	( *(__IO uint32_t *)( ( uint32_t ) ( ETH_MAC_ADDR_HBASE + ulIndex ) ) ) = ulTempReg;
+    /* Load the selected MAC address high register. */
+    ( *( __IO uint32_t * ) ( ( uint32_t ) ( ETH_MAC_ADDR_HBASE + ulIndex ) ) ) = ulTempReg;
 
-	/* Calculate the selected MAC address low register. */
-	ulTempReg = ( ( uint32_t ) Addr[ 3 ] << 24 ) | ( ( uint32_t ) Addr[ 2 ] << 16 ) | ( ( uint32_t ) Addr[ 1 ] << 8 ) | Addr[ 0 ];
+    /* Calculate the selected MAC address low register. */
+    ulTempReg = ( ( uint32_t ) Addr[ 3 ] << 24 ) | ( ( uint32_t ) Addr[ 2 ] << 16 ) | ( ( uint32_t ) Addr[ 1 ] << 8 ) | Addr[ 0 ];
 
-	/* Load the selected MAC address low register */
-	( *(__IO uint32_t *) ( ( uint32_t ) ( ETH_MAC_ADDR_LBASE + ulIndex ) ) ) = ulTempReg;
+    /* Load the selected MAC address low register */
+    ( *( __IO uint32_t * ) ( ( uint32_t ) ( ETH_MAC_ADDR_LBASE + ulIndex ) ) ) = ulTempReg;
 }
 /*-----------------------------------------------------------*/
 
-BaseType_t xNetworkInterfaceOutput( NetworkBufferDescriptor_t * const pxDescriptor, BaseType_t bReleaseAfterSend )
+BaseType_t xNetworkInterfaceOutput( NetworkBufferDescriptor_t * const pxDescriptor,
+                                    BaseType_t bReleaseAfterSend )
 {
-BaseType_t xReturn = pdFAIL;
-uint32_t ulTransmitSize = 0;
-__IO ETH_DMADescTypeDef *pxDmaTxDesc;
+    BaseType_t xReturn = pdFAIL;
+    uint32_t ulTransmitSize = 0;
+    __IO ETH_DMADescTypeDef * pxDmaTxDesc;
 /* Do not wait too long for a free TX DMA buffer. */
-const TickType_t xBlockTimeTicks = pdMS_TO_TICKS( 50u );
+    const TickType_t xBlockTimeTicks = pdMS_TO_TICKS( 50u );
 
-	/* Open a do {} while ( 0 ) loop to be able to call break. */
-	do
-	{
-		#if( ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM != 0 )
-		{
-		ProtocolPacket_t *pxPacket;
+    /* Open a do {} while ( 0 ) loop to be able to call break. */
+    do
+    {
+        #if ( ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM != 0 )
+            {
+                ProtocolPacket_t * pxPacket;
 
-			/* If the peripheral must calculate the checksum, it wants
-			the protocol checksum to have a value of zero. */
-			pxPacket = ( ProtocolPacket_t * ) ( pxDescriptor->pucEthernetBuffer );
+                /* If the peripheral must calculate the checksum, it wants
+                 * the protocol checksum to have a value of zero. */
+                pxPacket = ( ProtocolPacket_t * ) ( pxDescriptor->pucEthernetBuffer );
 
-			if( pxPacket->xICMPPacket.xIPHeader.ucProtocol == ( uint8_t ) ipPROTOCOL_ICMP )
-			{
-				pxPacket->xICMPPacket.xICMPHeader.usChecksum = ( uint16_t )0u;
-			}
-		}
-		#endif /* ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM */
-		if( xPhyObject.ulLinkStatusMask != 0 )
-		{
-			if( xSemaphoreTake( xTXDescriptorSemaphore, xBlockTimeTicks ) != pdPASS )
-			{
-				/* Time-out waiting for a free TX descriptor. */
-				break;
-			}
+                if( pxPacket->xICMPPacket.xIPHeader.ucProtocol == ( uint8_t ) ipPROTOCOL_ICMP )
+                {
+                    pxPacket->xICMPPacket.xICMPHeader.usChecksum = ( uint16_t ) 0u;
+                }
+            }
+        #endif /* ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM */
 
-			/* This function does the actual transmission of the packet. The packet is
-			contained in 'pxDescriptor' that is passed to the function. */
-			pxDmaTxDesc = xETH.TxDesc;
+        if( xPhyObject.ulLinkStatusMask != 0 )
+        {
+            if( xSemaphoreTake( xTXDescriptorSemaphore, xBlockTimeTicks ) != pdPASS )
+            {
+                /* Time-out waiting for a free TX descriptor. */
+                break;
+            }
 
-			/* Is this buffer available? */
-			configASSERT ( ( pxDmaTxDesc->Status & ETH_DMATXDESC_OWN ) == 0 );
+            /* This function does the actual transmission of the packet. The packet is
+             * contained in 'pxDescriptor' that is passed to the function. */
+            pxDmaTxDesc = xETH.TxDesc;
 
-			{
-				/* Is this buffer available? */
-				/* Get bytes in current buffer. */
-				ulTransmitSize = pxDescriptor->xDataLength;
+            /* Is this buffer available? */
+            configASSERT( ( pxDmaTxDesc->Status & ETH_DMATXDESC_OWN ) == 0 );
 
-				if( ulTransmitSize > ETH_TX_BUF_SIZE )
-				{
-					ulTransmitSize = ETH_TX_BUF_SIZE;
-				}
+            {
+                /* Is this buffer available? */
+                /* Get bytes in current buffer. */
+                ulTransmitSize = pxDescriptor->xDataLength;
 
-				#if( ipconfigZERO_COPY_TX_DRIVER == 0 )
-				{
-					/* Copy the bytes. */
-					memcpy( ( void * ) pxDmaTxDesc->Buffer1Addr, pxDescriptor->pucEthernetBuffer, ulTransmitSize );
-				}
-				#else
-				{
-					configASSERT( bReleaseAfterSend != 0 );
+                if( ulTransmitSize > ETH_TX_BUF_SIZE )
+                {
+                    ulTransmitSize = ETH_TX_BUF_SIZE;
+                }
 
-					/* Move the buffer. */
-					pxDmaTxDesc->Buffer1Addr = ( uint32_t )pxDescriptor->pucEthernetBuffer;
-					/* The Network Buffer has been passed to DMA, no need to release it. */
-					bReleaseAfterSend = pdFALSE_UNSIGNED;
-				}
-				#endif /* ipconfigZERO_COPY_TX_DRIVER */
+                #if ( ipconfigZERO_COPY_TX_DRIVER == 0 )
+                    {
+                        /* Copy the bytes. */
+                        memcpy( ( void * ) pxDmaTxDesc->Buffer1Addr, pxDescriptor->pucEthernetBuffer, ulTransmitSize );
+                    }
+                #else
+                    {
+                        configASSERT( bReleaseAfterSend != 0 );
 
-				/* Ask to set the IPv4 checksum.
-				Also need an Interrupt on Completion so that 'vClearTXBuffers()' will be called.. */
-				#if( ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM != 0 )
-				{
-					pxDmaTxDesc->Status |= ETH_DMATXDESC_CIC_TCPUDPICMP_FULL | ETH_DMATXDESC_IC;
-				}
-				#else
-				{
-					pxDmaTxDesc->Status &= ~( ( uint32_t ) ETH_DMATXDESC_CIC );
-					pxDmaTxDesc->Status |= ETH_DMATXDESC_IC;
-				}
-				#endif
-				
+                        /* Move the buffer. */
+                        pxDmaTxDesc->Buffer1Addr = ( uint32_t ) pxDescriptor->pucEthernetBuffer;
+                        /* The Network Buffer has been passed to DMA, no need to release it. */
+                        bReleaseAfterSend = pdFALSE_UNSIGNED;
+                    }
+                #endif /* ipconfigZERO_COPY_TX_DRIVER */
 
-				/* Prepare transmit descriptors to give to DMA. */
+                /* Ask to set the IPv4 checksum.
+                 * Also need an Interrupt on Completion so that 'vClearTXBuffers()' will be called.. */
+                #if ( ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM != 0 )
+                    {
+                        pxDmaTxDesc->Status |= ETH_DMATXDESC_CIC_TCPUDPICMP_FULL | ETH_DMATXDESC_IC;
+                    }
+                #else
+                    {
+                        pxDmaTxDesc->Status &= ~( ( uint32_t ) ETH_DMATXDESC_CIC );
+                        pxDmaTxDesc->Status |= ETH_DMATXDESC_IC;
+                    }
+                #endif
 
-				/* Set LAST and FIRST segment */
-				pxDmaTxDesc->Status |= ETH_DMATXDESC_FS | ETH_DMATXDESC_LS;
-				/* Set frame size */
-				pxDmaTxDesc->ControlBufferSize = ( ulTransmitSize & ETH_DMATXDESC_TBS1 );
 
-				#if( NETWORK_BUFFERS_CACHED	!= 0 )
-				{
-				BaseType_t xlength = CACHE_LINE_SIZE * ( ( ulTransmitSize + NETWORK_BUFFER_HEADER_SIZE + CACHE_LINE_SIZE - 1 ) / CACHE_LINE_SIZE );
-				uint32_t *pulBuffer = ( uint32_t )( pxDescriptor->pucEthernetBuffer - NETWORK_BUFFER_HEADER_SIZE );
-					cache_clean_invalidate_by_addr( pulBuffer, xlength );
-				}
-				#endif
+                /* Prepare transmit descriptors to give to DMA. */
 
-				/* Set Own bit of the Tx descriptor Status: gives the buffer back to ETHERNET DMA */
-				pxDmaTxDesc->Status |= ETH_DMATXDESC_OWN;
+                /* Set LAST and FIRST segment */
+                pxDmaTxDesc->Status |= ETH_DMATXDESC_FS | ETH_DMATXDESC_LS;
+                /* Set frame size */
+                pxDmaTxDesc->ControlBufferSize = ( ulTransmitSize & ETH_DMATXDESC_TBS1 );
 
-				/* Point to next descriptor */
-				xETH.TxDesc = ( ETH_DMADescTypeDef * ) ( xETH.TxDesc->Buffer2NextDescAddr );
-				/* Ensure completion of memory access */
-				__DSB();
-				/* Resume DMA transmission*/
-				xETH.Instance->DMATPDR = 0;
-				iptraceNETWORK_INTERFACE_TRANSMIT();
-				xReturn = pdPASS;
-			}
-		}
-		else
-		{
-			/* The PHY has no Link Status, packet shall be dropped. */
-		}
-	} while( 0 );
-	/* The buffer has been sent so can be released. */
-	if( bReleaseAfterSend != pdFALSE )
-	{
-		vReleaseNetworkBufferAndDescriptor( pxDescriptor );
-	}
+                #if ( NETWORK_BUFFERS_CACHED != 0 )
+                    {
+                        BaseType_t xlength = CACHE_LINE_SIZE * ( ( ulTransmitSize + NETWORK_BUFFER_HEADER_SIZE + CACHE_LINE_SIZE - 1 ) / CACHE_LINE_SIZE );
+                        uint32_t * pulBuffer = ( uint32_t ) ( pxDescriptor->pucEthernetBuffer - NETWORK_BUFFER_HEADER_SIZE );
+                        cache_clean_invalidate_by_addr( pulBuffer, xlength );
+                    }
+                #endif
 
-	return xReturn;
+                /* Set Own bit of the Tx descriptor Status: gives the buffer back to ETHERNET DMA */
+                pxDmaTxDesc->Status |= ETH_DMATXDESC_OWN;
+
+                /* Point to next descriptor */
+                xETH.TxDesc = ( ETH_DMADescTypeDef * ) ( xETH.TxDesc->Buffer2NextDescAddr );
+                /* Ensure completion of memory access */
+                __DSB();
+                /* Resume DMA transmission*/
+                xETH.Instance->DMATPDR = 0;
+                iptraceNETWORK_INTERFACE_TRANSMIT();
+                xReturn = pdPASS;
+            }
+        }
+        else
+        {
+            /* The PHY has no Link Status, packet shall be dropped. */
+        }
+    } while( 0 );
+
+    /* The buffer has been sent so can be released. */
+    if( bReleaseAfterSend != pdFALSE )
+    {
+        vReleaseNetworkBufferAndDescriptor( pxDescriptor );
+    }
+
+    return xReturn;
 }
 /*-----------------------------------------------------------*/
 
-static BaseType_t xMayAcceptPacket( uint8_t *pcBuffer )
+static BaseType_t xMayAcceptPacket( uint8_t * pcBuffer )
 {
-const ProtocolPacket_t *pxProtPacket = ( const ProtocolPacket_t * )pcBuffer;
+    const ProtocolPacket_t * pxProtPacket = ( const ProtocolPacket_t * ) pcBuffer;
 
-	switch( pxProtPacket->xTCPPacket.xEthernetHeader.usFrameType )
-	{
-	case ipARP_FRAME_TYPE:
-		/* Check it later. */
-		return pdTRUE;
-	case ipIPv4_FRAME_TYPE:
-		/* Check it here. */
-		break;
-	default:
-		/* Refuse the packet. */
-		return pdFALSE;
-	}
+    switch( pxProtPacket->xTCPPacket.xEthernetHeader.usFrameType )
+    {
+        case ipARP_FRAME_TYPE:
+            /* Check it later. */
+            return pdTRUE;
 
-	#if( ipconfigETHERNET_DRIVER_FILTERS_PACKETS == 1 )
-	{
-		const IPHeader_t *pxIPHeader = &(pxProtPacket->xTCPPacket.xIPHeader);
-		uint32_t ulDestinationIPAddress;
+        case ipIPv4_FRAME_TYPE:
+            /* Check it here. */
+            break;
 
-		/* Ensure that the incoming packet is not fragmented (only outgoing packets
-		 * can be fragmented) as these are the only handled IP frames currently. */
-		if( ( pxIPHeader->usFragmentOffset & FreeRTOS_ntohs( ipFRAGMENT_OFFSET_BIT_MASK ) ) != 0U )
-		{
-			return pdFALSE;
-		}
-		/* HT: Might want to make the following configurable because
-		 * most IP messages have a standard length of 20 bytes */
+        default:
+            /* Refuse the packet. */
+            return pdFALSE;
+    }
 
-		/* 0x45 means: IPv4 with an IP header of 5 x 4 = 20 bytes
-		 * 0x47 means: IPv4 with an IP header of 7 x 4 = 28 bytes */
-		if( pxIPHeader->ucVersionHeaderLength < 0x45 || pxIPHeader->ucVersionHeaderLength > 0x4F )
-		{
-			return pdFALSE;
-		}
+    #if ( ipconfigETHERNET_DRIVER_FILTERS_PACKETS == 1 )
+        {
+            const IPHeader_t * pxIPHeader = &( pxProtPacket->xTCPPacket.xIPHeader );
+            uint32_t ulDestinationIPAddress;
 
-		ulDestinationIPAddress = pxIPHeader->ulDestinationIPAddress;
-		/* Is the packet for this node? */
-		if( ( ulDestinationIPAddress != *ipLOCAL_IP_ADDRESS_POINTER ) &&
-			/* Is it a broadcast address x.x.x.255 ? */
-			( ( FreeRTOS_ntohl( ulDestinationIPAddress ) & 0xff ) != 0xff ) &&
-		#if( ipconfigUSE_LLMNR == 1 )
-			( ulDestinationIPAddress != ipLLMNR_IP_ADDR ) &&
-		#endif
-			( *ipLOCAL_IP_ADDRESS_POINTER != 0 ) ) {
-			FreeRTOS_printf( ( "Drop IP %lxip\n", FreeRTOS_ntohl( ulDestinationIPAddress ) ) );
-			return pdFALSE;
-		}
+            /* Ensure that the incoming packet is not fragmented (only outgoing packets
+             * can be fragmented) as these are the only handled IP frames currently. */
+            if( ( pxIPHeader->usFragmentOffset & FreeRTOS_ntohs( ipFRAGMENT_OFFSET_BIT_MASK ) ) != 0U )
+            {
+                return pdFALSE;
+            }
 
-		if( pxIPHeader->ucProtocol == ipPROTOCOL_UDP )
-		{
-		uint16_t usSourcePort = FreeRTOS_ntohs( pxProtPacket->xUDPPacket.xUDPHeader.usSourcePort );
-		uint16_t usDestinationPort = FreeRTOS_ntohs( pxProtPacket->xUDPPacket.xUDPHeader.usDestinationPort );
+            /* HT: Might want to make the following configurable because
+             * most IP messages have a standard length of 20 bytes */
 
-			if( ( xPortHasUDPSocket( pxProtPacket->xUDPPacket.xUDPHeader.usDestinationPort ) == pdFALSE )
-			#if ipconfigUSE_LLMNR == 1
-				&& ( usDestinationPort != ipLLMNR_PORT )
-				&& ( usSourcePort != ipLLMNR_PORT )
-			#endif
-			#if ipconfigUSE_NBNS == 1
-				&& ( usDestinationPort != ipNBNS_PORT )
-				&& ( usSourcePort != ipNBNS_PORT )
-			#endif
-			#if ipconfigUSE_DNS == 1
-				&& ( usSourcePort != ipDNS_PORT )
-			#endif
-				) {
-				/* Drop this packet, not for this device. */
-				/* FreeRTOS_printf( ( "Drop: UDP port %d -> %d\n", usSourcePort, usDestinationPort ) ); */
-				return pdFALSE;
-			}
-		}
-	}
-	#endif	/* ipconfigETHERNET_DRIVER_FILTERS_PACKETS */
-	return pdTRUE;
+            /* 0x45 means: IPv4 with an IP header of 5 x 4 = 20 bytes
+             * 0x47 means: IPv4 with an IP header of 7 x 4 = 28 bytes */
+            if( ( pxIPHeader->ucVersionHeaderLength < 0x45 ) || ( pxIPHeader->ucVersionHeaderLength > 0x4F ) )
+            {
+                return pdFALSE;
+            }
+
+            ulDestinationIPAddress = pxIPHeader->ulDestinationIPAddress;
+
+            /* Is the packet for this node? */
+            if( ( ulDestinationIPAddress != *ipLOCAL_IP_ADDRESS_POINTER ) &&
+                /* Is it a broadcast address x.x.x.255 ? */
+                ( ( FreeRTOS_ntohl( ulDestinationIPAddress ) & 0xff ) != 0xff ) &&
+                #if ( ipconfigUSE_LLMNR == 1 )
+                    ( ulDestinationIPAddress != ipLLMNR_IP_ADDR ) &&
+                #endif
+                ( *ipLOCAL_IP_ADDRESS_POINTER != 0 ) )
+            {
+                FreeRTOS_printf( ( "Drop IP %lxip\n", FreeRTOS_ntohl( ulDestinationIPAddress ) ) );
+                return pdFALSE;
+            }
+
+            if( pxIPHeader->ucProtocol == ipPROTOCOL_UDP )
+            {
+                uint16_t usSourcePort = FreeRTOS_ntohs( pxProtPacket->xUDPPacket.xUDPHeader.usSourcePort );
+                uint16_t usDestinationPort = FreeRTOS_ntohs( pxProtPacket->xUDPPacket.xUDPHeader.usDestinationPort );
+
+                if( ( xPortHasUDPSocket( pxProtPacket->xUDPPacket.xUDPHeader.usDestinationPort ) == pdFALSE )
+                    #if ipconfigUSE_LLMNR == 1
+                        && ( usDestinationPort != ipLLMNR_PORT ) &&
+                        ( usSourcePort != ipLLMNR_PORT )
+                    #endif
+                    #if ipconfigUSE_NBNS == 1
+                        && ( usDestinationPort != ipNBNS_PORT ) &&
+                        ( usSourcePort != ipNBNS_PORT )
+                    #endif
+                    #if ipconfigUSE_DNS == 1
+                        && ( usSourcePort != ipDNS_PORT )
+                    #endif
+                    )
+                {
+                    /* Drop this packet, not for this device. */
+                    /* FreeRTOS_printf( ( "Drop: UDP port %d -> %d\n", usSourcePort, usDestinationPort ) ); */
+                    return pdFALSE;
+                }
+            }
+        }
+    #endif /* ipconfigETHERNET_DRIVER_FILTERS_PACKETS */
+    return pdTRUE;
 }
 /*-----------------------------------------------------------*/
 
-static void prvPassEthMessages( NetworkBufferDescriptor_t *pxDescriptor )
+static void prvPassEthMessages( NetworkBufferDescriptor_t * pxDescriptor )
 {
-IPStackEvent_t xRxEvent;
+    IPStackEvent_t xRxEvent;
 
-	xRxEvent.eEventType = eNetworkRxEvent;
-	xRxEvent.pvData = ( void * ) pxDescriptor;
+    xRxEvent.eEventType = eNetworkRxEvent;
+    xRxEvent.pvData = ( void * ) pxDescriptor;
 
-	if( xSendEventStructToIPTask( &xRxEvent, ( TickType_t ) 1000 ) != pdPASS )
-	{
-		/* The buffer could not be sent to the stack so	must be released again.
-		This is a deferred handler taskr, not a real interrupt, so it is ok to
-		use the task level function here. */
-		#if( ipconfigUSE_LINKED_RX_MESSAGES != 0 )
-		{
-			do
-			{
-				NetworkBufferDescriptor_t *pxNext = pxDescriptor->pxNextBuffer;
-				vReleaseNetworkBufferAndDescriptor( pxDescriptor );
-				pxDescriptor = pxNext;
-			} while( pxDescriptor != NULL );
-		}
-		#else
-		{
-			vReleaseNetworkBufferAndDescriptor( pxDescriptor );
-		}
-		#endif	/* ipconfigUSE_LINKED_RX_MESSAGES */
-		iptraceETHERNET_RX_EVENT_LOST();
-		FreeRTOS_printf( ( "prvPassEthMessages: Can not queue return packet!\n" ) );
-	}
-	else
-	{
-		iptraceNETWORK_INTERFACE_RECEIVE();
-	}
+    if( xSendEventStructToIPTask( &xRxEvent, ( TickType_t ) 1000 ) != pdPASS )
+    {
+        /* The buffer could not be sent to the stack so	must be released again.
+         * This is a deferred handler taskr, not a real interrupt, so it is ok to
+         * use the task level function here. */
+        #if ( ipconfigUSE_LINKED_RX_MESSAGES != 0 )
+            {
+                do
+                {
+                    NetworkBufferDescriptor_t * pxNext = pxDescriptor->pxNextBuffer;
+                    vReleaseNetworkBufferAndDescriptor( pxDescriptor );
+                    pxDescriptor = pxNext;
+                } while( pxDescriptor != NULL );
+            }
+        #else
+            {
+                vReleaseNetworkBufferAndDescriptor( pxDescriptor );
+            }
+        #endif /* ipconfigUSE_LINKED_RX_MESSAGES */
+        iptraceETHERNET_RX_EVENT_LOST();
+        FreeRTOS_printf( ( "prvPassEthMessages: Can not queue return packet!\n" ) );
+    }
+    else
+    {
+        iptraceNETWORK_INTERFACE_RECEIVE();
+    }
 }
 
 static BaseType_t prvNetworkInterfaceInput( void )
 {
-NetworkBufferDescriptor_t *pxCurDescriptor;
-NetworkBufferDescriptor_t *pxNewDescriptor = NULL;
-#if( ipconfigUSE_LINKED_RX_MESSAGES != 0 )
-	NetworkBufferDescriptor_t *pxFirstDescriptor = NULL;
-	NetworkBufferDescriptor_t *pxLastDescriptor = NULL;
-#endif
-BaseType_t xReceivedLength = 0;
-__IO ETH_DMADescTypeDef *pxDMARxDescriptor;
-const TickType_t xDescriptorWaitTime = pdMS_TO_TICKS( niDESCRIPTOR_WAIT_TIME_MS );
-uint8_t *pucBuffer;
+    NetworkBufferDescriptor_t * pxCurDescriptor;
+    NetworkBufferDescriptor_t * pxNewDescriptor = NULL;
 
-	pxDMARxDescriptor = xETH.RxDesc;
+    #if ( ipconfigUSE_LINKED_RX_MESSAGES != 0 )
+        NetworkBufferDescriptor_t * pxFirstDescriptor = NULL;
+        NetworkBufferDescriptor_t * pxLastDescriptor = NULL;
+    #endif
+    BaseType_t xReceivedLength = 0;
+    __IO ETH_DMADescTypeDef * pxDMARxDescriptor;
+    const TickType_t xDescriptorWaitTime = pdMS_TO_TICKS( niDESCRIPTOR_WAIT_TIME_MS );
+    uint8_t * pucBuffer;
 
-	while( ( pxDMARxDescriptor->Status & ETH_DMARXDESC_OWN ) == 0u )
-	{
-	BaseType_t xAccepted = pdTRUE;
-		/* Get the Frame Length of the received packet: substruct 4 bytes of the CRC */
-		xReceivedLength = ( ( pxDMARxDescriptor->Status & ETH_DMARXDESC_FL ) >> ETH_DMARXDESC_FRAMELENGTHSHIFT ) - 4;
+    pxDMARxDescriptor = xETH.RxDesc;
 
-		pucBuffer = (uint8_t *) pxDMARxDescriptor->Buffer1Addr;
+    while( ( pxDMARxDescriptor->Status & ETH_DMARXDESC_OWN ) == 0u )
+    {
+        BaseType_t xAccepted = pdTRUE;
+        /* Get the Frame Length of the received packet: substruct 4 bytes of the CRC */
+        xReceivedLength = ( ( pxDMARxDescriptor->Status & ETH_DMARXDESC_FL ) >> ETH_DMARXDESC_FRAMELENGTHSHIFT ) - 4;
 
-		/* Update the ETHERNET DMA global Rx descriptor with next Rx descriptor */
-		/* Chained Mode */    
-		/* Selects the next DMA Rx descriptor list for next buffer to read */ 
-		xETH.RxDesc = ( ETH_DMADescTypeDef* )pxDMARxDescriptor->Buffer2NextDescAddr;
+        pucBuffer = ( uint8_t * ) pxDMARxDescriptor->Buffer1Addr;
 
-		/* In order to make the code easier and faster, only packets in a single buffer
-		will be accepted.  This can be done by making the buffers large enough to
-		hold a complete Ethernet packet (1536 bytes).
-		Therefore, two sanity checks: */
-		configASSERT( xReceivedLength <= ETH_RX_BUF_SIZE );
+        /* Update the ETHERNET DMA global Rx descriptor with next Rx descriptor */
+        /* Chained Mode */
+        /* Selects the next DMA Rx descriptor list for next buffer to read */
+        xETH.RxDesc = ( ETH_DMADescTypeDef * ) pxDMARxDescriptor->Buffer2NextDescAddr;
 
-		if( ( pxDMARxDescriptor->Status & ( ETH_DMARXDESC_CE | ETH_DMARXDESC_IPV4HCE | ETH_DMARXDESC_FT ) ) != ETH_DMARXDESC_FT )
-		{
-			/* Not an Ethernet frame-type or a checmsum error. */
-			xAccepted = pdFALSE;
-		}
-		else
-		{
-			/* See if this packet must be handled. */
-			xAccepted = xMayAcceptPacket( pucBuffer );
-		}
+        /* In order to make the code easier and faster, only packets in a single buffer
+         * will be accepted.  This can be done by making the buffers large enough to
+         * hold a complete Ethernet packet (1536 bytes).
+         * Therefore, two sanity checks: */
+        configASSERT( xReceivedLength <= ETH_RX_BUF_SIZE );
 
-		if( xAccepted != pdFALSE )
-		{
-			/* The packet wil be accepted, but check first if a new Network Buffer can
-			be obtained. If not, the packet will still be dropped. */
-			pxNewDescriptor = pxGetNetworkBufferWithDescriptor( ETH_RX_BUF_SIZE, xDescriptorWaitTime );
+        if( ( pxDMARxDescriptor->Status & ( ETH_DMARXDESC_CE | ETH_DMARXDESC_IPV4HCE | ETH_DMARXDESC_FT ) ) != ETH_DMARXDESC_FT )
+        {
+            /* Not an Ethernet frame-type or a checmsum error. */
+            xAccepted = pdFALSE;
+        }
+        else
+        {
+            /* See if this packet must be handled. */
+            xAccepted = xMayAcceptPacket( pucBuffer );
+        }
 
-			if( pxNewDescriptor == NULL )
-			{
-				/* A new descriptor can not be allocated now. This packet will be dropped. */
-				xAccepted = pdFALSE;
-			}
-		}
-		#if( ipconfigZERO_COPY_RX_DRIVER != 0 )
-		{
-			/* Find out which Network Buffer was originally passed to the descriptor. */
-			pxCurDescriptor = pxPacketBuffer_to_NetworkBuffer( pucBuffer );
-			configASSERT( pxCurDescriptor != NULL );
-		}
-		#else
-		{
-			/* In this mode, the two descriptors are the same. */
-			pxCurDescriptor = pxNewDescriptor;
-			if( pxNewDescriptor != NULL )
-			{
-				/* The packet is acepted and a new Network Buffer was created,
-				copy data to the Network Bufffer. */
-				memcpy( pxNewDescriptor->pucEthernetBuffer, pucBuffer, xReceivedLength );
-			}
-		}
-		#endif
+        if( xAccepted != pdFALSE )
+        {
+            /* The packet wil be accepted, but check first if a new Network Buffer can
+             * be obtained. If not, the packet will still be dropped. */
+            pxNewDescriptor = pxGetNetworkBufferWithDescriptor( ETH_RX_BUF_SIZE, xDescriptorWaitTime );
 
-		if( xAccepted != pdFALSE )
-		{
-			pxCurDescriptor->xDataLength = xReceivedLength;
-			#if( ipconfigUSE_LINKED_RX_MESSAGES != 0 )
-			{
-				pxCurDescriptor->pxNextBuffer = NULL;
+            if( pxNewDescriptor == NULL )
+            {
+                /* A new descriptor can not be allocated now. This packet will be dropped. */
+                xAccepted = pdFALSE;
+            }
+        }
 
-				if( pxFirstDescriptor == NULL )
-				{
-					// Becomes the first message
-					pxFirstDescriptor = pxCurDescriptor;
-				}
-				else if( pxLastDescriptor != NULL )
-				{
-					// Add to the tail
-					pxLastDescriptor->pxNextBuffer = pxCurDescriptor;
-				}
+        #if ( ipconfigZERO_COPY_RX_DRIVER != 0 )
+            {
+                /* Find out which Network Buffer was originally passed to the descriptor. */
+                pxCurDescriptor = pxPacketBuffer_to_NetworkBuffer( pucBuffer );
+                configASSERT( pxCurDescriptor != NULL );
+            }
+        #else
+            {
+                /* In this mode, the two descriptors are the same. */
+                pxCurDescriptor = pxNewDescriptor;
 
-				pxLastDescriptor = pxCurDescriptor;
-			}
-			#else
-			{
-				prvPassEthMessages( pxCurDescriptor );
-			}
-			#endif
-		}
+                if( pxNewDescriptor != NULL )
+                {
+                    /* The packet is acepted and a new Network Buffer was created,
+                     * copy data to the Network Bufffer. */
+                    memcpy( pxNewDescriptor->pucEthernetBuffer, pucBuffer, xReceivedLength );
+                }
+            }
+        #endif /* if ( ipconfigZERO_COPY_RX_DRIVER != 0 ) */
 
-		/* Release descriptors to DMA */
-		#if( ipconfigZERO_COPY_RX_DRIVER != 0 )
-		{
-			/* Set Buffer1 address pointer */
-			if( pxNewDescriptor != NULL )
-			{
-				pxDMARxDescriptor->Buffer1Addr = (uint32_t)pxNewDescriptor->pucEthernetBuffer;
-			}
-			else
-			{
-				/* The packet was dropped and the same Network
-				Buffer will be used to receive a new packet. */
-			}
-		}
-		#endif /* ipconfigZERO_COPY_RX_DRIVER */
+        if( xAccepted != pdFALSE )
+        {
+            pxCurDescriptor->xDataLength = xReceivedLength;
+            #if ( ipconfigUSE_LINKED_RX_MESSAGES != 0 )
+                {
+                    pxCurDescriptor->pxNextBuffer = NULL;
 
-		/* Set Buffer1 size and Second Address Chained bit */
-		pxDMARxDescriptor->ControlBufferSize = ETH_DMARXDESC_RCH | (uint32_t)ETH_RX_BUF_SIZE;  
-		pxDMARxDescriptor->Status = ETH_DMARXDESC_OWN;
+                    if( pxFirstDescriptor == NULL )
+                    {
+                        /* Becomes the first message */
+                        pxFirstDescriptor = pxCurDescriptor;
+                    }
+                    else if( pxLastDescriptor != NULL )
+                    {
+                        /* Add to the tail */
+                        pxLastDescriptor->pxNextBuffer = pxCurDescriptor;
+                    }
 
-		/* Ensure completion of memory access */
-		__DSB();
-		/* When Rx Buffer unavailable flag is set clear it and resume
-		reception. */
-		if( ( xETH.Instance->DMASR & ETH_DMASR_RBUS ) != 0 )
-		{
-			/* Clear RBUS ETHERNET DMA flag. */
-			xETH.Instance->DMASR = ETH_DMASR_RBUS;
+                    pxLastDescriptor = pxCurDescriptor;
+                }
+            #else /* if ( ipconfigUSE_LINKED_RX_MESSAGES != 0 ) */
+                {
+                    prvPassEthMessages( pxCurDescriptor );
+                }
+            #endif /* if ( ipconfigUSE_LINKED_RX_MESSAGES != 0 ) */
+        }
 
-			/* Resume DMA reception. */
-			xETH.Instance->DMARPDR = 0;
-		}
-		pxDMARxDescriptor = xETH.RxDesc;
-	}
+        /* Release descriptors to DMA */
+        #if ( ipconfigZERO_COPY_RX_DRIVER != 0 )
+            {
+                /* Set Buffer1 address pointer */
+                if( pxNewDescriptor != NULL )
+                {
+                    pxDMARxDescriptor->Buffer1Addr = ( uint32_t ) pxNewDescriptor->pucEthernetBuffer;
+                }
+                else
+                {
+                    /* The packet was dropped and the same Network
+                     * Buffer will be used to receive a new packet. */
+                }
+            }
+        #endif /* ipconfigZERO_COPY_RX_DRIVER */
 
-	#if( ipconfigUSE_LINKED_RX_MESSAGES != 0 )
-	{
-		if( pxFirstDescriptor != NULL )
-		{
-			prvPassEthMessages( pxFirstDescriptor );
-		}
-	}
-	#endif	/* ipconfigUSE_LINKED_RX_MESSAGES */
+        /* Set Buffer1 size and Second Address Chained bit */
+        pxDMARxDescriptor->ControlBufferSize = ETH_DMARXDESC_RCH | ( uint32_t ) ETH_RX_BUF_SIZE;
+        pxDMARxDescriptor->Status = ETH_DMARXDESC_OWN;
 
-	return ( xReceivedLength > 0 );
+        /* Ensure completion of memory access */
+        __DSB();
+
+        /* When Rx Buffer unavailable flag is set clear it and resume
+         * reception. */
+        if( ( xETH.Instance->DMASR & ETH_DMASR_RBUS ) != 0 )
+        {
+            /* Clear RBUS ETHERNET DMA flag. */
+            xETH.Instance->DMASR = ETH_DMASR_RBUS;
+
+            /* Resume DMA reception. */
+            xETH.Instance->DMARPDR = 0;
+        }
+
+        pxDMARxDescriptor = xETH.RxDesc;
+    }
+
+    #if ( ipconfigUSE_LINKED_RX_MESSAGES != 0 )
+        {
+            if( pxFirstDescriptor != NULL )
+            {
+                prvPassEthMessages( pxFirstDescriptor );
+            }
+        }
+    #endif /* ipconfigUSE_LINKED_RX_MESSAGES */
+
+    return( xReceivedLength > 0 );
 }
 /*-----------------------------------------------------------*/
 
 
-BaseType_t xSTM32_PhyRead( BaseType_t xAddress, BaseType_t xRegister, uint32_t *pulValue )
+BaseType_t xSTM32_PhyRead( BaseType_t xAddress,
+                           BaseType_t xRegister,
+                           uint32_t * pulValue )
 {
-uint16_t usPrevAddress = xETH.Init.PhyAddress;
-BaseType_t xResult;
-HAL_StatusTypeDef xHALResult;
+    uint16_t usPrevAddress = xETH.Init.PhyAddress;
+    BaseType_t xResult;
+    HAL_StatusTypeDef xHALResult;
 
-	xETH.Init.PhyAddress = xAddress;
-	xHALResult = HAL_ETH_ReadPHYRegister( &xETH, ( uint16_t )xRegister, pulValue );
-	xETH.Init.PhyAddress = usPrevAddress;
+    xETH.Init.PhyAddress = xAddress;
+    xHALResult = HAL_ETH_ReadPHYRegister( &xETH, ( uint16_t ) xRegister, pulValue );
+    xETH.Init.PhyAddress = usPrevAddress;
 
-	if( xHALResult == HAL_OK )
-	{
-		xResult = 0;
-	}
-	else
-	{
-		xResult = -1;
-	}
-	return xResult;
+    if( xHALResult == HAL_OK )
+    {
+        xResult = 0;
+    }
+    else
+    {
+        xResult = -1;
+    }
+
+    return xResult;
 }
 /*-----------------------------------------------------------*/
 
-BaseType_t xSTM32_PhyWrite( BaseType_t xAddress, BaseType_t xRegister, uint32_t ulValue )
+BaseType_t xSTM32_PhyWrite( BaseType_t xAddress,
+                            BaseType_t xRegister,
+                            uint32_t ulValue )
 {
-uint16_t usPrevAddress = xETH.Init.PhyAddress;
-BaseType_t xResult;
-HAL_StatusTypeDef xHALResult;
+    uint16_t usPrevAddress = xETH.Init.PhyAddress;
+    BaseType_t xResult;
+    HAL_StatusTypeDef xHALResult;
 
-	xETH.Init.PhyAddress = xAddress;
-	xHALResult = HAL_ETH_WritePHYRegister( &xETH, ( uint16_t )xRegister, ulValue );
-	xETH.Init.PhyAddress = usPrevAddress;
+    xETH.Init.PhyAddress = xAddress;
+    xHALResult = HAL_ETH_WritePHYRegister( &xETH, ( uint16_t ) xRegister, ulValue );
+    xETH.Init.PhyAddress = usPrevAddress;
 
-	if( xHALResult == HAL_OK )
-	{
-		xResult = 0;
-	}
-	else
-	{
-		xResult = -1;
-	}
-	return xResult;
+    if( xHALResult == HAL_OK )
+    {
+        xResult = 0;
+    }
+    else
+    {
+        xResult = -1;
+    }
+
+    return xResult;
 }
 /*-----------------------------------------------------------*/
 
 void vMACBProbePhy( void )
 {
-	vPhyInitialise( &xPhyObject, xSTM32_PhyRead, xSTM32_PhyWrite );
-	xPhyDiscover( &xPhyObject );
-	xPhyConfigure( &xPhyObject, &xPHYProperties );
+    vPhyInitialise( &xPhyObject, xSTM32_PhyRead, xSTM32_PhyWrite );
+    xPhyDiscover( &xPhyObject );
+    xPhyConfigure( &xPhyObject, &xPHYProperties );
 }
 /*-----------------------------------------------------------*/
 
 static void prvEthernetUpdateConfig( BaseType_t xForce )
 {
-	FreeRTOS_printf( ( "prvEthernetUpdateConfig: LS mask %02lX Force %d\n",
-		xPhyObject.ulLinkStatusMask,
-		( int )xForce ) );
+    FreeRTOS_printf( ( "prvEthernetUpdateConfig: LS mask %02lX Force %d\n",
+                       xPhyObject.ulLinkStatusMask,
+                       ( int ) xForce ) );
 
-	if( ( xForce != pdFALSE ) || ( xPhyObject.ulLinkStatusMask != 0 ) )
-	{
-		/* Restart the auto-negotiation. */
-		if( xETH.Init.AutoNegotiation != ETH_AUTONEGOTIATION_DISABLE )
-		{
-			xPhyStartAutoNegotiation( &xPhyObject, xPhyGetMask( &xPhyObject ) );
+    if( ( xForce != pdFALSE ) || ( xPhyObject.ulLinkStatusMask != 0 ) )
+    {
+        /* Restart the auto-negotiation. */
+        if( xETH.Init.AutoNegotiation != ETH_AUTONEGOTIATION_DISABLE )
+        {
+            xPhyStartAutoNegotiation( &xPhyObject, xPhyGetMask( &xPhyObject ) );
 
-			/* Configure the MAC with the Duplex Mode fixed by the
-			auto-negotiation process. */
-			if( xPhyObject.xPhyProperties.ucDuplex == PHY_DUPLEX_FULL )
-			{
-				xETH.Init.DuplexMode = ETH_MODE_FULLDUPLEX;
-			}
-			else
-			{
-				xETH.Init.DuplexMode = ETH_MODE_HALFDUPLEX;
-			}
+            /* Configure the MAC with the Duplex Mode fixed by the
+             * auto-negotiation process. */
+            if( xPhyObject.xPhyProperties.ucDuplex == PHY_DUPLEX_FULL )
+            {
+                xETH.Init.DuplexMode = ETH_MODE_FULLDUPLEX;
+            }
+            else
+            {
+                xETH.Init.DuplexMode = ETH_MODE_HALFDUPLEX;
+            }
 
-			/* Configure the MAC with the speed fixed by the
-			auto-negotiation process. */
-			if( xPhyObject.xPhyProperties.ucSpeed == PHY_SPEED_10 )
-			{
-				xETH.Init.Speed = ETH_SPEED_10M;
-			}
-			else
-			{
-				xETH.Init.Speed = ETH_SPEED_100M;
-			}
-		}
-		else /* AutoNegotiation Disable */
-		{
-			/* Check parameters */
-			assert_param( IS_ETH_SPEED( xETH.Init.Speed ) );
-			assert_param( IS_ETH_DUPLEX_MODE( xETH.Init.DuplexMode ) );
+            /* Configure the MAC with the speed fixed by the
+             * auto-negotiation process. */
+            if( xPhyObject.xPhyProperties.ucSpeed == PHY_SPEED_10 )
+            {
+                xETH.Init.Speed = ETH_SPEED_10M;
+            }
+            else
+            {
+                xETH.Init.Speed = ETH_SPEED_100M;
+            }
+        }
+        else /* AutoNegotiation Disable */
+        {
+            /* Check parameters */
+            assert_param( IS_ETH_SPEED( xETH.Init.Speed ) );
+            assert_param( IS_ETH_DUPLEX_MODE( xETH.Init.DuplexMode ) );
 
-			if( xETH.Init.DuplexMode == ETH_MODE_FULLDUPLEX )
-			{
-				xPhyObject.xPhyPreferences.ucDuplex = PHY_DUPLEX_HALF;
-			}
-			else
-			{
-				xPhyObject.xPhyPreferences.ucDuplex = PHY_DUPLEX_FULL;
-			}
+            if( xETH.Init.DuplexMode == ETH_MODE_FULLDUPLEX )
+            {
+                xPhyObject.xPhyPreferences.ucDuplex = PHY_DUPLEX_HALF;
+            }
+            else
+            {
+                xPhyObject.xPhyPreferences.ucDuplex = PHY_DUPLEX_FULL;
+            }
 
-			if( xETH.Init.Speed == ETH_SPEED_10M )
-			{
-				xPhyObject.xPhyPreferences.ucSpeed = PHY_SPEED_10;
-			}
-			else
-			{
-				xPhyObject.xPhyPreferences.ucSpeed = PHY_SPEED_100;
-			}
+            if( xETH.Init.Speed == ETH_SPEED_10M )
+            {
+                xPhyObject.xPhyPreferences.ucSpeed = PHY_SPEED_10;
+            }
+            else
+            {
+                xPhyObject.xPhyPreferences.ucSpeed = PHY_SPEED_100;
+            }
 
-			xPhyObject.xPhyPreferences.ucMDI_X = PHY_MDIX_AUTO;
+            xPhyObject.xPhyPreferences.ucMDI_X = PHY_MDIX_AUTO;
 
-			/* Use predefined (fixed) configuration. */
-			xPhyFixedValue( &xPhyObject, xPhyGetMask( &xPhyObject ) );
-		}
+            /* Use predefined (fixed) configuration. */
+            xPhyFixedValue( &xPhyObject, xPhyGetMask( &xPhyObject ) );
+        }
 
-		/* ETHERNET MAC Re-Configuration */
-		HAL_ETH_ConfigMAC( &xETH, (ETH_MACInitTypeDef *) NULL);
+        /* ETHERNET MAC Re-Configuration */
+        HAL_ETH_ConfigMAC( &xETH, ( ETH_MACInitTypeDef * ) NULL );
 
-		/* Restart MAC interface */
-		HAL_ETH_Start( &xETH);
-	}
-	else
-	{
-		/* Stop MAC interface */
-		HAL_ETH_Stop( &xETH );
-	}
+        /* Restart MAC interface */
+        HAL_ETH_Start( &xETH );
+    }
+    else
+    {
+        /* Stop MAC interface */
+        HAL_ETH_Stop( &xETH );
+    }
 }
 /*-----------------------------------------------------------*/
 
 BaseType_t xGetPhyLinkStatus( void )
 {
-BaseType_t xReturn;
+    BaseType_t xReturn;
 
-	if( xPhyObject.ulLinkStatusMask != 0 )
-	{
-		xReturn = pdPASS;
-	}
-	else
-	{
-		xReturn = pdFAIL;
-	}
+    if( xPhyObject.ulLinkStatusMask != 0 )
+    {
+        xReturn = pdPASS;
+    }
+    else
+    {
+        xReturn = pdFAIL;
+    }
 
-	return xReturn;
+    return xReturn;
 }
 /*-----------------------------------------------------------*/
 
@@ -1177,112 +1213,115 @@ BaseType_t xReturn;
 
 void vNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
 {
-static
-	#if defined(STM32F7xx)
-		__attribute__ ((section(".first_data")))
-	#endif
-	uint8_t ucNetworkPackets[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS * ETH_MAX_PACKET_SIZE ] __attribute__ ( ( aligned( 32 ) ) );
-uint8_t *ucRAMBuffer = ucNetworkPackets;
-uint32_t ul;
+    static
+    #if defined( STM32F7xx )
+        __attribute__( ( section( ".first_data" ) ) )
+    #endif
+    uint8_t ucNetworkPackets[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS * ETH_MAX_PACKET_SIZE ] __attribute__( ( aligned( 32 ) ) );
+    uint8_t * ucRAMBuffer = ucNetworkPackets;
+    uint32_t ul;
 
-	for( ul = 0; ul < ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS; ul++ )
-	{
-		pxNetworkBuffers[ ul ].pucEthernetBuffer = ucRAMBuffer + ipBUFFER_PADDING;
-		*( ( unsigned * ) ucRAMBuffer ) = ( unsigned ) ( &( pxNetworkBuffers[ ul ] ) );
-		ucRAMBuffer += ETH_MAX_PACKET_SIZE;
-	}
+    for( ul = 0; ul < ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS; ul++ )
+    {
+        pxNetworkBuffers[ ul ].pucEthernetBuffer = ucRAMBuffer + ipBUFFER_PADDING;
+        *( ( unsigned * ) ucRAMBuffer ) = ( unsigned ) ( &( pxNetworkBuffers[ ul ] ) );
+        ucRAMBuffer += ETH_MAX_PACKET_SIZE;
+    }
 }
 /*-----------------------------------------------------------*/
 
-static void prvEMACHandlerTask( void *pvParameters )
+static void prvEMACHandlerTask( void * pvParameters )
 {
-UBaseType_t uxLastMinBufferCount = 0;
-#if( ipconfigCHECK_IP_QUEUE_SPACE != 0 )
-UBaseType_t uxLastMinQueueSpace = 0;
-#endif
-UBaseType_t uxCurrentCount;
-BaseType_t xResult;
-const TickType_t ulMaxBlockTime = pdMS_TO_TICKS( 100UL );
+    UBaseType_t uxLastMinBufferCount = 0;
 
-	/* Remove compiler warnings about unused parameters. */
-	( void ) pvParameters;
+    #if ( ipconfigCHECK_IP_QUEUE_SPACE != 0 )
+        UBaseType_t uxLastMinQueueSpace = 0;
+    #endif
+    UBaseType_t uxCurrentCount;
+    BaseType_t xResult;
+    const TickType_t ulMaxBlockTime = pdMS_TO_TICKS( 100UL );
 
-	for( ;; )
-	{
-		xResult = 0;
-		uxCurrentCount = uxGetMinimumFreeNetworkBuffers();
-		if( uxLastMinBufferCount != uxCurrentCount )
-		{
-			/* The logging produced below may be helpful
-			while tuning +TCP: see how many buffers are in use. */
-			uxLastMinBufferCount = uxCurrentCount;
-			FreeRTOS_printf( ( "Network buffers: %lu lowest %lu\n",
-				uxGetNumberOfFreeNetworkBuffers(), uxCurrentCount ) );
-		}
+    /* Remove compiler warnings about unused parameters. */
+    ( void ) pvParameters;
 
-		if( xTXDescriptorSemaphore != NULL )
-		{
-		static UBaseType_t uxLowestSemCount = ( UBaseType_t ) ETH_TXBUFNB - 1;
+    for( ; ; )
+    {
+        xResult = 0;
+        uxCurrentCount = uxGetMinimumFreeNetworkBuffers();
 
-			uxCurrentCount = uxSemaphoreGetCount( xTXDescriptorSemaphore );
-			if( uxLowestSemCount > uxCurrentCount )
-			{
-				uxLowestSemCount = uxCurrentCount;
-				FreeRTOS_printf( ( "TX DMA buffers: lowest %lu\n", uxLowestSemCount ) );
-			}
+        if( uxLastMinBufferCount != uxCurrentCount )
+        {
+            /* The logging produced below may be helpful
+             * while tuning +TCP: see how many buffers are in use. */
+            uxLastMinBufferCount = uxCurrentCount;
+            FreeRTOS_printf( ( "Network buffers: %lu lowest %lu\n",
+                               uxGetNumberOfFreeNetworkBuffers(), uxCurrentCount ) );
+        }
 
-		}
+        if( xTXDescriptorSemaphore != NULL )
+        {
+            static UBaseType_t uxLowestSemCount = ( UBaseType_t ) ETH_TXBUFNB - 1;
 
-		#if( ipconfigCHECK_IP_QUEUE_SPACE != 0 )
-		{
-			uxCurrentCount = uxGetMinimumIPQueueSpace();
-			if( uxLastMinQueueSpace != uxCurrentCount )
-			{
-				/* The logging produced below may be helpful
-				while tuning +TCP: see how many buffers are in use. */
-				uxLastMinQueueSpace = uxCurrentCount;
-				FreeRTOS_printf( ( "Queue space: lowest %lu\n", uxCurrentCount ) );
-			}
-		}
-		#endif /* ipconfigCHECK_IP_QUEUE_SPACE */
+            uxCurrentCount = uxSemaphoreGetCount( xTXDescriptorSemaphore );
 
-		if( ( ulISREvents & EMAC_IF_ALL_EVENT ) == 0 )
-		{
-			/* No events to process now, wait for the next. */
-			ulTaskNotifyTake( pdFALSE, ulMaxBlockTime );
-		}
+            if( uxLowestSemCount > uxCurrentCount )
+            {
+                uxLowestSemCount = uxCurrentCount;
+                FreeRTOS_printf( ( "TX DMA buffers: lowest %lu\n", uxLowestSemCount ) );
+            }
+        }
 
-		if( ( ulISREvents & EMAC_IF_RX_EVENT ) != 0 )
-		{
-			ulISREvents &= ~EMAC_IF_RX_EVENT;
+        #if ( ipconfigCHECK_IP_QUEUE_SPACE != 0 )
+            {
+                uxCurrentCount = uxGetMinimumIPQueueSpace();
 
-			xResult = prvNetworkInterfaceInput();
-		}
+                if( uxLastMinQueueSpace != uxCurrentCount )
+                {
+                    /* The logging produced below may be helpful
+                     * while tuning +TCP: see how many buffers are in use. */
+                    uxLastMinQueueSpace = uxCurrentCount;
+                    FreeRTOS_printf( ( "Queue space: lowest %lu\n", uxCurrentCount ) );
+                }
+            }
+        #endif /* ipconfigCHECK_IP_QUEUE_SPACE */
 
-		if( ( ulISREvents & EMAC_IF_TX_EVENT ) != 0 )
-		{
-			/* Code to release TX buffers if zero-copy is used. */
-			ulISREvents &= ~EMAC_IF_TX_EVENT;
-			/* Check if DMA packets have been delivered. */
-			vClearTXBuffers();
-		}
+        if( ( ulISREvents & EMAC_IF_ALL_EVENT ) == 0 )
+        {
+            /* No events to process now, wait for the next. */
+            ulTaskNotifyTake( pdFALSE, ulMaxBlockTime );
+        }
 
-		if( ( ulISREvents & EMAC_IF_ERR_EVENT ) != 0 )
-		{
-			/* Future extension: logging about errors that occurred. */
-			ulISREvents &= ~EMAC_IF_ERR_EVENT;
-		}
-		if( xPhyCheckLinkStatus( &xPhyObject, xResult ) != 0 )
-		{
-			/* Something has changed to a Link Status, need re-check. */
-			prvEthernetUpdateConfig( pdFALSE );
-		}
-	}
+        if( ( ulISREvents & EMAC_IF_RX_EVENT ) != 0 )
+        {
+            ulISREvents &= ~EMAC_IF_RX_EVENT;
+
+            xResult = prvNetworkInterfaceInput();
+        }
+
+        if( ( ulISREvents & EMAC_IF_TX_EVENT ) != 0 )
+        {
+            /* Code to release TX buffers if zero-copy is used. */
+            ulISREvents &= ~EMAC_IF_TX_EVENT;
+            /* Check if DMA packets have been delivered. */
+            vClearTXBuffers();
+        }
+
+        if( ( ulISREvents & EMAC_IF_ERR_EVENT ) != 0 )
+        {
+            /* Future extension: logging about errors that occurred. */
+            ulISREvents &= ~EMAC_IF_ERR_EVENT;
+        }
+
+        if( xPhyCheckLinkStatus( &xPhyObject, xResult ) != 0 )
+        {
+            /* Something has changed to a Link Status, need re-check. */
+            prvEthernetUpdateConfig( pdFALSE );
+        }
+    }
 }
 /*-----------------------------------------------------------*/
 
 void ETH_IRQHandler( void )
 {
-	HAL_ETH_IRQHandler( &xETH );
+    HAL_ETH_IRQHandler( &xETH );
 }
-

--- a/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/portable/NetworkInterface/STM32Fxx/stm32fxx_hal_eth.c
+++ b/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/portable/NetworkInterface/STM32Fxx/stm32fxx_hal_eth.c
@@ -1,1468 +1,1492 @@
 /**
-  ******************************************************************************
-  * @file    stm32fxx_hal_eth.c
-  * @author  MCD Application Team
-  * @version V1.3.2
-  * @date    26-June-2015
-  * @brief   ETH HAL module driver.
-  *          This file provides firmware functions to manage the following
-  *          functionalities of the Ethernet (ETH) peripheral:
-  *           + Initialization and de-initialization functions
-  *           + IO operation functions
-  *           + Peripheral Control functions
-  *           + Peripheral State and Errors functions
-  *
-  @verbatim
-  ==============================================================================
-                    ##### How to use this driver #####
-  ==============================================================================
-    [..]
-      (#)Declare a ETH_HandleTypeDef handle structure, for example:
-         ETH_HandleTypeDef  heth;
-
-      (#)Fill parameters of Init structure in heth handle
-
-      (#)Call HAL_ETH_Init() API to initialize the Ethernet peripheral (MAC, DMA, ...)
-
-      (#)Initialize the ETH low level resources through the HAL_ETH_MspInit() API:
-          (##) Enable the Ethernet interface clock using
-               (+++) __HAL_RCC_ETHMAC_CLK_ENABLE();
-               (+++) __HAL_RCC_ETHMACTX_CLK_ENABLE();
-               (+++) __HAL_RCC_ETHMACRX_CLK_ENABLE();
-
-          (##) Initialize the related GPIO clocks
-          (##) Configure Ethernet pin-out
-          (##) Configure Ethernet NVIC interrupt (IT mode)
-
-      (#)Initialize Ethernet DMA Descriptors in chain mode and point to allocated buffers:
-          (##) HAL_ETH_DMATxDescListInit(); for Transmission process
-          (##) HAL_ETH_DMARxDescListInit(); for Reception process
-
-      (#)Enable MAC and DMA transmission and reception:
-          (##) HAL_ETH_Start();
-
-      (#)Prepare ETH DMA TX Descriptors and give the hand to ETH DMA to transfer
-         the frame to MAC TX FIFO:
-         (##) HAL_ETH_TransmitFrame();
-
-      (#)Poll for a received frame in ETH RX DMA Descriptors and get received
-         frame parameters
-         (##) HAL_ETH_GetReceivedFrame(); (should be called into an infinite loop)
-
-      (#) Get a received frame when an ETH RX interrupt occurs:
-         (##) HAL_ETH_GetReceivedFrame_IT(); (called in IT mode only)
-
-      (#) Communicate with external PHY device:
-         (##) Read a specific register from the PHY
-              HAL_ETH_ReadPHYRegister();
-         (##) Write data to a specific RHY register:
-              HAL_ETH_WritePHYRegister();
-
-      (#) Configure the Ethernet MAC after ETH peripheral initialization
-          HAL_ETH_ConfigMAC(); all MAC parameters should be filled.
-
-      (#) Configure the Ethernet DMA after ETH peripheral initialization
-          HAL_ETH_ConfigDMA(); all DMA parameters should be filled.
-
-      -@- The PTP protocol and the DMA descriptors ring mode are not supported
-          in this driver
-
-  @endverbatim
-  ******************************************************************************
-  * @attention
-  *
-  * <h2><center>&copy; COPYRIGHT(c) 2015 STMicroelectronics</center></h2>
-  *
-  * Redistribution and use in source and binary forms, with or without modification,
-  * are permitted provided that the following conditions are met:
-  *   1. Redistributions of source code must retain the above copyright notice,
-  *      this list of conditions and the following disclaimer.
-  *   2. Redistributions in binary form must reproduce the above copyright notice,
-  *      this list of conditions and the following disclaimer in the documentation
-  *      and/or other materials provided with the distribution.
-  *   3. Neither the name of STMicroelectronics nor the names of its contributors
-  *      may be used to endorse or promote products derived from this software
-  *      without specific prior written permission.
-  *
-  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-  *
-  ******************************************************************************
-  */
+ ******************************************************************************
+ * @file    stm32fxx_hal_eth.c
+ * @author  MCD Application Team
+ * @version V1.3.2
+ * @date    26-June-2015
+ * @brief   ETH HAL module driver.
+ *          This file provides firmware functions to manage the following
+ *          functionalities of the Ethernet (ETH) peripheral:
+ *           + Initialization and de-initialization functions
+ *           + IO operation functions
+ *           + Peripheral Control functions
+ *           + Peripheral State and Errors functions
+ *
+ * @verbatim
+ * ==============================================================================
+ ##### How to use this driver #####
+ #####==============================================================================
+ #####[..]
+ #####(#)Declare a ETH_HandleTypeDef handle structure, for example:
+ #####   ETH_HandleTypeDef  heth;
+ #####
+ #####(#)Fill parameters of Init structure in heth handle
+ #####
+ #####(#)Call HAL_ETH_Init() API to initialize the Ethernet peripheral (MAC, DMA, ...)
+ #####
+ #####(#)Initialize the ETH low level resources through the HAL_ETH_MspInit() API:
+ #####    (##) Enable the Ethernet interface clock using
+ #####         (+++) __HAL_RCC_ETHMAC_CLK_ENABLE();
+ #####         (+++) __HAL_RCC_ETHMACTX_CLK_ENABLE();
+ #####         (+++) __HAL_RCC_ETHMACRX_CLK_ENABLE();
+ #####
+ #####    (##) Initialize the related GPIO clocks
+ #####    (##) Configure Ethernet pin-out
+ #####    (##) Configure Ethernet NVIC interrupt (IT mode)
+ #####
+ #####(#)Initialize Ethernet DMA Descriptors in chain mode and point to allocated buffers:
+ #####    (##) HAL_ETH_DMATxDescListInit(); for Transmission process
+ #####    (##) HAL_ETH_DMARxDescListInit(); for Reception process
+ #####
+ #####(#)Enable MAC and DMA transmission and reception:
+ #####    (##) HAL_ETH_Start();
+ #####
+ #####(#)Prepare ETH DMA TX Descriptors and give the hand to ETH DMA to transfer
+ #####   the frame to MAC TX FIFO:
+ #####   (##) HAL_ETH_TransmitFrame();
+ #####
+ #####(#)Poll for a received frame in ETH RX DMA Descriptors and get received
+ #####   frame parameters
+ #####   (##) HAL_ETH_GetReceivedFrame(); (should be called into an infinite loop)
+ #####
+ #####(#) Get a received frame when an ETH RX interrupt occurs:
+ #####   (##) HAL_ETH_GetReceivedFrame_IT(); (called in IT mode only)
+ #####
+ #####(#) Communicate with external PHY device:
+ #####   (##) Read a specific register from the PHY
+ #####        HAL_ETH_ReadPHYRegister();
+ #####   (##) Write data to a specific RHY register:
+ #####        HAL_ETH_WritePHYRegister();
+ #####
+ #####(#) Configure the Ethernet MAC after ETH peripheral initialization
+ #####    HAL_ETH_ConfigMAC(); all MAC parameters should be filled.
+ #####
+ #####(#) Configure the Ethernet DMA after ETH peripheral initialization
+ #####    HAL_ETH_ConfigDMA(); all DMA parameters should be filled.
+ #####
+ #####-@- The PTP protocol and the DMA descriptors ring mode are not supported
+ #####    in this driver
+ #####
+ #####@endverbatim
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; COPYRIGHT(c) 2015 STMicroelectronics</center></h2>
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright notice,
+ *      this list of conditions and the following disclaimer in the documentation
+ *      and/or other materials provided with the distribution.
+ *   3. Neither the name of STMicroelectronics nor the names of its contributors
+ *      may be used to endorse or promote products derived from this software
+ *      without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************
+ */
 
 /* Includes ------------------------------------------------------------------*/
 
-#if defined(STM32F7xx)
-	#include "stm32f7xx_hal.h"
-	#define stm_is_F7	1
-#elif defined(STM32F407xx) || defined(STM32F417xx) || defined(STM32F427xx) || defined(STM32F437xx) || defined(STM32F429xx) || defined(STM32F439xx)
-	#include "stm32f4xx_hal.h"
-	#define stm_is_F4	1
-#elif defined(STM32F2xx)
-	#include "stm32f2xx_hal.h"
-	#define stm_is_F2	1
+#if defined( STM32F7xx )
+    #include "stm32f7xx_hal.h"
+    #define stm_is_F7    1
+#elif defined( STM32F407xx ) || defined( STM32F417xx ) || defined( STM32F427xx ) || defined( STM32F437xx ) || defined( STM32F429xx ) || defined( STM32F439xx )
+    #include "stm32f4xx_hal.h"
+    #define stm_is_F4    1
+#elif defined( STM32F2xx )
+    #include "stm32f2xx_hal.h"
+    #define stm_is_F2    1
 #else
-	#error For what part should this be compiled?
+    #error For what part should this be compiled?
 #endif
 
 #include "stm32fxx_hal_eth.h"
 
 /** @addtogroup STM32F4xx_HAL_Driver
-  * @{
-  */
+ * @{
+ */
 
 /** @defgroup ETH ETH
-  * @brief ETH HAL module driver
-  * @{
-  */
+ * @brief ETH HAL module driver
+ * @{
+ */
 
 #if !defined( ARRAY_SIZE )
-	#define ARRAY_SIZE( x ) ( sizeof ( x ) / sizeof ( x )[ 0 ] )
+    #define ARRAY_SIZE( x )    ( sizeof( x ) / sizeof( x )[ 0 ] )
 #endif
 
 #ifdef HAL_ETH_MODULE_ENABLED
 
-#if( stm_is_F2 != 0 || stm_is_F4 != 0 || stm_is_F7 )
+    #if ( stm_is_F2 != 0 || stm_is_F4 != 0 || stm_is_F7 )
 
 /* Private typedef -----------------------------------------------------------*/
 /* Private define ------------------------------------------------------------*/
+
 /** @defgroup ETH_Private_Constants ETH Private Constants
-  * @{
-  */
+ * @{
+ */
 
 /**
-  * @}
-  */
+ * @}
+ */
 /* Private macro -------------------------------------------------------------*/
 /* Private variables ---------------------------------------------------------*/
 /* Private function prototypes -----------------------------------------------*/
+
 /** @defgroup ETH_Private_Functions ETH Private Functions
-  * @{
-  */
-static void ETH_MACDMAConfig(ETH_HandleTypeDef *heth, uint32_t err);
-static void ETH_MACAddressConfig(ETH_HandleTypeDef *heth, uint32_t MacAddr, uint8_t *Addr);
-static void ETH_MACReceptionEnable(ETH_HandleTypeDef *heth);
-static void ETH_MACReceptionDisable(ETH_HandleTypeDef *heth);
-static void ETH_MACTransmissionEnable(ETH_HandleTypeDef *heth);
-static void ETH_MACTransmissionDisable(ETH_HandleTypeDef *heth);
-static void ETH_DMATransmissionEnable(ETH_HandleTypeDef *heth);
-static void ETH_DMATransmissionDisable(ETH_HandleTypeDef *heth);
-static void ETH_DMAReceptionEnable(ETH_HandleTypeDef *heth);
-static void ETH_DMAReceptionDisable(ETH_HandleTypeDef *heth);
-static void ETH_FlushTransmitFIFO(ETH_HandleTypeDef *heth);
+ * @{
+ */
+        static void ETH_MACDMAConfig( ETH_HandleTypeDef * heth,
+                                      uint32_t err );
+        static void ETH_MACAddressConfig( ETH_HandleTypeDef * heth,
+                                          uint32_t MacAddr,
+                                          uint8_t * Addr );
+        static void ETH_MACReceptionEnable( ETH_HandleTypeDef * heth );
+        static void ETH_MACReceptionDisable( ETH_HandleTypeDef * heth );
+        static void ETH_MACTransmissionEnable( ETH_HandleTypeDef * heth );
+        static void ETH_MACTransmissionDisable( ETH_HandleTypeDef * heth );
+        static void ETH_DMATransmissionEnable( ETH_HandleTypeDef * heth );
+        static void ETH_DMATransmissionDisable( ETH_HandleTypeDef * heth );
+        static void ETH_DMAReceptionEnable( ETH_HandleTypeDef * heth );
+        static void ETH_DMAReceptionDisable( ETH_HandleTypeDef * heth );
+        static void ETH_FlushTransmitFIFO( ETH_HandleTypeDef * heth );
 
 /**
-  * @}
-  */
+ * @}
+ */
 /* Private functions ---------------------------------------------------------*/
 
 /** @defgroup ETH_Exported_Functions ETH Exported Functions
-  * @{
-  */
+ * @{
+ */
 
 /** @defgroup ETH_Exported_Functions_Group1 Initialization and de-initialization functions
-  *  @brief   Initialization and Configuration functions
-  *
-  @verbatim
-  ===============================================================================
-            ##### Initialization and de-initialization functions #####
-  ===============================================================================
-  [..]  This section provides functions allowing to:
-      (+) Initialize and configure the Ethernet peripheral
-      (+) De-initialize the Ethernet peripheral
-
-  @endverbatim
-  * @{
-  */
-extern void vMACBProbePhy ( void );
-
-/**
-  * @brief  Initializes the Ethernet MAC and DMA according to default
-  *         parameters.
-  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
-  *         the configuration information for ETHERNET module
-  * @retval HAL status
-  */
-HAL_StatusTypeDef HAL_ETH_Init(ETH_HandleTypeDef *heth)
-{
-	uint32_t tmpreg = 0uL;
-	uint32_t hclk = 60000000uL;
-	uint32_t err = ETH_SUCCESS;
-
-	/* Check the ETH peripheral state */
-	if( heth == NULL )
-	{
-		return HAL_ERROR;
-	}
-
-	/* Check parameters */
-	assert_param(IS_ETH_AUTONEGOTIATION(heth->Init.AutoNegotiation));
-	assert_param(IS_ETH_RX_MODE(heth->Init.RxMode));
-	assert_param(IS_ETH_CHECKSUM_MODE(heth->Init.ChecksumMode));
-	assert_param(IS_ETH_MEDIA_INTERFACE(heth->Init.MediaInterface));
-
-	if( heth->State == HAL_ETH_STATE_RESET )
-	{
-		/* Init the low level hardware : GPIO, CLOCK, NVIC. */
-		HAL_ETH_MspInit( heth );
-	}
-
-	/* Enable SYSCFG Clock */
-	__HAL_RCC_SYSCFG_CLK_ENABLE();
-
-	/* Select MII or RMII Mode*/
-	SYSCFG->PMC &= ~(SYSCFG_PMC_MII_RMII_SEL);
-	SYSCFG->PMC |= (uint32_t)heth->Init.MediaInterface;
-
-	/* Ethernet Software reset */
-	/* Set the SWR bit: resets all MAC subsystem internal registers and logic */
-	/* After reset all the registers holds their respective reset values */
-	/* Also enable EDFE: Enhanced descriptor format enable. */
-	heth->Instance->DMABMR |= ETH_DMABMR_SR | ETH_DMABMR_EDE;
-
-	/* Wait for software reset */
-	while ((heth->Instance->DMABMR & ETH_DMABMR_SR) != (uint32_t)RESET)
-	{
-		/* If your program hangs here, please check the value of 'ipconfigUSE_RMII'. */
-	}
-
-	/*-------------------------------- MAC Initialization ----------------------*/
-	/* Get the ETHERNET MACMIIAR value */
-	tmpreg = heth->Instance->MACMIIAR;
-	/* Clear CSR Clock Range CR[2:0] bits */
-	tmpreg &= ETH_MACMIIAR_CR_MASK;
-
-	/* Get hclk frequency value (e.g. 168,000,000) */
-	hclk = HAL_RCC_GetHCLKFreq();
-
-	/* Set CR bits depending on hclk value */
-	if(( hclk >= 20000000uL ) && ( hclk < 35000000uL ) )
-	{
-		/* CSR Clock Range between 20-35 MHz */
-		tmpreg |= ( uint32_t) ETH_MACMIIAR_CR_Div16;
-	}
-	else if( ( hclk >= 35000000uL ) && ( hclk < 60000000uL ) )
-	{
-	/* CSR Clock Range between 35-60 MHz */
-	tmpreg |= ( uint32_t ) ETH_MACMIIAR_CR_Div26;
-	}
-	else if( ( hclk >= 60000000uL ) && ( hclk < 100000000uL ) )
-	{
-		/* CSR Clock Range between 60-100 MHz */
-		tmpreg |= (uint32_t)ETH_MACMIIAR_CR_Div42;
-	}
-	else if( ( hclk >= 100000000uL ) && ( hclk < 150000000uL ) )
-	{
-		/* CSR Clock Range between 100-150 MHz */
-		tmpreg |= (uint32_t)ETH_MACMIIAR_CR_Div62;
-	}
-	else /* ( ( hclk >= 150000000uL ) && ( hclk <= 183000000uL ) ) */
-	{
-		/* CSR Clock Range between 150-183 MHz */
-		tmpreg |= (uint32_t)ETH_MACMIIAR_CR_Div102;
-	}
-
-	/* Write to ETHERNET MAC MIIAR: Configure the ETHERNET CSR Clock Range */
-	heth->Instance->MACMIIAR = (uint32_t)tmpreg;
-
-	/* Initialise the MACB and set all PHY properties */
-	vMACBProbePhy();
-
-	/* Config MAC and DMA */
-	ETH_MACDMAConfig(heth, err);
-
-	/* Set ETH HAL State to Ready */
-	heth->State= HAL_ETH_STATE_READY;
-
-	/* Return function status */
-	return HAL_OK;
-}
+ *  @brief   Initialization and Configuration functions
+ *
+ * @verbatim
+ * ===============================================================================
+ ##### Initialization and de-initialization functions #####
+ #####===============================================================================
+ #####[..]  This section provides functions allowing to:
+ #####(+) Initialize and configure the Ethernet peripheral
+ #####(+) De-initialize the Ethernet peripheral
+ #####
+ #####@endverbatim
+ * @{
+ */
+        extern void vMACBProbePhy( void );
 
 /**
-  * @brief  De-Initializes the ETH peripheral.
-  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
-  *         the configuration information for ETHERNET module
-  * @retval HAL status
-  */
-HAL_StatusTypeDef HAL_ETH_DeInit(ETH_HandleTypeDef *heth)
-{
-	/* Set the ETH peripheral state to BUSY */
-	heth->State = HAL_ETH_STATE_BUSY;
+ * @brief  Initializes the Ethernet MAC and DMA according to default
+ *         parameters.
+ * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
+ *         the configuration information for ETHERNET module
+ * @retval HAL status
+ */
+        HAL_StatusTypeDef HAL_ETH_Init( ETH_HandleTypeDef * heth )
+        {
+            uint32_t tmpreg = 0uL;
+            uint32_t hclk = 60000000uL;
+            uint32_t err = ETH_SUCCESS;
 
-	/* De-Init the low level hardware : GPIO, CLOCK, NVIC. */
-	HAL_ETH_MspDeInit( heth );
+            /* Check the ETH peripheral state */
+            if( heth == NULL )
+            {
+                return HAL_ERROR;
+            }
 
-	/* Set ETH HAL state to Disabled */
-	heth->State= HAL_ETH_STATE_RESET;
+            /* Check parameters */
+            assert_param( IS_ETH_AUTONEGOTIATION( heth->Init.AutoNegotiation ) );
+            assert_param( IS_ETH_RX_MODE( heth->Init.RxMode ) );
+            assert_param( IS_ETH_CHECKSUM_MODE( heth->Init.ChecksumMode ) );
+            assert_param( IS_ETH_MEDIA_INTERFACE( heth->Init.MediaInterface ) );
 
-	/* Release Lock */
-	__HAL_UNLOCK( heth );
+            if( heth->State == HAL_ETH_STATE_RESET )
+            {
+                /* Init the low level hardware : GPIO, CLOCK, NVIC. */
+                HAL_ETH_MspInit( heth );
+            }
 
-	/* Return function status */
-	return HAL_OK;
-}
+            /* Enable SYSCFG Clock */
+            __HAL_RCC_SYSCFG_CLK_ENABLE();
+
+            /* Select MII or RMII Mode*/
+            SYSCFG->PMC &= ~( SYSCFG_PMC_MII_RMII_SEL );
+            SYSCFG->PMC |= ( uint32_t ) heth->Init.MediaInterface;
+
+            /* Ethernet Software reset */
+            /* Set the SWR bit: resets all MAC subsystem internal registers and logic */
+            /* After reset all the registers holds their respective reset values */
+            /* Also enable EDFE: Enhanced descriptor format enable. */
+            heth->Instance->DMABMR |= ETH_DMABMR_SR | ETH_DMABMR_EDE;
+
+            /* Wait for software reset */
+            while( ( heth->Instance->DMABMR & ETH_DMABMR_SR ) != ( uint32_t ) RESET )
+            {
+                /* If your program hangs here, please check the value of 'ipconfigUSE_RMII'. */
+            }
+
+            /*-------------------------------- MAC Initialization ----------------------*/
+            /* Get the ETHERNET MACMIIAR value */
+            tmpreg = heth->Instance->MACMIIAR;
+            /* Clear CSR Clock Range CR[2:0] bits */
+            tmpreg &= ETH_MACMIIAR_CR_MASK;
+
+            /* Get hclk frequency value (e.g. 168,000,000) */
+            hclk = HAL_RCC_GetHCLKFreq();
+
+            /* Set CR bits depending on hclk value */
+            if( ( hclk >= 20000000uL ) && ( hclk < 35000000uL ) )
+            {
+                /* CSR Clock Range between 20-35 MHz */
+                tmpreg |= ( uint32_t ) ETH_MACMIIAR_CR_Div16;
+            }
+            else if( ( hclk >= 35000000uL ) && ( hclk < 60000000uL ) )
+            {
+                /* CSR Clock Range between 35-60 MHz */
+                tmpreg |= ( uint32_t ) ETH_MACMIIAR_CR_Div26;
+            }
+            else if( ( hclk >= 60000000uL ) && ( hclk < 100000000uL ) )
+            {
+                /* CSR Clock Range between 60-100 MHz */
+                tmpreg |= ( uint32_t ) ETH_MACMIIAR_CR_Div42;
+            }
+            else if( ( hclk >= 100000000uL ) && ( hclk < 150000000uL ) )
+            {
+                /* CSR Clock Range between 100-150 MHz */
+                tmpreg |= ( uint32_t ) ETH_MACMIIAR_CR_Div62;
+            }
+            else /* ( ( hclk >= 150000000uL ) && ( hclk <= 183000000uL ) ) */
+            {
+                /* CSR Clock Range between 150-183 MHz */
+                tmpreg |= ( uint32_t ) ETH_MACMIIAR_CR_Div102;
+            }
+
+            /* Write to ETHERNET MAC MIIAR: Configure the ETHERNET CSR Clock Range */
+            heth->Instance->MACMIIAR = ( uint32_t ) tmpreg;
+
+            /* Initialise the MACB and set all PHY properties */
+            vMACBProbePhy();
+
+            /* Config MAC and DMA */
+            ETH_MACDMAConfig( heth, err );
+
+            /* Set ETH HAL State to Ready */
+            heth->State = HAL_ETH_STATE_READY;
+
+            /* Return function status */
+            return HAL_OK;
+        }
 
 /**
-  * @brief  Initializes the ETH MSP.
-  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
-  *         the configuration information for ETHERNET module
-  * @retval None
-  */
-__weak void HAL_ETH_MspInit(ETH_HandleTypeDef *heth)
-{
-  /* NOTE : This function Should not be modified, when the callback is needed,
-  the HAL_ETH_MspInit could be implemented in the user file
-  */
-  ( void ) heth;
-}
+ * @brief  De-Initializes the ETH peripheral.
+ * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
+ *         the configuration information for ETHERNET module
+ * @retval HAL status
+ */
+        HAL_StatusTypeDef HAL_ETH_DeInit( ETH_HandleTypeDef * heth )
+        {
+            /* Set the ETH peripheral state to BUSY */
+            heth->State = HAL_ETH_STATE_BUSY;
+
+            /* De-Init the low level hardware : GPIO, CLOCK, NVIC. */
+            HAL_ETH_MspDeInit( heth );
+
+            /* Set ETH HAL state to Disabled */
+            heth->State = HAL_ETH_STATE_RESET;
+
+            /* Release Lock */
+            __HAL_UNLOCK( heth );
+
+            /* Return function status */
+            return HAL_OK;
+        }
 
 /**
-  * @brief  DeInitializes ETH MSP.
-  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
-  *         the configuration information for ETHERNET module
-  * @retval None
-  */
-__weak void HAL_ETH_MspDeInit(ETH_HandleTypeDef *heth)
-{
-  /* NOTE : This function Should not be modified, when the callback is needed,
-  the HAL_ETH_MspDeInit could be implemented in the user file
-  */
-  ( void ) heth;
-}
+ * @brief  Initializes the ETH MSP.
+ * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
+ *         the configuration information for ETHERNET module
+ * @retval None
+ */
+        __weak void HAL_ETH_MspInit( ETH_HandleTypeDef * heth )
+        {
+            /* NOTE : This function Should not be modified, when the callback is needed,
+             * the HAL_ETH_MspInit could be implemented in the user file
+             */
+            ( void ) heth;
+        }
 
 /**
-  * @}
-  */
+ * @brief  DeInitializes ETH MSP.
+ * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
+ *         the configuration information for ETHERNET module
+ * @retval None
+ */
+        __weak void HAL_ETH_MspDeInit( ETH_HandleTypeDef * heth )
+        {
+            /* NOTE : This function Should not be modified, when the callback is needed,
+             * the HAL_ETH_MspDeInit could be implemented in the user file
+             */
+            ( void ) heth;
+        }
+
+/**
+ * @}
+ */
 
 /** @defgroup ETH_Exported_Functions_Group2 IO operation functions
-  *  @brief   Data transfers functions
-  *
-  @verbatim
-  ==============================================================================
-                          ##### IO operation functions #####
-  ==============================================================================
-  [..]  This section provides functions allowing to:
-        (+) Transmit a frame
-            HAL_ETH_TransmitFrame();
-        (+) Receive a frame
-            HAL_ETH_GetReceivedFrame();
-            HAL_ETH_GetReceivedFrame_IT();
-        (+) Read from an External PHY register
-            HAL_ETH_ReadPHYRegister();
-        (+) Write to an External PHY register
-            HAL_ETH_WritePHYRegister();
+ *  @brief   Data transfers functions
+ *
+ * @verbatim
+ * ==============================================================================
+ ##### IO operation functions #####
+ #####==============================================================================
+ #####[..]  This section provides functions allowing to:
+ #####  (+) Transmit a frame
+ #####      HAL_ETH_TransmitFrame();
+ #####  (+) Receive a frame
+ #####      HAL_ETH_GetReceivedFrame();
+ #####      HAL_ETH_GetReceivedFrame_IT();
+ #####  (+) Read from an External PHY register
+ #####      HAL_ETH_ReadPHYRegister();
+ #####  (+) Write to an External PHY register
+ #####      HAL_ETH_WritePHYRegister();
+ #####
+ #####@endverbatim
+ #####
+ * @{
+ */
 
-  @endverbatim
+        #define ETH_DMA_ALL_INTS                                                                           \
+    ( ETH_DMA_IT_TST | ETH_DMA_IT_PMT | ETH_DMA_IT_MMC | ETH_DMA_IT_NIS | ETH_DMA_IT_AIS | ETH_DMA_IT_ER | \
+      ETH_DMA_IT_FBE | ETH_DMA_IT_ET | ETH_DMA_IT_RWT | ETH_DMA_IT_RPS | ETH_DMA_IT_RBU | ETH_DMA_IT_R |   \
+      ETH_DMA_IT_TU | ETH_DMA_IT_RO | ETH_DMA_IT_TJT | ETH_DMA_IT_TPS | ETH_DMA_IT_T )
 
-  * @{
-  */
+/*#define ETH_DMA_ALL_INTS		ETH_DMA_IT_RBU | ETH_DMA_FLAG_T | ETH_DMA_FLAG_AIS */
 
-#define ETH_DMA_ALL_INTS \
-	( ETH_DMA_IT_TST | ETH_DMA_IT_PMT | ETH_DMA_IT_MMC | ETH_DMA_IT_NIS | ETH_DMA_IT_AIS | ETH_DMA_IT_ER | \
-	ETH_DMA_IT_FBE | ETH_DMA_IT_ET | ETH_DMA_IT_RWT | ETH_DMA_IT_RPS | ETH_DMA_IT_RBU | ETH_DMA_IT_R | \
-	ETH_DMA_IT_TU | ETH_DMA_IT_RO | ETH_DMA_IT_TJT | ETH_DMA_IT_TPS | ETH_DMA_IT_T )
+        #define INT_MASK    ( ( uint32_t ) ~( ETH_DMA_IT_TBU ) )
+        void HAL_ETH_IRQHandler( ETH_HandleTypeDef * heth )
+        {
+            uint32_t dmasr;
 
-//#define ETH_DMA_ALL_INTS		ETH_DMA_IT_RBU | ETH_DMA_FLAG_T | ETH_DMA_FLAG_AIS
+            dmasr = heth->Instance->DMASR & ETH_DMA_ALL_INTS;
+            heth->Instance->DMASR = dmasr;
 
-#define INT_MASK		( ( uint32_t ) ~ ( ETH_DMA_IT_TBU ) )
-void HAL_ETH_IRQHandler(ETH_HandleTypeDef *heth)
-{
-	uint32_t dmasr;
+            /* Frame received */
+            if( ( dmasr & ( ETH_DMA_FLAG_R | ETH_DMA_IT_RBU ) ) != 0 )
+            {
+                /* Receive complete callback */
+                HAL_ETH_RxCpltCallback( heth );
+            }
 
-	dmasr = heth->Instance->DMASR & ETH_DMA_ALL_INTS;
-	heth->Instance->DMASR = dmasr;
+            /* Frame transmitted */
+            if( ( dmasr & ( ETH_DMA_FLAG_T ) ) != 0 )
+            {
+                /* Transfer complete callback */
+                HAL_ETH_TxCpltCallback( heth );
+            }
 
-	/* Frame received */
-	if( ( dmasr & ( ETH_DMA_FLAG_R | ETH_DMA_IT_RBU ) ) != 0 )
-	{
-		/* Receive complete callback */
-		HAL_ETH_RxCpltCallback( heth );
-	}
-	/* Frame transmitted */
-	if( ( dmasr & ( ETH_DMA_FLAG_T ) ) != 0 )
-	{
-		/* Transfer complete callback */
-		HAL_ETH_TxCpltCallback( heth );
-	}
-
-	/* ETH DMA Error */
-	if( ( dmasr & ( ETH_DMA_FLAG_AIS ) ) != 0 )
-	{
-		/* Ethernet Error callback */
-		HAL_ETH_ErrorCallback( heth );
-	}
-}
-
-/**
-  * @brief  Tx Transfer completed callbacks.
-  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
-  *         the configuration information for ETHERNET module
-  * @retval None
-  */
-__weak void HAL_ETH_TxCpltCallback(ETH_HandleTypeDef *heth)
-{
-  /* NOTE : This function Should not be modified, when the callback is needed,
-  the HAL_ETH_TxCpltCallback could be implemented in the user file
-  */
-  ( void ) heth;
-}
+            /* ETH DMA Error */
+            if( ( dmasr & ( ETH_DMA_FLAG_AIS ) ) != 0 )
+            {
+                /* Ethernet Error callback */
+                HAL_ETH_ErrorCallback( heth );
+            }
+        }
 
 /**
-  * @brief  Rx Transfer completed callbacks.
-  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
-  *         the configuration information for ETHERNET module
-  * @retval None
-  */
-__weak void HAL_ETH_RxCpltCallback(ETH_HandleTypeDef *heth)
-{
-  /* NOTE : This function Should not be modified, when the callback is needed,
-  the HAL_ETH_TxCpltCallback could be implemented in the user file
-  */
-  ( void ) heth;
-}
+ * @brief  Tx Transfer completed callbacks.
+ * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
+ *         the configuration information for ETHERNET module
+ * @retval None
+ */
+        __weak void HAL_ETH_TxCpltCallback( ETH_HandleTypeDef * heth )
+        {
+            /* NOTE : This function Should not be modified, when the callback is needed,
+             * the HAL_ETH_TxCpltCallback could be implemented in the user file
+             */
+            ( void ) heth;
+        }
 
 /**
-  * @brief  Ethernet transfer error callbacks
-  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
-  *         the configuration information for ETHERNET module
-  * @retval None
-  */
-__weak void HAL_ETH_ErrorCallback(ETH_HandleTypeDef *heth)
-{
-  /* NOTE : This function Should not be modified, when the callback is needed,
-  the HAL_ETH_TxCpltCallback could be implemented in the user file
-  */
-  ( void ) heth;
-}
+ * @brief  Rx Transfer completed callbacks.
+ * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
+ *         the configuration information for ETHERNET module
+ * @retval None
+ */
+        __weak void HAL_ETH_RxCpltCallback( ETH_HandleTypeDef * heth )
+        {
+            /* NOTE : This function Should not be modified, when the callback is needed,
+             * the HAL_ETH_TxCpltCallback could be implemented in the user file
+             */
+            ( void ) heth;
+        }
 
 /**
-  * @brief  Reads a PHY register
-  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
-  *         the configuration information for ETHERNET module
-  * @param PHYReg: PHY register address, is the index of one of the 32 PHY register.
-  *                This parameter can be one of the following values:
-  *                   PHY_BCR: Transceiver Basic Control Register,
-  *                   PHY_BSR: Transceiver Basic Status Register.
-  *                   More PHY register could be read depending on the used PHY
-  * @param RegValue: PHY register value
-  * @retval HAL status
-  */
-HAL_StatusTypeDef HAL_ETH_ReadPHYRegister(ETH_HandleTypeDef *heth, uint16_t PHYReg, uint32_t *RegValue)
-{
-uint32_t tmpreg = 0uL;
-uint32_t tickstart = 0uL;
-HAL_StatusTypeDef xResult;
-
-	/* Check parameters */
-	assert_param(IS_ETH_PHY_ADDRESS(heth->Init.PhyAddress));
-
-	/* Check the ETH peripheral state */
-	if( heth->State == HAL_ETH_STATE_BUSY_RD )
-	{
-		xResult = HAL_BUSY;
-	}
-	else
-	{
-		__HAL_LOCK( heth );
-
-		/* Set ETH HAL State to BUSY_RD */
-		heth->State = HAL_ETH_STATE_BUSY_RD;
-
-		/* Get the ETHERNET MACMIIAR value */
-		tmpreg = heth->Instance->MACMIIAR;
-
-		/* Keep only the CSR Clock Range CR[2:0] bits value */
-		tmpreg &= ~ETH_MACMIIAR_CR_MASK;
-
-		/* Prepare the MII address register value */
-		tmpreg |= ( ( ( uint32_t )heth->Init.PhyAddress << 11) & ETH_MACMIIAR_PA );    /* Set the PHY device address   */
-		tmpreg |= ( ( ( uint32_t )PHYReg << 6 ) & ETH_MACMIIAR_MR );                   /* Set the PHY register address */
-		tmpreg &= ~ETH_MACMIIAR_MW;                                           /* Set the read mode            */
-		tmpreg |= ETH_MACMIIAR_MB;                                            /* Set the MII Busy bit         */
-
-		/* Write the result value into the MII Address register */
-		heth->Instance->MACMIIAR = tmpreg;
-
-		/* Get tick */
-		tickstart = HAL_GetTick();
-
-		/* Check for the Busy flag */
-		while( 1 )
-		{
-			tmpreg = heth->Instance->MACMIIAR;
-
-			if( ( tmpreg & ETH_MACMIIAR_MB ) == 0uL )
-			{
-				/* Get MACMIIDR value */
-				*RegValue = ( uint32_t ) heth->Instance->MACMIIDR;
-				xResult = HAL_OK;
-				break;
-			}
-			/* Check for the Timeout */
-			if( ( HAL_GetTick( ) - tickstart ) > PHY_READ_TO )
-			{
-				xResult = HAL_TIMEOUT;
-				break;
-			}
-
-		}
-
-		/* Set ETH HAL State to READY */
-		heth->State = HAL_ETH_STATE_READY;
-
-		/* Process Unlocked */
-		__HAL_UNLOCK( heth );
-	}
-
-	/* Return function status */
-	return xResult;
-}
+ * @brief  Ethernet transfer error callbacks
+ * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
+ *         the configuration information for ETHERNET module
+ * @retval None
+ */
+        __weak void HAL_ETH_ErrorCallback( ETH_HandleTypeDef * heth )
+        {
+            /* NOTE : This function Should not be modified, when the callback is needed,
+             * the HAL_ETH_TxCpltCallback could be implemented in the user file
+             */
+            ( void ) heth;
+        }
 
 /**
-  * @brief  Writes to a PHY register.
-  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
-  *         the configuration information for ETHERNET module
-  * @param  PHYReg: PHY register address, is the index of one of the 32 PHY register.
-  *          This parameter can be one of the following values:
-  *             PHY_BCR: Transceiver Control Register.
-  *             More PHY register could be written depending on the used PHY
-  * @param  RegValue: the value to write
-  * @retval HAL status
-  */
-HAL_StatusTypeDef HAL_ETH_WritePHYRegister(ETH_HandleTypeDef *heth, uint16_t PHYReg, uint32_t RegValue)
-{
-uint32_t tmpreg = 0;
-uint32_t tickstart = 0;
-HAL_StatusTypeDef xResult;
+ * @brief  Reads a PHY register
+ * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
+ *         the configuration information for ETHERNET module
+ * @param PHYReg: PHY register address, is the index of one of the 32 PHY register.
+ *                This parameter can be one of the following values:
+ *                   PHY_BCR: Transceiver Basic Control Register,
+ *                   PHY_BSR: Transceiver Basic Status Register.
+ *                   More PHY register could be read depending on the used PHY
+ * @param RegValue: PHY register value
+ * @retval HAL status
+ */
+        HAL_StatusTypeDef HAL_ETH_ReadPHYRegister( ETH_HandleTypeDef * heth,
+                                                   uint16_t PHYReg,
+                                                   uint32_t * RegValue )
+        {
+            uint32_t tmpreg = 0uL;
+            uint32_t tickstart = 0uL;
+            HAL_StatusTypeDef xResult;
 
-	/* Check parameters */
-	assert_param( IS_ETH_PHY_ADDRESS( heth->Init.PhyAddress ) );
+            /* Check parameters */
+            assert_param( IS_ETH_PHY_ADDRESS( heth->Init.PhyAddress ) );
 
-	/* Check the ETH peripheral state */
-	if( heth->State == HAL_ETH_STATE_BUSY_WR )
-	{
-		xResult = HAL_BUSY;
-	}
-	else
-	{
-		__HAL_LOCK( heth );
+            /* Check the ETH peripheral state */
+            if( heth->State == HAL_ETH_STATE_BUSY_RD )
+            {
+                xResult = HAL_BUSY;
+            }
+            else
+            {
+                __HAL_LOCK( heth );
 
-		/* Set ETH HAL State to BUSY_WR */
-		heth->State = HAL_ETH_STATE_BUSY_WR;
+                /* Set ETH HAL State to BUSY_RD */
+                heth->State = HAL_ETH_STATE_BUSY_RD;
 
-		/* Get the ETHERNET MACMIIAR value */
-		tmpreg = heth->Instance->MACMIIAR;
+                /* Get the ETHERNET MACMIIAR value */
+                tmpreg = heth->Instance->MACMIIAR;
 
-		/* Keep only the CSR Clock Range CR[2:0] bits value */
-		tmpreg &= ~ETH_MACMIIAR_CR_MASK;
+                /* Keep only the CSR Clock Range CR[2:0] bits value */
+                tmpreg &= ~ETH_MACMIIAR_CR_MASK;
 
-		/* Prepare the MII register address value */
-		tmpreg |= ( ( ( uint32_t ) heth->Init.PhyAddress << 11 ) & ETH_MACMIIAR_PA ); /* Set the PHY device address */
-		tmpreg |= ( ( ( uint32_t ) PHYReg << 6 ) & ETH_MACMIIAR_MR );                 /* Set the PHY register address */
-		tmpreg |= ETH_MACMIIAR_MW;                                          /* Set the write mode */
-		tmpreg |= ETH_MACMIIAR_MB;                                          /* Set the MII Busy bit */
+                /* Prepare the MII address register value */
+                tmpreg |= ( ( ( uint32_t ) heth->Init.PhyAddress << 11 ) & ETH_MACMIIAR_PA ); /* Set the PHY device address   */
+                tmpreg |= ( ( ( uint32_t ) PHYReg << 6 ) & ETH_MACMIIAR_MR );                 /* Set the PHY register address */
+                tmpreg &= ~ETH_MACMIIAR_MW;                                                   /* Set the read mode            */
+                tmpreg |= ETH_MACMIIAR_MB;                                                    /* Set the MII Busy bit         */
 
-		/* Give the value to the MII data register */
-		heth->Instance->MACMIIDR = ( uint16_t ) RegValue;
+                /* Write the result value into the MII Address register */
+                heth->Instance->MACMIIAR = tmpreg;
 
-		/* Write the result value into the MII Address register */
-		heth->Instance->MACMIIAR = tmpreg;
+                /* Get tick */
+                tickstart = HAL_GetTick();
 
-		/* Get tick */
-		tickstart = HAL_GetTick();
+                /* Check for the Busy flag */
+                while( 1 )
+                {
+                    tmpreg = heth->Instance->MACMIIAR;
 
-		/* Check for the Busy flag */
-		while( 1 )
-		{
-			tmpreg = heth->Instance->MACMIIAR;
+                    if( ( tmpreg & ETH_MACMIIAR_MB ) == 0uL )
+                    {
+                        /* Get MACMIIDR value */
+                        *RegValue = ( uint32_t ) heth->Instance->MACMIIDR;
+                        xResult = HAL_OK;
+                        break;
+                    }
 
-			if( ( tmpreg & ETH_MACMIIAR_MB ) == 0ul )
-			{
-				xResult = HAL_OK;
-				break;
-			}
-			/* Check for the Timeout */
-			if( ( HAL_GetTick( ) - tickstart ) > PHY_WRITE_TO )
-			{
-				xResult = HAL_TIMEOUT;
-				break;
-			}
-		}
+                    /* Check for the Timeout */
+                    if( ( HAL_GetTick() - tickstart ) > PHY_READ_TO )
+                    {
+                        xResult = HAL_TIMEOUT;
+                        break;
+                    }
+                }
 
-		/* Set ETH HAL State to READY */
-		heth->State = HAL_ETH_STATE_READY;
-		/* Process Unlocked */
-		__HAL_UNLOCK( heth );
-	}
+                /* Set ETH HAL State to READY */
+                heth->State = HAL_ETH_STATE_READY;
 
-	/* Return function status */
-	return xResult;
-}
+                /* Process Unlocked */
+                __HAL_UNLOCK( heth );
+            }
+
+            /* Return function status */
+            return xResult;
+        }
 
 /**
-  * @}
-  */
+ * @brief  Writes to a PHY register.
+ * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
+ *         the configuration information for ETHERNET module
+ * @param  PHYReg: PHY register address, is the index of one of the 32 PHY register.
+ *          This parameter can be one of the following values:
+ *             PHY_BCR: Transceiver Control Register.
+ *             More PHY register could be written depending on the used PHY
+ * @param  RegValue: the value to write
+ * @retval HAL status
+ */
+        HAL_StatusTypeDef HAL_ETH_WritePHYRegister( ETH_HandleTypeDef * heth,
+                                                    uint16_t PHYReg,
+                                                    uint32_t RegValue )
+        {
+            uint32_t tmpreg = 0;
+            uint32_t tickstart = 0;
+            HAL_StatusTypeDef xResult;
+
+            /* Check parameters */
+            assert_param( IS_ETH_PHY_ADDRESS( heth->Init.PhyAddress ) );
+
+            /* Check the ETH peripheral state */
+            if( heth->State == HAL_ETH_STATE_BUSY_WR )
+            {
+                xResult = HAL_BUSY;
+            }
+            else
+            {
+                __HAL_LOCK( heth );
+
+                /* Set ETH HAL State to BUSY_WR */
+                heth->State = HAL_ETH_STATE_BUSY_WR;
+
+                /* Get the ETHERNET MACMIIAR value */
+                tmpreg = heth->Instance->MACMIIAR;
+
+                /* Keep only the CSR Clock Range CR[2:0] bits value */
+                tmpreg &= ~ETH_MACMIIAR_CR_MASK;
+
+                /* Prepare the MII register address value */
+                tmpreg |= ( ( ( uint32_t ) heth->Init.PhyAddress << 11 ) & ETH_MACMIIAR_PA ); /* Set the PHY device address */
+                tmpreg |= ( ( ( uint32_t ) PHYReg << 6 ) & ETH_MACMIIAR_MR );                 /* Set the PHY register address */
+                tmpreg |= ETH_MACMIIAR_MW;                                                    /* Set the write mode */
+                tmpreg |= ETH_MACMIIAR_MB;                                                    /* Set the MII Busy bit */
+
+                /* Give the value to the MII data register */
+                heth->Instance->MACMIIDR = ( uint16_t ) RegValue;
+
+                /* Write the result value into the MII Address register */
+                heth->Instance->MACMIIAR = tmpreg;
+
+                /* Get tick */
+                tickstart = HAL_GetTick();
+
+                /* Check for the Busy flag */
+                while( 1 )
+                {
+                    tmpreg = heth->Instance->MACMIIAR;
+
+                    if( ( tmpreg & ETH_MACMIIAR_MB ) == 0ul )
+                    {
+                        xResult = HAL_OK;
+                        break;
+                    }
+
+                    /* Check for the Timeout */
+                    if( ( HAL_GetTick() - tickstart ) > PHY_WRITE_TO )
+                    {
+                        xResult = HAL_TIMEOUT;
+                        break;
+                    }
+                }
+
+                /* Set ETH HAL State to READY */
+                heth->State = HAL_ETH_STATE_READY;
+                /* Process Unlocked */
+                __HAL_UNLOCK( heth );
+            }
+
+            /* Return function status */
+            return xResult;
+        }
+
+/**
+ * @}
+ */
 
 /** @defgroup ETH_Exported_Functions_Group3 Peripheral Control functions
  *  @brief    Peripheral Control functions
  *
-@verbatim
- ===============================================================================
-                  ##### Peripheral Control functions #####
- ===============================================================================
-    [..]  This section provides functions allowing to:
-      (+) Enable MAC and DMA transmission and reception.
-          HAL_ETH_Start();
-      (+) Disable MAC and DMA transmission and reception.
-          HAL_ETH_Stop();
-      (+) Set the MAC configuration in runtime mode
-          HAL_ETH_ConfigMAC();
-      (+) Set the DMA configuration in runtime mode
-          HAL_ETH_ConfigDMA();
+ * @verbatim
+ * ===============================================================================
+ ##### Peripheral Control functions #####
+ #####===============================================================================
+ #####[..]  This section provides functions allowing to:
+ #####(+) Enable MAC and DMA transmission and reception.
+ #####    HAL_ETH_Start();
+ #####(+) Disable MAC and DMA transmission and reception.
+ #####    HAL_ETH_Stop();
+ #####(+) Set the MAC configuration in runtime mode
+ #####    HAL_ETH_ConfigMAC();
+ #####(+) Set the DMA configuration in runtime mode
+ #####    HAL_ETH_ConfigDMA();
+ #####
+ #####@endverbatim
+ * @{
+ */
 
-@endverbatim
-  * @{
-  */
+        /**
+         * @brief  Enables Ethernet MAC and DMA reception/transmission
+         * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
+         *         the configuration information for ETHERNET module
+         * @retval HAL status
+         */
+        HAL_StatusTypeDef HAL_ETH_Start( ETH_HandleTypeDef * heth )
+        {
+            /* Process Locked */
+            __HAL_LOCK( heth );
 
- /**
-  * @brief  Enables Ethernet MAC and DMA reception/transmission
-  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
-  *         the configuration information for ETHERNET module
-  * @retval HAL status
-  */
-HAL_StatusTypeDef HAL_ETH_Start( ETH_HandleTypeDef *heth )
-{
-	/* Process Locked */
-	__HAL_LOCK( heth );
+            /* Set the ETH peripheral state to BUSY */
+            heth->State = HAL_ETH_STATE_BUSY;
 
-	/* Set the ETH peripheral state to BUSY */
-	heth->State = HAL_ETH_STATE_BUSY;
+            /* Enable transmit state machine of the MAC for transmission on the MII */
+            ETH_MACTransmissionEnable( heth );
 
-	/* Enable transmit state machine of the MAC for transmission on the MII */
-	ETH_MACTransmissionEnable( heth );
+            /* Enable receive state machine of the MAC for reception from the MII */
+            ETH_MACReceptionEnable( heth );
 
-	/* Enable receive state machine of the MAC for reception from the MII */
-	ETH_MACReceptionEnable( heth );
+            /* Flush Transmit FIFO */
+            ETH_FlushTransmitFIFO( heth );
 
-	/* Flush Transmit FIFO */
-	ETH_FlushTransmitFIFO( heth );
+            /* Start DMA transmission */
+            ETH_DMATransmissionEnable( heth );
 
-	/* Start DMA transmission */
-	ETH_DMATransmissionEnable( heth );
+            /* Start DMA reception */
+            ETH_DMAReceptionEnable( heth );
 
-	/* Start DMA reception */
-	ETH_DMAReceptionEnable( heth );
+            /* Set the ETH state to READY*/
+            heth->State = HAL_ETH_STATE_READY;
 
-	/* Set the ETH state to READY*/
-	heth->State= HAL_ETH_STATE_READY;
+            /* Process Unlocked */
+            __HAL_UNLOCK( heth );
 
-	/* Process Unlocked */
-	__HAL_UNLOCK( heth );
-
-	/* Return function status */
-	return HAL_OK;
-}
-
-/**
-  * @brief  Stop Ethernet MAC and DMA reception/transmission
-  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
-  *         the configuration information for ETHERNET module
-  * @retval HAL status
-  */
-HAL_StatusTypeDef HAL_ETH_Stop(ETH_HandleTypeDef *heth)
-{
-  /* Process Locked */
-  __HAL_LOCK( heth );
-
-  /* Set the ETH peripheral state to BUSY */
-  heth->State = HAL_ETH_STATE_BUSY;
-
-  /* Stop DMA transmission */
-  ETH_DMATransmissionDisable( heth );
-
-  /* Stop DMA reception */
-  ETH_DMAReceptionDisable( heth );
-
-  /* Disable receive state machine of the MAC for reception from the MII */
-  ETH_MACReceptionDisable( heth );
-
-  /* Flush Transmit FIFO */
-  ETH_FlushTransmitFIFO( heth );
-
-  /* Disable transmit state machine of the MAC for transmission on the MII */
-  ETH_MACTransmissionDisable( heth );
-
-  /* Set the ETH state*/
-  heth->State = HAL_ETH_STATE_READY;
-
-  /* Process Unlocked */
-  __HAL_UNLOCK( heth );
-
-  /* Return function status */
-  return HAL_OK;
-}
-
-static void vRegisterDelay()
-{
-uint32_t uxCount;
-	/*
-	 * Regarding the HAL delay functions, I noticed that HAL delay is being used to workaround the
-	 * "Successive write operations to the same register might not be fully taken into account" errata.
-	 * The workaround requires a delay of four TX_CLK/RX_CLK clock cycles. For a 10 Mbit connection,
-	 * these clocks are running at 2.5 MHz, so this delay would be at most 1.6 microseconds.
-	 * 180 Mhz = 288 loops
-	 * 168 Mhz = 269 loops
-	 * 100 Mhz = 160 loops
-	 *  84 Mhz = 134 loops
-	 */
-	#define WAIT_TIME_NS	1600uL			/* 1.6 microseconds */
-	#define CPU_MAX_FREQ	SystemCoreClock	/* 84, 100, 168 or 180 MHz */
-	uint32_t NOP_COUNT = ( WAIT_TIME_NS * ( CPU_MAX_FREQ / 1000uL ) ) / 1000000uL;
-	for( uxCount = NOP_COUNT; uxCount > 0uL; uxCount-- )
-	{
-		__NOP();
-	}
-}
-
-static void prvWriteMACFCR( ETH_HandleTypeDef *heth, uint32_t ulValue)
-{
-	/* Enable the MAC transmission */
-	heth->Instance->MACFCR = ulValue;
-
-	/* Wait until the write operation will be taken into account:
-	at least four TX_CLK/RX_CLK clock cycles.
-	Read it back, wait a ms and */
-	( void ) heth->Instance->MACFCR;
-
-	vRegisterDelay();
-
-	heth->Instance->MACFCR = ulValue;
-}
-
-static void prvWriteDMAOMR( ETH_HandleTypeDef *heth, uint32_t ulValue)
-{
-	/* Enable the MAC transmission */
-	heth->Instance->DMAOMR = ulValue;
-
-	/* Wait until the write operation will be taken into account:
-	at least four TX_CLK/RX_CLK clock cycles.
-	Read it back, wait a ms and */
-	( void ) heth->Instance->DMAOMR;
-
-	vRegisterDelay();
-
-	heth->Instance->DMAOMR = ulValue;
-}
-
-static void prvWriteMACCR( ETH_HandleTypeDef *heth, uint32_t ulValue)
-{
-	/* Enable the MAC transmission */
-	heth->Instance->MACCR = ulValue;
-
-	/* Wait until the write operation will be taken into account:
-	at least four TX_CLK/RX_CLK clock cycles.
-	Read it back, wait a ms and */
-	( void ) heth->Instance->MACCR;
-
-	vRegisterDelay();
-
-	heth->Instance->MACCR = ulValue;
-}
+            /* Return function status */
+            return HAL_OK;
+        }
 
 /**
-  * @brief  Set ETH MAC Configuration.
-  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
-  *         the configuration information for ETHERNET module
-  * @param  macconf: MAC Configuration structure
-  * @retval HAL status
-  */
-HAL_StatusTypeDef HAL_ETH_ConfigMAC(ETH_HandleTypeDef *heth, ETH_MACInitTypeDef *macconf)
-{
-	uint32_t tmpreg = 0uL;
+ * @brief  Stop Ethernet MAC and DMA reception/transmission
+ * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
+ *         the configuration information for ETHERNET module
+ * @retval HAL status
+ */
+        HAL_StatusTypeDef HAL_ETH_Stop( ETH_HandleTypeDef * heth )
+        {
+            /* Process Locked */
+            __HAL_LOCK( heth );
 
-	/* Process Locked */
-	__HAL_LOCK( heth );
+            /* Set the ETH peripheral state to BUSY */
+            heth->State = HAL_ETH_STATE_BUSY;
 
-	/* Set the ETH peripheral state to BUSY */
-	heth->State= HAL_ETH_STATE_BUSY;
+            /* Stop DMA transmission */
+            ETH_DMATransmissionDisable( heth );
 
-	assert_param(IS_ETH_SPEED(heth->Init.Speed));
-	assert_param(IS_ETH_DUPLEX_MODE(heth->Init.DuplexMode));
+            /* Stop DMA reception */
+            ETH_DMAReceptionDisable( heth );
 
-	if (macconf != NULL)
-	{
-		/* Check the parameters */
-		assert_param(IS_ETH_WATCHDOG(macconf->Watchdog));
-		assert_param(IS_ETH_JABBER(macconf->Jabber));
-		assert_param(IS_ETH_INTER_FRAME_GAP(macconf->InterFrameGap));
-		assert_param(IS_ETH_CARRIER_SENSE(macconf->CarrierSense));
-		assert_param(IS_ETH_RECEIVE_OWN(macconf->ReceiveOwn));
-		assert_param(IS_ETH_LOOPBACK_MODE(macconf->LoopbackMode));
-		assert_param(IS_ETH_CHECKSUM_OFFLOAD(macconf->ChecksumOffload));
-		assert_param(IS_ETH_RETRY_TRANSMISSION(macconf->RetryTransmission));
-		assert_param(IS_ETH_AUTOMATIC_PADCRC_STRIP(macconf->AutomaticPadCRCStrip));
-		assert_param(IS_ETH_BACKOFF_LIMIT(macconf->BackOffLimit));
-		assert_param(IS_ETH_DEFERRAL_CHECK(macconf->DeferralCheck));
-		assert_param(IS_ETH_RECEIVE_ALL(macconf->ReceiveAll));
-		assert_param(IS_ETH_SOURCE_ADDR_FILTER(macconf->SourceAddrFilter));
-		assert_param(IS_ETH_CONTROL_FRAMES(macconf->PassControlFrames));
-		assert_param(IS_ETH_BROADCAST_FRAMES_RECEPTION(macconf->BroadcastFramesReception));
-		assert_param(IS_ETH_DESTINATION_ADDR_FILTER(macconf->DestinationAddrFilter));
-		assert_param(IS_ETH_PROMISCUOUS_MODE(macconf->PromiscuousMode));
-		assert_param(IS_ETH_MULTICAST_FRAMES_FILTER(macconf->MulticastFramesFilter));
-		assert_param(IS_ETH_UNICAST_FRAMES_FILTER(macconf->UnicastFramesFilter));
-		assert_param(IS_ETH_PAUSE_TIME(macconf->PauseTime));
-		assert_param(IS_ETH_ZEROQUANTA_PAUSE(macconf->ZeroQuantaPause));
-		assert_param(IS_ETH_PAUSE_LOW_THRESHOLD(macconf->PauseLowThreshold));
-		assert_param(IS_ETH_UNICAST_PAUSE_FRAME_DETECT(macconf->UnicastPauseFrameDetect));
-		assert_param(IS_ETH_RECEIVE_FLOWCONTROL(macconf->ReceiveFlowControl));
-		assert_param(IS_ETH_TRANSMIT_FLOWCONTROL(macconf->TransmitFlowControl));
-		assert_param(IS_ETH_VLAN_TAG_COMPARISON(macconf->VLANTagComparison));
-		assert_param(IS_ETH_VLAN_TAG_IDENTIFIER(macconf->VLANTagIdentifier));
+            /* Disable receive state machine of the MAC for reception from the MII */
+            ETH_MACReceptionDisable( heth );
 
-		/*------------------------ ETHERNET MACCR Configuration --------------------*/
-		/* Get the ETHERNET MACCR value */
-		tmpreg = heth->Instance->MACCR;
-		/* Clear WD, PCE, PS, TE and RE bits */
-		tmpreg &= ETH_MACCR_CLEAR_MASK;
+            /* Flush Transmit FIFO */
+            ETH_FlushTransmitFIFO( heth );
 
-		tmpreg |= (uint32_t)(
-			macconf->Watchdog |
-			macconf->Jabber |
-			macconf->InterFrameGap |
-			macconf->CarrierSense |
-			heth->Init.Speed |
-			macconf->ReceiveOwn |
-			macconf->LoopbackMode |
-			heth->Init.DuplexMode |
-			macconf->ChecksumOffload |
-			macconf->RetryTransmission |
-			macconf->AutomaticPadCRCStrip |
-			macconf->BackOffLimit |
-			macconf->DeferralCheck);
+            /* Disable transmit state machine of the MAC for transmission on the MII */
+            ETH_MACTransmissionDisable( heth );
 
-		/* Write to ETHERNET MACCR */
-		prvWriteMACCR( heth, tmpreg );
+            /* Set the ETH state*/
+            heth->State = HAL_ETH_STATE_READY;
 
-		/*----------------------- ETHERNET MACFFR Configuration --------------------*/
-		/* Write to ETHERNET MACFFR */
-		heth->Instance->MACFFR = (uint32_t)(
-			macconf->ReceiveAll |
-			macconf->SourceAddrFilter |
-			macconf->PassControlFrames |
-			macconf->BroadcastFramesReception |
-			macconf->DestinationAddrFilter |
-			macconf->PromiscuousMode |
-			macconf->MulticastFramesFilter |
-			macconf->UnicastFramesFilter);
+            /* Process Unlocked */
+            __HAL_UNLOCK( heth );
 
-		/* Wait until the write operation will be taken into account :
-		at least four TX_CLK/RX_CLK clock cycles */
-		tmpreg = heth->Instance->MACFFR;
-		vRegisterDelay();
-		heth->Instance->MACFFR = tmpreg;
+            /* Return function status */
+            return HAL_OK;
+        }
 
-		/*--------------- ETHERNET MACHTHR and MACHTLR Configuration ---------------*/
-		/* Write to ETHERNET MACHTHR */
-		heth->Instance->MACHTHR = (uint32_t)macconf->HashTableHigh;
+        static void vRegisterDelay()
+        {
+            uint32_t uxCount;
 
-		/* Write to ETHERNET MACHTLR */
-		heth->Instance->MACHTLR = (uint32_t)macconf->HashTableLow;
-		/*----------------------- ETHERNET MACFCR Configuration --------------------*/
+            /*
+             * Regarding the HAL delay functions, I noticed that HAL delay is being used to workaround the
+             * "Successive write operations to the same register might not be fully taken into account" errata.
+             * The workaround requires a delay of four TX_CLK/RX_CLK clock cycles. For a 10 Mbit connection,
+             * these clocks are running at 2.5 MHz, so this delay would be at most 1.6 microseconds.
+             * 180 Mhz = 288 loops
+             * 168 Mhz = 269 loops
+             * 100 Mhz = 160 loops
+             *  84 Mhz = 134 loops
+             */
+        #define WAIT_TIME_NS    1600uL          /* 1.6 microseconds */
+        #define CPU_MAX_FREQ    SystemCoreClock /* 84, 100, 168 or 180 MHz */
+            uint32_t NOP_COUNT = ( WAIT_TIME_NS * ( CPU_MAX_FREQ / 1000uL ) ) / 1000000uL;
 
-		/* Get the ETHERNET MACFCR value */
-		tmpreg = heth->Instance->MACFCR;
-		/* Clear xx bits */
-		tmpreg &= ETH_MACFCR_CLEAR_MASK;
+            for( uxCount = NOP_COUNT; uxCount > 0uL; uxCount-- )
+            {
+                __NOP();
+            }
+        }
 
-		tmpreg |= (uint32_t)((
-			macconf->PauseTime << 16) |
-			macconf->ZeroQuantaPause |
-			macconf->PauseLowThreshold |
-			macconf->UnicastPauseFrameDetect |
-			macconf->ReceiveFlowControl |
-			macconf->TransmitFlowControl);
+        static void prvWriteMACFCR( ETH_HandleTypeDef * heth,
+                                    uint32_t ulValue )
+        {
+            /* Enable the MAC transmission */
+            heth->Instance->MACFCR = ulValue;
 
-		/* Write to ETHERNET MACFCR */
-		prvWriteMACFCR( heth, tmpreg );
+            /* Wait until the write operation will be taken into account:
+             * at least four TX_CLK/RX_CLK clock cycles.
+             * Read it back, wait a ms and */
+            ( void ) heth->Instance->MACFCR;
 
-		/*----------------------- ETHERNET MACVLANTR Configuration -----------------*/
-		heth->Instance->MACVLANTR = (uint32_t)(macconf->VLANTagComparison |
-		macconf->VLANTagIdentifier);
+            vRegisterDelay();
 
-		/* Wait until the write operation will be taken into account :
-		at least four TX_CLK/RX_CLK clock cycles */
-		tmpreg = heth->Instance->MACVLANTR;
-		vRegisterDelay();
-		heth->Instance->MACVLANTR = tmpreg;
-	}
-	else /* macconf == NULL : here we just configure Speed and Duplex mode */
-	{
-		/*------------------------ ETHERNET MACCR Configuration --------------------*/
-		/* Get the ETHERNET MACCR value */
-		tmpreg = heth->Instance->MACCR;
+            heth->Instance->MACFCR = ulValue;
+        }
 
-		/* Clear FES and DM bits */
-		tmpreg &= ~( ( uint32_t ) 0x00004800uL );
+        static void prvWriteDMAOMR( ETH_HandleTypeDef * heth,
+                                    uint32_t ulValue )
+        {
+            /* Enable the MAC transmission */
+            heth->Instance->DMAOMR = ulValue;
 
-		tmpreg |= (uint32_t)(heth->Init.Speed | heth->Init.DuplexMode);
+            /* Wait until the write operation will be taken into account:
+             * at least four TX_CLK/RX_CLK clock cycles.
+             * Read it back, wait a ms and */
+            ( void ) heth->Instance->DMAOMR;
 
-		/* Write to ETHERNET MACCR */
-		prvWriteMACCR( heth, tmpreg );
-	}
+            vRegisterDelay();
 
-	/* Set the ETH state to Ready */
-	heth->State= HAL_ETH_STATE_READY;
+            heth->Instance->DMAOMR = ulValue;
+        }
 
-	/* Process Unlocked */
-	__HAL_UNLOCK( heth );
+        static void prvWriteMACCR( ETH_HandleTypeDef * heth,
+                                   uint32_t ulValue )
+        {
+            /* Enable the MAC transmission */
+            heth->Instance->MACCR = ulValue;
 
-	/* Return function status */
-	return HAL_OK;
-}
+            /* Wait until the write operation will be taken into account:
+             * at least four TX_CLK/RX_CLK clock cycles.
+             * Read it back, wait a ms and */
+            ( void ) heth->Instance->MACCR;
+
+            vRegisterDelay();
+
+            heth->Instance->MACCR = ulValue;
+        }
 
 /**
-  * @brief  Sets ETH DMA Configuration.
-  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
-  *         the configuration information for ETHERNET module
-  * @param  dmaconf: DMA Configuration structure
-  * @retval HAL status
-  */
-HAL_StatusTypeDef HAL_ETH_ConfigDMA(ETH_HandleTypeDef *heth, ETH_DMAInitTypeDef *dmaconf)
-{
-	uint32_t tmpreg = 0uL;
+ * @brief  Set ETH MAC Configuration.
+ * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
+ *         the configuration information for ETHERNET module
+ * @param  macconf: MAC Configuration structure
+ * @retval HAL status
+ */
+        HAL_StatusTypeDef HAL_ETH_ConfigMAC( ETH_HandleTypeDef * heth,
+                                             ETH_MACInitTypeDef * macconf )
+        {
+            uint32_t tmpreg = 0uL;
 
-	/* Process Locked */
-	__HAL_LOCK( heth );
+            /* Process Locked */
+            __HAL_LOCK( heth );
 
-	/* Set the ETH peripheral state to BUSY */
-	heth->State= HAL_ETH_STATE_BUSY;
+            /* Set the ETH peripheral state to BUSY */
+            heth->State = HAL_ETH_STATE_BUSY;
 
-	/* Check parameters */
-	assert_param(IS_ETH_DROP_TCPIP_CHECKSUM_FRAME(dmaconf->DropTCPIPChecksumErrorFrame));
-	assert_param(IS_ETH_RECEIVE_STORE_FORWARD(dmaconf->ReceiveStoreForward));
-	assert_param(IS_ETH_FLUSH_RECEIVE_FRAME(dmaconf->FlushReceivedFrame));
-	assert_param(IS_ETH_TRANSMIT_STORE_FORWARD(dmaconf->TransmitStoreForward));
-	assert_param(IS_ETH_TRANSMIT_THRESHOLD_CONTROL(dmaconf->TransmitThresholdControl));
-	assert_param(IS_ETH_FORWARD_ERROR_FRAMES(dmaconf->ForwardErrorFrames));
-	assert_param(IS_ETH_FORWARD_UNDERSIZED_GOOD_FRAMES(dmaconf->ForwardUndersizedGoodFrames));
-	assert_param(IS_ETH_RECEIVE_THRESHOLD_CONTROL(dmaconf->ReceiveThresholdControl));
-	assert_param(IS_ETH_SECOND_FRAME_OPERATE(dmaconf->SecondFrameOperate));
-	assert_param(IS_ETH_ADDRESS_ALIGNED_BEATS(dmaconf->AddressAlignedBeats));
-	assert_param(IS_ETH_FIXED_BURST(dmaconf->FixedBurst));
-	assert_param(IS_ETH_RXDMA_BURST_LENGTH(dmaconf->RxDMABurstLength));
-	assert_param(IS_ETH_TXDMA_BURST_LENGTH(dmaconf->TxDMABurstLength));
-	assert_param(IS_ETH_ENHANCED_DESCRIPTOR_FORMAT(dmaconf->EnhancedDescriptorFormat));
-	assert_param(IS_ETH_DMA_DESC_SKIP_LENGTH(dmaconf->DescriptorSkipLength));
-	assert_param(IS_ETH_DMA_ARBITRATION_ROUNDROBIN_RXTX(dmaconf->DMAArbitration));
+            assert_param( IS_ETH_SPEED( heth->Init.Speed ) );
+            assert_param( IS_ETH_DUPLEX_MODE( heth->Init.DuplexMode ) );
 
-	/*----------------------- ETHERNET DMAOMR Configuration --------------------*/
-	/* Get the ETHERNET DMAOMR value */
-	tmpreg = heth->Instance->DMAOMR;
-	/* Clear xx bits */
-	tmpreg &= ETH_DMAOMR_CLEAR_MASK;
+            if( macconf != NULL )
+            {
+                /* Check the parameters */
+                assert_param( IS_ETH_WATCHDOG( macconf->Watchdog ) );
+                assert_param( IS_ETH_JABBER( macconf->Jabber ) );
+                assert_param( IS_ETH_INTER_FRAME_GAP( macconf->InterFrameGap ) );
+                assert_param( IS_ETH_CARRIER_SENSE( macconf->CarrierSense ) );
+                assert_param( IS_ETH_RECEIVE_OWN( macconf->ReceiveOwn ) );
+                assert_param( IS_ETH_LOOPBACK_MODE( macconf->LoopbackMode ) );
+                assert_param( IS_ETH_CHECKSUM_OFFLOAD( macconf->ChecksumOffload ) );
+                assert_param( IS_ETH_RETRY_TRANSMISSION( macconf->RetryTransmission ) );
+                assert_param( IS_ETH_AUTOMATIC_PADCRC_STRIP( macconf->AutomaticPadCRCStrip ) );
+                assert_param( IS_ETH_BACKOFF_LIMIT( macconf->BackOffLimit ) );
+                assert_param( IS_ETH_DEFERRAL_CHECK( macconf->DeferralCheck ) );
+                assert_param( IS_ETH_RECEIVE_ALL( macconf->ReceiveAll ) );
+                assert_param( IS_ETH_SOURCE_ADDR_FILTER( macconf->SourceAddrFilter ) );
+                assert_param( IS_ETH_CONTROL_FRAMES( macconf->PassControlFrames ) );
+                assert_param( IS_ETH_BROADCAST_FRAMES_RECEPTION( macconf->BroadcastFramesReception ) );
+                assert_param( IS_ETH_DESTINATION_ADDR_FILTER( macconf->DestinationAddrFilter ) );
+                assert_param( IS_ETH_PROMISCUOUS_MODE( macconf->PromiscuousMode ) );
+                assert_param( IS_ETH_MULTICAST_FRAMES_FILTER( macconf->MulticastFramesFilter ) );
+                assert_param( IS_ETH_UNICAST_FRAMES_FILTER( macconf->UnicastFramesFilter ) );
+                assert_param( IS_ETH_PAUSE_TIME( macconf->PauseTime ) );
+                assert_param( IS_ETH_ZEROQUANTA_PAUSE( macconf->ZeroQuantaPause ) );
+                assert_param( IS_ETH_PAUSE_LOW_THRESHOLD( macconf->PauseLowThreshold ) );
+                assert_param( IS_ETH_UNICAST_PAUSE_FRAME_DETECT( macconf->UnicastPauseFrameDetect ) );
+                assert_param( IS_ETH_RECEIVE_FLOWCONTROL( macconf->ReceiveFlowControl ) );
+                assert_param( IS_ETH_TRANSMIT_FLOWCONTROL( macconf->TransmitFlowControl ) );
+                assert_param( IS_ETH_VLAN_TAG_COMPARISON( macconf->VLANTagComparison ) );
+                assert_param( IS_ETH_VLAN_TAG_IDENTIFIER( macconf->VLANTagIdentifier ) );
 
-	tmpreg |= (uint32_t)(
-		dmaconf->DropTCPIPChecksumErrorFrame |
-		dmaconf->ReceiveStoreForward |
-		dmaconf->FlushReceivedFrame |
-		dmaconf->TransmitStoreForward |
-		dmaconf->TransmitThresholdControl |
-		dmaconf->ForwardErrorFrames |
-		dmaconf->ForwardUndersizedGoodFrames |
-		dmaconf->ReceiveThresholdControl |
-		dmaconf->SecondFrameOperate);
+                /*------------------------ ETHERNET MACCR Configuration --------------------*/
+                /* Get the ETHERNET MACCR value */
+                tmpreg = heth->Instance->MACCR;
+                /* Clear WD, PCE, PS, TE and RE bits */
+                tmpreg &= ETH_MACCR_CLEAR_MASK;
 
-	/* Write to ETHERNET DMAOMR */
-	prvWriteDMAOMR( heth, tmpreg );
+                tmpreg |= ( uint32_t ) (
+                    macconf->Watchdog |
+                    macconf->Jabber |
+                    macconf->InterFrameGap |
+                    macconf->CarrierSense |
+                    heth->Init.Speed |
+                    macconf->ReceiveOwn |
+                    macconf->LoopbackMode |
+                    heth->Init.DuplexMode |
+                    macconf->ChecksumOffload |
+                    macconf->RetryTransmission |
+                    macconf->AutomaticPadCRCStrip |
+                    macconf->BackOffLimit |
+                    macconf->DeferralCheck );
 
-	/*----------------------- ETHERNET DMABMR Configuration --------------------*/
-	heth->Instance->DMABMR = (uint32_t)(dmaconf->AddressAlignedBeats |
-	dmaconf->FixedBurst |
-	dmaconf->RxDMABurstLength | /* !! if 4xPBL is selected for Tx or Rx it is applied for the other */
-	dmaconf->TxDMABurstLength |
-	dmaconf->EnhancedDescriptorFormat |
-	(dmaconf->DescriptorSkipLength << 2) |
-	dmaconf->DMAArbitration |
-	ETH_DMABMR_USP); /* Enable use of separate PBL for Rx and Tx */
+                /* Write to ETHERNET MACCR */
+                prvWriteMACCR( heth, tmpreg );
 
-	/* Wait until the write operation will be taken into account:
-	at least four TX_CLK/RX_CLK clock cycles */
-	tmpreg = heth->Instance->DMABMR;
-	vRegisterDelay();
-	heth->Instance->DMABMR = tmpreg;
+                /*----------------------- ETHERNET MACFFR Configuration --------------------*/
+                /* Write to ETHERNET MACFFR */
+                heth->Instance->MACFFR = ( uint32_t ) (
+                    macconf->ReceiveAll |
+                    macconf->SourceAddrFilter |
+                    macconf->PassControlFrames |
+                    macconf->BroadcastFramesReception |
+                    macconf->DestinationAddrFilter |
+                    macconf->PromiscuousMode |
+                    macconf->MulticastFramesFilter |
+                    macconf->UnicastFramesFilter );
 
-	/* Set the ETH state to Ready */
-	heth->State= HAL_ETH_STATE_READY;
+                /* Wait until the write operation will be taken into account :
+                 * at least four TX_CLK/RX_CLK clock cycles */
+                tmpreg = heth->Instance->MACFFR;
+                vRegisterDelay();
+                heth->Instance->MACFFR = tmpreg;
 
-	/* Process Unlocked */
-	__HAL_UNLOCK( heth );
+                /*--------------- ETHERNET MACHTHR and MACHTLR Configuration ---------------*/
+                /* Write to ETHERNET MACHTHR */
+                heth->Instance->MACHTHR = ( uint32_t ) macconf->HashTableHigh;
 
-	/* Return function status */
-	return HAL_OK;
-}
+                /* Write to ETHERNET MACHTLR */
+                heth->Instance->MACHTLR = ( uint32_t ) macconf->HashTableLow;
+                /*----------------------- ETHERNET MACFCR Configuration --------------------*/
+
+                /* Get the ETHERNET MACFCR value */
+                tmpreg = heth->Instance->MACFCR;
+                /* Clear xx bits */
+                tmpreg &= ETH_MACFCR_CLEAR_MASK;
+
+                tmpreg |= ( uint32_t ) ( (
+                                             macconf->PauseTime << 16 ) |
+                                         macconf->ZeroQuantaPause |
+                                         macconf->PauseLowThreshold |
+                                         macconf->UnicastPauseFrameDetect |
+                                         macconf->ReceiveFlowControl |
+                                         macconf->TransmitFlowControl );
+
+                /* Write to ETHERNET MACFCR */
+                prvWriteMACFCR( heth, tmpreg );
+
+                /*----------------------- ETHERNET MACVLANTR Configuration -----------------*/
+                heth->Instance->MACVLANTR = ( uint32_t ) ( macconf->VLANTagComparison |
+                                                           macconf->VLANTagIdentifier );
+
+                /* Wait until the write operation will be taken into account :
+                 * at least four TX_CLK/RX_CLK clock cycles */
+                tmpreg = heth->Instance->MACVLANTR;
+                vRegisterDelay();
+                heth->Instance->MACVLANTR = tmpreg;
+            }
+            else /* macconf == NULL : here we just configure Speed and Duplex mode */
+            {
+                /*------------------------ ETHERNET MACCR Configuration --------------------*/
+                /* Get the ETHERNET MACCR value */
+                tmpreg = heth->Instance->MACCR;
+
+                /* Clear FES and DM bits */
+                tmpreg &= ~( ( uint32_t ) 0x00004800uL );
+
+                tmpreg |= ( uint32_t ) ( heth->Init.Speed | heth->Init.DuplexMode );
+
+                /* Write to ETHERNET MACCR */
+                prvWriteMACCR( heth, tmpreg );
+            }
+
+            /* Set the ETH state to Ready */
+            heth->State = HAL_ETH_STATE_READY;
+
+            /* Process Unlocked */
+            __HAL_UNLOCK( heth );
+
+            /* Return function status */
+            return HAL_OK;
+        }
 
 /**
-  * @}
-  */
+ * @brief  Sets ETH DMA Configuration.
+ * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
+ *         the configuration information for ETHERNET module
+ * @param  dmaconf: DMA Configuration structure
+ * @retval HAL status
+ */
+        HAL_StatusTypeDef HAL_ETH_ConfigDMA( ETH_HandleTypeDef * heth,
+                                             ETH_DMAInitTypeDef * dmaconf )
+        {
+            uint32_t tmpreg = 0uL;
+
+            /* Process Locked */
+            __HAL_LOCK( heth );
+
+            /* Set the ETH peripheral state to BUSY */
+            heth->State = HAL_ETH_STATE_BUSY;
+
+            /* Check parameters */
+            assert_param( IS_ETH_DROP_TCPIP_CHECKSUM_FRAME( dmaconf->DropTCPIPChecksumErrorFrame ) );
+            assert_param( IS_ETH_RECEIVE_STORE_FORWARD( dmaconf->ReceiveStoreForward ) );
+            assert_param( IS_ETH_FLUSH_RECEIVE_FRAME( dmaconf->FlushReceivedFrame ) );
+            assert_param( IS_ETH_TRANSMIT_STORE_FORWARD( dmaconf->TransmitStoreForward ) );
+            assert_param( IS_ETH_TRANSMIT_THRESHOLD_CONTROL( dmaconf->TransmitThresholdControl ) );
+            assert_param( IS_ETH_FORWARD_ERROR_FRAMES( dmaconf->ForwardErrorFrames ) );
+            assert_param( IS_ETH_FORWARD_UNDERSIZED_GOOD_FRAMES( dmaconf->ForwardUndersizedGoodFrames ) );
+            assert_param( IS_ETH_RECEIVE_THRESHOLD_CONTROL( dmaconf->ReceiveThresholdControl ) );
+            assert_param( IS_ETH_SECOND_FRAME_OPERATE( dmaconf->SecondFrameOperate ) );
+            assert_param( IS_ETH_ADDRESS_ALIGNED_BEATS( dmaconf->AddressAlignedBeats ) );
+            assert_param( IS_ETH_FIXED_BURST( dmaconf->FixedBurst ) );
+            assert_param( IS_ETH_RXDMA_BURST_LENGTH( dmaconf->RxDMABurstLength ) );
+            assert_param( IS_ETH_TXDMA_BURST_LENGTH( dmaconf->TxDMABurstLength ) );
+            assert_param( IS_ETH_ENHANCED_DESCRIPTOR_FORMAT( dmaconf->EnhancedDescriptorFormat ) );
+            assert_param( IS_ETH_DMA_DESC_SKIP_LENGTH( dmaconf->DescriptorSkipLength ) );
+            assert_param( IS_ETH_DMA_ARBITRATION_ROUNDROBIN_RXTX( dmaconf->DMAArbitration ) );
+
+            /*----------------------- ETHERNET DMAOMR Configuration --------------------*/
+            /* Get the ETHERNET DMAOMR value */
+            tmpreg = heth->Instance->DMAOMR;
+            /* Clear xx bits */
+            tmpreg &= ETH_DMAOMR_CLEAR_MASK;
+
+            tmpreg |= ( uint32_t ) (
+                dmaconf->DropTCPIPChecksumErrorFrame |
+                dmaconf->ReceiveStoreForward |
+                dmaconf->FlushReceivedFrame |
+                dmaconf->TransmitStoreForward |
+                dmaconf->TransmitThresholdControl |
+                dmaconf->ForwardErrorFrames |
+                dmaconf->ForwardUndersizedGoodFrames |
+                dmaconf->ReceiveThresholdControl |
+                dmaconf->SecondFrameOperate );
+
+            /* Write to ETHERNET DMAOMR */
+            prvWriteDMAOMR( heth, tmpreg );
+
+            /*----------------------- ETHERNET DMABMR Configuration --------------------*/
+            heth->Instance->DMABMR = ( uint32_t ) ( dmaconf->AddressAlignedBeats |
+                                                    dmaconf->FixedBurst |
+                                                    dmaconf->RxDMABurstLength | /* !! if 4xPBL is selected for Tx or Rx it is applied for the other */
+                                                    dmaconf->TxDMABurstLength |
+                                                    dmaconf->EnhancedDescriptorFormat |
+                                                    ( dmaconf->DescriptorSkipLength << 2 ) |
+                                                    dmaconf->DMAArbitration |
+                                                    ETH_DMABMR_USP ); /* Enable use of separate PBL for Rx and Tx */
+
+            /* Wait until the write operation will be taken into account:
+             * at least four TX_CLK/RX_CLK clock cycles */
+            tmpreg = heth->Instance->DMABMR;
+            vRegisterDelay();
+            heth->Instance->DMABMR = tmpreg;
+
+            /* Set the ETH state to Ready */
+            heth->State = HAL_ETH_STATE_READY;
+
+            /* Process Unlocked */
+            __HAL_UNLOCK( heth );
+
+            /* Return function status */
+            return HAL_OK;
+        }
+
+/**
+ * @}
+ */
 
 /** @defgroup ETH_Exported_Functions_Group4 Peripheral State functions
-  *  @brief   Peripheral State functions
-  *
-  @verbatim
-  ===============================================================================
-                         ##### Peripheral State functions #####
-  ===============================================================================
-  [..]
-  This subsection permits to get in run-time the status of the peripheral
-  and the data flow.
-       (+) Get the ETH handle state:
-           HAL_ETH_GetState();
-
-
-  @endverbatim
-  * @{
-  */
-
-/**
-  * @brief  Return the ETH HAL state
-  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
-  *         the configuration information for ETHERNET module
-  * @retval HAL state
-  */
-HAL_ETH_StateTypeDef HAL_ETH_GetState(ETH_HandleTypeDef *heth)
-{
-  /* Return ETH state */
-  return heth->State;
-}
+ *  @brief   Peripheral State functions
+ *
+ * @verbatim
+ * ===============================================================================
+ ##### Peripheral State functions #####
+ #####===============================================================================
+ #####[..]
+ #####This subsection permits to get in run-time the status of the peripheral
+ #####and the data flow.
+ ##### (+) Get the ETH handle state:
+ #####     HAL_ETH_GetState();
+ #####
+ #####
+ #####@endverbatim
+ * @{
+ */
 
 /**
-  * @}
-  */
+ * @brief  Return the ETH HAL state
+ * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
+ *         the configuration information for ETHERNET module
+ * @retval HAL state
+ */
+        HAL_ETH_StateTypeDef HAL_ETH_GetState( ETH_HandleTypeDef * heth )
+        {
+            /* Return ETH state */
+            return heth->State;
+        }
 
 /**
-  * @}
-  */
+ * @}
+ */
+
+/**
+ * @}
+ */
 
 /** @addtogroup ETH_Private_Functions
-  * @{
-  */
+ * @{
+ */
 
 /**
-  * @brief  Configures Ethernet MAC and DMA with default parameters.
-  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
-  *         the configuration information for ETHERNET module
-  * @param  err: Ethernet Init error
-  * @retval HAL status
-  */
-static void ETH_MACDMAConfig(ETH_HandleTypeDef *heth, uint32_t err)
-{
-  ETH_MACInitTypeDef macinit;
-  ETH_DMAInitTypeDef dmainit;
-  uint32_t tmpreg = 0uL;
+ * @brief  Configures Ethernet MAC and DMA with default parameters.
+ * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
+ *         the configuration information for ETHERNET module
+ * @param  err: Ethernet Init error
+ * @retval HAL status
+ */
+        static void ETH_MACDMAConfig( ETH_HandleTypeDef * heth,
+                                      uint32_t err )
+        {
+            ETH_MACInitTypeDef macinit;
+            ETH_DMAInitTypeDef dmainit;
+            uint32_t tmpreg = 0uL;
 
-  if (err != ETH_SUCCESS) /* Auto-negotiation failed */
-  {
-    /* Set Ethernet duplex mode to Full-duplex */
-    heth->Init.DuplexMode = ETH_MODE_FULLDUPLEX;
+            if( err != ETH_SUCCESS ) /* Auto-negotiation failed */
+            {
+                /* Set Ethernet duplex mode to Full-duplex */
+                heth->Init.DuplexMode = ETH_MODE_FULLDUPLEX;
 
-    /* Set Ethernet speed to 100M */
-    heth->Init.Speed = ETH_SPEED_100M;
-  }
+                /* Set Ethernet speed to 100M */
+                heth->Init.Speed = ETH_SPEED_100M;
+            }
 
-  /* Ethernet MAC default initialization **************************************/
-  macinit.Watchdog = ETH_WATCHDOG_ENABLE;
-  macinit.Jabber = ETH_JABBER_ENABLE;
-  macinit.InterFrameGap = ETH_INTERFRAMEGAP_96BIT;
-  macinit.CarrierSense = ETH_CARRIERSENCE_ENABLE;
-  macinit.ReceiveOwn = ETH_RECEIVEOWN_ENABLE;
-  macinit.LoopbackMode = ETH_LOOPBACKMODE_DISABLE;
-  if(heth->Init.ChecksumMode == ETH_CHECKSUM_BY_HARDWARE)
-  {
-    macinit.ChecksumOffload = ETH_CHECKSUMOFFLAOD_ENABLE;
-  }
-  else
-  {
-    macinit.ChecksumOffload = ETH_CHECKSUMOFFLAOD_DISABLE;
-  }
-  macinit.RetryTransmission = ETH_RETRYTRANSMISSION_DISABLE;
-  macinit.AutomaticPadCRCStrip = ETH_AUTOMATICPADCRCSTRIP_DISABLE;
-  macinit.BackOffLimit = ETH_BACKOFFLIMIT_10;
-  macinit.DeferralCheck = ETH_DEFFERRALCHECK_DISABLE;
-  macinit.ReceiveAll = ETH_RECEIVEAll_DISABLE;
-  macinit.SourceAddrFilter = ETH_SOURCEADDRFILTER_DISABLE;
-  macinit.PassControlFrames = ETH_PASSCONTROLFRAMES_BLOCKALL;
-  macinit.BroadcastFramesReception = ETH_BROADCASTFRAMESRECEPTION_ENABLE;
-  macinit.DestinationAddrFilter = ETH_DESTINATIONADDRFILTER_NORMAL;
-  macinit.PromiscuousMode = ETH_PROMISCUOUS_MODE_DISABLE;
-  macinit.MulticastFramesFilter = ETH_MULTICASTFRAMESFILTER_PERFECT;
-  macinit.UnicastFramesFilter = ETH_UNICASTFRAMESFILTER_PERFECT;
-  macinit.HashTableHigh = 0x0uL;
-  macinit.HashTableLow = 0x0uL;
-  macinit.PauseTime = 0x0uL;
-  macinit.ZeroQuantaPause = ETH_ZEROQUANTAPAUSE_DISABLE;
-  macinit.PauseLowThreshold = ETH_PAUSELOWTHRESHOLD_MINUS4;
-  macinit.UnicastPauseFrameDetect = ETH_UNICASTPAUSEFRAMEDETECT_DISABLE;
-  macinit.ReceiveFlowControl = ETH_RECEIVEFLOWCONTROL_DISABLE;
-  macinit.TransmitFlowControl = ETH_TRANSMITFLOWCONTROL_DISABLE;
-  macinit.VLANTagComparison = ETH_VLANTAGCOMPARISON_16BIT;
-  macinit.VLANTagIdentifier = 0x0uL;
+            /* Ethernet MAC default initialization **************************************/
+            macinit.Watchdog = ETH_WATCHDOG_ENABLE;
+            macinit.Jabber = ETH_JABBER_ENABLE;
+            macinit.InterFrameGap = ETH_INTERFRAMEGAP_96BIT;
+            macinit.CarrierSense = ETH_CARRIERSENCE_ENABLE;
+            macinit.ReceiveOwn = ETH_RECEIVEOWN_ENABLE;
+            macinit.LoopbackMode = ETH_LOOPBACKMODE_DISABLE;
 
-  /*------------------------ ETHERNET MACCR Configuration --------------------*/
-  /* Get the ETHERNET MACCR value */
-  tmpreg = heth->Instance->MACCR;
-  /* Clear WD, PCE, PS, TE and RE bits */
-  tmpreg &= ETH_MACCR_CLEAR_MASK;
-  /* Set the WD bit according to ETH Watchdog value */
-  /* Set the JD: bit according to ETH Jabber value */
-  /* Set the IFG bit according to ETH InterFrameGap value */
-  /* Set the DCRS bit according to ETH CarrierSense value */
-  /* Set the FES bit according to ETH Speed value */
-  /* Set the DO bit according to ETH ReceiveOwn value */
-  /* Set the LM bit according to ETH LoopbackMode value */
-  /* Set the DM bit according to ETH Mode value */
-  /* Set the IPCO bit according to ETH ChecksumOffload value */
-  /* Set the DR bit according to ETH RetryTransmission value */
-  /* Set the ACS bit according to ETH AutomaticPadCRCStrip value */
-  /* Set the BL bit according to ETH BackOffLimit value */
-  /* Set the DC bit according to ETH DeferralCheck value */
-  tmpreg |= (uint32_t)(macinit.Watchdog |
-                       macinit.Jabber |
-                       macinit.InterFrameGap |
-                       macinit.CarrierSense |
-                       heth->Init.Speed |
-                       macinit.ReceiveOwn |
-                       macinit.LoopbackMode |
-                       heth->Init.DuplexMode |
-                       macinit.ChecksumOffload |
-                       macinit.RetryTransmission |
-                       macinit.AutomaticPadCRCStrip |
-                       macinit.BackOffLimit |
-                       macinit.DeferralCheck);
+            if( heth->Init.ChecksumMode == ETH_CHECKSUM_BY_HARDWARE )
+            {
+                macinit.ChecksumOffload = ETH_CHECKSUMOFFLAOD_ENABLE;
+            }
+            else
+            {
+                macinit.ChecksumOffload = ETH_CHECKSUMOFFLAOD_DISABLE;
+            }
 
-  /* Write to ETHERNET MACCR */
-  prvWriteMACCR( heth, tmpreg );
+            macinit.RetryTransmission = ETH_RETRYTRANSMISSION_DISABLE;
+            macinit.AutomaticPadCRCStrip = ETH_AUTOMATICPADCRCSTRIP_DISABLE;
+            macinit.BackOffLimit = ETH_BACKOFFLIMIT_10;
+            macinit.DeferralCheck = ETH_DEFFERRALCHECK_DISABLE;
+            macinit.ReceiveAll = ETH_RECEIVEAll_DISABLE;
+            macinit.SourceAddrFilter = ETH_SOURCEADDRFILTER_DISABLE;
+            macinit.PassControlFrames = ETH_PASSCONTROLFRAMES_BLOCKALL;
+            macinit.BroadcastFramesReception = ETH_BROADCASTFRAMESRECEPTION_ENABLE;
+            macinit.DestinationAddrFilter = ETH_DESTINATIONADDRFILTER_NORMAL;
+            macinit.PromiscuousMode = ETH_PROMISCUOUS_MODE_DISABLE;
+            macinit.MulticastFramesFilter = ETH_MULTICASTFRAMESFILTER_PERFECT;
+            macinit.UnicastFramesFilter = ETH_UNICASTFRAMESFILTER_PERFECT;
+            macinit.HashTableHigh = 0x0uL;
+            macinit.HashTableLow = 0x0uL;
+            macinit.PauseTime = 0x0uL;
+            macinit.ZeroQuantaPause = ETH_ZEROQUANTAPAUSE_DISABLE;
+            macinit.PauseLowThreshold = ETH_PAUSELOWTHRESHOLD_MINUS4;
+            macinit.UnicastPauseFrameDetect = ETH_UNICASTPAUSEFRAMEDETECT_DISABLE;
+            macinit.ReceiveFlowControl = ETH_RECEIVEFLOWCONTROL_DISABLE;
+            macinit.TransmitFlowControl = ETH_TRANSMITFLOWCONTROL_DISABLE;
+            macinit.VLANTagComparison = ETH_VLANTAGCOMPARISON_16BIT;
+            macinit.VLANTagIdentifier = 0x0uL;
 
-  /*----------------------- ETHERNET MACFFR Configuration --------------------*/
-  /* Set the RA bit according to ETH ReceiveAll value */
-  /* Set the SAF and SAIF bits according to ETH SourceAddrFilter value */
-  /* Set the PCF bit according to ETH PassControlFrames value */
-  /* Set the DBF bit according to ETH BroadcastFramesReception value */
-  /* Set the DAIF bit according to ETH DestinationAddrFilter value */
-  /* Set the PR bit according to ETH PromiscuousMode value */
-  /* Set the PM, HMC and HPF bits according to ETH MulticastFramesFilter value */
-  /* Set the HUC and HPF bits according to ETH UnicastFramesFilter value */
-  /* Write to ETHERNET MACFFR */
-  heth->Instance->MACFFR = (uint32_t)(macinit.ReceiveAll |
-                                        macinit.SourceAddrFilter |
-                                        macinit.PassControlFrames |
-                                        macinit.BroadcastFramesReception |
-                                        macinit.DestinationAddrFilter |
-                                        macinit.PromiscuousMode |
-                                        macinit.MulticastFramesFilter |
-                                        macinit.UnicastFramesFilter);
+            /*------------------------ ETHERNET MACCR Configuration --------------------*/
+            /* Get the ETHERNET MACCR value */
+            tmpreg = heth->Instance->MACCR;
+            /* Clear WD, PCE, PS, TE and RE bits */
+            tmpreg &= ETH_MACCR_CLEAR_MASK;
+            /* Set the WD bit according to ETH Watchdog value */
+            /* Set the JD: bit according to ETH Jabber value */
+            /* Set the IFG bit according to ETH InterFrameGap value */
+            /* Set the DCRS bit according to ETH CarrierSense value */
+            /* Set the FES bit according to ETH Speed value */
+            /* Set the DO bit according to ETH ReceiveOwn value */
+            /* Set the LM bit according to ETH LoopbackMode value */
+            /* Set the DM bit according to ETH Mode value */
+            /* Set the IPCO bit according to ETH ChecksumOffload value */
+            /* Set the DR bit according to ETH RetryTransmission value */
+            /* Set the ACS bit according to ETH AutomaticPadCRCStrip value */
+            /* Set the BL bit according to ETH BackOffLimit value */
+            /* Set the DC bit according to ETH DeferralCheck value */
+            tmpreg |= ( uint32_t ) ( macinit.Watchdog |
+                                     macinit.Jabber |
+                                     macinit.InterFrameGap |
+                                     macinit.CarrierSense |
+                                     heth->Init.Speed |
+                                     macinit.ReceiveOwn |
+                                     macinit.LoopbackMode |
+                                     heth->Init.DuplexMode |
+                                     macinit.ChecksumOffload |
+                                     macinit.RetryTransmission |
+                                     macinit.AutomaticPadCRCStrip |
+                                     macinit.BackOffLimit |
+                                     macinit.DeferralCheck );
 
-   /* Wait until the write operation will be taken into account:
-      at least four TX_CLK/RX_CLK clock cycles */
-   tmpreg = heth->Instance->MACFFR;
-   vRegisterDelay();
-   heth->Instance->MACFFR = tmpreg;
+            /* Write to ETHERNET MACCR */
+            prvWriteMACCR( heth, tmpreg );
 
-   /*--------------- ETHERNET MACHTHR and MACHTLR Configuration --------------*/
-   /* Write to ETHERNET MACHTHR */
-   heth->Instance->MACHTHR = (uint32_t)macinit.HashTableHigh;
+            /*----------------------- ETHERNET MACFFR Configuration --------------------*/
+            /* Set the RA bit according to ETH ReceiveAll value */
+            /* Set the SAF and SAIF bits according to ETH SourceAddrFilter value */
+            /* Set the PCF bit according to ETH PassControlFrames value */
+            /* Set the DBF bit according to ETH BroadcastFramesReception value */
+            /* Set the DAIF bit according to ETH DestinationAddrFilter value */
+            /* Set the PR bit according to ETH PromiscuousMode value */
+            /* Set the PM, HMC and HPF bits according to ETH MulticastFramesFilter value */
+            /* Set the HUC and HPF bits according to ETH UnicastFramesFilter value */
+            /* Write to ETHERNET MACFFR */
+            heth->Instance->MACFFR = ( uint32_t ) ( macinit.ReceiveAll |
+                                                    macinit.SourceAddrFilter |
+                                                    macinit.PassControlFrames |
+                                                    macinit.BroadcastFramesReception |
+                                                    macinit.DestinationAddrFilter |
+                                                    macinit.PromiscuousMode |
+                                                    macinit.MulticastFramesFilter |
+                                                    macinit.UnicastFramesFilter );
 
-   /* Write to ETHERNET MACHTLR */
-   heth->Instance->MACHTLR = (uint32_t)macinit.HashTableLow;
-   /*----------------------- ETHERNET MACFCR Configuration -------------------*/
+            /* Wait until the write operation will be taken into account:
+             * at least four TX_CLK/RX_CLK clock cycles */
+            tmpreg = heth->Instance->MACFFR;
+            vRegisterDelay();
+            heth->Instance->MACFFR = tmpreg;
 
-   /* Get the ETHERNET MACFCR value */
-   tmpreg = heth->Instance->MACFCR;
-   /* Clear xx bits */
-   tmpreg &= ETH_MACFCR_CLEAR_MASK;
+            /*--------------- ETHERNET MACHTHR and MACHTLR Configuration --------------*/
+            /* Write to ETHERNET MACHTHR */
+            heth->Instance->MACHTHR = ( uint32_t ) macinit.HashTableHigh;
 
-   /* Set the PT bit according to ETH PauseTime value */
-   /* Set the DZPQ bit according to ETH ZeroQuantaPause value */
-   /* Set the PLT bit according to ETH PauseLowThreshold value */
-   /* Set the UP bit according to ETH UnicastPauseFrameDetect value */
-   /* Set the RFE bit according to ETH ReceiveFlowControl value */
-   /* Set the TFE bit according to ETH TransmitFlowControl value */
-   tmpreg |= (uint32_t)((macinit.PauseTime << 16) |
-                        macinit.ZeroQuantaPause |
-                        macinit.PauseLowThreshold |
-                        macinit.UnicastPauseFrameDetect |
-                        macinit.ReceiveFlowControl |
-                        macinit.TransmitFlowControl);
+            /* Write to ETHERNET MACHTLR */
+            heth->Instance->MACHTLR = ( uint32_t ) macinit.HashTableLow;
+            /*----------------------- ETHERNET MACFCR Configuration -------------------*/
 
-   /* Write to ETHERNET MACFCR */
-   prvWriteMACFCR( heth, tmpreg );
+            /* Get the ETHERNET MACFCR value */
+            tmpreg = heth->Instance->MACFCR;
+            /* Clear xx bits */
+            tmpreg &= ETH_MACFCR_CLEAR_MASK;
 
-   /*----------------------- ETHERNET MACVLANTR Configuration ----------------*/
-   /* Set the ETV bit according to ETH VLANTagComparison value */
-   /* Set the VL bit according to ETH VLANTagIdentifier value */
-   heth->Instance->MACVLANTR = (uint32_t)(macinit.VLANTagComparison |
-                                            macinit.VLANTagIdentifier);
+            /* Set the PT bit according to ETH PauseTime value */
+            /* Set the DZPQ bit according to ETH ZeroQuantaPause value */
+            /* Set the PLT bit according to ETH PauseLowThreshold value */
+            /* Set the UP bit according to ETH UnicastPauseFrameDetect value */
+            /* Set the RFE bit according to ETH ReceiveFlowControl value */
+            /* Set the TFE bit according to ETH TransmitFlowControl value */
+            tmpreg |= ( uint32_t ) ( ( macinit.PauseTime << 16 ) |
+                                     macinit.ZeroQuantaPause |
+                                     macinit.PauseLowThreshold |
+                                     macinit.UnicastPauseFrameDetect |
+                                     macinit.ReceiveFlowControl |
+                                     macinit.TransmitFlowControl );
 
-    /* Wait until the write operation will be taken into account:
-       at least four TX_CLK/RX_CLK clock cycles */
-    tmpreg = heth->Instance->MACVLANTR;
-    vRegisterDelay();
-    heth->Instance->MACVLANTR = tmpreg;
+            /* Write to ETHERNET MACFCR */
+            prvWriteMACFCR( heth, tmpreg );
 
-    /* Ethernet DMA default initialization ************************************/
-    dmainit.DropTCPIPChecksumErrorFrame = ETH_DROPTCPIPCHECKSUMERRORFRAME_ENABLE;
-    dmainit.ReceiveStoreForward = ETH_RECEIVESTOREFORWARD_ENABLE;
-    dmainit.FlushReceivedFrame = ETH_FLUSHRECEIVEDFRAME_ENABLE;
-    dmainit.TransmitStoreForward = ETH_TRANSMITSTOREFORWARD_ENABLE;
-    dmainit.TransmitThresholdControl = ETH_TRANSMITTHRESHOLDCONTROL_64BYTES;
-    dmainit.ForwardErrorFrames = ETH_FORWARDERRORFRAMES_DISABLE;
-    dmainit.ForwardUndersizedGoodFrames = ETH_FORWARDUNDERSIZEDGOODFRAMES_DISABLE;
-    dmainit.ReceiveThresholdControl = ETH_RECEIVEDTHRESHOLDCONTROL_64BYTES;
-    dmainit.SecondFrameOperate = ETH_SECONDFRAMEOPERARTE_ENABLE;
-    dmainit.AddressAlignedBeats = ETH_ADDRESSALIGNEDBEATS_ENABLE;
-    dmainit.FixedBurst = ETH_FIXEDBURST_ENABLE;
-    dmainit.RxDMABurstLength = ETH_RXDMABURSTLENGTH_32BEAT;
-    dmainit.TxDMABurstLength = ETH_TXDMABURSTLENGTH_32BEAT;
-    dmainit.EnhancedDescriptorFormat = ETH_DMAENHANCEDDESCRIPTOR_ENABLE;
-    dmainit.DescriptorSkipLength = 0x0uL;
-    dmainit.DMAArbitration = ETH_DMAARBITRATION_ROUNDROBIN_RXTX_1_1;
+            /*----------------------- ETHERNET MACVLANTR Configuration ----------------*/
+            /* Set the ETV bit according to ETH VLANTagComparison value */
+            /* Set the VL bit according to ETH VLANTagIdentifier value */
+            heth->Instance->MACVLANTR = ( uint32_t ) ( macinit.VLANTagComparison |
+                                                       macinit.VLANTagIdentifier );
 
-    /* Get the ETHERNET DMAOMR value */
-    tmpreg = heth->Instance->DMAOMR;
-    /* Clear xx bits */
-    tmpreg &= ETH_DMAOMR_CLEAR_MASK;
+            /* Wait until the write operation will be taken into account:
+             * at least four TX_CLK/RX_CLK clock cycles */
+            tmpreg = heth->Instance->MACVLANTR;
+            vRegisterDelay();
+            heth->Instance->MACVLANTR = tmpreg;
 
-    /* Set the DT bit according to ETH DropTCPIPChecksumErrorFrame value */
-    /* Set the RSF bit according to ETH ReceiveStoreForward value */
-    /* Set the DFF bit according to ETH FlushReceivedFrame value */
-    /* Set the TSF bit according to ETH TransmitStoreForward value */
-    /* Set the TTC bit according to ETH TransmitThresholdControl value */
-    /* Set the FEF bit according to ETH ForwardErrorFrames value */
-    /* Set the FUF bit according to ETH ForwardUndersizedGoodFrames value */
-    /* Set the RTC bit according to ETH ReceiveThresholdControl value */
-    /* Set the OSF bit according to ETH SecondFrameOperate value */
-    tmpreg |= (uint32_t)(dmainit.DropTCPIPChecksumErrorFrame |
-                         dmainit.ReceiveStoreForward |
-                         dmainit.FlushReceivedFrame |
-                         dmainit.TransmitStoreForward |
-                         dmainit.TransmitThresholdControl |
-                         dmainit.ForwardErrorFrames |
-                         dmainit.ForwardUndersizedGoodFrames |
-                         dmainit.ReceiveThresholdControl |
-                         dmainit.SecondFrameOperate);
+            /* Ethernet DMA default initialization ************************************/
+            dmainit.DropTCPIPChecksumErrorFrame = ETH_DROPTCPIPCHECKSUMERRORFRAME_ENABLE;
+            dmainit.ReceiveStoreForward = ETH_RECEIVESTOREFORWARD_ENABLE;
+            dmainit.FlushReceivedFrame = ETH_FLUSHRECEIVEDFRAME_ENABLE;
+            dmainit.TransmitStoreForward = ETH_TRANSMITSTOREFORWARD_ENABLE;
+            dmainit.TransmitThresholdControl = ETH_TRANSMITTHRESHOLDCONTROL_64BYTES;
+            dmainit.ForwardErrorFrames = ETH_FORWARDERRORFRAMES_DISABLE;
+            dmainit.ForwardUndersizedGoodFrames = ETH_FORWARDUNDERSIZEDGOODFRAMES_DISABLE;
+            dmainit.ReceiveThresholdControl = ETH_RECEIVEDTHRESHOLDCONTROL_64BYTES;
+            dmainit.SecondFrameOperate = ETH_SECONDFRAMEOPERARTE_ENABLE;
+            dmainit.AddressAlignedBeats = ETH_ADDRESSALIGNEDBEATS_ENABLE;
+            dmainit.FixedBurst = ETH_FIXEDBURST_ENABLE;
+            dmainit.RxDMABurstLength = ETH_RXDMABURSTLENGTH_32BEAT;
+            dmainit.TxDMABurstLength = ETH_TXDMABURSTLENGTH_32BEAT;
+            dmainit.EnhancedDescriptorFormat = ETH_DMAENHANCEDDESCRIPTOR_ENABLE;
+            dmainit.DescriptorSkipLength = 0x0uL;
+            dmainit.DMAArbitration = ETH_DMAARBITRATION_ROUNDROBIN_RXTX_1_1;
 
-    /* Write to ETHERNET DMAOMR */
-    prvWriteDMAOMR( heth, tmpreg );
+            /* Get the ETHERNET DMAOMR value */
+            tmpreg = heth->Instance->DMAOMR;
+            /* Clear xx bits */
+            tmpreg &= ETH_DMAOMR_CLEAR_MASK;
 
-    /*----------------------- ETHERNET DMABMR Configuration ------------------*/
-    /* Set the AAL bit according to ETH AddressAlignedBeats value */
-    /* Set the FB bit according to ETH FixedBurst value */
-    /* Set the RPBL and 4*PBL bits according to ETH RxDMABurstLength value */
-    /* Set the PBL and 4*PBL bits according to ETH TxDMABurstLength value */
-    /* Set the Enhanced DMA descriptors bit according to ETH EnhancedDescriptorFormat value*/
-    /* Set the DSL bit according to ETH DesciptorSkipLength value */
-    /* Set the PR and DA bits according to ETH DMAArbitration value */
-    heth->Instance->DMABMR = (uint32_t)(dmainit.AddressAlignedBeats |
-                                          dmainit.FixedBurst |
-                                          dmainit.RxDMABurstLength |    /* !! if 4xPBL is selected for Tx or Rx it is applied for the other */
-                                          dmainit.TxDMABurstLength |
-                                          dmainit.EnhancedDescriptorFormat |
-                                          (dmainit.DescriptorSkipLength << 2) |
-                                          dmainit.DMAArbitration |
-                                          ETH_DMABMR_USP); /* Enable use of separate PBL for Rx and Tx */
+            /* Set the DT bit according to ETH DropTCPIPChecksumErrorFrame value */
+            /* Set the RSF bit according to ETH ReceiveStoreForward value */
+            /* Set the DFF bit according to ETH FlushReceivedFrame value */
+            /* Set the TSF bit according to ETH TransmitStoreForward value */
+            /* Set the TTC bit according to ETH TransmitThresholdControl value */
+            /* Set the FEF bit according to ETH ForwardErrorFrames value */
+            /* Set the FUF bit according to ETH ForwardUndersizedGoodFrames value */
+            /* Set the RTC bit according to ETH ReceiveThresholdControl value */
+            /* Set the OSF bit according to ETH SecondFrameOperate value */
+            tmpreg |= ( uint32_t ) ( dmainit.DropTCPIPChecksumErrorFrame |
+                                     dmainit.ReceiveStoreForward |
+                                     dmainit.FlushReceivedFrame |
+                                     dmainit.TransmitStoreForward |
+                                     dmainit.TransmitThresholdControl |
+                                     dmainit.ForwardErrorFrames |
+                                     dmainit.ForwardUndersizedGoodFrames |
+                                     dmainit.ReceiveThresholdControl |
+                                     dmainit.SecondFrameOperate );
 
-     /* Wait until the write operation will be taken into account:
-        at least four TX_CLK/RX_CLK clock cycles */
-     tmpreg = heth->Instance->DMABMR;
-     vRegisterDelay();
-     heth->Instance->DMABMR = tmpreg;
+            /* Write to ETHERNET DMAOMR */
+            prvWriteDMAOMR( heth, tmpreg );
 
-     if(heth->Init.RxMode == ETH_RXINTERRUPT_MODE)
-     {
-       /* Enable the Ethernet Rx Interrupt */
-       __HAL_ETH_DMA_ENABLE_IT(( heth ), ETH_DMA_IT_NIS | ETH_DMA_IT_R);
-     }
+            /*----------------------- ETHERNET DMABMR Configuration ------------------*/
+            /* Set the AAL bit according to ETH AddressAlignedBeats value */
+            /* Set the FB bit according to ETH FixedBurst value */
+            /* Set the RPBL and 4*PBL bits according to ETH RxDMABurstLength value */
+            /* Set the PBL and 4*PBL bits according to ETH TxDMABurstLength value */
+            /* Set the Enhanced DMA descriptors bit according to ETH EnhancedDescriptorFormat value*/
+            /* Set the DSL bit according to ETH DesciptorSkipLength value */
+            /* Set the PR and DA bits according to ETH DMAArbitration value */
+            heth->Instance->DMABMR = ( uint32_t ) ( dmainit.AddressAlignedBeats |
+                                                    dmainit.FixedBurst |
+                                                    dmainit.RxDMABurstLength | /* !! if 4xPBL is selected for Tx or Rx it is applied for the other */
+                                                    dmainit.TxDMABurstLength |
+                                                    dmainit.EnhancedDescriptorFormat |
+                                                    ( dmainit.DescriptorSkipLength << 2 ) |
+                                                    dmainit.DMAArbitration |
+                                                    ETH_DMABMR_USP ); /* Enable use of separate PBL for Rx and Tx */
 
-     /* Initialize MAC address in ethernet MAC */
-     ETH_MACAddressConfig(heth, ETH_MAC_ADDRESS0, heth->Init.MACAddr);
-}
+            /* Wait until the write operation will be taken into account:
+             * at least four TX_CLK/RX_CLK clock cycles */
+            tmpreg = heth->Instance->DMABMR;
+            vRegisterDelay();
+            heth->Instance->DMABMR = tmpreg;
 
-/**
-  * @brief  Configures the selected MAC address.
-  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
-  *         the configuration information for ETHERNET module
-  * @param  MacAddr: The MAC address to configure
-  *          This parameter can be one of the following values:
-  *             @arg ETH_MAC_Address0: MAC Address0
-  *             @arg ETH_MAC_Address1: MAC Address1
-  *             @arg ETH_MAC_Address2: MAC Address2
-  *             @arg ETH_MAC_Address3: MAC Address3
-  * @param  Addr: Pointer to MAC address buffer data (6 bytes)
-  * @retval HAL status
-  */
-static void ETH_MACAddressConfig(ETH_HandleTypeDef *heth, uint32_t MacAddr, uint8_t *Addr)
-{
-	uint32_t tmpreg;
+            if( heth->Init.RxMode == ETH_RXINTERRUPT_MODE )
+            {
+                /* Enable the Ethernet Rx Interrupt */
+                __HAL_ETH_DMA_ENABLE_IT( ( heth ), ETH_DMA_IT_NIS | ETH_DMA_IT_R );
+            }
 
-	( void ) heth;
-
-	/* Check the parameters */
-	assert_param( IS_ETH_MAC_ADDRESS0123( MacAddr ) );
-
-	/* Calculate the selected MAC address high register */
-	/* Register ETH_MACA0HR: Bit 31 MO: Always 1. */
-	tmpreg = 0x80000000uL | ( ( uint32_t )Addr[ 5 ] << 8) | (uint32_t)Addr[ 4 ];
-	/* Load the selected MAC address high register */
-	( * ( __IO uint32_t * ) ( ( uint32_t ) ( ETH_MAC_ADDR_HBASE + MacAddr ) ) ) = tmpreg;
-	/* Calculate the selected MAC address low register */
-	tmpreg = ( ( uint32_t )Addr[ 3 ] << 24 ) | ( ( uint32_t )Addr[ 2 ] << 16 ) | ( ( uint32_t )Addr[ 1 ] << 8 ) | Addr[ 0 ];
-
-	/* Load the selected MAC address low register */
-	( * ( __IO uint32_t * ) ( ( uint32_t ) ( ETH_MAC_ADDR_LBASE + MacAddr ) ) ) = tmpreg;
-}
+            /* Initialize MAC address in ethernet MAC */
+            ETH_MACAddressConfig( heth, ETH_MAC_ADDRESS0, heth->Init.MACAddr );
+        }
 
 /**
-  * @brief  Enables the MAC transmission.
-  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
-  *         the configuration information for ETHERNET module
-  * @retval None
-  */
-static void ETH_MACTransmissionEnable(ETH_HandleTypeDef *heth)
-{
-	uint32_t tmpreg = heth->Instance->MACCR | ETH_MACCR_TE;
+ * @brief  Configures the selected MAC address.
+ * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
+ *         the configuration information for ETHERNET module
+ * @param  MacAddr: The MAC address to configure
+ *          This parameter can be one of the following values:
+ *             @arg ETH_MAC_Address0: MAC Address0
+ *             @arg ETH_MAC_Address1: MAC Address1
+ *             @arg ETH_MAC_Address2: MAC Address2
+ *             @arg ETH_MAC_Address3: MAC Address3
+ * @param  Addr: Pointer to MAC address buffer data (6 bytes)
+ * @retval HAL status
+ */
+        static void ETH_MACAddressConfig( ETH_HandleTypeDef * heth,
+                                          uint32_t MacAddr,
+                                          uint8_t * Addr )
+        {
+            uint32_t tmpreg;
 
-	prvWriteMACCR( heth, tmpreg );
-}
+            ( void ) heth;
 
-/**
-  * @brief  Disables the MAC transmission.
-  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
-  *         the configuration information for ETHERNET module
-  * @retval None
-  */
-static void ETH_MACTransmissionDisable(ETH_HandleTypeDef *heth)
-{
-	uint32_t tmpreg = heth->Instance->MACCR & ~( ETH_MACCR_TE );
+            /* Check the parameters */
+            assert_param( IS_ETH_MAC_ADDRESS0123( MacAddr ) );
 
-	prvWriteMACCR( heth, tmpreg );
-}
+            /* Calculate the selected MAC address high register */
+            /* Register ETH_MACA0HR: Bit 31 MO: Always 1. */
+            tmpreg = 0x80000000uL | ( ( uint32_t ) Addr[ 5 ] << 8 ) | ( uint32_t ) Addr[ 4 ];
+            /* Load the selected MAC address high register */
+            ( *( __IO uint32_t * ) ( ( uint32_t ) ( ETH_MAC_ADDR_HBASE + MacAddr ) ) ) = tmpreg;
+            /* Calculate the selected MAC address low register */
+            tmpreg = ( ( uint32_t ) Addr[ 3 ] << 24 ) | ( ( uint32_t ) Addr[ 2 ] << 16 ) | ( ( uint32_t ) Addr[ 1 ] << 8 ) | Addr[ 0 ];
 
-/**
-  * @brief  Enables the MAC reception.
-  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
-  *         the configuration information for ETHERNET module
-  * @retval None
-  */
-static void ETH_MACReceptionEnable(ETH_HandleTypeDef *heth)
-{
-	__IO uint32_t tmpreg = heth->Instance->MACCR | ETH_MACCR_RE;
-
-	prvWriteMACCR( heth, tmpreg );
-}
+            /* Load the selected MAC address low register */
+            ( *( __IO uint32_t * ) ( ( uint32_t ) ( ETH_MAC_ADDR_LBASE + MacAddr ) ) ) = tmpreg;
+        }
 
 /**
-  * @brief  Disables the MAC reception.
-  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
-  *         the configuration information for ETHERNET module
-  * @retval None
-  */
-static void ETH_MACReceptionDisable(ETH_HandleTypeDef *heth)
-{
-	__IO uint32_t tmpreg = heth->Instance->MACCR & ~( ETH_MACCR_RE );
+ * @brief  Enables the MAC transmission.
+ * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
+ *         the configuration information for ETHERNET module
+ * @retval None
+ */
+        static void ETH_MACTransmissionEnable( ETH_HandleTypeDef * heth )
+        {
+            uint32_t tmpreg = heth->Instance->MACCR | ETH_MACCR_TE;
 
-	prvWriteMACCR( heth, tmpreg );
-}
-
-/**
-  * @brief  Enables the DMA transmission.
-  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
-  *         the configuration information for ETHERNET module
-  * @retval None
-  */
-static void ETH_DMATransmissionEnable(ETH_HandleTypeDef *heth)
-{
-	/* Enable the DMA transmission */
-	__IO uint32_t tmpreg = heth->Instance->DMAOMR | ETH_DMAOMR_ST;
-
-	prvWriteDMAOMR( heth, tmpreg );
-}
+            prvWriteMACCR( heth, tmpreg );
+        }
 
 /**
-  * @brief  Disables the DMA transmission.
-  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
-  *         the configuration information for ETHERNET module
-  * @retval None
-  */
-static void ETH_DMATransmissionDisable(ETH_HandleTypeDef *heth)
-{
-	/* Disable the DMA transmission */
-	__IO uint32_t tmpreg = heth->Instance->DMAOMR & ~( ETH_DMAOMR_ST );
+ * @brief  Disables the MAC transmission.
+ * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
+ *         the configuration information for ETHERNET module
+ * @retval None
+ */
+        static void ETH_MACTransmissionDisable( ETH_HandleTypeDef * heth )
+        {
+            uint32_t tmpreg = heth->Instance->MACCR & ~( ETH_MACCR_TE );
 
-	prvWriteDMAOMR( heth, tmpreg );
-}
-
-/**
-  * @brief  Enables the DMA reception.
-  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
-  *         the configuration information for ETHERNET module
-  * @retval None
-  */
-static void ETH_DMAReceptionEnable(ETH_HandleTypeDef *heth)
-{
-	/* Enable the DMA reception */
-	__IO uint32_t tmpreg = heth->Instance->DMAOMR | ETH_DMAOMR_SR;
-
-	prvWriteDMAOMR( heth, tmpreg );
-}
+            prvWriteMACCR( heth, tmpreg );
+        }
 
 /**
-  * @brief  Disables the DMA reception.
-  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
-  *         the configuration information for ETHERNET module
-  * @retval None
-  */
-static void ETH_DMAReceptionDisable(ETH_HandleTypeDef *heth)
-{
-	/* Disable the DMA reception */
-	__IO uint32_t tmpreg = heth->Instance->DMAOMR & ~( ETH_DMAOMR_SR );
+ * @brief  Enables the MAC reception.
+ * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
+ *         the configuration information for ETHERNET module
+ * @retval None
+ */
+        static void ETH_MACReceptionEnable( ETH_HandleTypeDef * heth )
+        {
+            __IO uint32_t tmpreg = heth->Instance->MACCR | ETH_MACCR_RE;
 
-	prvWriteDMAOMR( heth, tmpreg );
-}
-
-/**
-  * @brief  Clears the ETHERNET transmit FIFO.
-  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
-  *         the configuration information for ETHERNET module
-  * @retval None
-  */
-static void ETH_FlushTransmitFIFO(ETH_HandleTypeDef *heth)
-{
-	/* Set the Flush Transmit FIFO bit */
-	__IO uint32_t tmpreg = heth->Instance->DMAOMR | ETH_DMAOMR_FTF;
-
-	prvWriteDMAOMR( heth, tmpreg );
-}
+            prvWriteMACCR( heth, tmpreg );
+        }
 
 /**
-  * @}
-  */
-#endif /* stm_is_F2 != 0 || stm_is_F4 != 0 || stm_is_F7 */
+ * @brief  Disables the MAC reception.
+ * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
+ *         the configuration information for ETHERNET module
+ * @retval None
+ */
+        static void ETH_MACReceptionDisable( ETH_HandleTypeDef * heth )
+        {
+            __IO uint32_t tmpreg = heth->Instance->MACCR & ~( ETH_MACCR_RE );
+
+            prvWriteMACCR( heth, tmpreg );
+        }
+
+/**
+ * @brief  Enables the DMA transmission.
+ * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
+ *         the configuration information for ETHERNET module
+ * @retval None
+ */
+        static void ETH_DMATransmissionEnable( ETH_HandleTypeDef * heth )
+        {
+            /* Enable the DMA transmission */
+            __IO uint32_t tmpreg = heth->Instance->DMAOMR | ETH_DMAOMR_ST;
+
+            prvWriteDMAOMR( heth, tmpreg );
+        }
+
+/**
+ * @brief  Disables the DMA transmission.
+ * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
+ *         the configuration information for ETHERNET module
+ * @retval None
+ */
+        static void ETH_DMATransmissionDisable( ETH_HandleTypeDef * heth )
+        {
+            /* Disable the DMA transmission */
+            __IO uint32_t tmpreg = heth->Instance->DMAOMR & ~( ETH_DMAOMR_ST );
+
+            prvWriteDMAOMR( heth, tmpreg );
+        }
+
+/**
+ * @brief  Enables the DMA reception.
+ * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
+ *         the configuration information for ETHERNET module
+ * @retval None
+ */
+        static void ETH_DMAReceptionEnable( ETH_HandleTypeDef * heth )
+        {
+            /* Enable the DMA reception */
+            __IO uint32_t tmpreg = heth->Instance->DMAOMR | ETH_DMAOMR_SR;
+
+            prvWriteDMAOMR( heth, tmpreg );
+        }
+
+/**
+ * @brief  Disables the DMA reception.
+ * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
+ *         the configuration information for ETHERNET module
+ * @retval None
+ */
+        static void ETH_DMAReceptionDisable( ETH_HandleTypeDef * heth )
+        {
+            /* Disable the DMA reception */
+            __IO uint32_t tmpreg = heth->Instance->DMAOMR & ~( ETH_DMAOMR_SR );
+
+            prvWriteDMAOMR( heth, tmpreg );
+        }
+
+/**
+ * @brief  Clears the ETHERNET transmit FIFO.
+ * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
+ *         the configuration information for ETHERNET module
+ * @retval None
+ */
+        static void ETH_FlushTransmitFIFO( ETH_HandleTypeDef * heth )
+        {
+            /* Set the Flush Transmit FIFO bit */
+            __IO uint32_t tmpreg = heth->Instance->DMAOMR | ETH_DMAOMR_FTF;
+
+            prvWriteDMAOMR( heth, tmpreg );
+        }
+
+/**
+ * @}
+ */
+    #endif /* stm_is_F2 != 0 || stm_is_F4 != 0 || stm_is_F7 */
 
 #endif /* HAL_ETH_MODULE_ENABLED */
-/**
-  * @}
-  */
 
 /**
-  * @}
-  */
+ * @}
+ */
+
+/**
+ * @}
+ */
 
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/portable/NetworkInterface/STM32Fxx/stm32fxx_hal_eth.h
+++ b/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/portable/NetworkInterface/STM32Fxx/stm32fxx_hal_eth.h
@@ -1,2260 +1,2406 @@
 /**
-  ******************************************************************************
-  * @file    stm32fxx_hal_eth.h
-  * @author  MCD Application Team
-  * @version V1.2.2
-  * @date    14-April-2017
-  * @brief   Header file of ETH HAL module.
-  ******************************************************************************
-  * @attention
-  *
-  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
-  *
-  * Redistribution and use in source and binary forms, with or without modification,
-  * are permitted provided that the following conditions are met:
-  *   1. Redistributions of source code must retain the above copyright notice,
-  *      this list of conditions and the following disclaimer.
-  *   2. Redistributions in binary form must reproduce the above copyright notice,
-  *      this list of conditions and the following disclaimer in the documentation
-  *      and/or other materials provided with the distribution.
-  *   3. Neither the name of STMicroelectronics nor the names of its contributors
-  *      may be used to endorse or promote products derived from this software
-  *      without specific prior written permission.
-  *
-  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-  *
-  ******************************************************************************
-  */
+ ******************************************************************************
+ * @file    stm32fxx_hal_eth.h
+ * @author  MCD Application Team
+ * @version V1.2.2
+ * @date    14-April-2017
+ * @brief   Header file of ETH HAL module.
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright notice,
+ *      this list of conditions and the following disclaimer in the documentation
+ *      and/or other materials provided with the distribution.
+ *   3. Neither the name of STMicroelectronics nor the names of its contributors
+ *      may be used to endorse or promote products derived from this software
+ *      without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************
+ */
 
 /* Define to prevent recursive inclusion -------------------------------------*/
 #ifndef __STM32Fxx_HAL_ETH_H
-#define __STM32Fxx_HAL_ETH_H
+    #define __STM32Fxx_HAL_ETH_H
 
 /* make sure that the original ETH headers files won't be included after this. */
-#define __STM32F2xx_HAL_ETH_H
-#define __STM32F4xx_HAL_ETH_H
-#define __STM32F7xx_HAL_ETH_H
+    #define __STM32F2xx_HAL_ETH_H
+    #define __STM32F4xx_HAL_ETH_H
+    #define __STM32F7xx_HAL_ETH_H
 
-#if defined(STM32F7xx)
-	#include "stm32f7xx_hal_def.h"
-#elif defined(STM32F407xx) || defined(STM32F417xx) || defined(STM32F427xx) || defined(STM32F437xx) || defined(STM32F429xx) || defined(STM32F439xx)
-	#include "stm32f4xx_hal_def.h"
-#elif defined(STM32F2xx)
-	#include "stm32f2xx_hal_def.h"
-#endif
+    #if defined( STM32F7xx )
+        #include "stm32f7xx_hal_def.h"
+    #elif defined( STM32F407xx ) || defined( STM32F417xx ) || defined( STM32F427xx ) || defined( STM32F437xx ) || defined( STM32F429xx ) || defined( STM32F439xx )
+        #include "stm32f4xx_hal_def.h"
+    #elif defined( STM32F2xx )
+        #include "stm32f2xx_hal_def.h"
+    #endif
 
-#ifdef __cplusplus
- extern "C" {
-#endif
+    #ifdef __cplusplus
+        extern "C" {
+    #endif
 
 /** @addtogroup STM32Fxx_HAL_Driver
-  * @{
-  */
+ * @{
+ */
 
 /** @addtogroup ETH
-  * @{
-  */
+ * @{
+ */
 
 /** @addtogroup ETH_Private_Macros
-  * @{
-  */
-#define IS_ETH_PHY_ADDRESS(ADDRESS) ((ADDRESS) <= 0x20)
-#define IS_ETH_AUTONEGOTIATION(CMD) (((CMD) == ETH_AUTONEGOTIATION_ENABLE) || \
-                                     ((CMD) == ETH_AUTONEGOTIATION_DISABLE))
-#define IS_ETH_SPEED(SPEED) (((SPEED) == ETH_SPEED_10M) || \
-                             ((SPEED) == ETH_SPEED_100M))
-#define IS_ETH_DUPLEX_MODE(MODE)  (((MODE) == ETH_MODE_FULLDUPLEX) || \
-                                  ((MODE) == ETH_MODE_HALFDUPLEX))
-#define IS_ETH_DUPLEX_MODE(MODE)  (((MODE) == ETH_MODE_FULLDUPLEX) || \
-                                  ((MODE) == ETH_MODE_HALFDUPLEX))
-#define IS_ETH_RX_MODE(MODE)    (((MODE) == ETH_RXPOLLING_MODE) || \
-                                 ((MODE) == ETH_RXINTERRUPT_MODE))
-#define IS_ETH_RX_MODE(MODE)    (((MODE) == ETH_RXPOLLING_MODE) || \
-                                 ((MODE) == ETH_RXINTERRUPT_MODE))
-#define IS_ETH_RX_MODE(MODE)    (((MODE) == ETH_RXPOLLING_MODE) || \
-                                 ((MODE) == ETH_RXINTERRUPT_MODE))
-#define IS_ETH_CHECKSUM_MODE(MODE)    (((MODE) == ETH_CHECKSUM_BY_HARDWARE) || \
-                                      ((MODE) == ETH_CHECKSUM_BY_SOFTWARE))
-#define IS_ETH_MEDIA_INTERFACE(MODE)         (((MODE) == ETH_MEDIA_INTERFACE_MII) || \
-                                              ((MODE) == ETH_MEDIA_INTERFACE_RMII))
-#define IS_ETH_WATCHDOG(CMD) (((CMD) == ETH_WATCHDOG_ENABLE) || \
-                              ((CMD) == ETH_WATCHDOG_DISABLE))
-#define IS_ETH_JABBER(CMD) (((CMD) == ETH_JABBER_ENABLE) || \
-                            ((CMD) == ETH_JABBER_DISABLE))
-#define IS_ETH_INTER_FRAME_GAP(GAP) (((GAP) == ETH_INTERFRAMEGAP_96BIT) || \
-                                     ((GAP) == ETH_INTERFRAMEGAP_88BIT) || \
-                                     ((GAP) == ETH_INTERFRAMEGAP_80BIT) || \
-                                     ((GAP) == ETH_INTERFRAMEGAP_72BIT) || \
-                                     ((GAP) == ETH_INTERFRAMEGAP_64BIT) || \
-                                     ((GAP) == ETH_INTERFRAMEGAP_56BIT) || \
-                                     ((GAP) == ETH_INTERFRAMEGAP_48BIT) || \
-                                     ((GAP) == ETH_INTERFRAMEGAP_40BIT))
-#define IS_ETH_CARRIER_SENSE(CMD) (((CMD) == ETH_CARRIERSENCE_ENABLE) || \
-                                   ((CMD) == ETH_CARRIERSENCE_DISABLE))
-#define IS_ETH_RECEIVE_OWN(CMD) (((CMD) == ETH_RECEIVEOWN_ENABLE) || \
-                                 ((CMD) == ETH_RECEIVEOWN_DISABLE))
-#define IS_ETH_LOOPBACK_MODE(CMD) (((CMD) == ETH_LOOPBACKMODE_ENABLE) || \
-                                   ((CMD) == ETH_LOOPBACKMODE_DISABLE))
-#define IS_ETH_CHECKSUM_OFFLOAD(CMD) (((CMD) == ETH_CHECKSUMOFFLAOD_ENABLE) || \
-                                      ((CMD) == ETH_CHECKSUMOFFLAOD_DISABLE))
-#define IS_ETH_RETRY_TRANSMISSION(CMD) (((CMD) == ETH_RETRYTRANSMISSION_ENABLE) || \
-                                        ((CMD) == ETH_RETRYTRANSMISSION_DISABLE))
-#define IS_ETH_AUTOMATIC_PADCRC_STRIP(CMD) (((CMD) == ETH_AUTOMATICPADCRCSTRIP_ENABLE) || \
-                                            ((CMD) == ETH_AUTOMATICPADCRCSTRIP_DISABLE))
-#define IS_ETH_BACKOFF_LIMIT(LIMIT) (((LIMIT) == ETH_BACKOFFLIMIT_10) || \
-                                     ((LIMIT) == ETH_BACKOFFLIMIT_8) || \
-                                     ((LIMIT) == ETH_BACKOFFLIMIT_4) || \
-                                     ((LIMIT) == ETH_BACKOFFLIMIT_1))
-#define IS_ETH_DEFERRAL_CHECK(CMD) (((CMD) == ETH_DEFFERRALCHECK_ENABLE) || \
-                                    ((CMD) == ETH_DEFFERRALCHECK_DISABLE))
-#define IS_ETH_RECEIVE_ALL(CMD) (((CMD) == ETH_RECEIVEALL_ENABLE) || \
-                                 ((CMD) == ETH_RECEIVEAll_DISABLE))
-#define IS_ETH_SOURCE_ADDR_FILTER(CMD) (((CMD) == ETH_SOURCEADDRFILTER_NORMAL_ENABLE) || \
-                                        ((CMD) == ETH_SOURCEADDRFILTER_INVERSE_ENABLE) || \
-                                        ((CMD) == ETH_SOURCEADDRFILTER_DISABLE))
-#define IS_ETH_CONTROL_FRAMES(PASS) (((PASS) == ETH_PASSCONTROLFRAMES_BLOCKALL) || \
-                                     ((PASS) == ETH_PASSCONTROLFRAMES_FORWARDALL) || \
-                                     ((PASS) == ETH_PASSCONTROLFRAMES_FORWARDPASSEDADDRFILTER))
-#define IS_ETH_BROADCAST_FRAMES_RECEPTION(CMD) (((CMD) == ETH_BROADCASTFRAMESRECEPTION_ENABLE) || \
-                                                ((CMD) == ETH_BROADCASTFRAMESRECEPTION_DISABLE))
-#define IS_ETH_DESTINATION_ADDR_FILTER(FILTER) (((FILTER) == ETH_DESTINATIONADDRFILTER_NORMAL) || \
-                                                ((FILTER) == ETH_DESTINATIONADDRFILTER_INVERSE))
-#define IS_ETH_PROMISCUOUS_MODE(CMD) (((CMD) == ETH_PROMISCUOUS_MODE_ENABLE) || \
-                                      ((CMD) == ETH_PROMISCUOUS_MODE_DISABLE))
-#define IS_ETH_MULTICAST_FRAMES_FILTER(FILTER) (((FILTER) == ETH_MULTICASTFRAMESFILTER_PERFECTHASHTABLE) || \
-                                                ((FILTER) == ETH_MULTICASTFRAMESFILTER_HASHTABLE) || \
-                                                ((FILTER) == ETH_MULTICASTFRAMESFILTER_PERFECT) || \
-                                                ((FILTER) == ETH_MULTICASTFRAMESFILTER_NONE))
-#define IS_ETH_UNICAST_FRAMES_FILTER(FILTER) (((FILTER) == ETH_UNICASTFRAMESFILTER_PERFECTHASHTABLE) || \
-                                              ((FILTER) == ETH_UNICASTFRAMESFILTER_HASHTABLE) || \
-                                              ((FILTER) == ETH_UNICASTFRAMESFILTER_PERFECT))
-#define IS_ETH_PAUSE_TIME(TIME) ((TIME) <= 0xFFFF)
-#define IS_ETH_ZEROQUANTA_PAUSE(CMD)   (((CMD) == ETH_ZEROQUANTAPAUSE_ENABLE) || \
-                                        ((CMD) == ETH_ZEROQUANTAPAUSE_DISABLE))
-#define IS_ETH_PAUSE_LOW_THRESHOLD(THRESHOLD) (((THRESHOLD) == ETH_PAUSELOWTHRESHOLD_MINUS4) || \
-                                               ((THRESHOLD) == ETH_PAUSELOWTHRESHOLD_MINUS28) || \
-                                               ((THRESHOLD) == ETH_PAUSELOWTHRESHOLD_MINUS144) || \
-                                               ((THRESHOLD) == ETH_PAUSELOWTHRESHOLD_MINUS256))
-#define IS_ETH_UNICAST_PAUSE_FRAME_DETECT(CMD) (((CMD) == ETH_UNICASTPAUSEFRAMEDETECT_ENABLE) || \
-                                                ((CMD) == ETH_UNICASTPAUSEFRAMEDETECT_DISABLE))
-#define IS_ETH_RECEIVE_FLOWCONTROL(CMD) (((CMD) == ETH_RECEIVEFLOWCONTROL_ENABLE) || \
-                                         ((CMD) == ETH_RECEIVEFLOWCONTROL_DISABLE))
-#define IS_ETH_TRANSMIT_FLOWCONTROL(CMD) (((CMD) == ETH_TRANSMITFLOWCONTROL_ENABLE) || \
-                                          ((CMD) == ETH_TRANSMITFLOWCONTROL_DISABLE))
-#define IS_ETH_VLAN_TAG_COMPARISON(COMPARISON) (((COMPARISON) == ETH_VLANTAGCOMPARISON_12BIT) || \
-                                                ((COMPARISON) == ETH_VLANTAGCOMPARISON_16BIT))
-#define IS_ETH_VLAN_TAG_IDENTIFIER(IDENTIFIER) ((IDENTIFIER) <= 0xFFFF)
-#define IS_ETH_MAC_ADDRESS0123(ADDRESS) (((ADDRESS) == ETH_MAC_ADDRESS0) || \
-                                         ((ADDRESS) == ETH_MAC_ADDRESS1) || \
-                                         ((ADDRESS) == ETH_MAC_ADDRESS2) || \
-                                         ((ADDRESS) == ETH_MAC_ADDRESS3))
-#define IS_ETH_MAC_ADDRESS123(ADDRESS) (((ADDRESS) == ETH_MAC_ADDRESS1) || \
-                                        ((ADDRESS) == ETH_MAC_ADDRESS2) || \
-                                        ((ADDRESS) == ETH_MAC_ADDRESS3))
-#define IS_ETH_MAC_ADDRESS_FILTER(FILTER) (((FILTER) == ETH_MAC_ADDRESSFILTER_SA) || \
-                                           ((FILTER) == ETH_MAC_ADDRESSFILTER_DA))
-#define IS_ETH_MAC_ADDRESS_MASK(MASK) (((MASK) == ETH_MAC_ADDRESSMASK_BYTE6) || \
-                                       ((MASK) == ETH_MAC_ADDRESSMASK_BYTE5) || \
-                                       ((MASK) == ETH_MAC_ADDRESSMASK_BYTE4) || \
-                                       ((MASK) == ETH_MAC_ADDRESSMASK_BYTE3) || \
-                                       ((MASK) == ETH_MAC_ADDRESSMASK_BYTE2) || \
-                                       ((MASK) == ETH_MAC_ADDRESSMASK_BYTE1))
-#define IS_ETH_DROP_TCPIP_CHECKSUM_FRAME(CMD) (((CMD) == ETH_DROPTCPIPCHECKSUMERRORFRAME_ENABLE) || \
-                                               ((CMD) == ETH_DROPTCPIPCHECKSUMERRORFRAME_DISABLE))
-#define IS_ETH_RECEIVE_STORE_FORWARD(CMD) (((CMD) == ETH_RECEIVESTOREFORWARD_ENABLE) || \
-                                           ((CMD) == ETH_RECEIVESTOREFORWARD_DISABLE))
-#define IS_ETH_FLUSH_RECEIVE_FRAME(CMD) (((CMD) == ETH_FLUSHRECEIVEDFRAME_ENABLE) || \
-                                         ((CMD) == ETH_FLUSHRECEIVEDFRAME_DISABLE))
-#define IS_ETH_TRANSMIT_STORE_FORWARD(CMD) (((CMD) == ETH_TRANSMITSTOREFORWARD_ENABLE) || \
-                                            ((CMD) == ETH_TRANSMITSTOREFORWARD_DISABLE))
-#define IS_ETH_TRANSMIT_THRESHOLD_CONTROL(THRESHOLD) (((THRESHOLD) == ETH_TRANSMITTHRESHOLDCONTROL_64BYTES) || \
-                                                      ((THRESHOLD) == ETH_TRANSMITTHRESHOLDCONTROL_128BYTES) || \
-                                                      ((THRESHOLD) == ETH_TRANSMITTHRESHOLDCONTROL_192BYTES) || \
-                                                      ((THRESHOLD) == ETH_TRANSMITTHRESHOLDCONTROL_256BYTES) || \
-                                                      ((THRESHOLD) == ETH_TRANSMITTHRESHOLDCONTROL_40BYTES) || \
-                                                      ((THRESHOLD) == ETH_TRANSMITTHRESHOLDCONTROL_32BYTES) || \
-                                                      ((THRESHOLD) == ETH_TRANSMITTHRESHOLDCONTROL_24BYTES) || \
-                                                      ((THRESHOLD) == ETH_TRANSMITTHRESHOLDCONTROL_16BYTES))
-#define IS_ETH_FORWARD_ERROR_FRAMES(CMD) (((CMD) == ETH_FORWARDERRORFRAMES_ENABLE) || \
-                                          ((CMD) == ETH_FORWARDERRORFRAMES_DISABLE))
-#define IS_ETH_FORWARD_UNDERSIZED_GOOD_FRAMES(CMD) (((CMD) == ETH_FORWARDUNDERSIZEDGOODFRAMES_ENABLE) || \
-                                                    ((CMD) == ETH_FORWARDUNDERSIZEDGOODFRAMES_DISABLE))
-#define IS_ETH_RECEIVE_THRESHOLD_CONTROL(THRESHOLD) (((THRESHOLD) == ETH_RECEIVEDTHRESHOLDCONTROL_64BYTES) || \
-                                                     ((THRESHOLD) == ETH_RECEIVEDTHRESHOLDCONTROL_32BYTES) || \
-                                                     ((THRESHOLD) == ETH_RECEIVEDTHRESHOLDCONTROL_96BYTES) || \
-                                                     ((THRESHOLD) == ETH_RECEIVEDTHRESHOLDCONTROL_128BYTES))
-#define IS_ETH_SECOND_FRAME_OPERATE(CMD) (((CMD) == ETH_SECONDFRAMEOPERARTE_ENABLE) || \
-                                          ((CMD) == ETH_SECONDFRAMEOPERARTE_DISABLE))
-#define IS_ETH_ADDRESS_ALIGNED_BEATS(CMD) (((CMD) == ETH_ADDRESSALIGNEDBEATS_ENABLE) || \
-                                           ((CMD) == ETH_ADDRESSALIGNEDBEATS_DISABLE))
-#define IS_ETH_FIXED_BURST(CMD) (((CMD) == ETH_FIXEDBURST_ENABLE) || \
-                                 ((CMD) == ETH_FIXEDBURST_DISABLE))
-#define IS_ETH_RXDMA_BURST_LENGTH(LENGTH) (((LENGTH) == ETH_RXDMABURSTLENGTH_1BEAT) || \
-                                           ((LENGTH) == ETH_RXDMABURSTLENGTH_2BEAT) || \
-                                           ((LENGTH) == ETH_RXDMABURSTLENGTH_4BEAT) || \
-                                           ((LENGTH) == ETH_RXDMABURSTLENGTH_8BEAT) || \
-                                           ((LENGTH) == ETH_RXDMABURSTLENGTH_16BEAT) || \
-                                           ((LENGTH) == ETH_RXDMABURSTLENGTH_32BEAT) || \
-                                           ((LENGTH) == ETH_RXDMABURSTLENGTH_4XPBL_4BEAT) || \
-                                           ((LENGTH) == ETH_RXDMABURSTLENGTH_4XPBL_8BEAT) || \
-                                           ((LENGTH) == ETH_RXDMABURSTLENGTH_4XPBL_16BEAT) || \
-                                           ((LENGTH) == ETH_RXDMABURSTLENGTH_4XPBL_32BEAT) || \
-                                           ((LENGTH) == ETH_RXDMABURSTLENGTH_4XPBL_64BEAT) || \
-                                           ((LENGTH) == ETH_RXDMABURSTLENGTH_4XPBL_128BEAT))
-#define IS_ETH_TXDMA_BURST_LENGTH(LENGTH) (((LENGTH) == ETH_TXDMABURSTLENGTH_1BEAT) || \
-                                           ((LENGTH) == ETH_TXDMABURSTLENGTH_2BEAT) || \
-                                           ((LENGTH) == ETH_TXDMABURSTLENGTH_4BEAT) || \
-                                           ((LENGTH) == ETH_TXDMABURSTLENGTH_8BEAT) || \
-                                           ((LENGTH) == ETH_TXDMABURSTLENGTH_16BEAT) || \
-                                           ((LENGTH) == ETH_TXDMABURSTLENGTH_32BEAT) || \
-                                           ((LENGTH) == ETH_TXDMABURSTLENGTH_4XPBL_4BEAT) || \
-                                           ((LENGTH) == ETH_TXDMABURSTLENGTH_4XPBL_8BEAT) || \
-                                           ((LENGTH) == ETH_TXDMABURSTLENGTH_4XPBL_16BEAT) || \
-                                           ((LENGTH) == ETH_TXDMABURSTLENGTH_4XPBL_32BEAT) || \
-                                           ((LENGTH) == ETH_TXDMABURSTLENGTH_4XPBL_64BEAT) || \
-                                           ((LENGTH) == ETH_TXDMABURSTLENGTH_4XPBL_128BEAT))
-#define IS_ETH_DMA_DESC_SKIP_LENGTH(LENGTH) ((LENGTH) <= 0x1F)
-#define IS_ETH_DMA_ARBITRATION_ROUNDROBIN_RXTX(RATIO) (((RATIO) == ETH_DMAARBITRATION_ROUNDROBIN_RXTX_1_1) || \
-                                                       ((RATIO) == ETH_DMAARBITRATION_ROUNDROBIN_RXTX_2_1) || \
-                                                       ((RATIO) == ETH_DMAARBITRATION_ROUNDROBIN_RXTX_3_1) || \
-                                                       ((RATIO) == ETH_DMAARBITRATION_ROUNDROBIN_RXTX_4_1) || \
-                                                       ((RATIO) == ETH_DMAARBITRATION_RXPRIORTX))
-#define IS_ETH_DMATXDESC_GET_FLAG(FLAG) (((FLAG) == ETH_DMATXDESC_OWN) || \
-                                         ((FLAG) == ETH_DMATXDESC_IC) || \
-                                         ((FLAG) == ETH_DMATXDESC_LS) || \
-                                         ((FLAG) == ETH_DMATXDESC_FS) || \
-                                         ((FLAG) == ETH_DMATXDESC_DC) || \
-                                         ((FLAG) == ETH_DMATXDESC_DP) || \
-                                         ((FLAG) == ETH_DMATXDESC_TTSE) || \
-                                         ((FLAG) == ETH_DMATXDESC_TER) || \
-                                         ((FLAG) == ETH_DMATXDESC_TCH) || \
-                                         ((FLAG) == ETH_DMATXDESC_TTSS) || \
-                                         ((FLAG) == ETH_DMATXDESC_IHE) || \
-                                         ((FLAG) == ETH_DMATXDESC_ES) || \
-                                         ((FLAG) == ETH_DMATXDESC_JT) || \
-                                         ((FLAG) == ETH_DMATXDESC_FF) || \
-                                         ((FLAG) == ETH_DMATXDESC_PCE) || \
-                                         ((FLAG) == ETH_DMATXDESC_LCA) || \
-                                         ((FLAG) == ETH_DMATXDESC_NC) || \
-                                         ((FLAG) == ETH_DMATXDESC_LCO) || \
-                                         ((FLAG) == ETH_DMATXDESC_EC) || \
-                                         ((FLAG) == ETH_DMATXDESC_VF) || \
-                                         ((FLAG) == ETH_DMATXDESC_CC) || \
-                                         ((FLAG) == ETH_DMATXDESC_ED) || \
-                                         ((FLAG) == ETH_DMATXDESC_UF) || \
-                                         ((FLAG) == ETH_DMATXDESC_DB))
-#define IS_ETH_DMA_TXDESC_SEGMENT(SEGMENT) (((SEGMENT) == ETH_DMATXDESC_LASTSEGMENTS) || \
-                                            ((SEGMENT) == ETH_DMATXDESC_FIRSTSEGMENT))
-#define IS_ETH_DMA_TXDESC_CHECKSUM(CHECKSUM) (((CHECKSUM) == ETH_DMATXDESC_CHECKSUMBYPASS) || \
-                                              ((CHECKSUM) == ETH_DMATXDESC_CHECKSUMIPV4HEADER) || \
-                                              ((CHECKSUM) == ETH_DMATXDESC_CHECKSUMTCPUDPICMPSEGMENT) || \
-                                              ((CHECKSUM) == ETH_DMATXDESC_CHECKSUMTCPUDPICMPFULL))
-#define IS_ETH_DMATXDESC_BUFFER_SIZE(SIZE) ((SIZE) <= 0x1FFF)
-#define IS_ETH_DMARXDESC_GET_FLAG(FLAG) (((FLAG) == ETH_DMARXDESC_OWN) || \
-                                         ((FLAG) == ETH_DMARXDESC_AFM) || \
-                                         ((FLAG) == ETH_DMARXDESC_ES) || \
-                                         ((FLAG) == ETH_DMARXDESC_DE) || \
-                                         ((FLAG) == ETH_DMARXDESC_SAF) || \
-                                         ((FLAG) == ETH_DMARXDESC_LE) || \
-                                         ((FLAG) == ETH_DMARXDESC_OE) || \
-                                         ((FLAG) == ETH_DMARXDESC_VLAN) || \
-                                         ((FLAG) == ETH_DMARXDESC_FS) || \
-                                         ((FLAG) == ETH_DMARXDESC_LS) || \
-                                         ((FLAG) == ETH_DMARXDESC_IPV4HCE) || \
-                                         ((FLAG) == ETH_DMARXDESC_LC) || \
-                                         ((FLAG) == ETH_DMARXDESC_FT) || \
-                                         ((FLAG) == ETH_DMARXDESC_RWT) || \
-                                         ((FLAG) == ETH_DMARXDESC_RE) || \
-                                         ((FLAG) == ETH_DMARXDESC_DBE) || \
-                                         ((FLAG) == ETH_DMARXDESC_CE) || \
-                                         ((FLAG) == ETH_DMARXDESC_MAMPCE))
-#define IS_ETH_DMA_RXDESC_BUFFER(BUFFER) (((BUFFER) == ETH_DMARXDESC_BUFFER1) || \
-                                          ((BUFFER) == ETH_DMARXDESC_BUFFER2))
-#define IS_ETH_PMT_GET_FLAG(FLAG) (((FLAG) == ETH_PMT_FLAG_WUFR) || \
-                                   ((FLAG) == ETH_PMT_FLAG_MPR))
-#define IS_ETH_DMA_FLAG(FLAG) ((((FLAG) & (uint32_t)0xC7FE1800) == 0x00) && ((FLAG) != 0x00))
-#define IS_ETH_DMA_GET_FLAG(FLAG) (((FLAG) == ETH_DMA_FLAG_TST) || ((FLAG) == ETH_DMA_FLAG_PMT) || \
-                                   ((FLAG) == ETH_DMA_FLAG_MMC) || ((FLAG) == ETH_DMA_FLAG_DATATRANSFERERROR) || \
-                                   ((FLAG) == ETH_DMA_FLAG_READWRITEERROR) || ((FLAG) == ETH_DMA_FLAG_ACCESSERROR) || \
-                                   ((FLAG) == ETH_DMA_FLAG_NIS) || ((FLAG) == ETH_DMA_FLAG_AIS) || \
-                                   ((FLAG) == ETH_DMA_FLAG_ER) || ((FLAG) == ETH_DMA_FLAG_FBE) || \
-                                   ((FLAG) == ETH_DMA_FLAG_ET) || ((FLAG) == ETH_DMA_FLAG_RWT) || \
-                                   ((FLAG) == ETH_DMA_FLAG_RPS) || ((FLAG) == ETH_DMA_FLAG_RBU) || \
-                                   ((FLAG) == ETH_DMA_FLAG_R) || ((FLAG) == ETH_DMA_FLAG_TU) || \
-                                   ((FLAG) == ETH_DMA_FLAG_RO) || ((FLAG) == ETH_DMA_FLAG_TJT) || \
-                                   ((FLAG) == ETH_DMA_FLAG_TBU) || ((FLAG) == ETH_DMA_FLAG_TPS) || \
-                                   ((FLAG) == ETH_DMA_FLAG_T))
-#define IS_ETH_MAC_IT(IT) ((((IT) & (uint32_t)0xFFFFFDF1) == 0x00) && ((IT) != 0x00))
-#define IS_ETH_MAC_GET_IT(IT) (((IT) == ETH_MAC_IT_TST) || ((IT) == ETH_MAC_IT_MMCT) || \
-                               ((IT) == ETH_MAC_IT_MMCR) || ((IT) == ETH_MAC_IT_MMC) || \
-                               ((IT) == ETH_MAC_IT_PMT))
-#define IS_ETH_MAC_GET_FLAG(FLAG) (((FLAG) == ETH_MAC_FLAG_TST) || ((FLAG) == ETH_MAC_FLAG_MMCT) || \
-                                   ((FLAG) == ETH_MAC_FLAG_MMCR) || ((FLAG) == ETH_MAC_FLAG_MMC) || \
-                                   ((FLAG) == ETH_MAC_FLAG_PMT))
-#define IS_ETH_DMA_IT(IT) ((((IT) & (uint32_t)0xC7FE1800) == 0x00) && ((IT) != 0x00))
-#define IS_ETH_DMA_GET_IT(IT) (((IT) == ETH_DMA_IT_TST) || ((IT) == ETH_DMA_IT_PMT) || \
-                               ((IT) == ETH_DMA_IT_MMC) || ((IT) == ETH_DMA_IT_NIS) || \
-                               ((IT) == ETH_DMA_IT_AIS) || ((IT) == ETH_DMA_IT_ER) || \
-                               ((IT) == ETH_DMA_IT_FBE) || ((IT) == ETH_DMA_IT_ET) || \
-                               ((IT) == ETH_DMA_IT_RWT) || ((IT) == ETH_DMA_IT_RPS) || \
-                               ((IT) == ETH_DMA_IT_RBU) || ((IT) == ETH_DMA_IT_R) || \
-                               ((IT) == ETH_DMA_IT_TU) || ((IT) == ETH_DMA_IT_RO) || \
-                               ((IT) == ETH_DMA_IT_TJT) || ((IT) == ETH_DMA_IT_TBU) || \
-                               ((IT) == ETH_DMA_IT_TPS) || ((IT) == ETH_DMA_IT_T))
-#define IS_ETH_DMA_GET_OVERFLOW(OVERFLOW) (((OVERFLOW) == ETH_DMA_OVERFLOW_RXFIFOCOUNTER) || \
-                                           ((OVERFLOW) == ETH_DMA_OVERFLOW_MISSEDFRAMECOUNTER))
-#define IS_ETH_MMC_IT(IT) (((((IT) & (uint32_t)0xFFDF3FFF) == 0x00) || (((IT) & (uint32_t)0xEFFDFF9F) == 0x00)) && \
-                           ((IT) != 0x00))
-#define IS_ETH_MMC_GET_IT(IT) (((IT) == ETH_MMC_IT_TGF) || ((IT) == ETH_MMC_IT_TGFMSC) || \
-                               ((IT) == ETH_MMC_IT_TGFSC) || ((IT) == ETH_MMC_IT_RGUF) || \
-                               ((IT) == ETH_MMC_IT_RFAE) || ((IT) == ETH_MMC_IT_RFCE))
-#define IS_ETH_ENHANCED_DESCRIPTOR_FORMAT(CMD) (((CMD) == ETH_DMAENHANCEDDESCRIPTOR_ENABLE) || \
-                                                ((CMD) == ETH_DMAENHANCEDDESCRIPTOR_DISABLE))
+ * @{
+ */
+    #define IS_ETH_PHY_ADDRESS( ADDRESS )    ( ( ADDRESS ) <= 0x20 )
+    #define IS_ETH_AUTONEGOTIATION( CMD )          \
+    ( ( ( CMD ) == ETH_AUTONEGOTIATION_ENABLE ) || \
+      ( ( CMD ) == ETH_AUTONEGOTIATION_DISABLE ) )
+    #define IS_ETH_SPEED( SPEED )       \
+    ( ( ( SPEED ) == ETH_SPEED_10M ) || \
+      ( ( SPEED ) == ETH_SPEED_100M ) )
+    #define IS_ETH_DUPLEX_MODE( MODE )       \
+    ( ( ( MODE ) == ETH_MODE_FULLDUPLEX ) || \
+      ( ( MODE ) == ETH_MODE_HALFDUPLEX ) )
+    #define IS_ETH_DUPLEX_MODE( MODE )       \
+    ( ( ( MODE ) == ETH_MODE_FULLDUPLEX ) || \
+      ( ( MODE ) == ETH_MODE_HALFDUPLEX ) )
+    #define IS_ETH_RX_MODE( MODE )          \
+    ( ( ( MODE ) == ETH_RXPOLLING_MODE ) || \
+      ( ( MODE ) == ETH_RXINTERRUPT_MODE ) )
+    #define IS_ETH_RX_MODE( MODE )          \
+    ( ( ( MODE ) == ETH_RXPOLLING_MODE ) || \
+      ( ( MODE ) == ETH_RXINTERRUPT_MODE ) )
+    #define IS_ETH_RX_MODE( MODE )          \
+    ( ( ( MODE ) == ETH_RXPOLLING_MODE ) || \
+      ( ( MODE ) == ETH_RXINTERRUPT_MODE ) )
+    #define IS_ETH_CHECKSUM_MODE( MODE )          \
+    ( ( ( MODE ) == ETH_CHECKSUM_BY_HARDWARE ) || \
+      ( ( MODE ) == ETH_CHECKSUM_BY_SOFTWARE ) )
+    #define IS_ETH_MEDIA_INTERFACE( MODE )       \
+    ( ( ( MODE ) == ETH_MEDIA_INTERFACE_MII ) || \
+      ( ( MODE ) == ETH_MEDIA_INTERFACE_RMII ) )
+    #define IS_ETH_WATCHDOG( CMD )          \
+    ( ( ( CMD ) == ETH_WATCHDOG_ENABLE ) || \
+      ( ( CMD ) == ETH_WATCHDOG_DISABLE ) )
+    #define IS_ETH_JABBER( CMD )          \
+    ( ( ( CMD ) == ETH_JABBER_ENABLE ) || \
+      ( ( CMD ) == ETH_JABBER_DISABLE ) )
+    #define IS_ETH_INTER_FRAME_GAP( GAP )       \
+    ( ( ( GAP ) == ETH_INTERFRAMEGAP_96BIT ) || \
+      ( ( GAP ) == ETH_INTERFRAMEGAP_88BIT ) || \
+      ( ( GAP ) == ETH_INTERFRAMEGAP_80BIT ) || \
+      ( ( GAP ) == ETH_INTERFRAMEGAP_72BIT ) || \
+      ( ( GAP ) == ETH_INTERFRAMEGAP_64BIT ) || \
+      ( ( GAP ) == ETH_INTERFRAMEGAP_56BIT ) || \
+      ( ( GAP ) == ETH_INTERFRAMEGAP_48BIT ) || \
+      ( ( GAP ) == ETH_INTERFRAMEGAP_40BIT ) )
+    #define IS_ETH_CARRIER_SENSE( CMD )         \
+    ( ( ( CMD ) == ETH_CARRIERSENCE_ENABLE ) || \
+      ( ( CMD ) == ETH_CARRIERSENCE_DISABLE ) )
+    #define IS_ETH_RECEIVE_OWN( CMD )         \
+    ( ( ( CMD ) == ETH_RECEIVEOWN_ENABLE ) || \
+      ( ( CMD ) == ETH_RECEIVEOWN_DISABLE ) )
+    #define IS_ETH_LOOPBACK_MODE( CMD )         \
+    ( ( ( CMD ) == ETH_LOOPBACKMODE_ENABLE ) || \
+      ( ( CMD ) == ETH_LOOPBACKMODE_DISABLE ) )
+    #define IS_ETH_CHECKSUM_OFFLOAD( CMD )         \
+    ( ( ( CMD ) == ETH_CHECKSUMOFFLAOD_ENABLE ) || \
+      ( ( CMD ) == ETH_CHECKSUMOFFLAOD_DISABLE ) )
+    #define IS_ETH_RETRY_TRANSMISSION( CMD )         \
+    ( ( ( CMD ) == ETH_RETRYTRANSMISSION_ENABLE ) || \
+      ( ( CMD ) == ETH_RETRYTRANSMISSION_DISABLE ) )
+    #define IS_ETH_AUTOMATIC_PADCRC_STRIP( CMD )        \
+    ( ( ( CMD ) == ETH_AUTOMATICPADCRCSTRIP_ENABLE ) || \
+      ( ( CMD ) == ETH_AUTOMATICPADCRCSTRIP_DISABLE ) )
+    #define IS_ETH_BACKOFF_LIMIT( LIMIT )     \
+    ( ( ( LIMIT ) == ETH_BACKOFFLIMIT_10 ) || \
+      ( ( LIMIT ) == ETH_BACKOFFLIMIT_8 ) ||  \
+      ( ( LIMIT ) == ETH_BACKOFFLIMIT_4 ) ||  \
+      ( ( LIMIT ) == ETH_BACKOFFLIMIT_1 ) )
+    #define IS_ETH_DEFERRAL_CHECK( CMD )          \
+    ( ( ( CMD ) == ETH_DEFFERRALCHECK_ENABLE ) || \
+      ( ( CMD ) == ETH_DEFFERRALCHECK_DISABLE ) )
+    #define IS_ETH_RECEIVE_ALL( CMD )         \
+    ( ( ( CMD ) == ETH_RECEIVEALL_ENABLE ) || \
+      ( ( CMD ) == ETH_RECEIVEAll_DISABLE ) )
+    #define IS_ETH_SOURCE_ADDR_FILTER( CMD )                \
+    ( ( ( CMD ) == ETH_SOURCEADDRFILTER_NORMAL_ENABLE ) ||  \
+      ( ( CMD ) == ETH_SOURCEADDRFILTER_INVERSE_ENABLE ) || \
+      ( ( CMD ) == ETH_SOURCEADDRFILTER_DISABLE ) )
+    #define IS_ETH_CONTROL_FRAMES( PASS )                 \
+    ( ( ( PASS ) == ETH_PASSCONTROLFRAMES_BLOCKALL ) ||   \
+      ( ( PASS ) == ETH_PASSCONTROLFRAMES_FORWARDALL ) || \
+      ( ( PASS ) == ETH_PASSCONTROLFRAMES_FORWARDPASSEDADDRFILTER ) )
+    #define IS_ETH_BROADCAST_FRAMES_RECEPTION( CMD )        \
+    ( ( ( CMD ) == ETH_BROADCASTFRAMESRECEPTION_ENABLE ) || \
+      ( ( CMD ) == ETH_BROADCASTFRAMESRECEPTION_DISABLE ) )
+    #define IS_ETH_DESTINATION_ADDR_FILTER( FILTER )        \
+    ( ( ( FILTER ) == ETH_DESTINATIONADDRFILTER_NORMAL ) || \
+      ( ( FILTER ) == ETH_DESTINATIONADDRFILTER_INVERSE ) )
+    #define IS_ETH_PROMISCUOUS_MODE( CMD )          \
+    ( ( ( CMD ) == ETH_PROMISCUOUS_MODE_ENABLE ) || \
+      ( ( CMD ) == ETH_PROMISCUOUS_MODE_DISABLE ) )
+    #define IS_ETH_MULTICAST_FRAMES_FILTER( FILTER )                  \
+    ( ( ( FILTER ) == ETH_MULTICASTFRAMESFILTER_PERFECTHASHTABLE ) || \
+      ( ( FILTER ) == ETH_MULTICASTFRAMESFILTER_HASHTABLE ) ||        \
+      ( ( FILTER ) == ETH_MULTICASTFRAMESFILTER_PERFECT ) ||          \
+      ( ( FILTER ) == ETH_MULTICASTFRAMESFILTER_NONE ) )
+    #define IS_ETH_UNICAST_FRAMES_FILTER( FILTER )                  \
+    ( ( ( FILTER ) == ETH_UNICASTFRAMESFILTER_PERFECTHASHTABLE ) || \
+      ( ( FILTER ) == ETH_UNICASTFRAMESFILTER_HASHTABLE ) ||        \
+      ( ( FILTER ) == ETH_UNICASTFRAMESFILTER_PERFECT ) )
+    #define IS_ETH_PAUSE_TIME( TIME )    ( ( TIME ) <= 0xFFFF )
+    #define IS_ETH_ZEROQUANTA_PAUSE( CMD )         \
+    ( ( ( CMD ) == ETH_ZEROQUANTAPAUSE_ENABLE ) || \
+      ( ( CMD ) == ETH_ZEROQUANTAPAUSE_DISABLE ) )
+    #define IS_ETH_PAUSE_LOW_THRESHOLD( THRESHOLD )          \
+    ( ( ( THRESHOLD ) == ETH_PAUSELOWTHRESHOLD_MINUS4 ) ||   \
+      ( ( THRESHOLD ) == ETH_PAUSELOWTHRESHOLD_MINUS28 ) ||  \
+      ( ( THRESHOLD ) == ETH_PAUSELOWTHRESHOLD_MINUS144 ) || \
+      ( ( THRESHOLD ) == ETH_PAUSELOWTHRESHOLD_MINUS256 ) )
+    #define IS_ETH_UNICAST_PAUSE_FRAME_DETECT( CMD )       \
+    ( ( ( CMD ) == ETH_UNICASTPAUSEFRAMEDETECT_ENABLE ) || \
+      ( ( CMD ) == ETH_UNICASTPAUSEFRAMEDETECT_DISABLE ) )
+    #define IS_ETH_RECEIVE_FLOWCONTROL( CMD )         \
+    ( ( ( CMD ) == ETH_RECEIVEFLOWCONTROL_ENABLE ) || \
+      ( ( CMD ) == ETH_RECEIVEFLOWCONTROL_DISABLE ) )
+    #define IS_ETH_TRANSMIT_FLOWCONTROL( CMD )         \
+    ( ( ( CMD ) == ETH_TRANSMITFLOWCONTROL_ENABLE ) || \
+      ( ( CMD ) == ETH_TRANSMITFLOWCONTROL_DISABLE ) )
+    #define IS_ETH_VLAN_TAG_COMPARISON( COMPARISON )       \
+    ( ( ( COMPARISON ) == ETH_VLANTAGCOMPARISON_12BIT ) || \
+      ( ( COMPARISON ) == ETH_VLANTAGCOMPARISON_16BIT ) )
+    #define IS_ETH_VLAN_TAG_IDENTIFIER( IDENTIFIER )    ( ( IDENTIFIER ) <= 0xFFFF )
+    #define IS_ETH_MAC_ADDRESS0123( ADDRESS ) \
+    ( ( ( ADDRESS ) == ETH_MAC_ADDRESS0 ) ||  \
+      ( ( ADDRESS ) == ETH_MAC_ADDRESS1 ) ||  \
+      ( ( ADDRESS ) == ETH_MAC_ADDRESS2 ) ||  \
+      ( ( ADDRESS ) == ETH_MAC_ADDRESS3 ) )
+    #define IS_ETH_MAC_ADDRESS123( ADDRESS ) \
+    ( ( ( ADDRESS ) == ETH_MAC_ADDRESS1 ) || \
+      ( ( ADDRESS ) == ETH_MAC_ADDRESS2 ) || \
+      ( ( ADDRESS ) == ETH_MAC_ADDRESS3 ) )
+    #define IS_ETH_MAC_ADDRESS_FILTER( FILTER )     \
+    ( ( ( FILTER ) == ETH_MAC_ADDRESSFILTER_SA ) || \
+      ( ( FILTER ) == ETH_MAC_ADDRESSFILTER_DA ) )
+    #define IS_ETH_MAC_ADDRESS_MASK( MASK )        \
+    ( ( ( MASK ) == ETH_MAC_ADDRESSMASK_BYTE6 ) || \
+      ( ( MASK ) == ETH_MAC_ADDRESSMASK_BYTE5 ) || \
+      ( ( MASK ) == ETH_MAC_ADDRESSMASK_BYTE4 ) || \
+      ( ( MASK ) == ETH_MAC_ADDRESSMASK_BYTE3 ) || \
+      ( ( MASK ) == ETH_MAC_ADDRESSMASK_BYTE2 ) || \
+      ( ( MASK ) == ETH_MAC_ADDRESSMASK_BYTE1 ) )
+    #define IS_ETH_DROP_TCPIP_CHECKSUM_FRAME( CMD )            \
+    ( ( ( CMD ) == ETH_DROPTCPIPCHECKSUMERRORFRAME_ENABLE ) || \
+      ( ( CMD ) == ETH_DROPTCPIPCHECKSUMERRORFRAME_DISABLE ) )
+    #define IS_ETH_RECEIVE_STORE_FORWARD( CMD )        \
+    ( ( ( CMD ) == ETH_RECEIVESTOREFORWARD_ENABLE ) || \
+      ( ( CMD ) == ETH_RECEIVESTOREFORWARD_DISABLE ) )
+    #define IS_ETH_FLUSH_RECEIVE_FRAME( CMD )         \
+    ( ( ( CMD ) == ETH_FLUSHRECEIVEDFRAME_ENABLE ) || \
+      ( ( CMD ) == ETH_FLUSHRECEIVEDFRAME_DISABLE ) )
+    #define IS_ETH_TRANSMIT_STORE_FORWARD( CMD )        \
+    ( ( ( CMD ) == ETH_TRANSMITSTOREFORWARD_ENABLE ) || \
+      ( ( CMD ) == ETH_TRANSMITSTOREFORWARD_DISABLE ) )
+    #define IS_ETH_TRANSMIT_THRESHOLD_CONTROL( THRESHOLD )          \
+    ( ( ( THRESHOLD ) == ETH_TRANSMITTHRESHOLDCONTROL_64BYTES ) ||  \
+      ( ( THRESHOLD ) == ETH_TRANSMITTHRESHOLDCONTROL_128BYTES ) || \
+      ( ( THRESHOLD ) == ETH_TRANSMITTHRESHOLDCONTROL_192BYTES ) || \
+      ( ( THRESHOLD ) == ETH_TRANSMITTHRESHOLDCONTROL_256BYTES ) || \
+      ( ( THRESHOLD ) == ETH_TRANSMITTHRESHOLDCONTROL_40BYTES ) ||  \
+      ( ( THRESHOLD ) == ETH_TRANSMITTHRESHOLDCONTROL_32BYTES ) ||  \
+      ( ( THRESHOLD ) == ETH_TRANSMITTHRESHOLDCONTROL_24BYTES ) ||  \
+      ( ( THRESHOLD ) == ETH_TRANSMITTHRESHOLDCONTROL_16BYTES ) )
+    #define IS_ETH_FORWARD_ERROR_FRAMES( CMD )        \
+    ( ( ( CMD ) == ETH_FORWARDERRORFRAMES_ENABLE ) || \
+      ( ( CMD ) == ETH_FORWARDERRORFRAMES_DISABLE ) )
+    #define IS_ETH_FORWARD_UNDERSIZED_GOOD_FRAMES( CMD )       \
+    ( ( ( CMD ) == ETH_FORWARDUNDERSIZEDGOODFRAMES_ENABLE ) || \
+      ( ( CMD ) == ETH_FORWARDUNDERSIZEDGOODFRAMES_DISABLE ) )
+    #define IS_ETH_RECEIVE_THRESHOLD_CONTROL( THRESHOLD )          \
+    ( ( ( THRESHOLD ) == ETH_RECEIVEDTHRESHOLDCONTROL_64BYTES ) || \
+      ( ( THRESHOLD ) == ETH_RECEIVEDTHRESHOLDCONTROL_32BYTES ) || \
+      ( ( THRESHOLD ) == ETH_RECEIVEDTHRESHOLDCONTROL_96BYTES ) || \
+      ( ( THRESHOLD ) == ETH_RECEIVEDTHRESHOLDCONTROL_128BYTES ) )
+    #define IS_ETH_SECOND_FRAME_OPERATE( CMD )         \
+    ( ( ( CMD ) == ETH_SECONDFRAMEOPERARTE_ENABLE ) || \
+      ( ( CMD ) == ETH_SECONDFRAMEOPERARTE_DISABLE ) )
+    #define IS_ETH_ADDRESS_ALIGNED_BEATS( CMD )        \
+    ( ( ( CMD ) == ETH_ADDRESSALIGNEDBEATS_ENABLE ) || \
+      ( ( CMD ) == ETH_ADDRESSALIGNEDBEATS_DISABLE ) )
+    #define IS_ETH_FIXED_BURST( CMD )         \
+    ( ( ( CMD ) == ETH_FIXEDBURST_ENABLE ) || \
+      ( ( CMD ) == ETH_FIXEDBURST_DISABLE ) )
+    #define IS_ETH_RXDMA_BURST_LENGTH( LENGTH )              \
+    ( ( ( LENGTH ) == ETH_RXDMABURSTLENGTH_1BEAT ) ||        \
+      ( ( LENGTH ) == ETH_RXDMABURSTLENGTH_2BEAT ) ||        \
+      ( ( LENGTH ) == ETH_RXDMABURSTLENGTH_4BEAT ) ||        \
+      ( ( LENGTH ) == ETH_RXDMABURSTLENGTH_8BEAT ) ||        \
+      ( ( LENGTH ) == ETH_RXDMABURSTLENGTH_16BEAT ) ||       \
+      ( ( LENGTH ) == ETH_RXDMABURSTLENGTH_32BEAT ) ||       \
+      ( ( LENGTH ) == ETH_RXDMABURSTLENGTH_4XPBL_4BEAT ) ||  \
+      ( ( LENGTH ) == ETH_RXDMABURSTLENGTH_4XPBL_8BEAT ) ||  \
+      ( ( LENGTH ) == ETH_RXDMABURSTLENGTH_4XPBL_16BEAT ) || \
+      ( ( LENGTH ) == ETH_RXDMABURSTLENGTH_4XPBL_32BEAT ) || \
+      ( ( LENGTH ) == ETH_RXDMABURSTLENGTH_4XPBL_64BEAT ) || \
+      ( ( LENGTH ) == ETH_RXDMABURSTLENGTH_4XPBL_128BEAT ) )
+    #define IS_ETH_TXDMA_BURST_LENGTH( LENGTH )              \
+    ( ( ( LENGTH ) == ETH_TXDMABURSTLENGTH_1BEAT ) ||        \
+      ( ( LENGTH ) == ETH_TXDMABURSTLENGTH_2BEAT ) ||        \
+      ( ( LENGTH ) == ETH_TXDMABURSTLENGTH_4BEAT ) ||        \
+      ( ( LENGTH ) == ETH_TXDMABURSTLENGTH_8BEAT ) ||        \
+      ( ( LENGTH ) == ETH_TXDMABURSTLENGTH_16BEAT ) ||       \
+      ( ( LENGTH ) == ETH_TXDMABURSTLENGTH_32BEAT ) ||       \
+      ( ( LENGTH ) == ETH_TXDMABURSTLENGTH_4XPBL_4BEAT ) ||  \
+      ( ( LENGTH ) == ETH_TXDMABURSTLENGTH_4XPBL_8BEAT ) ||  \
+      ( ( LENGTH ) == ETH_TXDMABURSTLENGTH_4XPBL_16BEAT ) || \
+      ( ( LENGTH ) == ETH_TXDMABURSTLENGTH_4XPBL_32BEAT ) || \
+      ( ( LENGTH ) == ETH_TXDMABURSTLENGTH_4XPBL_64BEAT ) || \
+      ( ( LENGTH ) == ETH_TXDMABURSTLENGTH_4XPBL_128BEAT ) )
+    #define IS_ETH_DMA_DESC_SKIP_LENGTH( LENGTH )    ( ( LENGTH ) <= 0x1F )
+    #define IS_ETH_DMA_ARBITRATION_ROUNDROBIN_RXTX( RATIO )      \
+    ( ( ( RATIO ) == ETH_DMAARBITRATION_ROUNDROBIN_RXTX_1_1 ) || \
+      ( ( RATIO ) == ETH_DMAARBITRATION_ROUNDROBIN_RXTX_2_1 ) || \
+      ( ( RATIO ) == ETH_DMAARBITRATION_ROUNDROBIN_RXTX_3_1 ) || \
+      ( ( RATIO ) == ETH_DMAARBITRATION_ROUNDROBIN_RXTX_4_1 ) || \
+      ( ( RATIO ) == ETH_DMAARBITRATION_RXPRIORTX ) )
+    #define IS_ETH_DMATXDESC_GET_FLAG( FLAG ) \
+    ( ( ( FLAG ) == ETH_DMATXDESC_OWN ) ||    \
+      ( ( FLAG ) == ETH_DMATXDESC_IC ) ||     \
+      ( ( FLAG ) == ETH_DMATXDESC_LS ) ||     \
+      ( ( FLAG ) == ETH_DMATXDESC_FS ) ||     \
+      ( ( FLAG ) == ETH_DMATXDESC_DC ) ||     \
+      ( ( FLAG ) == ETH_DMATXDESC_DP ) ||     \
+      ( ( FLAG ) == ETH_DMATXDESC_TTSE ) ||   \
+      ( ( FLAG ) == ETH_DMATXDESC_TER ) ||    \
+      ( ( FLAG ) == ETH_DMATXDESC_TCH ) ||    \
+      ( ( FLAG ) == ETH_DMATXDESC_TTSS ) ||   \
+      ( ( FLAG ) == ETH_DMATXDESC_IHE ) ||    \
+      ( ( FLAG ) == ETH_DMATXDESC_ES ) ||     \
+      ( ( FLAG ) == ETH_DMATXDESC_JT ) ||     \
+      ( ( FLAG ) == ETH_DMATXDESC_FF ) ||     \
+      ( ( FLAG ) == ETH_DMATXDESC_PCE ) ||    \
+      ( ( FLAG ) == ETH_DMATXDESC_LCA ) ||    \
+      ( ( FLAG ) == ETH_DMATXDESC_NC ) ||     \
+      ( ( FLAG ) == ETH_DMATXDESC_LCO ) ||    \
+      ( ( FLAG ) == ETH_DMATXDESC_EC ) ||     \
+      ( ( FLAG ) == ETH_DMATXDESC_VF ) ||     \
+      ( ( FLAG ) == ETH_DMATXDESC_CC ) ||     \
+      ( ( FLAG ) == ETH_DMATXDESC_ED ) ||     \
+      ( ( FLAG ) == ETH_DMATXDESC_UF ) ||     \
+      ( ( FLAG ) == ETH_DMATXDESC_DB ) )
+    #define IS_ETH_DMA_TXDESC_SEGMENT( SEGMENT )       \
+    ( ( ( SEGMENT ) == ETH_DMATXDESC_LASTSEGMENTS ) || \
+      ( ( SEGMENT ) == ETH_DMATXDESC_FIRSTSEGMENT ) )
+    #define IS_ETH_DMA_TXDESC_CHECKSUM( CHECKSUM )                   \
+    ( ( ( CHECKSUM ) == ETH_DMATXDESC_CHECKSUMBYPASS ) ||            \
+      ( ( CHECKSUM ) == ETH_DMATXDESC_CHECKSUMIPV4HEADER ) ||        \
+      ( ( CHECKSUM ) == ETH_DMATXDESC_CHECKSUMTCPUDPICMPSEGMENT ) || \
+      ( ( CHECKSUM ) == ETH_DMATXDESC_CHECKSUMTCPUDPICMPFULL ) )
+    #define IS_ETH_DMATXDESC_BUFFER_SIZE( SIZE )    ( ( SIZE ) <= 0x1FFF )
+    #define IS_ETH_DMARXDESC_GET_FLAG( FLAG )  \
+    ( ( ( FLAG ) == ETH_DMARXDESC_OWN ) ||     \
+      ( ( FLAG ) == ETH_DMARXDESC_AFM ) ||     \
+      ( ( FLAG ) == ETH_DMARXDESC_ES ) ||      \
+      ( ( FLAG ) == ETH_DMARXDESC_DE ) ||      \
+      ( ( FLAG ) == ETH_DMARXDESC_SAF ) ||     \
+      ( ( FLAG ) == ETH_DMARXDESC_LE ) ||      \
+      ( ( FLAG ) == ETH_DMARXDESC_OE ) ||      \
+      ( ( FLAG ) == ETH_DMARXDESC_VLAN ) ||    \
+      ( ( FLAG ) == ETH_DMARXDESC_FS ) ||      \
+      ( ( FLAG ) == ETH_DMARXDESC_LS ) ||      \
+      ( ( FLAG ) == ETH_DMARXDESC_IPV4HCE ) || \
+      ( ( FLAG ) == ETH_DMARXDESC_LC ) ||      \
+      ( ( FLAG ) == ETH_DMARXDESC_FT ) ||      \
+      ( ( FLAG ) == ETH_DMARXDESC_RWT ) ||     \
+      ( ( FLAG ) == ETH_DMARXDESC_RE ) ||      \
+      ( ( FLAG ) == ETH_DMARXDESC_DBE ) ||     \
+      ( ( FLAG ) == ETH_DMARXDESC_CE ) ||      \
+      ( ( FLAG ) == ETH_DMARXDESC_MAMPCE ) )
+    #define IS_ETH_DMA_RXDESC_BUFFER( BUFFER )   \
+    ( ( ( BUFFER ) == ETH_DMARXDESC_BUFFER1 ) || \
+      ( ( BUFFER ) == ETH_DMARXDESC_BUFFER2 ) )
+    #define IS_ETH_PMT_GET_FLAG( FLAG )    \
+    ( ( ( FLAG ) == ETH_PMT_FLAG_WUFR ) || \
+      ( ( FLAG ) == ETH_PMT_FLAG_MPR ) )
+    #define IS_ETH_DMA_FLAG( FLAG )    ( ( ( ( FLAG ) &( uint32_t ) 0xC7FE1800 ) == 0x00 ) && ( ( FLAG ) != 0x00 ) )
+    #define IS_ETH_DMA_GET_FLAG( FLAG )                                                          \
+    ( ( ( FLAG ) == ETH_DMA_FLAG_TST ) || ( ( FLAG ) == ETH_DMA_FLAG_PMT ) ||                    \
+      ( ( FLAG ) == ETH_DMA_FLAG_MMC ) || ( ( FLAG ) == ETH_DMA_FLAG_DATATRANSFERERROR ) ||      \
+      ( ( FLAG ) == ETH_DMA_FLAG_READWRITEERROR ) || ( ( FLAG ) == ETH_DMA_FLAG_ACCESSERROR ) || \
+      ( ( FLAG ) == ETH_DMA_FLAG_NIS ) || ( ( FLAG ) == ETH_DMA_FLAG_AIS ) ||                    \
+      ( ( FLAG ) == ETH_DMA_FLAG_ER ) || ( ( FLAG ) == ETH_DMA_FLAG_FBE ) ||                     \
+      ( ( FLAG ) == ETH_DMA_FLAG_ET ) || ( ( FLAG ) == ETH_DMA_FLAG_RWT ) ||                     \
+      ( ( FLAG ) == ETH_DMA_FLAG_RPS ) || ( ( FLAG ) == ETH_DMA_FLAG_RBU ) ||                    \
+      ( ( FLAG ) == ETH_DMA_FLAG_R ) || ( ( FLAG ) == ETH_DMA_FLAG_TU ) ||                       \
+      ( ( FLAG ) == ETH_DMA_FLAG_RO ) || ( ( FLAG ) == ETH_DMA_FLAG_TJT ) ||                     \
+      ( ( FLAG ) == ETH_DMA_FLAG_TBU ) || ( ( FLAG ) == ETH_DMA_FLAG_TPS ) ||                    \
+      ( ( FLAG ) == ETH_DMA_FLAG_T ) )
+    #define IS_ETH_MAC_IT( IT )        ( ( ( ( IT ) &( uint32_t ) 0xFFFFFDF1 ) == 0x00 ) && ( ( IT ) != 0x00 ) )
+    #define IS_ETH_MAC_GET_IT( IT )                                    \
+    ( ( ( IT ) == ETH_MAC_IT_TST ) || ( ( IT ) == ETH_MAC_IT_MMCT ) || \
+      ( ( IT ) == ETH_MAC_IT_MMCR ) || ( ( IT ) == ETH_MAC_IT_MMC ) || \
+      ( ( IT ) == ETH_MAC_IT_PMT ) )
+    #define IS_ETH_MAC_GET_FLAG( FLAG )                                        \
+    ( ( ( FLAG ) == ETH_MAC_FLAG_TST ) || ( ( FLAG ) == ETH_MAC_FLAG_MMCT ) || \
+      ( ( FLAG ) == ETH_MAC_FLAG_MMCR ) || ( ( FLAG ) == ETH_MAC_FLAG_MMC ) || \
+      ( ( FLAG ) == ETH_MAC_FLAG_PMT ) )
+    #define IS_ETH_DMA_IT( IT )        ( ( ( ( IT ) &( uint32_t ) 0xC7FE1800 ) == 0x00 ) && ( ( IT ) != 0x00 ) )
+    #define IS_ETH_DMA_GET_IT( IT )                                   \
+    ( ( ( IT ) == ETH_DMA_IT_TST ) || ( ( IT ) == ETH_DMA_IT_PMT ) || \
+      ( ( IT ) == ETH_DMA_IT_MMC ) || ( ( IT ) == ETH_DMA_IT_NIS ) || \
+      ( ( IT ) == ETH_DMA_IT_AIS ) || ( ( IT ) == ETH_DMA_IT_ER ) ||  \
+      ( ( IT ) == ETH_DMA_IT_FBE ) || ( ( IT ) == ETH_DMA_IT_ET ) ||  \
+      ( ( IT ) == ETH_DMA_IT_RWT ) || ( ( IT ) == ETH_DMA_IT_RPS ) || \
+      ( ( IT ) == ETH_DMA_IT_RBU ) || ( ( IT ) == ETH_DMA_IT_R ) ||   \
+      ( ( IT ) == ETH_DMA_IT_TU ) || ( ( IT ) == ETH_DMA_IT_RO ) ||   \
+      ( ( IT ) == ETH_DMA_IT_TJT ) || ( ( IT ) == ETH_DMA_IT_TBU ) || \
+      ( ( IT ) == ETH_DMA_IT_TPS ) || ( ( IT ) == ETH_DMA_IT_T ) )
+    #define IS_ETH_DMA_GET_OVERFLOW( OVERFLOW )             \
+    ( ( ( OVERFLOW ) == ETH_DMA_OVERFLOW_RXFIFOCOUNTER ) || \
+      ( ( OVERFLOW ) == ETH_DMA_OVERFLOW_MISSEDFRAMECOUNTER ) )
+    #define IS_ETH_MMC_IT( IT )                                                                                 \
+    ( ( ( ( ( IT ) &( uint32_t ) 0xFFDF3FFF ) == 0x00 ) || ( ( ( IT ) &( uint32_t ) 0xEFFDFF9F ) == 0x00 ) ) && \
+      ( ( IT ) != 0x00 ) )
+    #define IS_ETH_MMC_GET_IT( IT )                                      \
+    ( ( ( IT ) == ETH_MMC_IT_TGF ) || ( ( IT ) == ETH_MMC_IT_TGFMSC ) || \
+      ( ( IT ) == ETH_MMC_IT_TGFSC ) || ( ( IT ) == ETH_MMC_IT_RGUF ) || \
+      ( ( IT ) == ETH_MMC_IT_RFAE ) || ( ( IT ) == ETH_MMC_IT_RFCE ) )
+    #define IS_ETH_ENHANCED_DESCRIPTOR_FORMAT( CMD )     \
+    ( ( ( CMD ) == ETH_DMAENHANCEDDESCRIPTOR_ENABLE ) || \
+      ( ( CMD ) == ETH_DMAENHANCEDDESCRIPTOR_DISABLE ) )
 
 
 /**
-  * @}
-  */
+ * @}
+ */
 
 /** @addtogroup ETH_Private_Defines
-  * @{
-  */
+ * @{
+ */
 /* Delay to wait when writing to some Ethernet registers */
-#define ETH_REG_WRITE_DELAY ((uint32_t)0x00000001U)
+    #define ETH_REG_WRITE_DELAY                               ( ( uint32_t ) 0x00000001U )
 
 /* Ethernet Errors */
-#define  ETH_SUCCESS            ((uint32_t)0U)
-#define  ETH_ERROR              ((uint32_t)1U)
+    #define  ETH_SUCCESS                                      ( ( uint32_t ) 0U )
+    #define  ETH_ERROR                                        ( ( uint32_t ) 1U )
 
 /* Ethernet DMA Tx descriptors Collision Count Shift */
-#define  ETH_DMATXDESC_COLLISION_COUNTSHIFT         ((uint32_t)3U)
+    #define  ETH_DMATXDESC_COLLISION_COUNTSHIFT               ( ( uint32_t ) 3U )
 
 /* Ethernet DMA Tx descriptors Buffer2 Size Shift */
-#define  ETH_DMATXDESC_BUFFER2_SIZESHIFT           ((uint32_t)16U)
+    #define  ETH_DMATXDESC_BUFFER2_SIZESHIFT                  ( ( uint32_t ) 16U )
 
 /* Ethernet DMA Rx descriptors Frame Length Shift */
-#define  ETH_DMARXDESC_FRAME_LENGTHSHIFT           ((uint32_t)16U)
+    #define  ETH_DMARXDESC_FRAME_LENGTHSHIFT                  ( ( uint32_t ) 16U )
 
 /* Ethernet DMA Rx descriptors Buffer2 Size Shift */
-#define  ETH_DMARXDESC_BUFFER2_SIZESHIFT           ((uint32_t)16U)
+    #define  ETH_DMARXDESC_BUFFER2_SIZESHIFT                  ( ( uint32_t ) 16U )
 
 /* Ethernet DMA Rx descriptors Frame length Shift */
-#define  ETH_DMARXDESC_FRAMELENGTHSHIFT            ((uint32_t)16U)
+    #define  ETH_DMARXDESC_FRAMELENGTHSHIFT                   ( ( uint32_t ) 16U )
 
 /* Ethernet MAC address offsets */
-#define ETH_MAC_ADDR_HBASE    (uint32_t)(ETH_MAC_BASE + (uint32_t)0x40U)  /* Ethernet MAC address high offset */
-#define ETH_MAC_ADDR_LBASE    (uint32_t)(ETH_MAC_BASE + (uint32_t)0x44U)  /* Ethernet MAC address low offset */
+    #define ETH_MAC_ADDR_HBASE                                ( uint32_t ) ( ETH_MAC_BASE + ( uint32_t ) 0x40U ) /* Ethernet MAC address high offset */
+    #define ETH_MAC_ADDR_LBASE                                ( uint32_t ) ( ETH_MAC_BASE + ( uint32_t ) 0x44U ) /* Ethernet MAC address low offset */
 
 /* Ethernet MACMIIAR register Mask */
-#define ETH_MACMIIAR_CR_MASK    ((uint32_t)0xFFFFFFE3U)
+    #define ETH_MACMIIAR_CR_MASK                              ( ( uint32_t ) 0xFFFFFFE3U )
 
 /* Ethernet MACCR register Mask */
-#define ETH_MACCR_CLEAR_MASK    ((uint32_t)0xFF20810FU)
+    #define ETH_MACCR_CLEAR_MASK                              ( ( uint32_t ) 0xFF20810FU )
 
 /* Ethernet MACFCR register Mask */
-#define ETH_MACFCR_CLEAR_MASK   ((uint32_t)0x0000FF41U)
+    #define ETH_MACFCR_CLEAR_MASK                             ( ( uint32_t ) 0x0000FF41U )
 
 /* Ethernet DMAOMR register Mask */
-#define ETH_DMAOMR_CLEAR_MASK   ((uint32_t)0xF8DE3F23U)
+    #define ETH_DMAOMR_CLEAR_MASK                             ( ( uint32_t ) 0xF8DE3F23U )
 
 /* Ethernet Remote Wake-up frame register length */
-#define ETH_WAKEUP_REGISTER_LENGTH      8U
+    #define ETH_WAKEUP_REGISTER_LENGTH                        8U
 
 /* Ethernet Missed frames counter Shift */
-#define  ETH_DMA_RX_OVERFLOW_MISSEDFRAMES_COUNTERSHIFT     17U
- /**
-  * @}
-  */
+    #define  ETH_DMA_RX_OVERFLOW_MISSEDFRAMES_COUNTERSHIFT    17U
 
-#ifdef _lint
-	#ifdef __IO
-		#undef __IO
-	#endif
-	#define __IO
+    /**
+     * @}
+     */
 
-	#ifdef ETH_TypeDef
-		#undef ETH_TypeDef
-	#endif
-	#define ETH_TypeDef	void
+    #ifdef _lint
+        #ifdef __IO
+            #undef __IO
+        #endif
+        #define __IO
 
-	#ifdef HAL_LockTypeDef
-		#undef HAL_LockTypeDef
-	#endif
-	#define HAL_LockTypeDef	unsigned
+        #ifdef ETH_TypeDef
+            #undef ETH_TypeDef
+        #endif
+        #define ETH_TypeDef    void
 
-	#ifdef ETH_RX_BUF_SIZE
-		#undef ETH_RX_BUF_SIZE
-	#endif
-	#define ETH_RX_BUF_SIZE	1536
+        #ifdef HAL_LockTypeDef
+            #undef HAL_LockTypeDef
+        #endif
+        #define HAL_LockTypeDef    unsigned
 
-	#ifdef ETH_TX_BUF_SIZE
-		#undef ETH_TX_BUF_SIZE
-	#endif
-	#define ETH_TX_BUF_SIZE	1536
-#endif
+        #ifdef ETH_RX_BUF_SIZE
+            #undef ETH_RX_BUF_SIZE
+        #endif
+        #define ETH_RX_BUF_SIZE    1536
+
+        #ifdef ETH_TX_BUF_SIZE
+            #undef ETH_TX_BUF_SIZE
+        #endif
+        #define ETH_TX_BUF_SIZE    1536
+    #endif /* ifdef _lint */
 
 /* Exported types ------------------------------------------------------------*/
+
 /** @defgroup ETH_Exported_Types ETH Exported Types
-  * @{
-  */
+ * @{
+ */
 
 /**
-  * @brief  HAL State structures definition
-  */
-typedef enum
-{
-  HAL_ETH_STATE_RESET             = 0x00U,    /*!< Peripheral not yet Initialized or disabled         */
-  HAL_ETH_STATE_READY             = 0x01U,    /*!< Peripheral Initialized and ready for use           */
-  HAL_ETH_STATE_BUSY              = 0x02U,    /*!< an internal process is ongoing                     */
-  HAL_ETH_STATE_BUSY_TX           = 0x12U,    /*!< Data Transmission process is ongoing               */
-  HAL_ETH_STATE_BUSY_RX           = 0x22U,    /*!< Data Reception process is ongoing                  */
-  HAL_ETH_STATE_BUSY_TX_RX        = 0x32U,    /*!< Data Transmission and Reception process is ongoing */
-  HAL_ETH_STATE_BUSY_WR           = 0x42U,    /*!< Write process is ongoing                           */
-  HAL_ETH_STATE_BUSY_RD           = 0x82U,    /*!< Read process is ongoing                            */
-  HAL_ETH_STATE_TIMEOUT           = 0x03U,    /*!< Timeout state                                      */
-  HAL_ETH_STATE_ERROR             = 0x04U     /*!< Reception process is ongoing                       */
-}HAL_ETH_StateTypeDef;
+ * @brief  HAL State structures definition
+ */
+    typedef enum
+    {
+        HAL_ETH_STATE_RESET = 0x00U,      /*!< Peripheral not yet Initialized or disabled         */
+        HAL_ETH_STATE_READY = 0x01U,      /*!< Peripheral Initialized and ready for use           */
+        HAL_ETH_STATE_BUSY = 0x02U,       /*!< an internal process is ongoing                     */
+        HAL_ETH_STATE_BUSY_TX = 0x12U,    /*!< Data Transmission process is ongoing               */
+        HAL_ETH_STATE_BUSY_RX = 0x22U,    /*!< Data Reception process is ongoing                  */
+        HAL_ETH_STATE_BUSY_TX_RX = 0x32U, /*!< Data Transmission and Reception process is ongoing */
+        HAL_ETH_STATE_BUSY_WR = 0x42U,    /*!< Write process is ongoing                           */
+        HAL_ETH_STATE_BUSY_RD = 0x82U,    /*!< Read process is ongoing                            */
+        HAL_ETH_STATE_TIMEOUT = 0x03U,    /*!< Timeout state                                      */
+        HAL_ETH_STATE_ERROR = 0x04U       /*!< Reception process is ongoing                       */
+    } HAL_ETH_StateTypeDef;
 
 /**
-  * @brief  ETH Init Structure definition
-  */
+ * @brief  ETH Init Structure definition
+ */
 
-typedef struct
-{
-  uint32_t             AutoNegotiation;           /*!< Selects or not the AutoNegotiation mode for the external PHY
-                                                           The AutoNegotiation allows an automatic setting of the Speed (10/100Mbps)
-                                                           and the mode (half/full-duplex).
-                                                           This parameter can be a value of @ref ETH_AutoNegotiation */
+    typedef struct
+    {
+        uint32_t AutoNegotiation; /*!< Selects or not the AutoNegotiation mode for the external PHY
+                                   *       The AutoNegotiation allows an automatic setting of the Speed (10/100Mbps)
+                                   *       and the mode (half/full-duplex).
+                                   *       This parameter can be a value of @ref ETH_AutoNegotiation */
 
-  uint32_t             Speed;                     /*!< Sets the Ethernet speed: 10/100 Mbps.
-                                                           This parameter can be a value of @ref ETH_Speed */
+        uint32_t Speed;           /*!< Sets the Ethernet speed: 10/100 Mbps.
+                                   *       This parameter can be a value of @ref ETH_Speed */
 
-  uint32_t             DuplexMode;                /*!< Selects the MAC duplex mode: Half-Duplex or Full-Duplex mode
-                                                           This parameter can be a value of @ref ETH_Duplex_Mode */
+        uint32_t DuplexMode;      /*!< Selects the MAC duplex mode: Half-Duplex or Full-Duplex mode
+                                   *       This parameter can be a value of @ref ETH_Duplex_Mode */
 
-  uint16_t             PhyAddress;                /*!< Ethernet PHY address.
-                                                           This parameter must be a number between Min_Data = 0 and Max_Data = 32 */
+        uint16_t PhyAddress;      /*!< Ethernet PHY address.
+                                   *       This parameter must be a number between Min_Data = 0 and Max_Data = 32 */
 
-  uint8_t             *MACAddr;                   /*!< MAC Address of used Hardware: must be pointer on an array of 6 bytes */
+        uint8_t * MACAddr;        /*!< MAC Address of used Hardware: must be pointer on an array of 6 bytes */
 
-  uint32_t             RxMode;                    /*!< Selects the Ethernet Rx mode: Polling mode, Interrupt mode.
-                                                           This parameter can be a value of @ref ETH_Rx_Mode */
+        uint32_t RxMode;          /*!< Selects the Ethernet Rx mode: Polling mode, Interrupt mode.
+                                   *       This parameter can be a value of @ref ETH_Rx_Mode */
 
-  uint32_t             ChecksumMode;              /*!< Selects if the checksum is check by hardware or by software.
-                                                         This parameter can be a value of @ref ETH_Checksum_Mode */
+        uint32_t ChecksumMode;    /*!< Selects if the checksum is check by hardware or by software.
+                                   *     This parameter can be a value of @ref ETH_Checksum_Mode */
 
-  uint32_t             MediaInterface    ;               /*!< Selects the media-independent interface or the reduced media-independent interface.
-                                                         This parameter can be a value of @ref ETH_Media_Interface */
+        uint32_t MediaInterface;  /*!< Selects the media-independent interface or the reduced media-independent interface.
+                                   * This parameter can be a value of @ref ETH_Media_Interface */
+    } ETH_InitTypeDef;
 
-} ETH_InitTypeDef;
 
+    /**
+     * @brief  ETH MAC Configuration Structure definition
+     */
 
- /**
-  * @brief  ETH MAC Configuration Structure definition
-  */
+    typedef struct
+    {
+        uint32_t Watchdog;                 /*!< Selects or not the Watchdog timer
+                                            *       When enabled, the MAC allows no more then 2048 bytes to be received.
+                                            *       When disabled, the MAC can receive up to 16384 bytes.
+                                            *       This parameter can be a value of @ref ETH_Watchdog */
 
-typedef struct
-{
-  uint32_t             Watchdog;                  /*!< Selects or not the Watchdog timer
-                                                           When enabled, the MAC allows no more then 2048 bytes to be received.
-                                                           When disabled, the MAC can receive up to 16384 bytes.
-                                                           This parameter can be a value of @ref ETH_Watchdog */
+        uint32_t Jabber;                   /*!< Selects or not Jabber timer
+                                            *       When enabled, the MAC allows no more then 2048 bytes to be sent.
+                                            *       When disabled, the MAC can send up to 16384 bytes.
+                                            *       This parameter can be a value of @ref ETH_Jabber */
 
-  uint32_t             Jabber;                    /*!< Selects or not Jabber timer
-                                                           When enabled, the MAC allows no more then 2048 bytes to be sent.
-                                                           When disabled, the MAC can send up to 16384 bytes.
-                                                           This parameter can be a value of @ref ETH_Jabber */
+        uint32_t InterFrameGap;            /*!< Selects the minimum IFG between frames during transmission.
+                                            *       This parameter can be a value of @ref ETH_Inter_Frame_Gap */
 
-  uint32_t             InterFrameGap;             /*!< Selects the minimum IFG between frames during transmission.
-                                                           This parameter can be a value of @ref ETH_Inter_Frame_Gap */
+        uint32_t CarrierSense;             /*!< Selects or not the Carrier Sense.
+                                            *       This parameter can be a value of @ref ETH_Carrier_Sense */
 
-  uint32_t             CarrierSense;              /*!< Selects or not the Carrier Sense.
-                                                           This parameter can be a value of @ref ETH_Carrier_Sense */
+        uint32_t ReceiveOwn;               /*!< Selects or not the ReceiveOwn,
+                                            *       ReceiveOwn allows the reception of frames when the TX_EN signal is asserted
+                                            *       in Half-Duplex mode.
+                                            *       This parameter can be a value of @ref ETH_Receive_Own */
 
-  uint32_t             ReceiveOwn;                /*!< Selects or not the ReceiveOwn,
-                                                           ReceiveOwn allows the reception of frames when the TX_EN signal is asserted
-                                                           in Half-Duplex mode.
-                                                           This parameter can be a value of @ref ETH_Receive_Own */
+        uint32_t LoopbackMode;             /*!< Selects or not the internal MAC MII Loopback mode.
+                                            *       This parameter can be a value of @ref ETH_Loop_Back_Mode */
 
-  uint32_t             LoopbackMode;              /*!< Selects or not the internal MAC MII Loopback mode.
-                                                           This parameter can be a value of @ref ETH_Loop_Back_Mode */
+        uint32_t ChecksumOffload;          /*!< Selects or not the IPv4 checksum checking for received frame payloads' TCP/UDP/ICMP headers.
+                                            *       This parameter can be a value of @ref ETH_Checksum_Offload */
 
-  uint32_t             ChecksumOffload;           /*!< Selects or not the IPv4 checksum checking for received frame payloads' TCP/UDP/ICMP headers.
-                                                           This parameter can be a value of @ref ETH_Checksum_Offload */
+        uint32_t RetryTransmission;        /*!< Selects or not the MAC attempt retries transmission, based on the settings of BL,
+                                            *       when a collision occurs (Half-Duplex mode).
+                                            *       This parameter can be a value of @ref ETH_Retry_Transmission */
 
-  uint32_t             RetryTransmission;         /*!< Selects or not the MAC attempt retries transmission, based on the settings of BL,
-                                                           when a collision occurs (Half-Duplex mode).
-                                                           This parameter can be a value of @ref ETH_Retry_Transmission */
+        uint32_t AutomaticPadCRCStrip;     /*!< Selects or not the Automatic MAC Pad/CRC Stripping.
+                                            *       This parameter can be a value of @ref ETH_Automatic_Pad_CRC_Strip */
 
-  uint32_t             AutomaticPadCRCStrip;      /*!< Selects or not the Automatic MAC Pad/CRC Stripping.
-                                                           This parameter can be a value of @ref ETH_Automatic_Pad_CRC_Strip */
+        uint32_t BackOffLimit;             /*!< Selects the BackOff limit value.
+                                            *       This parameter can be a value of @ref ETH_Back_Off_Limit */
 
-  uint32_t             BackOffLimit;              /*!< Selects the BackOff limit value.
-                                                           This parameter can be a value of @ref ETH_Back_Off_Limit */
+        uint32_t DeferralCheck;            /*!< Selects or not the deferral check function (Half-Duplex mode).
+                                           *       This parameter can be a value of @ref ETH_Deferral_Check */
 
-  uint32_t             DeferralCheck;             /*!< Selects or not the deferral check function (Half-Duplex mode).
-                                                           This parameter can be a value of @ref ETH_Deferral_Check */
+        uint32_t ReceiveAll;               /*!< Selects or not all frames reception by the MAC (No filtering).
+                                            *       This parameter can be a value of @ref ETH_Receive_All */
 
-  uint32_t             ReceiveAll;                /*!< Selects or not all frames reception by the MAC (No filtering).
-                                                           This parameter can be a value of @ref ETH_Receive_All */
+        uint32_t SourceAddrFilter;         /*!< Selects the Source Address Filter mode.
+                                            *       This parameter can be a value of @ref ETH_Source_Addr_Filter */
 
-  uint32_t             SourceAddrFilter;          /*!< Selects the Source Address Filter mode.
-                                                           This parameter can be a value of @ref ETH_Source_Addr_Filter */
+        uint32_t PassControlFrames;        /*!< Sets the forwarding mode of the control frames (including unicast and multicast PAUSE frames)
+                                            *       This parameter can be a value of @ref ETH_Pass_Control_Frames */
 
-  uint32_t             PassControlFrames;         /*!< Sets the forwarding mode of the control frames (including unicast and multicast PAUSE frames)
-                                                           This parameter can be a value of @ref ETH_Pass_Control_Frames */
+        uint32_t BroadcastFramesReception; /*!< Selects or not the reception of Broadcast Frames.
+                                            *       This parameter can be a value of @ref ETH_Broadcast_Frames_Reception */
 
-  uint32_t             BroadcastFramesReception;  /*!< Selects or not the reception of Broadcast Frames.
-                                                           This parameter can be a value of @ref ETH_Broadcast_Frames_Reception */
+        uint32_t DestinationAddrFilter;    /*!< Sets the destination filter mode for both unicast and multicast frames.
+                                           *       This parameter can be a value of @ref ETH_Destination_Addr_Filter */
 
-  uint32_t             DestinationAddrFilter;     /*!< Sets the destination filter mode for both unicast and multicast frames.
-                                                           This parameter can be a value of @ref ETH_Destination_Addr_Filter */
+        uint32_t PromiscuousMode;          /*!< Selects or not the Promiscuous Mode
+                                            *       This parameter can be a value of @ref ETH_Promiscuous_Mode */
 
-  uint32_t             PromiscuousMode;           /*!< Selects or not the Promiscuous Mode
-                                                           This parameter can be a value of @ref ETH_Promiscuous_Mode */
+        uint32_t MulticastFramesFilter;    /*!< Selects the Multicast Frames filter mode: None/HashTableFilter/PerfectFilter/PerfectHashTableFilter.
+                                            *       This parameter can be a value of @ref ETH_Multicast_Frames_Filter */
 
-  uint32_t             MulticastFramesFilter;     /*!< Selects the Multicast Frames filter mode: None/HashTableFilter/PerfectFilter/PerfectHashTableFilter.
-                                                           This parameter can be a value of @ref ETH_Multicast_Frames_Filter */
+        uint32_t UnicastFramesFilter;      /*!< Selects the Unicast Frames filter mode: HashTableFilter/PerfectFilter/PerfectHashTableFilter.
+                                            *       This parameter can be a value of @ref ETH_Unicast_Frames_Filter */
 
-  uint32_t             UnicastFramesFilter;       /*!< Selects the Unicast Frames filter mode: HashTableFilter/PerfectFilter/PerfectHashTableFilter.
-                                                           This parameter can be a value of @ref ETH_Unicast_Frames_Filter */
+        uint32_t HashTableHigh;            /*!< This field holds the higher 32 bits of Hash table.
+                                            *       This parameter must be a number between Min_Data = 0x0 and Max_Data = 0xFFFFFFFF */
 
-  uint32_t             HashTableHigh;             /*!< This field holds the higher 32 bits of Hash table.
-                                                           This parameter must be a number between Min_Data = 0x0 and Max_Data = 0xFFFFFFFF */
+        uint32_t HashTableLow;             /*!< This field holds the lower 32 bits of Hash table.
+                                            *       This parameter must be a number between Min_Data = 0x0 and Max_Data = 0xFFFFFFFF  */
 
-  uint32_t             HashTableLow;              /*!< This field holds the lower 32 bits of Hash table.
-                                                           This parameter must be a number between Min_Data = 0x0 and Max_Data = 0xFFFFFFFF  */
+        uint32_t PauseTime;                /*!< This field holds the value to be used in the Pause Time field in the transmit control frame.
+                                            *       This parameter must be a number between Min_Data = 0x0 and Max_Data = 0xFFFF */
 
-  uint32_t             PauseTime;                 /*!< This field holds the value to be used in the Pause Time field in the transmit control frame.
-                                                           This parameter must be a number between Min_Data = 0x0 and Max_Data = 0xFFFF */
+        uint32_t ZeroQuantaPause;          /*!< Selects or not the automatic generation of Zero-Quanta Pause Control frames.
+                                            *       This parameter can be a value of @ref ETH_Zero_Quanta_Pause */
 
-  uint32_t             ZeroQuantaPause;           /*!< Selects or not the automatic generation of Zero-Quanta Pause Control frames.
-                                                           This parameter can be a value of @ref ETH_Zero_Quanta_Pause */
+        uint32_t PauseLowThreshold;        /*!< This field configures the threshold of the PAUSE to be checked for
+                                            *       automatic retransmission of PAUSE Frame.
+                                            *       This parameter can be a value of @ref ETH_Pause_Low_Threshold */
 
-  uint32_t             PauseLowThreshold;         /*!< This field configures the threshold of the PAUSE to be checked for
-                                                           automatic retransmission of PAUSE Frame.
-                                                           This parameter can be a value of @ref ETH_Pause_Low_Threshold */
+        uint32_t UnicastPauseFrameDetect;  /*!< Selects or not the MAC detection of the Pause frames (with MAC Address0
+                                            *       unicast address and unique multicast address).
+                                            *       This parameter can be a value of @ref ETH_Unicast_Pause_Frame_Detect */
 
-  uint32_t             UnicastPauseFrameDetect;   /*!< Selects or not the MAC detection of the Pause frames (with MAC Address0
-                                                           unicast address and unique multicast address).
-                                                           This parameter can be a value of @ref ETH_Unicast_Pause_Frame_Detect */
+        uint32_t ReceiveFlowControl;       /*!< Enables or disables the MAC to decode the received Pause frame and
+                                            *       disable its transmitter for a specified time (Pause Time)
+                                            *       This parameter can be a value of @ref ETH_Receive_Flow_Control */
 
-  uint32_t             ReceiveFlowControl;        /*!< Enables or disables the MAC to decode the received Pause frame and
-                                                           disable its transmitter for a specified time (Pause Time)
-                                                           This parameter can be a value of @ref ETH_Receive_Flow_Control */
+        uint32_t TransmitFlowControl;      /*!< Enables or disables the MAC to transmit Pause frames (Full-Duplex mode)
+                                            *       or the MAC back-pressure operation (Half-Duplex mode)
+                                            *       This parameter can be a value of @ref ETH_Transmit_Flow_Control */
 
-  uint32_t             TransmitFlowControl;       /*!< Enables or disables the MAC to transmit Pause frames (Full-Duplex mode)
-                                                           or the MAC back-pressure operation (Half-Duplex mode)
-                                                           This parameter can be a value of @ref ETH_Transmit_Flow_Control */
+        uint32_t VLANTagComparison;        /*!< Selects the 12-bit VLAN identifier or the complete 16-bit VLAN tag for
+                                            *       comparison and filtering.
+                                            *       This parameter can be a value of @ref ETH_VLAN_Tag_Comparison */
 
-  uint32_t             VLANTagComparison;         /*!< Selects the 12-bit VLAN identifier or the complete 16-bit VLAN tag for
-                                                           comparison and filtering.
-                                                           This parameter can be a value of @ref ETH_VLAN_Tag_Comparison */
-
-  uint32_t             VLANTagIdentifier;         /*!< Holds the VLAN tag identifier for receive frames */
-
-} ETH_MACInitTypeDef;
+        uint32_t VLANTagIdentifier;        /*!< Holds the VLAN tag identifier for receive frames */
+    } ETH_MACInitTypeDef;
 
 
 /**
-  * @brief  ETH DMA Configuration Structure definition
-  */
+ * @brief  ETH DMA Configuration Structure definition
+ */
 
-typedef struct
-{
- uint32_t              DropTCPIPChecksumErrorFrame; /*!< Selects or not the Dropping of TCP/IP Checksum Error Frames.
-                                                             This parameter can be a value of @ref ETH_Drop_TCP_IP_Checksum_Error_Frame */
+    typedef struct
+    {
+        uint32_t DropTCPIPChecksumErrorFrame; /*!< Selects or not the Dropping of TCP/IP Checksum Error Frames.
+                                               *       This parameter can be a value of @ref ETH_Drop_TCP_IP_Checksum_Error_Frame */
 
-  uint32_t             ReceiveStoreForward;         /*!< Enables or disables the Receive store and forward mode.
-                                                             This parameter can be a value of @ref ETH_Receive_Store_Forward */
+        uint32_t ReceiveStoreForward;         /*!< Enables or disables the Receive store and forward mode.
+                                               *       This parameter can be a value of @ref ETH_Receive_Store_Forward */
 
-  uint32_t             FlushReceivedFrame;          /*!< Enables or disables the flushing of received frames.
-                                                             This parameter can be a value of @ref ETH_Flush_Received_Frame */
+        uint32_t FlushReceivedFrame;          /*!< Enables or disables the flushing of received frames.
+                                               *       This parameter can be a value of @ref ETH_Flush_Received_Frame */
 
-  uint32_t             TransmitStoreForward;        /*!< Enables or disables Transmit store and forward mode.
-                                                             This parameter can be a value of @ref ETH_Transmit_Store_Forward */
+        uint32_t TransmitStoreForward;        /*!< Enables or disables Transmit store and forward mode.
+                                               *       This parameter can be a value of @ref ETH_Transmit_Store_Forward */
 
-  uint32_t             TransmitThresholdControl;    /*!< Selects or not the Transmit Threshold Control.
-                                                             This parameter can be a value of @ref ETH_Transmit_Threshold_Control */
+        uint32_t TransmitThresholdControl;    /*!< Selects or not the Transmit Threshold Control.
+                                               *       This parameter can be a value of @ref ETH_Transmit_Threshold_Control */
 
-  uint32_t             ForwardErrorFrames;          /*!< Selects or not the forward to the DMA of erroneous frames.
-                                                             This parameter can be a value of @ref ETH_Forward_Error_Frames */
+        uint32_t ForwardErrorFrames;          /*!< Selects or not the forward to the DMA of erroneous frames.
+                                               *       This parameter can be a value of @ref ETH_Forward_Error_Frames */
 
-  uint32_t             ForwardUndersizedGoodFrames; /*!< Enables or disables the Rx FIFO to forward Undersized frames (frames with no Error
-                                                             and length less than 64 bytes) including pad-bytes and CRC)
-                                                             This parameter can be a value of @ref ETH_Forward_Undersized_Good_Frames */
+        uint32_t ForwardUndersizedGoodFrames; /*!< Enables or disables the Rx FIFO to forward Undersized frames (frames with no Error
+                                               *       and length less than 64 bytes) including pad-bytes and CRC)
+                                               *       This parameter can be a value of @ref ETH_Forward_Undersized_Good_Frames */
 
-  uint32_t             ReceiveThresholdControl;     /*!< Selects the threshold level of the Receive FIFO.
-                                                             This parameter can be a value of @ref ETH_Receive_Threshold_Control */
+        uint32_t ReceiveThresholdControl;     /*!< Selects the threshold level of the Receive FIFO.
+                                               *       This parameter can be a value of @ref ETH_Receive_Threshold_Control */
 
-  uint32_t             SecondFrameOperate;          /*!< Selects or not the Operate on second frame mode, which allows the DMA to process a second
-                                                             frame of Transmit data even before obtaining the status for the first frame.
-                                                             This parameter can be a value of @ref ETH_Second_Frame_Operate */
+        uint32_t SecondFrameOperate;          /*!< Selects or not the Operate on second frame mode, which allows the DMA to process a second
+                                               *       frame of Transmit data even before obtaining the status for the first frame.
+                                               *       This parameter can be a value of @ref ETH_Second_Frame_Operate */
 
-  uint32_t             AddressAlignedBeats;         /*!< Enables or disables the Address Aligned Beats.
-                                                             This parameter can be a value of @ref ETH_Address_Aligned_Beats */
+        uint32_t AddressAlignedBeats;         /*!< Enables or disables the Address Aligned Beats.
+                                               *       This parameter can be a value of @ref ETH_Address_Aligned_Beats */
 
-  uint32_t             FixedBurst;                  /*!< Enables or disables the AHB Master interface fixed burst transfers.
-                                                             This parameter can be a value of @ref ETH_Fixed_Burst */
+        uint32_t FixedBurst;                  /*!< Enables or disables the AHB Master interface fixed burst transfers.
+                                               *       This parameter can be a value of @ref ETH_Fixed_Burst */
 
-  uint32_t             RxDMABurstLength;            /*!< Indicates the maximum number of beats to be transferred in one Rx DMA transaction.
-                                                             This parameter can be a value of @ref ETH_Rx_DMA_Burst_Length */
+        uint32_t RxDMABurstLength;            /*!< Indicates the maximum number of beats to be transferred in one Rx DMA transaction.
+                                               *       This parameter can be a value of @ref ETH_Rx_DMA_Burst_Length */
 
-  uint32_t             TxDMABurstLength;            /*!< Indicates the maximum number of beats to be transferred in one Tx DMA transaction.
-                                                             This parameter can be a value of @ref ETH_Tx_DMA_Burst_Length */
+        uint32_t TxDMABurstLength;            /*!< Indicates the maximum number of beats to be transferred in one Tx DMA transaction.
+                                               *       This parameter can be a value of @ref ETH_Tx_DMA_Burst_Length */
 
-  uint32_t             EnhancedDescriptorFormat;    /*!< Enables the enhanced descriptor format.
-                                                             This parameter can be a value of @ref ETH_DMA_Enhanced_descriptor_format */
+        uint32_t EnhancedDescriptorFormat;    /*!< Enables the enhanced descriptor format.
+                                               *       This parameter can be a value of @ref ETH_DMA_Enhanced_descriptor_format */
 
-  uint32_t             DescriptorSkipLength;        /*!< Specifies the number of word to skip between two unchained descriptors (Ring mode)
-                                                             This parameter must be a number between Min_Data = 0 and Max_Data = 32 */
+        uint32_t DescriptorSkipLength;        /*!< Specifies the number of word to skip between two unchained descriptors (Ring mode)
+                                               *       This parameter must be a number between Min_Data = 0 and Max_Data = 32 */
 
-  uint32_t             DMAArbitration;              /*!< Selects the DMA Tx/Rx arbitration.
-                                                             This parameter can be a value of @ref ETH_DMA_Arbitration */
-} ETH_DMAInitTypeDef;
-
-
-/**
-  * @brief  ETH DMA Descriptors data structure definition
-  */
-
-typedef struct
-{
-  __IO uint32_t   Status;           /*!< Status */
-
-  uint32_t   ControlBufferSize;     /*!< Control and Buffer1, Buffer2 lengths */
-
-  uint32_t   Buffer1Addr;           /*!< Buffer1 address pointer */
-
-  uint32_t   Buffer2NextDescAddr;   /*!< Buffer2 or next descriptor address pointer */
-
-  /*!< Enhanced Ethernet DMA PTP Descriptors */
-  uint32_t   ExtendedStatus;        /*!< Extended status for PTP receive descriptor */
-
-  uint32_t   Reserved1;             /*!< Reserved */
-
-  uint32_t   TimeStampLow;          /*!< Time Stamp Low value for transmit and receive */
-
-  uint32_t   TimeStampHigh;         /*!< Time Stamp High value for transmit and receive */
-
-} ETH_DMADescTypeDef;
+        uint32_t DMAArbitration;              /*!< Selects the DMA Tx/Rx arbitration.
+                                               *       This parameter can be a value of @ref ETH_DMA_Arbitration */
+    } ETH_DMAInitTypeDef;
 
 
 /**
-  * @brief  Received Frame Informations structure definition
-  */
-typedef struct
-{
-  ETH_DMADescTypeDef *FSRxDesc;          /*!< First Segment Rx Desc */
+ * @brief  ETH DMA Descriptors data structure definition
+ */
 
-  ETH_DMADescTypeDef *LSRxDesc;          /*!< Last Segment Rx Desc */
+    typedef struct
+    {
+        __IO uint32_t Status;         /*!< Status */
 
-  uint32_t  SegCount;                    /*!< Segment count */
+        uint32_t ControlBufferSize;   /*!< Control and Buffer1, Buffer2 lengths */
 
-  uint32_t length;                       /*!< Frame length */
+        uint32_t Buffer1Addr;         /*!< Buffer1 address pointer */
 
-  uint32_t buffer;                       /*!< Frame buffer */
+        uint32_t Buffer2NextDescAddr; /*!< Buffer2 or next descriptor address pointer */
 
-} ETH_DMARxFrameInfos;
+        /*!< Enhanced Ethernet DMA PTP Descriptors */
+        uint32_t ExtendedStatus; /*!< Extended status for PTP receive descriptor */
+
+        uint32_t Reserved1;      /*!< Reserved */
+
+        uint32_t TimeStampLow;   /*!< Time Stamp Low value for transmit and receive */
+
+        uint32_t TimeStampHigh;  /*!< Time Stamp High value for transmit and receive */
+    } ETH_DMADescTypeDef;
 
 
 /**
-  * @brief  ETH Handle Structure definition
-  */
+ * @brief  Received Frame Informations structure definition
+ */
+    typedef struct
+    {
+        ETH_DMADescTypeDef * FSRxDesc; /*!< First Segment Rx Desc */
 
-typedef struct
-{
-  ETH_TypeDef                *Instance;     /*!< Register base address       */
+        ETH_DMADescTypeDef * LSRxDesc; /*!< Last Segment Rx Desc */
 
-  ETH_InitTypeDef            Init;          /*!< Ethernet Init Configuration */
+        uint32_t SegCount;             /*!< Segment count */
 
-  uint32_t                   LinkStatus;    /*!< Ethernet link status        */
+        uint32_t length;               /*!< Frame length */
 
-  ETH_DMADescTypeDef         *RxDesc;       /*!< Rx descriptor to Get        */
+        uint32_t buffer;               /*!< Frame buffer */
+    } ETH_DMARxFrameInfos;
 
-  ETH_DMADescTypeDef         *TxDesc;       /*!< Tx descriptor to Set        */
 
-  ETH_DMARxFrameInfos        RxFrameInfos;  /*!< last Rx frame infos         */
+/**
+ * @brief  ETH Handle Structure definition
+ */
 
-  __IO HAL_ETH_StateTypeDef  State;         /*!< ETH communication state     */
+    typedef struct
+    {
+        ETH_TypeDef * Instance;           /*!< Register base address       */
 
-  HAL_LockTypeDef            Lock;          /*!< ETH Lock                    */
+        ETH_InitTypeDef Init;             /*!< Ethernet Init Configuration */
 
-} ETH_HandleTypeDef;
+        uint32_t LinkStatus;              /*!< Ethernet link status        */
 
- /**
-  * @}
-  */
+        ETH_DMADescTypeDef * RxDesc;      /*!< Rx descriptor to Get        */
+
+        ETH_DMADescTypeDef * TxDesc;      /*!< Tx descriptor to Set        */
+
+        ETH_DMARxFrameInfos RxFrameInfos; /*!< last Rx frame infos         */
+
+        __IO HAL_ETH_StateTypeDef State;  /*!< ETH communication state     */
+
+        HAL_LockTypeDef Lock;             /*!< ETH Lock                    */
+    } ETH_HandleTypeDef;
+
+    /**
+     * @}
+     */
 
 /* Exported constants --------------------------------------------------------*/
+
 /** @defgroup ETH_Exported_Constants ETH Exported Constants
-  * @{
-  */
+ * @{
+ */
 
 /** @defgroup ETH_Buffers_setting ETH Buffers setting
-  * @{
-  */
-#define ETH_MAX_PACKET_SIZE    ((uint32_t)1536U)    /*!< ETH_HEADER + ETH_EXTRA + ETH_VLAN_TAG + ETH_MAX_ETH_PAYLOAD + ETH_CRC */
-#define ETH_HEADER               ((uint32_t)14U)    /*!< 6 byte Dest addr, 6 byte Src addr, 2 byte length/type */
-#define ETH_CRC                   ((uint32_t)4U)    /*!< Ethernet CRC */
-#define ETH_EXTRA                 ((uint32_t)2U)    /*!< Extra bytes in some cases */
-#define ETH_VLAN_TAG              ((uint32_t)4U)    /*!< optional 802.1q VLAN Tag */
-#define ETH_MIN_ETH_PAYLOAD       ((uint32_t)46U)    /*!< Minimum Ethernet payload size */
-#define ETH_MAX_ETH_PAYLOAD       ((uint32_t)1500U)    /*!< Maximum Ethernet payload size */
-#define ETH_JUMBO_FRAME_PAYLOAD   ((uint32_t)9000U)    /*!< Jumbo frame payload size */
+ * @{
+ */
+    #define ETH_MAX_PACKET_SIZE        ( ( uint32_t ) 1536U ) /*!< ETH_HEADER + ETH_EXTRA + ETH_VLAN_TAG + ETH_MAX_ETH_PAYLOAD + ETH_CRC */
+    #define ETH_HEADER                 ( ( uint32_t ) 14U )   /*!< 6 byte Dest addr, 6 byte Src addr, 2 byte length/type */
+    #define ETH_CRC                    ( ( uint32_t ) 4U )    /*!< Ethernet CRC */
+    #define ETH_EXTRA                  ( ( uint32_t ) 2U )    /*!< Extra bytes in some cases */
+    #define ETH_VLAN_TAG               ( ( uint32_t ) 4U )    /*!< optional 802.1q VLAN Tag */
+    #define ETH_MIN_ETH_PAYLOAD        ( ( uint32_t ) 46U )   /*!< Minimum Ethernet payload size */
+    #define ETH_MAX_ETH_PAYLOAD        ( ( uint32_t ) 1500U ) /*!< Maximum Ethernet payload size */
+    #define ETH_JUMBO_FRAME_PAYLOAD    ( ( uint32_t ) 9000U ) /*!< Jumbo frame payload size */
 
- /* Ethernet driver receive buffers are organized in a chained linked-list, when
-    an Ethernet packet is received, the Rx-DMA will transfer the packet from RxFIFO
-    to the driver receive buffers memory.
-
-    Depending on the size of the received Ethernet packet and the size of
-    each Ethernet driver receive buffer, the received packet can take one or more
-    Ethernet driver receive buffer.
-
-    In below are defined the size of one Ethernet driver receive buffer ETH_RX_BUF_SIZE
-    and the total count of the driver receive buffers ETH_RXBUFNB.
-
-    The configured value for ETH_RX_BUF_SIZE and ETH_RXBUFNB are only provided as
-    example, they can be reconfigured in the application layer to fit the application
-    needs */
+    /* Ethernet driver receive buffers are organized in a chained linked-list, when
+     * an Ethernet packet is received, the Rx-DMA will transfer the packet from RxFIFO
+     * to the driver receive buffers memory.
+     *
+     * Depending on the size of the received Ethernet packet and the size of
+     * each Ethernet driver receive buffer, the received packet can take one or more
+     * Ethernet driver receive buffer.
+     *
+     * In below are defined the size of one Ethernet driver receive buffer ETH_RX_BUF_SIZE
+     * and the total count of the driver receive buffers ETH_RXBUFNB.
+     *
+     * The configured value for ETH_RX_BUF_SIZE and ETH_RXBUFNB are only provided as
+     * example, they can be reconfigured in the application layer to fit the application
+     * needs */
 
 /* Here we configure each Ethernet driver receive buffer to fit the Max size Ethernet
-   packet */
-#ifndef ETH_RX_BUF_SIZE
- #error please define ETH_RX_BUF_SIZE
- #define ETH_RX_BUF_SIZE         ETH_MAX_PACKET_SIZE
-#endif
+ * packet */
+    #ifndef ETH_RX_BUF_SIZE
+        #error please define ETH_RX_BUF_SIZE
+        #define ETH_RX_BUF_SIZE    ETH_MAX_PACKET_SIZE
+    #endif
 
 /* 5 Ethernet driver receive buffers are used (in a chained linked list)*/
-#ifndef ETH_RXBUFNB
- #define ETH_RXBUFNB             ((uint32_t)5U)     /*  5 Rx buffers of size ETH_RX_BUF_SIZE */
-#endif
+    #ifndef ETH_RXBUFNB
+        #define ETH_RXBUFNB    ( ( uint32_t ) 5U )  /*  5 Rx buffers of size ETH_RX_BUF_SIZE */
+    #endif
 
 
- /* Ethernet driver transmit buffers are organized in a chained linked-list, when
-    an Ethernet packet is transmitted, Tx-DMA will transfer the packet from the
-    driver transmit buffers memory to the TxFIFO.
-
-    Depending on the size of the Ethernet packet to be transmitted and the size of
-    each Ethernet driver transmit buffer, the packet to be transmitted can take
-    one or more Ethernet driver transmit buffer.
-
-    In below are defined the size of one Ethernet driver transmit buffer ETH_TX_BUF_SIZE
-    and the total count of the driver transmit buffers ETH_TXBUFNB.
-
-    The configured value for ETH_TX_BUF_SIZE and ETH_TXBUFNB are only provided as
-    example, they can be reconfigured in the application layer to fit the application
-    needs */
+    /* Ethernet driver transmit buffers are organized in a chained linked-list, when
+     * an Ethernet packet is transmitted, Tx-DMA will transfer the packet from the
+     * driver transmit buffers memory to the TxFIFO.
+     *
+     * Depending on the size of the Ethernet packet to be transmitted and the size of
+     * each Ethernet driver transmit buffer, the packet to be transmitted can take
+     * one or more Ethernet driver transmit buffer.
+     *
+     * In below are defined the size of one Ethernet driver transmit buffer ETH_TX_BUF_SIZE
+     * and the total count of the driver transmit buffers ETH_TXBUFNB.
+     *
+     * The configured value for ETH_TX_BUF_SIZE and ETH_TXBUFNB are only provided as
+     * example, they can be reconfigured in the application layer to fit the application
+     * needs */
 
 /* Here we configure each Ethernet driver transmit buffer to fit the Max size Ethernet
-   packet */
-#ifndef ETH_TX_BUF_SIZE
- #error please define ETH_TX_BUF_SIZE
- #define ETH_TX_BUF_SIZE         ETH_MAX_PACKET_SIZE
-#endif
+ * packet */
+    #ifndef ETH_TX_BUF_SIZE
+        #error please define ETH_TX_BUF_SIZE
+        #define ETH_TX_BUF_SIZE    ETH_MAX_PACKET_SIZE
+    #endif
 
 /* 5 Ethernet driver transmit buffers are used (in a chained linked list)*/
-#ifndef ETH_TXBUFNB
- #define ETH_TXBUFNB             ((uint32_t)5U)      /* 5  Tx buffers of size ETH_TX_BUF_SIZE */
-#endif
+    #ifndef ETH_TXBUFNB
+        #define ETH_TXBUFNB    ( ( uint32_t ) 5U )   /* 5  Tx buffers of size ETH_TX_BUF_SIZE */
+    #endif
 
- /**
-  * @}
-  */
+    /**
+     * @}
+     */
 
 /** @defgroup ETH_DMA_TX_Descriptor ETH DMA TX Descriptor
-  * @{
-  */
+ * @{
+ */
 
 /*
-   DMA Tx Descriptor
-  -----------------------------------------------------------------------------------------------
-  TDES0 | OWN(31) | CTRL[30:26] | Reserved[25:24] | CTRL[23:20] | Reserved[19:17] | Status[16:0] |
-  -----------------------------------------------------------------------------------------------
-  TDES1 | Reserved[31:29] | Buffer2 ByteCount[28:16] | Reserved[15:13] | Buffer1 ByteCount[12:0] |
-  -----------------------------------------------------------------------------------------------
-  TDES2 |                         Buffer1 Address [31:0]                                         |
-  -----------------------------------------------------------------------------------------------
-  TDES3 |                   Buffer2 Address [31:0] / Next Descriptor Address [31:0]              |
-  -----------------------------------------------------------------------------------------------
-*/
+ * DMA Tx Descriptor
+ * -----------------------------------------------------------------------------------------------
+ * TDES0 | OWN(31) | CTRL[30:26] | Reserved[25:24] | CTRL[23:20] | Reserved[19:17] | Status[16:0] |
+ * -----------------------------------------------------------------------------------------------
+ * TDES1 | Reserved[31:29] | Buffer2 ByteCount[28:16] | Reserved[15:13] | Buffer1 ByteCount[12:0] |
+ * -----------------------------------------------------------------------------------------------
+ * TDES2 |                         Buffer1 Address [31:0]                                         |
+ * -----------------------------------------------------------------------------------------------
+ * TDES3 |                   Buffer2 Address [31:0] / Next Descriptor Address [31:0]              |
+ * -----------------------------------------------------------------------------------------------
+ */
 
 /**
-  * @brief  Bit definition of TDES0 register: DMA Tx descriptor status register
-  */
-#define ETH_DMATXDESC_OWN                     ((uint32_t)0x80000000U)  /*!< OWN bit: descriptor is owned by DMA engine */
-#define ETH_DMATXDESC_IC                      ((uint32_t)0x40000000U)  /*!< Interrupt on Completion */
-#define ETH_DMATXDESC_LS                      ((uint32_t)0x20000000U)  /*!< Last Segment */
-#define ETH_DMATXDESC_FS                      ((uint32_t)0x10000000U)  /*!< First Segment */
-#define ETH_DMATXDESC_DC                      ((uint32_t)0x08000000U)  /*!< Disable CRC */
-#define ETH_DMATXDESC_DP                      ((uint32_t)0x04000000U)  /*!< Disable Padding */
-#define ETH_DMATXDESC_TTSE                    ((uint32_t)0x02000000U)  /*!< Transmit Time Stamp Enable */
-#define ETH_DMATXDESC_CIC                     ((uint32_t)0x00C00000U)  /*!< Checksum Insertion Control: 4 cases */
-#define ETH_DMATXDESC_CIC_BYPASS              ((uint32_t)0x00000000U)  /*!< Do Nothing: Checksum Engine is bypassed */
-#define ETH_DMATXDESC_CIC_IPV4HEADER          ((uint32_t)0x00400000U)  /*!< IPV4 header Checksum Insertion */
-#define ETH_DMATXDESC_CIC_TCPUDPICMP_SEGMENT  ((uint32_t)0x00800000U)  /*!< TCP/UDP/ICMP Checksum Insertion calculated over segment only */
-#define ETH_DMATXDESC_CIC_TCPUDPICMP_FULL     ((uint32_t)0x00C00000U)  /*!< TCP/UDP/ICMP Checksum Insertion fully calculated */
-#define ETH_DMATXDESC_TER                     ((uint32_t)0x00200000U)  /*!< Transmit End of Ring */
-#define ETH_DMATXDESC_TCH                     ((uint32_t)0x00100000U)  /*!< Second Address Chained */
-#define ETH_DMATXDESC_TTSS                    ((uint32_t)0x00020000U)  /*!< Tx Time Stamp Status */
-#define ETH_DMATXDESC_IHE                     ((uint32_t)0x00010000U)  /*!< IP Header Error */
-#define ETH_DMATXDESC_ES                      ((uint32_t)0x00008000U)  /*!< Error summary: OR of the following bits: UE || ED || EC || LCO || NC || LCA || FF || JT */
-#define ETH_DMATXDESC_JT                      ((uint32_t)0x00004000U)  /*!< Jabber Timeout */
-#define ETH_DMATXDESC_FF                      ((uint32_t)0x00002000U)  /*!< Frame Flushed: DMA/MTL flushed the frame due to SW flush */
-#define ETH_DMATXDESC_PCE                     ((uint32_t)0x00001000U)  /*!< Payload Checksum Error */
-#define ETH_DMATXDESC_LCA                     ((uint32_t)0x00000800U)  /*!< Loss of Carrier: carrier lost during transmission */
-#define ETH_DMATXDESC_NC                      ((uint32_t)0x00000400U)  /*!< No Carrier: no carrier signal from the transceiver */
-#define ETH_DMATXDESC_LCO                     ((uint32_t)0x00000200U)  /*!< Late Collision: transmission aborted due to collision */
-#define ETH_DMATXDESC_EC                      ((uint32_t)0x00000100U)  /*!< Excessive Collision: transmission aborted after 16 collisions */
-#define ETH_DMATXDESC_VF                      ((uint32_t)0x00000080U)  /*!< VLAN Frame */
-#define ETH_DMATXDESC_CC                      ((uint32_t)0x00000078U)  /*!< Collision Count */
-#define ETH_DMATXDESC_ED                      ((uint32_t)0x00000004U)  /*!< Excessive Deferral */
-#define ETH_DMATXDESC_UF                      ((uint32_t)0x00000002U)  /*!< Underflow Error: late data arrival from the memory */
-#define ETH_DMATXDESC_DB                      ((uint32_t)0x00000001U)  /*!< Deferred Bit */
+ * @brief  Bit definition of TDES0 register: DMA Tx descriptor status register
+ */
+    #define ETH_DMATXDESC_OWN                       ( ( uint32_t ) 0x80000000U ) /*!< OWN bit: descriptor is owned by DMA engine */
+    #define ETH_DMATXDESC_IC                        ( ( uint32_t ) 0x40000000U ) /*!< Interrupt on Completion */
+    #define ETH_DMATXDESC_LS                        ( ( uint32_t ) 0x20000000U ) /*!< Last Segment */
+    #define ETH_DMATXDESC_FS                        ( ( uint32_t ) 0x10000000U ) /*!< First Segment */
+    #define ETH_DMATXDESC_DC                        ( ( uint32_t ) 0x08000000U ) /*!< Disable CRC */
+    #define ETH_DMATXDESC_DP                        ( ( uint32_t ) 0x04000000U ) /*!< Disable Padding */
+    #define ETH_DMATXDESC_TTSE                      ( ( uint32_t ) 0x02000000U ) /*!< Transmit Time Stamp Enable */
+    #define ETH_DMATXDESC_CIC                       ( ( uint32_t ) 0x00C00000U ) /*!< Checksum Insertion Control: 4 cases */
+    #define ETH_DMATXDESC_CIC_BYPASS                ( ( uint32_t ) 0x00000000U ) /*!< Do Nothing: Checksum Engine is bypassed */
+    #define ETH_DMATXDESC_CIC_IPV4HEADER            ( ( uint32_t ) 0x00400000U ) /*!< IPV4 header Checksum Insertion */
+    #define ETH_DMATXDESC_CIC_TCPUDPICMP_SEGMENT    ( ( uint32_t ) 0x00800000U ) /*!< TCP/UDP/ICMP Checksum Insertion calculated over segment only */
+    #define ETH_DMATXDESC_CIC_TCPUDPICMP_FULL       ( ( uint32_t ) 0x00C00000U ) /*!< TCP/UDP/ICMP Checksum Insertion fully calculated */
+    #define ETH_DMATXDESC_TER                       ( ( uint32_t ) 0x00200000U ) /*!< Transmit End of Ring */
+    #define ETH_DMATXDESC_TCH                       ( ( uint32_t ) 0x00100000U ) /*!< Second Address Chained */
+    #define ETH_DMATXDESC_TTSS                      ( ( uint32_t ) 0x00020000U ) /*!< Tx Time Stamp Status */
+    #define ETH_DMATXDESC_IHE                       ( ( uint32_t ) 0x00010000U ) /*!< IP Header Error */
+    #define ETH_DMATXDESC_ES                        ( ( uint32_t ) 0x00008000U ) /*!< Error summary: OR of the following bits: UE || ED || EC || LCO || NC || LCA || FF || JT */
+    #define ETH_DMATXDESC_JT                        ( ( uint32_t ) 0x00004000U ) /*!< Jabber Timeout */
+    #define ETH_DMATXDESC_FF                        ( ( uint32_t ) 0x00002000U ) /*!< Frame Flushed: DMA/MTL flushed the frame due to SW flush */
+    #define ETH_DMATXDESC_PCE                       ( ( uint32_t ) 0x00001000U ) /*!< Payload Checksum Error */
+    #define ETH_DMATXDESC_LCA                       ( ( uint32_t ) 0x00000800U ) /*!< Loss of Carrier: carrier lost during transmission */
+    #define ETH_DMATXDESC_NC                        ( ( uint32_t ) 0x00000400U ) /*!< No Carrier: no carrier signal from the transceiver */
+    #define ETH_DMATXDESC_LCO                       ( ( uint32_t ) 0x00000200U ) /*!< Late Collision: transmission aborted due to collision */
+    #define ETH_DMATXDESC_EC                        ( ( uint32_t ) 0x00000100U ) /*!< Excessive Collision: transmission aborted after 16 collisions */
+    #define ETH_DMATXDESC_VF                        ( ( uint32_t ) 0x00000080U ) /*!< VLAN Frame */
+    #define ETH_DMATXDESC_CC                        ( ( uint32_t ) 0x00000078U ) /*!< Collision Count */
+    #define ETH_DMATXDESC_ED                        ( ( uint32_t ) 0x00000004U ) /*!< Excessive Deferral */
+    #define ETH_DMATXDESC_UF                        ( ( uint32_t ) 0x00000002U ) /*!< Underflow Error: late data arrival from the memory */
+    #define ETH_DMATXDESC_DB                        ( ( uint32_t ) 0x00000001U ) /*!< Deferred Bit */
 
 /**
-  * @brief  Bit definition of TDES1 register
-  */
-#define ETH_DMATXDESC_TBS2  ((uint32_t)0x1FFF0000U)  /*!< Transmit Buffer2 Size */
-#define ETH_DMATXDESC_TBS1  ((uint32_t)0x00001FFFU)  /*!< Transmit Buffer1 Size */
+ * @brief  Bit definition of TDES1 register
+ */
+    #define ETH_DMATXDESC_TBS2                      ( ( uint32_t ) 0x1FFF0000U ) /*!< Transmit Buffer2 Size */
+    #define ETH_DMATXDESC_TBS1                      ( ( uint32_t ) 0x00001FFFU ) /*!< Transmit Buffer1 Size */
 
 /**
-  * @brief  Bit definition of TDES2 register
-  */
-#define ETH_DMATXDESC_B1AP  ((uint32_t)0xFFFFFFFFU)  /*!< Buffer1 Address Pointer */
+ * @brief  Bit definition of TDES2 register
+ */
+    #define ETH_DMATXDESC_B1AP                      ( ( uint32_t ) 0xFFFFFFFFU ) /*!< Buffer1 Address Pointer */
 
 /**
-  * @brief  Bit definition of TDES3 register
-  */
-#define ETH_DMATXDESC_B2AP  ((uint32_t)0xFFFFFFFFU)  /*!< Buffer2 Address Pointer */
+ * @brief  Bit definition of TDES3 register
+ */
+    #define ETH_DMATXDESC_B2AP                      ( ( uint32_t ) 0xFFFFFFFFU ) /*!< Buffer2 Address Pointer */
 
-  /*---------------------------------------------------------------------------------------------
-  TDES6 |                         Transmit Time Stamp Low [31:0]                                 |
-  -----------------------------------------------------------------------------------------------
-  TDES7 |                         Transmit Time Stamp High [31:0]                                |
-  ----------------------------------------------------------------------------------------------*/
+    /*---------------------------------------------------------------------------------------------
+     * TDES6 |                         Transmit Time Stamp Low [31:0]                                 |
+     * -----------------------------------------------------------------------------------------------
+     * TDES7 |                         Transmit Time Stamp High [31:0]                                |
+     * ----------------------------------------------------------------------------------------------*/
 
 /* Bit definition of TDES6 register */
- #define ETH_DMAPTPTXDESC_TTSL  ((uint32_t)0xFFFFFFFFU)  /* Transmit Time Stamp Low */
+    #define ETH_DMAPTPTXDESC_TTSL    ( ( uint32_t ) 0xFFFFFFFFU ) /* Transmit Time Stamp Low */
 
 /* Bit definition of TDES7 register */
- #define ETH_DMAPTPTXDESC_TTSH  ((uint32_t)0xFFFFFFFFU)  /* Transmit Time Stamp High */
+    #define ETH_DMAPTPTXDESC_TTSH    ( ( uint32_t ) 0xFFFFFFFFU ) /* Transmit Time Stamp High */
 
 /**
-  * @}
-  */
+ * @}
+ */
 /** @defgroup ETH_DMA_RX_Descriptor ETH DMA RX Descriptor
-  * @{
-  */
+ * @{
+ */
 
 /*
-  DMA Rx Descriptor
-  --------------------------------------------------------------------------------------------------------------------
-  RDES0 | OWN(31) |                                             Status [30:0]                                          |
-  ---------------------------------------------------------------------------------------------------------------------
-  RDES1 | CTRL(31) | Reserved[30:29] | Buffer2 ByteCount[28:16] | CTRL[15:14] | Reserved(13) | Buffer1 ByteCount[12:0] |
-  ---------------------------------------------------------------------------------------------------------------------
-  RDES2 |                                       Buffer1 Address [31:0]                                                 |
-  ---------------------------------------------------------------------------------------------------------------------
-  RDES3 |                          Buffer2 Address [31:0] / Next Descriptor Address [31:0]                             |
-  ---------------------------------------------------------------------------------------------------------------------
-*/
+ * DMA Rx Descriptor
+ * --------------------------------------------------------------------------------------------------------------------
+ * RDES0 | OWN(31) |                                             Status [30:0]                                          |
+ * ---------------------------------------------------------------------------------------------------------------------
+ * RDES1 | CTRL(31) | Reserved[30:29] | Buffer2 ByteCount[28:16] | CTRL[15:14] | Reserved(13) | Buffer1 ByteCount[12:0] |
+ * ---------------------------------------------------------------------------------------------------------------------
+ * RDES2 |                                       Buffer1 Address [31:0]                                                 |
+ * ---------------------------------------------------------------------------------------------------------------------
+ * RDES3 |                          Buffer2 Address [31:0] / Next Descriptor Address [31:0]                             |
+ * ---------------------------------------------------------------------------------------------------------------------
+ */
 
 /**
-  * @brief  Bit definition of RDES0 register: DMA Rx descriptor status register
-  */
-#define ETH_DMARXDESC_OWN         ((uint32_t)0x80000000U)  /*!< OWN bit: descriptor is owned by DMA engine  */
-#define ETH_DMARXDESC_AFM         ((uint32_t)0x40000000U)  /*!< DA Filter Fail for the rx frame  */
-#define ETH_DMARXDESC_FL          ((uint32_t)0x3FFF0000U)  /*!< Receive descriptor frame length  */
-#define ETH_DMARXDESC_ES          ((uint32_t)0x00008000U)  /*!< Error summary: OR of the following bits: DE || OE || IPC || LC || RWT || RE || CE */
-#define ETH_DMARXDESC_DE          ((uint32_t)0x00004000U)  /*!< Descriptor error: no more descriptors for receive frame  */
-#define ETH_DMARXDESC_SAF         ((uint32_t)0x00002000U)  /*!< SA Filter Fail for the received frame */
-#define ETH_DMARXDESC_LE          ((uint32_t)0x00001000U)  /*!< Frame size not matching with length field */
-#define ETH_DMARXDESC_OE          ((uint32_t)0x00000800U)  /*!< Overflow Error: Frame was damaged due to buffer overflow */
-#define ETH_DMARXDESC_VLAN        ((uint32_t)0x00000400U)  /*!< VLAN Tag: received frame is a VLAN frame */
-#define ETH_DMARXDESC_FS          ((uint32_t)0x00000200U)  /*!< First descriptor of the frame  */
-#define ETH_DMARXDESC_LS          ((uint32_t)0x00000100U)  /*!< Last descriptor of the frame  */
-#define ETH_DMARXDESC_IPV4HCE     ((uint32_t)0x00000080U)  /*!< IPC Checksum Error: Rx Ipv4 header checksum error   */
-#define ETH_DMARXDESC_LC          ((uint32_t)0x00000040U)  /*!< Late collision occurred during reception   */
-#define ETH_DMARXDESC_FT          ((uint32_t)0x00000020U)  /*!< Frame type - Ethernet, otherwise 802.3    */
-#define ETH_DMARXDESC_RWT         ((uint32_t)0x00000010U)  /*!< Receive Watchdog Timeout: watchdog timer expired during reception    */
-#define ETH_DMARXDESC_RE          ((uint32_t)0x00000008U)  /*!< Receive error: error reported by MII interface  */
-#define ETH_DMARXDESC_DBE         ((uint32_t)0x00000004U)  /*!< Dribble bit error: frame contains non int multiple of 8 bits  */
-#define ETH_DMARXDESC_CE          ((uint32_t)0x00000002U)  /*!< CRC error */
-#define ETH_DMARXDESC_MAMPCE      ((uint32_t)0x00000001U)  /*!< Rx MAC Address/Payload Checksum Error: Rx MAC address matched/ Rx Payload Checksum Error */
+ * @brief  Bit definition of RDES0 register: DMA Rx descriptor status register
+ */
+    #define ETH_DMARXDESC_OWN        ( ( uint32_t ) 0x80000000U ) /*!< OWN bit: descriptor is owned by DMA engine  */
+    #define ETH_DMARXDESC_AFM        ( ( uint32_t ) 0x40000000U ) /*!< DA Filter Fail for the rx frame  */
+    #define ETH_DMARXDESC_FL         ( ( uint32_t ) 0x3FFF0000U ) /*!< Receive descriptor frame length  */
+    #define ETH_DMARXDESC_ES         ( ( uint32_t ) 0x00008000U ) /*!< Error summary: OR of the following bits: DE || OE || IPC || LC || RWT || RE || CE */
+    #define ETH_DMARXDESC_DE         ( ( uint32_t ) 0x00004000U ) /*!< Descriptor error: no more descriptors for receive frame  */
+    #define ETH_DMARXDESC_SAF        ( ( uint32_t ) 0x00002000U ) /*!< SA Filter Fail for the received frame */
+    #define ETH_DMARXDESC_LE         ( ( uint32_t ) 0x00001000U ) /*!< Frame size not matching with length field */
+    #define ETH_DMARXDESC_OE         ( ( uint32_t ) 0x00000800U ) /*!< Overflow Error: Frame was damaged due to buffer overflow */
+    #define ETH_DMARXDESC_VLAN       ( ( uint32_t ) 0x00000400U ) /*!< VLAN Tag: received frame is a VLAN frame */
+    #define ETH_DMARXDESC_FS         ( ( uint32_t ) 0x00000200U ) /*!< First descriptor of the frame  */
+    #define ETH_DMARXDESC_LS         ( ( uint32_t ) 0x00000100U ) /*!< Last descriptor of the frame  */
+    #define ETH_DMARXDESC_IPV4HCE    ( ( uint32_t ) 0x00000080U ) /*!< IPC Checksum Error: Rx Ipv4 header checksum error   */
+    #define ETH_DMARXDESC_LC         ( ( uint32_t ) 0x00000040U ) /*!< Late collision occurred during reception   */
+    #define ETH_DMARXDESC_FT         ( ( uint32_t ) 0x00000020U ) /*!< Frame type - Ethernet, otherwise 802.3    */
+    #define ETH_DMARXDESC_RWT        ( ( uint32_t ) 0x00000010U ) /*!< Receive Watchdog Timeout: watchdog timer expired during reception    */
+    #define ETH_DMARXDESC_RE         ( ( uint32_t ) 0x00000008U ) /*!< Receive error: error reported by MII interface  */
+    #define ETH_DMARXDESC_DBE        ( ( uint32_t ) 0x00000004U ) /*!< Dribble bit error: frame contains non int multiple of 8 bits  */
+    #define ETH_DMARXDESC_CE         ( ( uint32_t ) 0x00000002U ) /*!< CRC error */
+    #define ETH_DMARXDESC_MAMPCE     ( ( uint32_t ) 0x00000001U ) /*!< Rx MAC Address/Payload Checksum Error: Rx MAC address matched/ Rx Payload Checksum Error */
 
 /**
-  * @brief  Bit definition of RDES1 register
-  */
-#define ETH_DMARXDESC_DIC   ((uint32_t)0x80000000U)  /*!< Disable Interrupt on Completion */
-#define ETH_DMARXDESC_RBS2  ((uint32_t)0x1FFF0000U)  /*!< Receive Buffer2 Size */
-#define ETH_DMARXDESC_RER   ((uint32_t)0x00008000U)  /*!< Receive End of Ring */
-#define ETH_DMARXDESC_RCH   ((uint32_t)0x00004000U)  /*!< Second Address Chained */
-#define ETH_DMARXDESC_RBS1  ((uint32_t)0x00001FFFU)  /*!< Receive Buffer1 Size */
+ * @brief  Bit definition of RDES1 register
+ */
+    #define ETH_DMARXDESC_DIC        ( ( uint32_t ) 0x80000000U ) /*!< Disable Interrupt on Completion */
+    #define ETH_DMARXDESC_RBS2       ( ( uint32_t ) 0x1FFF0000U ) /*!< Receive Buffer2 Size */
+    #define ETH_DMARXDESC_RER        ( ( uint32_t ) 0x00008000U ) /*!< Receive End of Ring */
+    #define ETH_DMARXDESC_RCH        ( ( uint32_t ) 0x00004000U ) /*!< Second Address Chained */
+    #define ETH_DMARXDESC_RBS1       ( ( uint32_t ) 0x00001FFFU ) /*!< Receive Buffer1 Size */
 
 /**
-  * @brief  Bit definition of RDES2 register
-  */
-#define ETH_DMARXDESC_B1AP  ((uint32_t)0xFFFFFFFFU)  /*!< Buffer1 Address Pointer */
+ * @brief  Bit definition of RDES2 register
+ */
+    #define ETH_DMARXDESC_B1AP       ( ( uint32_t ) 0xFFFFFFFFU ) /*!< Buffer1 Address Pointer */
 
 /**
-  * @brief  Bit definition of RDES3 register
-  */
-#define ETH_DMARXDESC_B2AP  ((uint32_t)0xFFFFFFFFU)  /*!< Buffer2 Address Pointer */
+ * @brief  Bit definition of RDES3 register
+ */
+    #define ETH_DMARXDESC_B2AP       ( ( uint32_t ) 0xFFFFFFFFU ) /*!< Buffer2 Address Pointer */
 
 /*---------------------------------------------------------------------------------------------------------------------
-  RDES4 |                   Reserved[31:15]              |             Extended Status [14:0]                          |
-  ---------------------------------------------------------------------------------------------------------------------
-  RDES5 |                                            Reserved[31:0]                                                    |
-  ---------------------------------------------------------------------------------------------------------------------
-  RDES6 |                                       Receive Time Stamp Low [31:0]                                          |
-  ---------------------------------------------------------------------------------------------------------------------
-  RDES7 |                                       Receive Time Stamp High [31:0]                                         |
-  --------------------------------------------------------------------------------------------------------------------*/
+ * RDES4 |                   Reserved[31:15]              |             Extended Status [14:0]                          |
+ * ---------------------------------------------------------------------------------------------------------------------
+ * RDES5 |                                            Reserved[31:0]                                                    |
+ * ---------------------------------------------------------------------------------------------------------------------
+ * RDES6 |                                       Receive Time Stamp Low [31:0]                                          |
+ * ---------------------------------------------------------------------------------------------------------------------
+ * RDES7 |                                       Receive Time Stamp High [31:0]                                         |
+ * --------------------------------------------------------------------------------------------------------------------*/
 
 /* Bit definition of RDES4 register */
-#define ETH_DMAPTPRXDESC_PTPV                            ((uint32_t)0x00002000U)  /* PTP Version */
-#define ETH_DMAPTPRXDESC_PTPFT                           ((uint32_t)0x00001000U)  /* PTP Frame Type */
-#define ETH_DMAPTPRXDESC_PTPMT                           ((uint32_t)0x00000F00U)  /* PTP Message Type */
-  #define ETH_DMAPTPRXDESC_PTPMT_SYNC                      ((uint32_t)0x00000100U)  /* SYNC message (all clock types) */
-  #define ETH_DMAPTPRXDESC_PTPMT_FOLLOWUP                  ((uint32_t)0x00000200U)  /* FollowUp message (all clock types) */
-  #define ETH_DMAPTPRXDESC_PTPMT_DELAYREQ                  ((uint32_t)0x00000300U)  /* DelayReq message (all clock types) */
-  #define ETH_DMAPTPRXDESC_PTPMT_DELAYRESP                 ((uint32_t)0x00000400U)  /* DelayResp message (all clock types) */
-  #define ETH_DMAPTPRXDESC_PTPMT_PDELAYREQ_ANNOUNCE        ((uint32_t)0x00000500U)  /* PdelayReq message (peer-to-peer transparent clock) or Announce message (Ordinary or Boundary clock) */
-  #define ETH_DMAPTPRXDESC_PTPMT_PDELAYRESP_MANAG          ((uint32_t)0x00000600U)  /* PdelayResp message (peer-to-peer transparent clock) or Management message (Ordinary or Boundary clock)  */
-  #define ETH_DMAPTPRXDESC_PTPMT_PDELAYRESPFOLLOWUP_SIGNAL ((uint32_t)0x00000700U)  /* PdelayRespFollowUp message (peer-to-peer transparent clock) or Signaling message (Ordinary or Boundary clock) */
-#define ETH_DMAPTPRXDESC_IPV6PR                          ((uint32_t)0x00000080U)  /* IPv6 Packet Received */
-#define ETH_DMAPTPRXDESC_IPV4PR                          ((uint32_t)0x00000040U)  /* IPv4 Packet Received */
-#define ETH_DMAPTPRXDESC_IPCB                            ((uint32_t)0x00000020U)  /* IP Checksum Bypassed */
-#define ETH_DMAPTPRXDESC_IPPE                            ((uint32_t)0x00000010U)  /* IP Payload Error */
-#define ETH_DMAPTPRXDESC_IPHE                            ((uint32_t)0x00000008U)  /* IP Header Error */
-#define ETH_DMAPTPRXDESC_IPPT                            ((uint32_t)0x00000007U)  /* IP Payload Type */
-  #define ETH_DMAPTPRXDESC_IPPT_UDP                      ((uint32_t)0x00000001U)  /* UDP payload encapsulated in the IP datagram */
-  #define ETH_DMAPTPRXDESC_IPPT_TCP                      ((uint32_t)0x00000002U)  /* TCP payload encapsulated in the IP datagram */
-  #define ETH_DMAPTPRXDESC_IPPT_ICMP                     ((uint32_t)0x00000003U)  /* ICMP payload encapsulated in the IP datagram */
+    #define ETH_DMAPTPRXDESC_PTPV                               ( ( uint32_t ) 0x00002000U ) /* PTP Version */
+    #define ETH_DMAPTPRXDESC_PTPFT                              ( ( uint32_t ) 0x00001000U ) /* PTP Frame Type */
+    #define ETH_DMAPTPRXDESC_PTPMT                              ( ( uint32_t ) 0x00000F00U ) /* PTP Message Type */
+    #define ETH_DMAPTPRXDESC_PTPMT_SYNC                         ( ( uint32_t ) 0x00000100U ) /* SYNC message (all clock types) */
+    #define ETH_DMAPTPRXDESC_PTPMT_FOLLOWUP                     ( ( uint32_t ) 0x00000200U ) /* FollowUp message (all clock types) */
+    #define ETH_DMAPTPRXDESC_PTPMT_DELAYREQ                     ( ( uint32_t ) 0x00000300U ) /* DelayReq message (all clock types) */
+    #define ETH_DMAPTPRXDESC_PTPMT_DELAYRESP                    ( ( uint32_t ) 0x00000400U ) /* DelayResp message (all clock types) */
+    #define ETH_DMAPTPRXDESC_PTPMT_PDELAYREQ_ANNOUNCE           ( ( uint32_t ) 0x00000500U ) /* PdelayReq message (peer-to-peer transparent clock) or Announce message (Ordinary or Boundary clock) */
+    #define ETH_DMAPTPRXDESC_PTPMT_PDELAYRESP_MANAG             ( ( uint32_t ) 0x00000600U ) /* PdelayResp message (peer-to-peer transparent clock) or Management message (Ordinary or Boundary clock)  */
+    #define ETH_DMAPTPRXDESC_PTPMT_PDELAYRESPFOLLOWUP_SIGNAL    ( ( uint32_t ) 0x00000700U ) /* PdelayRespFollowUp message (peer-to-peer transparent clock) or Signaling message (Ordinary or Boundary clock) */
+    #define ETH_DMAPTPRXDESC_IPV6PR                             ( ( uint32_t ) 0x00000080U ) /* IPv6 Packet Received */
+    #define ETH_DMAPTPRXDESC_IPV4PR                             ( ( uint32_t ) 0x00000040U ) /* IPv4 Packet Received */
+    #define ETH_DMAPTPRXDESC_IPCB                               ( ( uint32_t ) 0x00000020U ) /* IP Checksum Bypassed */
+    #define ETH_DMAPTPRXDESC_IPPE                               ( ( uint32_t ) 0x00000010U ) /* IP Payload Error */
+    #define ETH_DMAPTPRXDESC_IPHE                               ( ( uint32_t ) 0x00000008U ) /* IP Header Error */
+    #define ETH_DMAPTPRXDESC_IPPT                               ( ( uint32_t ) 0x00000007U ) /* IP Payload Type */
+    #define ETH_DMAPTPRXDESC_IPPT_UDP                           ( ( uint32_t ) 0x00000001U ) /* UDP payload encapsulated in the IP datagram */
+    #define ETH_DMAPTPRXDESC_IPPT_TCP                           ( ( uint32_t ) 0x00000002U ) /* TCP payload encapsulated in the IP datagram */
+    #define ETH_DMAPTPRXDESC_IPPT_ICMP                          ( ( uint32_t ) 0x00000003U ) /* ICMP payload encapsulated in the IP datagram */
 
 /* Bit definition of RDES6 register */
-#define ETH_DMAPTPRXDESC_RTSL  ((uint32_t)0xFFFFFFFFU)  /* Receive Time Stamp Low */
+    #define ETH_DMAPTPRXDESC_RTSL                               ( ( uint32_t ) 0xFFFFFFFFU ) /* Receive Time Stamp Low */
 
 /* Bit definition of RDES7 register */
-#define ETH_DMAPTPRXDESC_RTSH  ((uint32_t)0xFFFFFFFFU)  /* Receive Time Stamp High */
-/**
-  * @}
-  */
- /** @defgroup ETH_AutoNegotiation ETH AutoNegotiation
-  * @{
-  */
-#define ETH_AUTONEGOTIATION_ENABLE     ((uint32_t)0x00000001U)
-#define ETH_AUTONEGOTIATION_DISABLE    ((uint32_t)0x00000000U)
+    #define ETH_DMAPTPRXDESC_RTSH                               ( ( uint32_t ) 0xFFFFFFFFU ) /* Receive Time Stamp High */
 
 /**
-  * @}
-  */
+ * @}
+ */
+/** @defgroup ETH_AutoNegotiation ETH AutoNegotiation
+ * @{
+ */
+    #define ETH_AUTONEGOTIATION_ENABLE     ( ( uint32_t ) 0x00000001U )
+    #define ETH_AUTONEGOTIATION_DISABLE    ( ( uint32_t ) 0x00000000U )
+
+/**
+ * @}
+ */
 /** @defgroup ETH_Speed ETH Speed
-  * @{
-  */
-#define ETH_SPEED_10M        ((uint32_t)0x00000000U)
-#define ETH_SPEED_100M       ((uint32_t)0x00004000U)
+ * @{
+ */
+    #define ETH_SPEED_10M     ( ( uint32_t ) 0x00000000U )
+    #define ETH_SPEED_100M    ( ( uint32_t ) 0x00004000U )
 
 /**
-  * @}
-  */
+ * @}
+ */
 /** @defgroup ETH_Duplex_Mode ETH Duplex Mode
-  * @{
-  */
-#define ETH_MODE_FULLDUPLEX       ((uint32_t)0x00000800U)
-#define ETH_MODE_HALFDUPLEX       ((uint32_t)0x00000000U)
+ * @{
+ */
+    #define ETH_MODE_FULLDUPLEX    ( ( uint32_t ) 0x00000800U )
+    #define ETH_MODE_HALFDUPLEX    ( ( uint32_t ) 0x00000000U )
+
 /**
-  * @}
-  */
+ * @}
+ */
 /** @defgroup ETH_Rx_Mode ETH Rx Mode
-  * @{
-  */
-#define ETH_RXPOLLING_MODE      ((uint32_t)0x00000000U)
-#define ETH_RXINTERRUPT_MODE    ((uint32_t)0x00000001U)
+ * @{
+ */
+    #define ETH_RXPOLLING_MODE      ( ( uint32_t ) 0x00000000U )
+    #define ETH_RXINTERRUPT_MODE    ( ( uint32_t ) 0x00000001U )
+
 /**
-  * @}
-  */
+ * @}
+ */
 
 /** @defgroup ETH_Checksum_Mode ETH Checksum Mode
-  * @{
-  */
-#define ETH_CHECKSUM_BY_HARDWARE      ((uint32_t)0x00000000U)
-#define ETH_CHECKSUM_BY_SOFTWARE      ((uint32_t)0x00000001U)
+ * @{
+ */
+    #define ETH_CHECKSUM_BY_HARDWARE    ( ( uint32_t ) 0x00000000U )
+    #define ETH_CHECKSUM_BY_SOFTWARE    ( ( uint32_t ) 0x00000001U )
+
 /**
-  * @}
-  */
+ * @}
+ */
 
 /** @defgroup ETH_Media_Interface ETH Media Interface
-  * @{
-  */
-#define ETH_MEDIA_INTERFACE_MII       ((uint32_t)0x00000000U)
-#define ETH_MEDIA_INTERFACE_RMII      ((uint32_t)SYSCFG_PMC_MII_RMII_SEL)
+ * @{
+ */
+    #define ETH_MEDIA_INTERFACE_MII     ( ( uint32_t ) 0x00000000U )
+    #define ETH_MEDIA_INTERFACE_RMII    ( ( uint32_t ) SYSCFG_PMC_MII_RMII_SEL )
+
 /**
-  * @}
-  */
+ * @}
+ */
 
 /** @defgroup ETH_Watchdog ETH Watchdog
-  * @{
-  */
-#define ETH_WATCHDOG_ENABLE       ((uint32_t)0x00000000U)
-#define ETH_WATCHDOG_DISABLE      ((uint32_t)0x00800000U)
+ * @{
+ */
+    #define ETH_WATCHDOG_ENABLE     ( ( uint32_t ) 0x00000000U )
+    #define ETH_WATCHDOG_DISABLE    ( ( uint32_t ) 0x00800000U )
+
 /**
-  * @}
-  */
+ * @}
+ */
 
 /** @defgroup ETH_Jabber ETH Jabber
-  * @{
-  */
-#define ETH_JABBER_ENABLE    ((uint32_t)0x00000000U)
-#define ETH_JABBER_DISABLE   ((uint32_t)0x00400000U)
+ * @{
+ */
+    #define ETH_JABBER_ENABLE     ( ( uint32_t ) 0x00000000U )
+    #define ETH_JABBER_DISABLE    ( ( uint32_t ) 0x00400000U )
+
 /**
-  * @}
-  */
+ * @}
+ */
 
 /** @defgroup ETH_Inter_Frame_Gap ETH Inter Frame Gap
-  * @{
-  */
-#define ETH_INTERFRAMEGAP_96BIT   ((uint32_t)0x00000000U)  /*!< minimum IFG between frames during transmission is 96Bit */
-#define ETH_INTERFRAMEGAP_88BIT   ((uint32_t)0x00020000U)  /*!< minimum IFG between frames during transmission is 88Bit */
-#define ETH_INTERFRAMEGAP_80BIT   ((uint32_t)0x00040000U)  /*!< minimum IFG between frames during transmission is 80Bit */
-#define ETH_INTERFRAMEGAP_72BIT   ((uint32_t)0x00060000U)  /*!< minimum IFG between frames during transmission is 72Bit */
-#define ETH_INTERFRAMEGAP_64BIT   ((uint32_t)0x00080000U)  /*!< minimum IFG between frames during transmission is 64Bit */
-#define ETH_INTERFRAMEGAP_56BIT   ((uint32_t)0x000A0000U)  /*!< minimum IFG between frames during transmission is 56Bit */
-#define ETH_INTERFRAMEGAP_48BIT   ((uint32_t)0x000C0000U)  /*!< minimum IFG between frames during transmission is 48Bit */
-#define ETH_INTERFRAMEGAP_40BIT   ((uint32_t)0x000E0000U)  /*!< minimum IFG between frames during transmission is 40Bit */
+ * @{
+ */
+    #define ETH_INTERFRAMEGAP_96BIT    ( ( uint32_t ) 0x00000000U ) /*!< minimum IFG between frames during transmission is 96Bit */
+    #define ETH_INTERFRAMEGAP_88BIT    ( ( uint32_t ) 0x00020000U ) /*!< minimum IFG between frames during transmission is 88Bit */
+    #define ETH_INTERFRAMEGAP_80BIT    ( ( uint32_t ) 0x00040000U ) /*!< minimum IFG between frames during transmission is 80Bit */
+    #define ETH_INTERFRAMEGAP_72BIT    ( ( uint32_t ) 0x00060000U ) /*!< minimum IFG between frames during transmission is 72Bit */
+    #define ETH_INTERFRAMEGAP_64BIT    ( ( uint32_t ) 0x00080000U ) /*!< minimum IFG between frames during transmission is 64Bit */
+    #define ETH_INTERFRAMEGAP_56BIT    ( ( uint32_t ) 0x000A0000U ) /*!< minimum IFG between frames during transmission is 56Bit */
+    #define ETH_INTERFRAMEGAP_48BIT    ( ( uint32_t ) 0x000C0000U ) /*!< minimum IFG between frames during transmission is 48Bit */
+    #define ETH_INTERFRAMEGAP_40BIT    ( ( uint32_t ) 0x000E0000U ) /*!< minimum IFG between frames during transmission is 40Bit */
+
 /**
-  * @}
-  */
+ * @}
+ */
 
 /** @defgroup ETH_Carrier_Sense ETH Carrier Sense
-  * @{
-  */
-#define ETH_CARRIERSENCE_ENABLE   ((uint32_t)0x00000000U)
-#define ETH_CARRIERSENCE_DISABLE  ((uint32_t)0x00010000U)
+ * @{
+ */
+    #define ETH_CARRIERSENCE_ENABLE     ( ( uint32_t ) 0x00000000U )
+    #define ETH_CARRIERSENCE_DISABLE    ( ( uint32_t ) 0x00010000U )
+
 /**
-  * @}
-  */
+ * @}
+ */
 
 /** @defgroup ETH_Receive_Own ETH Receive Own
-  * @{
-  */
-#define ETH_RECEIVEOWN_ENABLE     ((uint32_t)0x00000000U)
-#define ETH_RECEIVEOWN_DISABLE    ((uint32_t)0x00002000U)
+ * @{
+ */
+    #define ETH_RECEIVEOWN_ENABLE     ( ( uint32_t ) 0x00000000U )
+    #define ETH_RECEIVEOWN_DISABLE    ( ( uint32_t ) 0x00002000U )
+
 /**
-  * @}
-  */
+ * @}
+ */
 
 /** @defgroup ETH_Loop_Back_Mode ETH Loop Back Mode
-  * @{
-  */
-#define ETH_LOOPBACKMODE_ENABLE        ((uint32_t)0x00001000U)
-#define ETH_LOOPBACKMODE_DISABLE       ((uint32_t)0x00000000U)
+ * @{
+ */
+    #define ETH_LOOPBACKMODE_ENABLE     ( ( uint32_t ) 0x00001000U )
+    #define ETH_LOOPBACKMODE_DISABLE    ( ( uint32_t ) 0x00000000U )
+
 /**
-  * @}
-  */
+ * @}
+ */
 
 /** @defgroup ETH_Checksum_Offload ETH Checksum Offload
-  * @{
-  */
-#define ETH_CHECKSUMOFFLAOD_ENABLE     ((uint32_t)0x00000400U)
-#define ETH_CHECKSUMOFFLAOD_DISABLE    ((uint32_t)0x00000000U)
+ * @{
+ */
+    #define ETH_CHECKSUMOFFLAOD_ENABLE     ( ( uint32_t ) 0x00000400U )
+    #define ETH_CHECKSUMOFFLAOD_DISABLE    ( ( uint32_t ) 0x00000000U )
+
 /**
-  * @}
-  */
+ * @}
+ */
 
 /** @defgroup ETH_Retry_Transmission ETH Retry Transmission
-  * @{
-  */
-#define ETH_RETRYTRANSMISSION_ENABLE   ((uint32_t)0x00000000U)
-#define ETH_RETRYTRANSMISSION_DISABLE  ((uint32_t)0x00000200U)
+ * @{
+ */
+    #define ETH_RETRYTRANSMISSION_ENABLE     ( ( uint32_t ) 0x00000000U )
+    #define ETH_RETRYTRANSMISSION_DISABLE    ( ( uint32_t ) 0x00000200U )
+
 /**
-  * @}
-  */
+ * @}
+ */
 
 /** @defgroup ETH_Automatic_Pad_CRC_Strip ETH Automatic Pad CRC Strip
-  * @{
-  */
-#define ETH_AUTOMATICPADCRCSTRIP_ENABLE     ((uint32_t)0x00000080U)
-#define ETH_AUTOMATICPADCRCSTRIP_DISABLE    ((uint32_t)0x00000000U)
+ * @{
+ */
+    #define ETH_AUTOMATICPADCRCSTRIP_ENABLE     ( ( uint32_t ) 0x00000080U )
+    #define ETH_AUTOMATICPADCRCSTRIP_DISABLE    ( ( uint32_t ) 0x00000000U )
+
 /**
-  * @}
-  */
+ * @}
+ */
 
 /** @defgroup ETH_Back_Off_Limit ETH Back Off Limit
-  * @{
-  */
-#define ETH_BACKOFFLIMIT_10  ((uint32_t)0x00000000U)
-#define ETH_BACKOFFLIMIT_8   ((uint32_t)0x00000020U)
-#define ETH_BACKOFFLIMIT_4   ((uint32_t)0x00000040U)
-#define ETH_BACKOFFLIMIT_1   ((uint32_t)0x00000060U)
+ * @{
+ */
+    #define ETH_BACKOFFLIMIT_10    ( ( uint32_t ) 0x00000000U )
+    #define ETH_BACKOFFLIMIT_8     ( ( uint32_t ) 0x00000020U )
+    #define ETH_BACKOFFLIMIT_4     ( ( uint32_t ) 0x00000040U )
+    #define ETH_BACKOFFLIMIT_1     ( ( uint32_t ) 0x00000060U )
+
 /**
-  * @}
-  */
+ * @}
+ */
 
 /** @defgroup ETH_Deferral_Check ETH Deferral Check
-  * @{
-  */
-#define ETH_DEFFERRALCHECK_ENABLE       ((uint32_t)0x00000010U)
-#define ETH_DEFFERRALCHECK_DISABLE      ((uint32_t)0x00000000U)
+ * @{
+ */
+    #define ETH_DEFFERRALCHECK_ENABLE     ( ( uint32_t ) 0x00000010U )
+    #define ETH_DEFFERRALCHECK_DISABLE    ( ( uint32_t ) 0x00000000U )
+
 /**
-  * @}
-  */
+ * @}
+ */
 
 /** @defgroup ETH_Receive_All ETH Receive All
-  * @{
-  */
-#define ETH_RECEIVEALL_ENABLE     ((uint32_t)0x80000000U)
-#define ETH_RECEIVEAll_DISABLE    ((uint32_t)0x00000000U)
+ * @{
+ */
+    #define ETH_RECEIVEALL_ENABLE     ( ( uint32_t ) 0x80000000U )
+    #define ETH_RECEIVEAll_DISABLE    ( ( uint32_t ) 0x00000000U )
+
 /**
-  * @}
-  */
+ * @}
+ */
 
 /** @defgroup ETH_Source_Addr_Filter ETH Source Addr Filter
-  * @{
-  */
-#define ETH_SOURCEADDRFILTER_NORMAL_ENABLE       ((uint32_t)0x00000200U)
-#define ETH_SOURCEADDRFILTER_INVERSE_ENABLE      ((uint32_t)0x00000300U)
-#define ETH_SOURCEADDRFILTER_DISABLE             ((uint32_t)0x00000000U)
+ * @{
+ */
+    #define ETH_SOURCEADDRFILTER_NORMAL_ENABLE     ( ( uint32_t ) 0x00000200U )
+    #define ETH_SOURCEADDRFILTER_INVERSE_ENABLE    ( ( uint32_t ) 0x00000300U )
+    #define ETH_SOURCEADDRFILTER_DISABLE           ( ( uint32_t ) 0x00000000U )
+
 /**
-  * @}
-  */
+ * @}
+ */
 
 /** @defgroup ETH_Pass_Control_Frames ETH Pass Control Frames
-  * @{
-  */
-#define ETH_PASSCONTROLFRAMES_BLOCKALL                ((uint32_t)0x00000040U)  /*!< MAC filters all control frames from reaching the application */
-#define ETH_PASSCONTROLFRAMES_FORWARDALL              ((uint32_t)0x00000080U)  /*!< MAC forwards all control frames to application even if they fail the Address Filter */
-#define ETH_PASSCONTROLFRAMES_FORWARDPASSEDADDRFILTER ((uint32_t)0x000000C0U)  /*!< MAC forwards control frames that pass the Address Filter. */
+ * @{
+ */
+    #define ETH_PASSCONTROLFRAMES_BLOCKALL                   ( ( uint32_t ) 0x00000040U ) /*!< MAC filters all control frames from reaching the application */
+    #define ETH_PASSCONTROLFRAMES_FORWARDALL                 ( ( uint32_t ) 0x00000080U ) /*!< MAC forwards all control frames to application even if they fail the Address Filter */
+    #define ETH_PASSCONTROLFRAMES_FORWARDPASSEDADDRFILTER    ( ( uint32_t ) 0x000000C0U ) /*!< MAC forwards control frames that pass the Address Filter. */
+
 /**
-  * @}
-  */
+ * @}
+ */
 
 /** @defgroup ETH_Broadcast_Frames_Reception ETH Broadcast Frames Reception
-  * @{
-  */
-#define ETH_BROADCASTFRAMESRECEPTION_ENABLE     ((uint32_t)0x00000000U)
-#define ETH_BROADCASTFRAMESRECEPTION_DISABLE    ((uint32_t)0x00000020U)
+ * @{
+ */
+    #define ETH_BROADCASTFRAMESRECEPTION_ENABLE     ( ( uint32_t ) 0x00000000U )
+    #define ETH_BROADCASTFRAMESRECEPTION_DISABLE    ( ( uint32_t ) 0x00000020U )
+
 /**
-  * @}
-  */
+ * @}
+ */
 
 /** @defgroup ETH_Destination_Addr_Filter ETH Destination Addr Filter
-  * @{
-  */
-#define ETH_DESTINATIONADDRFILTER_NORMAL    ((uint32_t)0x00000000U)
-#define ETH_DESTINATIONADDRFILTER_INVERSE   ((uint32_t)0x00000008U)
+ * @{
+ */
+    #define ETH_DESTINATIONADDRFILTER_NORMAL     ( ( uint32_t ) 0x00000000U )
+    #define ETH_DESTINATIONADDRFILTER_INVERSE    ( ( uint32_t ) 0x00000008U )
+
 /**
-  * @}
-  */
+ * @}
+ */
 
 /** @defgroup ETH_Promiscuous_Mode ETH Promiscuous Mode
-  * @{
-  */
-#define ETH_PROMISCUOUS_MODE_ENABLE     ((uint32_t)0x00000001U)
-#define ETH_PROMISCUOUS_MODE_DISABLE    ((uint32_t)0x00000000U)
+ * @{
+ */
+    #define ETH_PROMISCUOUS_MODE_ENABLE     ( ( uint32_t ) 0x00000001U )
+    #define ETH_PROMISCUOUS_MODE_DISABLE    ( ( uint32_t ) 0x00000000U )
+
 /**
-  * @}
-  */
+ * @}
+ */
 
 /** @defgroup ETH_Multicast_Frames_Filter ETH Multicast Frames Filter
-  * @{
-  */
-#define ETH_MULTICASTFRAMESFILTER_PERFECTHASHTABLE    ((uint32_t)0x00000404U)
-#define ETH_MULTICASTFRAMESFILTER_HASHTABLE           ((uint32_t)0x00000004U)
-#define ETH_MULTICASTFRAMESFILTER_PERFECT             ((uint32_t)0x00000000U)
-#define ETH_MULTICASTFRAMESFILTER_NONE                ((uint32_t)0x00000010U)
+ * @{
+ */
+    #define ETH_MULTICASTFRAMESFILTER_PERFECTHASHTABLE    ( ( uint32_t ) 0x00000404U )
+    #define ETH_MULTICASTFRAMESFILTER_HASHTABLE           ( ( uint32_t ) 0x00000004U )
+    #define ETH_MULTICASTFRAMESFILTER_PERFECT             ( ( uint32_t ) 0x00000000U )
+    #define ETH_MULTICASTFRAMESFILTER_NONE                ( ( uint32_t ) 0x00000010U )
+
 /**
-  * @}
-  */
+ * @}
+ */
 
 /** @defgroup ETH_Unicast_Frames_Filter ETH Unicast Frames Filter
-  * @{
-  */
-#define ETH_UNICASTFRAMESFILTER_PERFECTHASHTABLE ((uint32_t)0x00000402U)
-#define ETH_UNICASTFRAMESFILTER_HASHTABLE        ((uint32_t)0x00000002U)
-#define ETH_UNICASTFRAMESFILTER_PERFECT          ((uint32_t)0x00000000U)
+ * @{
+ */
+    #define ETH_UNICASTFRAMESFILTER_PERFECTHASHTABLE    ( ( uint32_t ) 0x00000402U )
+    #define ETH_UNICASTFRAMESFILTER_HASHTABLE           ( ( uint32_t ) 0x00000002U )
+    #define ETH_UNICASTFRAMESFILTER_PERFECT             ( ( uint32_t ) 0x00000000U )
+
 /**
-  * @}
-  */
+ * @}
+ */
 
 /** @defgroup ETH_Zero_Quanta_Pause ETH Zero Quanta Pause
-  * @{
-  */
-#define ETH_ZEROQUANTAPAUSE_ENABLE     ((uint32_t)0x00000000U)
-#define ETH_ZEROQUANTAPAUSE_DISABLE    ((uint32_t)0x00000080U)
+ * @{
+ */
+    #define ETH_ZEROQUANTAPAUSE_ENABLE     ( ( uint32_t ) 0x00000000U )
+    #define ETH_ZEROQUANTAPAUSE_DISABLE    ( ( uint32_t ) 0x00000080U )
+
 /**
-  * @}
-  */
+ * @}
+ */
 
 /** @defgroup ETH_Pause_Low_Threshold ETH Pause Low Threshold
-  * @{
-  */
-#define ETH_PAUSELOWTHRESHOLD_MINUS4        ((uint32_t)0x00000000U)  /*!< Pause time minus 4 slot times */
-#define ETH_PAUSELOWTHRESHOLD_MINUS28       ((uint32_t)0x00000010U)  /*!< Pause time minus 28 slot times */
-#define ETH_PAUSELOWTHRESHOLD_MINUS144      ((uint32_t)0x00000020U)  /*!< Pause time minus 144 slot times */
-#define ETH_PAUSELOWTHRESHOLD_MINUS256      ((uint32_t)0x00000030U)  /*!< Pause time minus 256 slot times */
+ * @{
+ */
+    #define ETH_PAUSELOWTHRESHOLD_MINUS4      ( ( uint32_t ) 0x00000000U ) /*!< Pause time minus 4 slot times */
+    #define ETH_PAUSELOWTHRESHOLD_MINUS28     ( ( uint32_t ) 0x00000010U ) /*!< Pause time minus 28 slot times */
+    #define ETH_PAUSELOWTHRESHOLD_MINUS144    ( ( uint32_t ) 0x00000020U ) /*!< Pause time minus 144 slot times */
+    #define ETH_PAUSELOWTHRESHOLD_MINUS256    ( ( uint32_t ) 0x00000030U ) /*!< Pause time minus 256 slot times */
+
 /**
-  * @}
-  */
+ * @}
+ */
 
 /** @defgroup ETH_Unicast_Pause_Frame_Detect ETH Unicast Pause Frame Detect
-  * @{
-  */
-#define ETH_UNICASTPAUSEFRAMEDETECT_ENABLE  ((uint32_t)0x00000008U)
-#define ETH_UNICASTPAUSEFRAMEDETECT_DISABLE ((uint32_t)0x00000000U)
+ * @{
+ */
+    #define ETH_UNICASTPAUSEFRAMEDETECT_ENABLE     ( ( uint32_t ) 0x00000008U )
+    #define ETH_UNICASTPAUSEFRAMEDETECT_DISABLE    ( ( uint32_t ) 0x00000000U )
+
 /**
-  * @}
-  */
+ * @}
+ */
 
 /** @defgroup ETH_Receive_Flow_Control ETH Receive Flow Control
-  * @{
-  */
-#define ETH_RECEIVEFLOWCONTROL_ENABLE       ((uint32_t)0x00000004U)
-#define ETH_RECEIVEFLOWCONTROL_DISABLE      ((uint32_t)0x00000000U)
+ * @{
+ */
+    #define ETH_RECEIVEFLOWCONTROL_ENABLE     ( ( uint32_t ) 0x00000004U )
+    #define ETH_RECEIVEFLOWCONTROL_DISABLE    ( ( uint32_t ) 0x00000000U )
+
 /**
-  * @}
-  */
+ * @}
+ */
 
 /** @defgroup ETH_Transmit_Flow_Control ETH Transmit Flow Control
-  * @{
-  */
-#define ETH_TRANSMITFLOWCONTROL_ENABLE      ((uint32_t)0x00000002U)
-#define ETH_TRANSMITFLOWCONTROL_DISABLE     ((uint32_t)0x00000000U)
+ * @{
+ */
+    #define ETH_TRANSMITFLOWCONTROL_ENABLE     ( ( uint32_t ) 0x00000002U )
+    #define ETH_TRANSMITFLOWCONTROL_DISABLE    ( ( uint32_t ) 0x00000000U )
+
 /**
-  * @}
-  */
+ * @}
+ */
 
 /** @defgroup ETH_VLAN_Tag_Comparison ETH VLAN Tag Comparison
-  * @{
-  */
-#define ETH_VLANTAGCOMPARISON_12BIT    ((uint32_t)0x00010000U)
-#define ETH_VLANTAGCOMPARISON_16BIT    ((uint32_t)0x00000000U)
+ * @{
+ */
+    #define ETH_VLANTAGCOMPARISON_12BIT    ( ( uint32_t ) 0x00010000U )
+    #define ETH_VLANTAGCOMPARISON_16BIT    ( ( uint32_t ) 0x00000000U )
+
 /**
-  * @}
-  */
+ * @}
+ */
 
 /** @defgroup ETH_MAC_addresses ETH MAC addresses
-  * @{
-  */
-#define ETH_MAC_ADDRESS0     ((uint32_t)0x00000000U)
-#define ETH_MAC_ADDRESS1     ((uint32_t)0x00000008U)
-#define ETH_MAC_ADDRESS2     ((uint32_t)0x00000010U)
-#define ETH_MAC_ADDRESS3     ((uint32_t)0x00000018U)
+ * @{
+ */
+    #define ETH_MAC_ADDRESS0    ( ( uint32_t ) 0x00000000U )
+    #define ETH_MAC_ADDRESS1    ( ( uint32_t ) 0x00000008U )
+    #define ETH_MAC_ADDRESS2    ( ( uint32_t ) 0x00000010U )
+    #define ETH_MAC_ADDRESS3    ( ( uint32_t ) 0x00000018U )
+
 /**
-  * @}
-  */
+ * @}
+ */
 
 /** @defgroup ETH_MAC_addresses_filter_SA_DA ETH MAC addresses filter SA DA
-  * @{
-  */
-#define ETH_MAC_ADDRESSFILTER_SA       ((uint32_t)0x00000000U)
-#define ETH_MAC_ADDRESSFILTER_DA       ((uint32_t)0x00000008U)
+ * @{
+ */
+    #define ETH_MAC_ADDRESSFILTER_SA    ( ( uint32_t ) 0x00000000U )
+    #define ETH_MAC_ADDRESSFILTER_DA    ( ( uint32_t ) 0x00000008U )
+
 /**
-  * @}
-  */
+ * @}
+ */
 
 /** @defgroup ETH_MAC_addresses_filter_Mask_bytes ETH MAC addresses filter Mask bytes
-  * @{
-  */
-#define ETH_MAC_ADDRESSMASK_BYTE6      ((uint32_t)0x20000000U)  /*!< Mask MAC Address high reg bits [15:8] */
-#define ETH_MAC_ADDRESSMASK_BYTE5      ((uint32_t)0x10000000U)  /*!< Mask MAC Address high reg bits [7:0] */
-#define ETH_MAC_ADDRESSMASK_BYTE4      ((uint32_t)0x08000000U)  /*!< Mask MAC Address low reg bits [31:24] */
-#define ETH_MAC_ADDRESSMASK_BYTE3      ((uint32_t)0x04000000U)  /*!< Mask MAC Address low reg bits [23:16] */
-#define ETH_MAC_ADDRESSMASK_BYTE2      ((uint32_t)0x02000000U)  /*!< Mask MAC Address low reg bits [15:8] */
-#define ETH_MAC_ADDRESSMASK_BYTE1      ((uint32_t)0x01000000U)  /*!< Mask MAC Address low reg bits [70] */
+ * @{
+ */
+    #define ETH_MAC_ADDRESSMASK_BYTE6    ( ( uint32_t ) 0x20000000U ) /*!< Mask MAC Address high reg bits [15:8] */
+    #define ETH_MAC_ADDRESSMASK_BYTE5    ( ( uint32_t ) 0x10000000U ) /*!< Mask MAC Address high reg bits [7:0] */
+    #define ETH_MAC_ADDRESSMASK_BYTE4    ( ( uint32_t ) 0x08000000U ) /*!< Mask MAC Address low reg bits [31:24] */
+    #define ETH_MAC_ADDRESSMASK_BYTE3    ( ( uint32_t ) 0x04000000U ) /*!< Mask MAC Address low reg bits [23:16] */
+    #define ETH_MAC_ADDRESSMASK_BYTE2    ( ( uint32_t ) 0x02000000U ) /*!< Mask MAC Address low reg bits [15:8] */
+    #define ETH_MAC_ADDRESSMASK_BYTE1    ( ( uint32_t ) 0x01000000U ) /*!< Mask MAC Address low reg bits [70] */
+
 /**
-  * @}
-  */
+ * @}
+ */
 
 /** @defgroup ETH_MAC_Debug_flags ETH MAC Debug flags
-  * @{
-  */
-#ifndef ETH_MAC_TXFIFO_FULL
-	#define ETH_MAC_TXFIFO_FULL          ((uint32_t)0x02000000)  /* Tx FIFO full */
-	#define ETH_MAC_TXFIFONOT_EMPTY      ((uint32_t)0x01000000)  /* Tx FIFO not empty */
-	#define ETH_MAC_TXFIFO_WRITE_ACTIVE  ((uint32_t)0x00400000)  /* Tx FIFO write active */
-	#define ETH_MAC_TXFIFO_IDLE     ((uint32_t)0x00000000)  /* Tx FIFO read status: Idle */
-	#define ETH_MAC_TXFIFO_READ     ((uint32_t)0x00100000)  /* Tx FIFO read status: Read (transferring data to the MAC transmitter) */
-	#define ETH_MAC_TXFIFO_WAITING  ((uint32_t)0x00200000)  /* Tx FIFO read status: Waiting for TxStatus from MAC transmitter */
-	#define ETH_MAC_TXFIFO_WRITING  ((uint32_t)0x00300000)  /* Tx FIFO read status: Writing the received TxStatus or flushing the TxFIFO */
-	#define ETH_MAC_TRANSMISSION_PAUSE     ((uint32_t)0x00080000)  /* MAC transmitter in pause */
-	#define ETH_MAC_TRANSMITFRAMECONTROLLER_IDLE            ((uint32_t)0x00000000)  /* MAC transmit frame controller: Idle */
-	#define ETH_MAC_TRANSMITFRAMECONTROLLER_WAITING         ((uint32_t)0x00020000)  /* MAC transmit frame controller: Waiting for Status of previous frame or IFG/backoff period to be over */
-	#define ETH_MAC_TRANSMITFRAMECONTROLLER_GENRATING_PCF   ((uint32_t)0x00040000)  /* MAC transmit frame controller: Generating and transmitting a Pause control frame (in full duplex mode) */
-	#define ETH_MAC_TRANSMITFRAMECONTROLLER_TRANSFERRING    ((uint32_t)0x00060000)  /* MAC transmit frame controller: Transferring input frame for transmission */
-	#define ETH_MAC_MII_TRANSMIT_ACTIVE      ((uint32_t)0x00010000)  /* MAC MII transmit engine active */
-	#define ETH_MAC_RXFIFO_EMPTY             ((uint32_t)0x00000000)  /* Rx FIFO fill level: empty */
-	#define ETH_MAC_RXFIFO_BELOW_THRESHOLD   ((uint32_t)0x00000100)  /* Rx FIFO fill level: fill-level below flow-control de-activate threshold */
-	#define ETH_MAC_RXFIFO_ABOVE_THRESHOLD   ((uint32_t)0x00000200)  /* Rx FIFO fill level: fill-level above flow-control activate threshold */
-	#define ETH_MAC_RXFIFO_FULL              ((uint32_t)0x00000300)  /* Rx FIFO fill level: full */
-	#define ETH_MAC_READCONTROLLER_IDLE            ((uint32_t)0x00000060)  /* Rx FIFO read controller IDLE state */
-	#define ETH_MAC_READCONTROLLER_READING_DATA    ((uint32_t)0x00000060)  /* Rx FIFO read controller Reading frame data */
-	#define ETH_MAC_READCONTROLLER_READING_STATUS  ((uint32_t)0x00000060)  /* Rx FIFO read controller Reading frame status (or time-stamp) */
-	#define ETH_MAC_READCONTROLLER_ FLUSHING       ((uint32_t)0x00000060)  /* Rx FIFO read controller Flushing the frame data and status */
-	#define ETH_MAC_RXFIFO_WRITE_ACTIVE     ((uint32_t)0x00000010)  /* Rx FIFO write controller active */
-	#define ETH_MAC_SMALL_FIFO_NOTACTIVE    ((uint32_t)0x00000000)  /* MAC small FIFO read / write controllers not active */
-	#define ETH_MAC_SMALL_FIFO_READ_ACTIVE  ((uint32_t)0x00000002)  /* MAC small FIFO read controller active */
-	#define ETH_MAC_SMALL_FIFO_WRITE_ACTIVE ((uint32_t)0x00000004)  /* MAC small FIFO write controller active */
-	#define ETH_MAC_SMALL_FIFO_RW_ACTIVE    ((uint32_t)0x00000006)  /* MAC small FIFO read / write controllers active */
-	#define ETH_MAC_MII_RECEIVE_PROTOCOL_ACTIVE   ((uint32_t)0x00000001)  /* MAC MII receive protocol engine active */
-#else
-	/* stm32_hal_legacy.h has probably been included. That file defines 'ETH_MAC_TXFIFO_FULL' and all macro's here below. */
-#endif
+ * @{
+ */
+    #ifndef ETH_MAC_TXFIFO_FULL
+        #define ETH_MAC_TXFIFO_FULL                              ( ( uint32_t ) 0x02000000 )         /* Tx FIFO full */
+        #define ETH_MAC_TXFIFONOT_EMPTY                          ( ( uint32_t ) 0x01000000 )         /* Tx FIFO not empty */
+        #define ETH_MAC_TXFIFO_WRITE_ACTIVE                      ( ( uint32_t ) 0x00400000 )         /* Tx FIFO write active */
+        #define ETH_MAC_TXFIFO_IDLE                              ( ( uint32_t ) 0x00000000 )         /* Tx FIFO read status: Idle */
+        #define ETH_MAC_TXFIFO_READ                              ( ( uint32_t ) 0x00100000 )         /* Tx FIFO read status: Read (transferring data to the MAC transmitter) */
+        #define ETH_MAC_TXFIFO_WAITING                           ( ( uint32_t ) 0x00200000 )         /* Tx FIFO read status: Waiting for TxStatus from MAC transmitter */
+        #define ETH_MAC_TXFIFO_WRITING                           ( ( uint32_t ) 0x00300000 )         /* Tx FIFO read status: Writing the received TxStatus or flushing the TxFIFO */
+        #define ETH_MAC_TRANSMISSION_PAUSE                       ( ( uint32_t ) 0x00080000 )         /* MAC transmitter in pause */
+        #define ETH_MAC_TRANSMITFRAMECONTROLLER_IDLE             ( ( uint32_t ) 0x00000000 )         /* MAC transmit frame controller: Idle */
+        #define ETH_MAC_TRANSMITFRAMECONTROLLER_WAITING          ( ( uint32_t ) 0x00020000 )         /* MAC transmit frame controller: Waiting for Status of previous frame or IFG/backoff period to be over */
+        #define ETH_MAC_TRANSMITFRAMECONTROLLER_GENRATING_PCF    ( ( uint32_t ) 0x00040000 )         /* MAC transmit frame controller: Generating and transmitting a Pause control frame (in full duplex mode) */
+        #define ETH_MAC_TRANSMITFRAMECONTROLLER_TRANSFERRING     ( ( uint32_t ) 0x00060000 )         /* MAC transmit frame controller: Transferring input frame for transmission */
+        #define ETH_MAC_MII_TRANSMIT_ACTIVE                      ( ( uint32_t ) 0x00010000 )         /* MAC MII transmit engine active */
+        #define ETH_MAC_RXFIFO_EMPTY                             ( ( uint32_t ) 0x00000000 )         /* Rx FIFO fill level: empty */
+        #define ETH_MAC_RXFIFO_BELOW_THRESHOLD                   ( ( uint32_t ) 0x00000100 )         /* Rx FIFO fill level: fill-level below flow-control de-activate threshold */
+        #define ETH_MAC_RXFIFO_ABOVE_THRESHOLD                   ( ( uint32_t ) 0x00000200 )         /* Rx FIFO fill level: fill-level above flow-control activate threshold */
+        #define ETH_MAC_RXFIFO_FULL                              ( ( uint32_t ) 0x00000300 )         /* Rx FIFO fill level: full */
+        #define ETH_MAC_READCONTROLLER_IDLE                      ( ( uint32_t ) 0x00000060 )         /* Rx FIFO read controller IDLE state */
+        #define ETH_MAC_READCONTROLLER_READING_DATA              ( ( uint32_t ) 0x00000060 )         /* Rx FIFO read controller Reading frame data */
+        #define ETH_MAC_READCONTROLLER_READING_STATUS            ( ( uint32_t ) 0x00000060 )         /* Rx FIFO read controller Reading frame status (or time-stamp) */
+        #define ETH_MAC_READCONTROLLER_                          FLUSHING( ( uint32_t ) 0x00000060 ) /* Rx FIFO read controller Flushing the frame data and status */
+        #define ETH_MAC_RXFIFO_WRITE_ACTIVE                      ( ( uint32_t ) 0x00000010 )         /* Rx FIFO write controller active */
+        #define ETH_MAC_SMALL_FIFO_NOTACTIVE                     ( ( uint32_t ) 0x00000000 )         /* MAC small FIFO read / write controllers not active */
+        #define ETH_MAC_SMALL_FIFO_READ_ACTIVE                   ( ( uint32_t ) 0x00000002 )         /* MAC small FIFO read controller active */
+        #define ETH_MAC_SMALL_FIFO_WRITE_ACTIVE                  ( ( uint32_t ) 0x00000004 )         /* MAC small FIFO write controller active */
+        #define ETH_MAC_SMALL_FIFO_RW_ACTIVE                     ( ( uint32_t ) 0x00000006 )         /* MAC small FIFO read / write controllers active */
+        #define ETH_MAC_MII_RECEIVE_PROTOCOL_ACTIVE              ( ( uint32_t ) 0x00000001 )         /* MAC MII receive protocol engine active */
+    #else /* ifndef ETH_MAC_TXFIFO_FULL */
+        /* stm32_hal_legacy.h has probably been included. That file defines 'ETH_MAC_TXFIFO_FULL' and all macro's here below. */
+    #endif /* ifndef ETH_MAC_TXFIFO_FULL */
+
 /**
-  * @}
-  */
+ * @}
+ */
 
 /** @defgroup ETH_Drop_TCP_IP_Checksum_Error_Frame ETH Drop TCP IP Checksum Error Frame
-  * @{
-  */
-#define ETH_DROPTCPIPCHECKSUMERRORFRAME_ENABLE   ((uint32_t)0x00000000U)
-#define ETH_DROPTCPIPCHECKSUMERRORFRAME_DISABLE  ((uint32_t)0x04000000U)
+ * @{
+ */
+    #define ETH_DROPTCPIPCHECKSUMERRORFRAME_ENABLE     ( ( uint32_t ) 0x00000000U )
+    #define ETH_DROPTCPIPCHECKSUMERRORFRAME_DISABLE    ( ( uint32_t ) 0x04000000U )
+
 /**
-  * @}
-  */
+ * @}
+ */
 
 /** @defgroup ETH_Receive_Store_Forward ETH Receive Store Forward
-  * @{
-  */
-#define ETH_RECEIVESTOREFORWARD_ENABLE      ((uint32_t)0x02000000U)
-#define ETH_RECEIVESTOREFORWARD_DISABLE     ((uint32_t)0x00000000U)
+ * @{
+ */
+    #define ETH_RECEIVESTOREFORWARD_ENABLE     ( ( uint32_t ) 0x02000000U )
+    #define ETH_RECEIVESTOREFORWARD_DISABLE    ( ( uint32_t ) 0x00000000U )
+
 /**
-  * @}
-  */
+ * @}
+ */
 
 /** @defgroup ETH_Flush_Received_Frame ETH Flush Received Frame
-  * @{
-  */
-#define ETH_FLUSHRECEIVEDFRAME_ENABLE       ((uint32_t)0x00000000U)
-#define ETH_FLUSHRECEIVEDFRAME_DISABLE      ((uint32_t)0x01000000U)
+ * @{
+ */
+    #define ETH_FLUSHRECEIVEDFRAME_ENABLE     ( ( uint32_t ) 0x00000000U )
+    #define ETH_FLUSHRECEIVEDFRAME_DISABLE    ( ( uint32_t ) 0x01000000U )
+
 /**
-  * @}
-  */
+ * @}
+ */
 
 /** @defgroup ETH_Transmit_Store_Forward ETH Transmit Store Forward
-  * @{
-  */
-#define ETH_TRANSMITSTOREFORWARD_ENABLE     ((uint32_t)0x00200000U)
-#define ETH_TRANSMITSTOREFORWARD_DISABLE    ((uint32_t)0x00000000U)
+ * @{
+ */
+    #define ETH_TRANSMITSTOREFORWARD_ENABLE     ( ( uint32_t ) 0x00200000U )
+    #define ETH_TRANSMITSTOREFORWARD_DISABLE    ( ( uint32_t ) 0x00000000U )
+
 /**
-  * @}
-  */
+ * @}
+ */
 
 /** @defgroup ETH_Transmit_Threshold_Control ETH Transmit Threshold Control
-  * @{
-  */
-#define ETH_TRANSMITTHRESHOLDCONTROL_64BYTES     ((uint32_t)0x00000000U)  /*!< threshold level of the MTL Transmit FIFO is 64 Bytes */
-#define ETH_TRANSMITTHRESHOLDCONTROL_128BYTES    ((uint32_t)0x00004000U)  /*!< threshold level of the MTL Transmit FIFO is 128 Bytes */
-#define ETH_TRANSMITTHRESHOLDCONTROL_192BYTES    ((uint32_t)0x00008000U)  /*!< threshold level of the MTL Transmit FIFO is 192 Bytes */
-#define ETH_TRANSMITTHRESHOLDCONTROL_256BYTES    ((uint32_t)0x0000C000U)  /*!< threshold level of the MTL Transmit FIFO is 256 Bytes */
-#define ETH_TRANSMITTHRESHOLDCONTROL_40BYTES     ((uint32_t)0x00010000U)  /*!< threshold level of the MTL Transmit FIFO is 40 Bytes */
-#define ETH_TRANSMITTHRESHOLDCONTROL_32BYTES     ((uint32_t)0x00014000U)  /*!< threshold level of the MTL Transmit FIFO is 32 Bytes */
-#define ETH_TRANSMITTHRESHOLDCONTROL_24BYTES     ((uint32_t)0x00018000U)  /*!< threshold level of the MTL Transmit FIFO is 24 Bytes */
-#define ETH_TRANSMITTHRESHOLDCONTROL_16BYTES     ((uint32_t)0x0001C000U)  /*!< threshold level of the MTL Transmit FIFO is 16 Bytes */
+ * @{
+ */
+    #define ETH_TRANSMITTHRESHOLDCONTROL_64BYTES     ( ( uint32_t ) 0x00000000U ) /*!< threshold level of the MTL Transmit FIFO is 64 Bytes */
+    #define ETH_TRANSMITTHRESHOLDCONTROL_128BYTES    ( ( uint32_t ) 0x00004000U ) /*!< threshold level of the MTL Transmit FIFO is 128 Bytes */
+    #define ETH_TRANSMITTHRESHOLDCONTROL_192BYTES    ( ( uint32_t ) 0x00008000U ) /*!< threshold level of the MTL Transmit FIFO is 192 Bytes */
+    #define ETH_TRANSMITTHRESHOLDCONTROL_256BYTES    ( ( uint32_t ) 0x0000C000U ) /*!< threshold level of the MTL Transmit FIFO is 256 Bytes */
+    #define ETH_TRANSMITTHRESHOLDCONTROL_40BYTES     ( ( uint32_t ) 0x00010000U ) /*!< threshold level of the MTL Transmit FIFO is 40 Bytes */
+    #define ETH_TRANSMITTHRESHOLDCONTROL_32BYTES     ( ( uint32_t ) 0x00014000U ) /*!< threshold level of the MTL Transmit FIFO is 32 Bytes */
+    #define ETH_TRANSMITTHRESHOLDCONTROL_24BYTES     ( ( uint32_t ) 0x00018000U ) /*!< threshold level of the MTL Transmit FIFO is 24 Bytes */
+    #define ETH_TRANSMITTHRESHOLDCONTROL_16BYTES     ( ( uint32_t ) 0x0001C000U ) /*!< threshold level of the MTL Transmit FIFO is 16 Bytes */
+
 /**
-  * @}
-  */
+ * @}
+ */
 
 /** @defgroup ETH_Forward_Error_Frames ETH Forward Error Frames
-  * @{
-  */
-#define ETH_FORWARDERRORFRAMES_ENABLE       ((uint32_t)0x00000080U)
-#define ETH_FORWARDERRORFRAMES_DISABLE      ((uint32_t)0x00000000U)
+ * @{
+ */
+    #define ETH_FORWARDERRORFRAMES_ENABLE     ( ( uint32_t ) 0x00000080U )
+    #define ETH_FORWARDERRORFRAMES_DISABLE    ( ( uint32_t ) 0x00000000U )
+
 /**
-  * @}
-  */
+ * @}
+ */
 
 /** @defgroup ETH_Forward_Undersized_Good_Frames ETH Forward Undersized Good Frames
-  * @{
-  */
-#define ETH_FORWARDUNDERSIZEDGOODFRAMES_ENABLE   ((uint32_t)0x00000040U)
-#define ETH_FORWARDUNDERSIZEDGOODFRAMES_DISABLE  ((uint32_t)0x00000000U)
+ * @{
+ */
+    #define ETH_FORWARDUNDERSIZEDGOODFRAMES_ENABLE     ( ( uint32_t ) 0x00000040U )
+    #define ETH_FORWARDUNDERSIZEDGOODFRAMES_DISABLE    ( ( uint32_t ) 0x00000000U )
+
 /**
-  * @}
-  */
+ * @}
+ */
 
 /** @defgroup ETH_Receive_Threshold_Control ETH Receive Threshold Control
-  * @{
-  */
-#define ETH_RECEIVEDTHRESHOLDCONTROL_64BYTES      ((uint32_t)0x00000000U)  /*!< threshold level of the MTL Receive FIFO is 64 Bytes */
-#define ETH_RECEIVEDTHRESHOLDCONTROL_32BYTES      ((uint32_t)0x00000008U)  /*!< threshold level of the MTL Receive FIFO is 32 Bytes */
-#define ETH_RECEIVEDTHRESHOLDCONTROL_96BYTES      ((uint32_t)0x00000010U)  /*!< threshold level of the MTL Receive FIFO is 96 Bytes */
-#define ETH_RECEIVEDTHRESHOLDCONTROL_128BYTES     ((uint32_t)0x00000018U)  /*!< threshold level of the MTL Receive FIFO is 128 Bytes */
+ * @{
+ */
+    #define ETH_RECEIVEDTHRESHOLDCONTROL_64BYTES     ( ( uint32_t ) 0x00000000U ) /*!< threshold level of the MTL Receive FIFO is 64 Bytes */
+    #define ETH_RECEIVEDTHRESHOLDCONTROL_32BYTES     ( ( uint32_t ) 0x00000008U ) /*!< threshold level of the MTL Receive FIFO is 32 Bytes */
+    #define ETH_RECEIVEDTHRESHOLDCONTROL_96BYTES     ( ( uint32_t ) 0x00000010U ) /*!< threshold level of the MTL Receive FIFO is 96 Bytes */
+    #define ETH_RECEIVEDTHRESHOLDCONTROL_128BYTES    ( ( uint32_t ) 0x00000018U ) /*!< threshold level of the MTL Receive FIFO is 128 Bytes */
+
 /**
-  * @}
-  */
+ * @}
+ */
 
 /** @defgroup ETH_Second_Frame_Operate ETH Second Frame Operate
-  * @{
-  */
-#define ETH_SECONDFRAMEOPERARTE_ENABLE       ((uint32_t)0x00000004U)
-#define ETH_SECONDFRAMEOPERARTE_DISABLE      ((uint32_t)0x00000000U)
+ * @{
+ */
+    #define ETH_SECONDFRAMEOPERARTE_ENABLE     ( ( uint32_t ) 0x00000004U )
+    #define ETH_SECONDFRAMEOPERARTE_DISABLE    ( ( uint32_t ) 0x00000000U )
+
 /**
-  * @}
-  */
+ * @}
+ */
 
 /** @defgroup ETH_Address_Aligned_Beats ETH Address Aligned Beats
-  * @{
-  */
-#define ETH_ADDRESSALIGNEDBEATS_ENABLE      ((uint32_t)0x02000000U)
-#define ETH_ADDRESSALIGNEDBEATS_DISABLE     ((uint32_t)0x00000000U)
+ * @{
+ */
+    #define ETH_ADDRESSALIGNEDBEATS_ENABLE     ( ( uint32_t ) 0x02000000U )
+    #define ETH_ADDRESSALIGNEDBEATS_DISABLE    ( ( uint32_t ) 0x00000000U )
+
 /**
-  * @}
-  */
+ * @}
+ */
 
 /** @defgroup ETH_Fixed_Burst ETH Fixed Burst
-  * @{
-  */
-#define ETH_FIXEDBURST_ENABLE     ((uint32_t)0x00010000U)
-#define ETH_FIXEDBURST_DISABLE    ((uint32_t)0x00000000U)
+ * @{
+ */
+    #define ETH_FIXEDBURST_ENABLE     ( ( uint32_t ) 0x00010000U )
+    #define ETH_FIXEDBURST_DISABLE    ( ( uint32_t ) 0x00000000U )
+
 /**
-  * @}
-  */
+ * @}
+ */
 
 /** @defgroup ETH_Rx_DMA_Burst_Length ETH Rx DMA Burst Length
-  * @{
-  */
-#define ETH_RXDMABURSTLENGTH_1BEAT          ((uint32_t)0x00020000U)  /*!< maximum number of beats to be transferred in one RxDMA transaction is 1 */
-#define ETH_RXDMABURSTLENGTH_2BEAT          ((uint32_t)0x00040000U)  /*!< maximum number of beats to be transferred in one RxDMA transaction is 2 */
-#define ETH_RXDMABURSTLENGTH_4BEAT          ((uint32_t)0x00080000U)  /*!< maximum number of beats to be transferred in one RxDMA transaction is 4 */
-#define ETH_RXDMABURSTLENGTH_8BEAT          ((uint32_t)0x00100000U)  /*!< maximum number of beats to be transferred in one RxDMA transaction is 8 */
-#define ETH_RXDMABURSTLENGTH_16BEAT         ((uint32_t)0x00200000U)  /*!< maximum number of beats to be transferred in one RxDMA transaction is 16 */
-#define ETH_RXDMABURSTLENGTH_32BEAT         ((uint32_t)0x00400000U)  /*!< maximum number of beats to be transferred in one RxDMA transaction is 32 */
-#define ETH_RXDMABURSTLENGTH_4XPBL_4BEAT    ((uint32_t)0x01020000U)  /*!< maximum number of beats to be transferred in one RxDMA transaction is 4 */
-#define ETH_RXDMABURSTLENGTH_4XPBL_8BEAT    ((uint32_t)0x01040000U)  /*!< maximum number of beats to be transferred in one RxDMA transaction is 8 */
-#define ETH_RXDMABURSTLENGTH_4XPBL_16BEAT   ((uint32_t)0x01080000U)  /*!< maximum number of beats to be transferred in one RxDMA transaction is 16 */
-#define ETH_RXDMABURSTLENGTH_4XPBL_32BEAT   ((uint32_t)0x01100000U)  /*!< maximum number of beats to be transferred in one RxDMA transaction is 32 */
-#define ETH_RXDMABURSTLENGTH_4XPBL_64BEAT   ((uint32_t)0x01200000U)  /*!< maximum number of beats to be transferred in one RxDMA transaction is 64 */
-#define ETH_RXDMABURSTLENGTH_4XPBL_128BEAT  ((uint32_t)0x01400000U)  /*!< maximum number of beats to be transferred in one RxDMA transaction is 128 */
+ * @{
+ */
+    #define ETH_RXDMABURSTLENGTH_1BEAT            ( ( uint32_t ) 0x00020000U ) /*!< maximum number of beats to be transferred in one RxDMA transaction is 1 */
+    #define ETH_RXDMABURSTLENGTH_2BEAT            ( ( uint32_t ) 0x00040000U ) /*!< maximum number of beats to be transferred in one RxDMA transaction is 2 */
+    #define ETH_RXDMABURSTLENGTH_4BEAT            ( ( uint32_t ) 0x00080000U ) /*!< maximum number of beats to be transferred in one RxDMA transaction is 4 */
+    #define ETH_RXDMABURSTLENGTH_8BEAT            ( ( uint32_t ) 0x00100000U ) /*!< maximum number of beats to be transferred in one RxDMA transaction is 8 */
+    #define ETH_RXDMABURSTLENGTH_16BEAT           ( ( uint32_t ) 0x00200000U ) /*!< maximum number of beats to be transferred in one RxDMA transaction is 16 */
+    #define ETH_RXDMABURSTLENGTH_32BEAT           ( ( uint32_t ) 0x00400000U ) /*!< maximum number of beats to be transferred in one RxDMA transaction is 32 */
+    #define ETH_RXDMABURSTLENGTH_4XPBL_4BEAT      ( ( uint32_t ) 0x01020000U ) /*!< maximum number of beats to be transferred in one RxDMA transaction is 4 */
+    #define ETH_RXDMABURSTLENGTH_4XPBL_8BEAT      ( ( uint32_t ) 0x01040000U ) /*!< maximum number of beats to be transferred in one RxDMA transaction is 8 */
+    #define ETH_RXDMABURSTLENGTH_4XPBL_16BEAT     ( ( uint32_t ) 0x01080000U ) /*!< maximum number of beats to be transferred in one RxDMA transaction is 16 */
+    #define ETH_RXDMABURSTLENGTH_4XPBL_32BEAT     ( ( uint32_t ) 0x01100000U ) /*!< maximum number of beats to be transferred in one RxDMA transaction is 32 */
+    #define ETH_RXDMABURSTLENGTH_4XPBL_64BEAT     ( ( uint32_t ) 0x01200000U ) /*!< maximum number of beats to be transferred in one RxDMA transaction is 64 */
+    #define ETH_RXDMABURSTLENGTH_4XPBL_128BEAT    ( ( uint32_t ) 0x01400000U ) /*!< maximum number of beats to be transferred in one RxDMA transaction is 128 */
+
 /**
-  * @}
-  */
+ * @}
+ */
 
 /** @defgroup ETH_Tx_DMA_Burst_Length ETH Tx DMA Burst Length
-  * @{
-  */
-#define ETH_TXDMABURSTLENGTH_1BEAT          ((uint32_t)0x00000100U)  /*!< maximum number of beats to be transferred in one TxDMA (or both) transaction is 1 */
-#define ETH_TXDMABURSTLENGTH_2BEAT          ((uint32_t)0x00000200U)  /*!< maximum number of beats to be transferred in one TxDMA (or both) transaction is 2 */
-#define ETH_TXDMABURSTLENGTH_4BEAT          ((uint32_t)0x00000400U)  /*!< maximum number of beats to be transferred in one TxDMA (or both) transaction is 4 */
-#define ETH_TXDMABURSTLENGTH_8BEAT          ((uint32_t)0x00000800U)  /*!< maximum number of beats to be transferred in one TxDMA (or both) transaction is 8 */
-#define ETH_TXDMABURSTLENGTH_16BEAT         ((uint32_t)0x00001000U)  /*!< maximum number of beats to be transferred in one TxDMA (or both) transaction is 16 */
-#define ETH_TXDMABURSTLENGTH_32BEAT         ((uint32_t)0x00002000U)  /*!< maximum number of beats to be transferred in one TxDMA (or both) transaction is 32 */
-#define ETH_TXDMABURSTLENGTH_4XPBL_4BEAT    ((uint32_t)0x01000100U)  /*!< maximum number of beats to be transferred in one TxDMA (or both) transaction is 4 */
-#define ETH_TXDMABURSTLENGTH_4XPBL_8BEAT    ((uint32_t)0x01000200U)  /*!< maximum number of beats to be transferred in one TxDMA (or both) transaction is 8 */
-#define ETH_TXDMABURSTLENGTH_4XPBL_16BEAT   ((uint32_t)0x01000400U)  /*!< maximum number of beats to be transferred in one TxDMA (or both) transaction is 16 */
-#define ETH_TXDMABURSTLENGTH_4XPBL_32BEAT   ((uint32_t)0x01000800U)  /*!< maximum number of beats to be transferred in one TxDMA (or both) transaction is 32 */
-#define ETH_TXDMABURSTLENGTH_4XPBL_64BEAT   ((uint32_t)0x01001000U)  /*!< maximum number of beats to be transferred in one TxDMA (or both) transaction is 64 */
-#define ETH_TXDMABURSTLENGTH_4XPBL_128BEAT  ((uint32_t)0x01002000U)  /*!< maximum number of beats to be transferred in one TxDMA (or both) transaction is 128 */
+ * @{
+ */
+    #define ETH_TXDMABURSTLENGTH_1BEAT            ( ( uint32_t ) 0x00000100U ) /*!< maximum number of beats to be transferred in one TxDMA (or both) transaction is 1 */
+    #define ETH_TXDMABURSTLENGTH_2BEAT            ( ( uint32_t ) 0x00000200U ) /*!< maximum number of beats to be transferred in one TxDMA (or both) transaction is 2 */
+    #define ETH_TXDMABURSTLENGTH_4BEAT            ( ( uint32_t ) 0x00000400U ) /*!< maximum number of beats to be transferred in one TxDMA (or both) transaction is 4 */
+    #define ETH_TXDMABURSTLENGTH_8BEAT            ( ( uint32_t ) 0x00000800U ) /*!< maximum number of beats to be transferred in one TxDMA (or both) transaction is 8 */
+    #define ETH_TXDMABURSTLENGTH_16BEAT           ( ( uint32_t ) 0x00001000U ) /*!< maximum number of beats to be transferred in one TxDMA (or both) transaction is 16 */
+    #define ETH_TXDMABURSTLENGTH_32BEAT           ( ( uint32_t ) 0x00002000U ) /*!< maximum number of beats to be transferred in one TxDMA (or both) transaction is 32 */
+    #define ETH_TXDMABURSTLENGTH_4XPBL_4BEAT      ( ( uint32_t ) 0x01000100U ) /*!< maximum number of beats to be transferred in one TxDMA (or both) transaction is 4 */
+    #define ETH_TXDMABURSTLENGTH_4XPBL_8BEAT      ( ( uint32_t ) 0x01000200U ) /*!< maximum number of beats to be transferred in one TxDMA (or both) transaction is 8 */
+    #define ETH_TXDMABURSTLENGTH_4XPBL_16BEAT     ( ( uint32_t ) 0x01000400U ) /*!< maximum number of beats to be transferred in one TxDMA (or both) transaction is 16 */
+    #define ETH_TXDMABURSTLENGTH_4XPBL_32BEAT     ( ( uint32_t ) 0x01000800U ) /*!< maximum number of beats to be transferred in one TxDMA (or both) transaction is 32 */
+    #define ETH_TXDMABURSTLENGTH_4XPBL_64BEAT     ( ( uint32_t ) 0x01001000U ) /*!< maximum number of beats to be transferred in one TxDMA (or both) transaction is 64 */
+    #define ETH_TXDMABURSTLENGTH_4XPBL_128BEAT    ( ( uint32_t ) 0x01002000U ) /*!< maximum number of beats to be transferred in one TxDMA (or both) transaction is 128 */
+
 /**
-  * @}
-  */
+ * @}
+ */
 
 /** @defgroup ETH_DMA_Enhanced_descriptor_format ETH DMA Enhanced descriptor format
-  * @{
-  */
-#define ETH_DMAENHANCEDDESCRIPTOR_ENABLE              ((uint32_t)0x00000080U)
-#define ETH_DMAENHANCEDDESCRIPTOR_DISABLE             ((uint32_t)0x00000000U)
+ * @{
+ */
+    #define ETH_DMAENHANCEDDESCRIPTOR_ENABLE     ( ( uint32_t ) 0x00000080U )
+    #define ETH_DMAENHANCEDDESCRIPTOR_DISABLE    ( ( uint32_t ) 0x00000000U )
+
 /**
-  * @}
-  */
+ * @}
+ */
 
 /** @defgroup ETH_DMA_Arbitration ETH DMA Arbitration
-  * @{
-  */
-#define ETH_DMAARBITRATION_ROUNDROBIN_RXTX_1_1   ((uint32_t)0x00000000U)
-#define ETH_DMAARBITRATION_ROUNDROBIN_RXTX_2_1   ((uint32_t)0x00004000U)
-#define ETH_DMAARBITRATION_ROUNDROBIN_RXTX_3_1   ((uint32_t)0x00008000U)
-#define ETH_DMAARBITRATION_ROUNDROBIN_RXTX_4_1   ((uint32_t)0x0000C000U)
-#define ETH_DMAARBITRATION_RXPRIORTX             ((uint32_t)0x00000002U)
+ * @{
+ */
+    #define ETH_DMAARBITRATION_ROUNDROBIN_RXTX_1_1    ( ( uint32_t ) 0x00000000U )
+    #define ETH_DMAARBITRATION_ROUNDROBIN_RXTX_2_1    ( ( uint32_t ) 0x00004000U )
+    #define ETH_DMAARBITRATION_ROUNDROBIN_RXTX_3_1    ( ( uint32_t ) 0x00008000U )
+    #define ETH_DMAARBITRATION_ROUNDROBIN_RXTX_4_1    ( ( uint32_t ) 0x0000C000U )
+    #define ETH_DMAARBITRATION_RXPRIORTX              ( ( uint32_t ) 0x00000002U )
+
 /**
-  * @}
-  */
+ * @}
+ */
 
 /** @defgroup ETH_DMA_Tx_descriptor_segment ETH DMA Tx descriptor segment
-  * @{
-  */
-#define ETH_DMATXDESC_LASTSEGMENTS      ((uint32_t)0x40000000U)  /*!< Last Segment */
-#define ETH_DMATXDESC_FIRSTSEGMENT      ((uint32_t)0x20000000U)  /*!< First Segment */
+ * @{
+ */
+    #define ETH_DMATXDESC_LASTSEGMENTS    ( ( uint32_t ) 0x40000000U ) /*!< Last Segment */
+    #define ETH_DMATXDESC_FIRSTSEGMENT    ( ( uint32_t ) 0x20000000U ) /*!< First Segment */
+
 /**
-  * @}
-  */
+ * @}
+ */
 
 /** @defgroup ETH_DMA_Tx_descriptor_Checksum_Insertion_Control ETH DMA Tx descriptor Checksum Insertion Control
-  * @{
-  */
-#define ETH_DMATXDESC_CHECKSUMBYPASS             ((uint32_t)0x00000000U)   /*!< Checksum engine bypass */
-#define ETH_DMATXDESC_CHECKSUMIPV4HEADER         ((uint32_t)0x00400000U)   /*!< IPv4 header checksum insertion  */
-#define ETH_DMATXDESC_CHECKSUMTCPUDPICMPSEGMENT  ((uint32_t)0x00800000U)   /*!< TCP/UDP/ICMP checksum insertion. Pseudo header checksum is assumed to be present */
-#define ETH_DMATXDESC_CHECKSUMTCPUDPICMPFULL     ((uint32_t)0x00C00000U)   /*!< TCP/UDP/ICMP checksum fully in hardware including pseudo header */
+ * @{
+ */
+    #define ETH_DMATXDESC_CHECKSUMBYPASS               ( ( uint32_t ) 0x00000000U ) /*!< Checksum engine bypass */
+    #define ETH_DMATXDESC_CHECKSUMIPV4HEADER           ( ( uint32_t ) 0x00400000U ) /*!< IPv4 header checksum insertion  */
+    #define ETH_DMATXDESC_CHECKSUMTCPUDPICMPSEGMENT    ( ( uint32_t ) 0x00800000U ) /*!< TCP/UDP/ICMP checksum insertion. Pseudo header checksum is assumed to be present */
+    #define ETH_DMATXDESC_CHECKSUMTCPUDPICMPFULL       ( ( uint32_t ) 0x00C00000U ) /*!< TCP/UDP/ICMP checksum fully in hardware including pseudo header */
+
 /**
-  * @}
-  */
+ * @}
+ */
 
 /** @defgroup ETH_DMA_Rx_descriptor_buffers ETH DMA Rx descriptor buffers
-  * @{
-  */
-#define ETH_DMARXDESC_BUFFER1     ((uint32_t)0x00000000U)  /*!< DMA Rx Desc Buffer1 */
-#define ETH_DMARXDESC_BUFFER2     ((uint32_t)0x00000001U)  /*!< DMA Rx Desc Buffer2 */
+ * @{
+ */
+    #define ETH_DMARXDESC_BUFFER1    ( ( uint32_t ) 0x00000000U ) /*!< DMA Rx Desc Buffer1 */
+    #define ETH_DMARXDESC_BUFFER2    ( ( uint32_t ) 0x00000001U ) /*!< DMA Rx Desc Buffer2 */
+
 /**
-  * @}
-  */
+ * @}
+ */
 
 /** @defgroup ETH_PMT_Flags ETH PMT Flags
-  * @{
-  */
-#define ETH_PMT_FLAG_WUFFRPR      ((uint32_t)0x80000000U)  /*!< Wake-Up Frame Filter Register Pointer Reset */
-#define ETH_PMT_FLAG_WUFR         ((uint32_t)0x00000040U)  /*!< Wake-Up Frame Received */
-#define ETH_PMT_FLAG_MPR          ((uint32_t)0x00000020U)  /*!< Magic Packet Received */
+ * @{
+ */
+    #define ETH_PMT_FLAG_WUFFRPR    ( ( uint32_t ) 0x80000000U ) /*!< Wake-Up Frame Filter Register Pointer Reset */
+    #define ETH_PMT_FLAG_WUFR       ( ( uint32_t ) 0x00000040U ) /*!< Wake-Up Frame Received */
+    #define ETH_PMT_FLAG_MPR        ( ( uint32_t ) 0x00000020U ) /*!< Magic Packet Received */
+
 /**
-  * @}
-  */
+ * @}
+ */
 
 /** @defgroup ETH_MMC_Tx_Interrupts ETH MMC Tx Interrupts
-  * @{
-  */
-#define ETH_MMC_IT_TGF       ((uint32_t)0x00200000U)  /*!< When Tx good frame counter reaches half the maximum value */
-#define ETH_MMC_IT_TGFMSC    ((uint32_t)0x00008000U)  /*!< When Tx good multi col counter reaches half the maximum value */
-#define ETH_MMC_IT_TGFSC     ((uint32_t)0x00004000U)  /*!< When Tx good single col counter reaches half the maximum value */
+ * @{
+ */
+    #define ETH_MMC_IT_TGF       ( ( uint32_t ) 0x00200000U ) /*!< When Tx good frame counter reaches half the maximum value */
+    #define ETH_MMC_IT_TGFMSC    ( ( uint32_t ) 0x00008000U ) /*!< When Tx good multi col counter reaches half the maximum value */
+    #define ETH_MMC_IT_TGFSC     ( ( uint32_t ) 0x00004000U ) /*!< When Tx good single col counter reaches half the maximum value */
+
 /**
-  * @}
-  */
+ * @}
+ */
 
 /** @defgroup ETH_MMC_Rx_Interrupts ETH MMC Rx Interrupts
-  * @{
-  */
-#define ETH_MMC_IT_RGUF      ((uint32_t)0x10020000U)  /*!< When Rx good unicast frames counter reaches half the maximum value */
-#define ETH_MMC_IT_RFAE      ((uint32_t)0x10000040U)  /*!< When Rx alignment error counter reaches half the maximum value */
-#define ETH_MMC_IT_RFCE      ((uint32_t)0x10000020U)  /*!< When Rx crc error counter reaches half the maximum value */
+ * @{
+ */
+    #define ETH_MMC_IT_RGUF    ( ( uint32_t ) 0x10020000U ) /*!< When Rx good unicast frames counter reaches half the maximum value */
+    #define ETH_MMC_IT_RFAE    ( ( uint32_t ) 0x10000040U ) /*!< When Rx alignment error counter reaches half the maximum value */
+    #define ETH_MMC_IT_RFCE    ( ( uint32_t ) 0x10000020U ) /*!< When Rx crc error counter reaches half the maximum value */
+
 /**
-  * @}
-  */
+ * @}
+ */
 
 /** @defgroup ETH_MAC_Flags ETH MAC Flags
-  * @{
-  */
-#define ETH_MAC_FLAG_TST     ((uint32_t)0x00000200U)  /*!< Time stamp trigger flag (on MAC) */
-#define ETH_MAC_FLAG_MMCT    ((uint32_t)0x00000040U)  /*!< MMC transmit flag  */
-#define ETH_MAC_FLAG_MMCR    ((uint32_t)0x00000020U)  /*!< MMC receive flag */
-#define ETH_MAC_FLAG_MMC     ((uint32_t)0x00000010U)  /*!< MMC flag (on MAC) */
-#define ETH_MAC_FLAG_PMT     ((uint32_t)0x00000008U)  /*!< PMT flag (on MAC) */
+ * @{
+ */
+    #define ETH_MAC_FLAG_TST     ( ( uint32_t ) 0x00000200U ) /*!< Time stamp trigger flag (on MAC) */
+    #define ETH_MAC_FLAG_MMCT    ( ( uint32_t ) 0x00000040U ) /*!< MMC transmit flag  */
+    #define ETH_MAC_FLAG_MMCR    ( ( uint32_t ) 0x00000020U ) /*!< MMC receive flag */
+    #define ETH_MAC_FLAG_MMC     ( ( uint32_t ) 0x00000010U ) /*!< MMC flag (on MAC) */
+    #define ETH_MAC_FLAG_PMT     ( ( uint32_t ) 0x00000008U ) /*!< PMT flag (on MAC) */
+
 /**
-  * @}
-  */
+ * @}
+ */
 
 /** @defgroup ETH_DMA_Flags ETH DMA Flags
-  * @{
-  */
-#define ETH_DMA_FLAG_TST               ((uint32_t)0x20000000U)  /*!< Time-stamp trigger interrupt (on DMA) */
-#define ETH_DMA_FLAG_PMT               ((uint32_t)0x10000000U)  /*!< PMT interrupt (on DMA) */
-#define ETH_DMA_FLAG_MMC               ((uint32_t)0x08000000U)  /*!< MMC interrupt (on DMA) */
-#define ETH_DMA_FLAG_DATATRANSFERERROR ((uint32_t)0x00800000U)  /*!< Error bits 0-Rx DMA, 1-Tx DMA */
-#define ETH_DMA_FLAG_READWRITEERROR    ((uint32_t)0x01000000U)  /*!< Error bits 0-write transfer, 1-read transfer */
-#define ETH_DMA_FLAG_ACCESSERROR       ((uint32_t)0x02000000U)  /*!< Error bits 0-data buffer, 1-desc. access */
-#define ETH_DMA_FLAG_NIS               ((uint32_t)0x00010000U)  /*!< Normal interrupt summary flag */
-#define ETH_DMA_FLAG_AIS               ((uint32_t)0x00008000U)  /*!< Abnormal interrupt summary flag */
-#define ETH_DMA_FLAG_ER                ((uint32_t)0x00004000U)  /*!< Early receive flag */
-#define ETH_DMA_FLAG_FBE               ((uint32_t)0x00002000U)  /*!< Fatal bus error flag */
-#define ETH_DMA_FLAG_ET                ((uint32_t)0x00000400U)  /*!< Early transmit flag */
-#define ETH_DMA_FLAG_RWT               ((uint32_t)0x00000200U)  /*!< Receive watchdog timeout flag */
-#define ETH_DMA_FLAG_RPS               ((uint32_t)0x00000100U)  /*!< Receive process stopped flag */
-#define ETH_DMA_FLAG_RBU               ((uint32_t)0x00000080U)  /*!< Receive buffer unavailable flag */
-#define ETH_DMA_FLAG_R                 ((uint32_t)0x00000040U)  /*!< Receive flag */
-#define ETH_DMA_FLAG_TU                ((uint32_t)0x00000020U)  /*!< Underflow flag */
-#define ETH_DMA_FLAG_RO                ((uint32_t)0x00000010U)  /*!< Overflow flag */
-#define ETH_DMA_FLAG_TJT               ((uint32_t)0x00000008U)  /*!< Transmit jabber timeout flag */
-#define ETH_DMA_FLAG_TBU               ((uint32_t)0x00000004U)  /*!< Transmit buffer unavailable flag */
-#define ETH_DMA_FLAG_TPS               ((uint32_t)0x00000002U)  /*!< Transmit process stopped flag */
-#define ETH_DMA_FLAG_T                 ((uint32_t)0x00000001U)  /*!< Transmit flag */
+ * @{
+ */
+    #define ETH_DMA_FLAG_TST                  ( ( uint32_t ) 0x20000000U ) /*!< Time-stamp trigger interrupt (on DMA) */
+    #define ETH_DMA_FLAG_PMT                  ( ( uint32_t ) 0x10000000U ) /*!< PMT interrupt (on DMA) */
+    #define ETH_DMA_FLAG_MMC                  ( ( uint32_t ) 0x08000000U ) /*!< MMC interrupt (on DMA) */
+    #define ETH_DMA_FLAG_DATATRANSFERERROR    ( ( uint32_t ) 0x00800000U ) /*!< Error bits 0-Rx DMA, 1-Tx DMA */
+    #define ETH_DMA_FLAG_READWRITEERROR       ( ( uint32_t ) 0x01000000U ) /*!< Error bits 0-write transfer, 1-read transfer */
+    #define ETH_DMA_FLAG_ACCESSERROR          ( ( uint32_t ) 0x02000000U ) /*!< Error bits 0-data buffer, 1-desc. access */
+    #define ETH_DMA_FLAG_NIS                  ( ( uint32_t ) 0x00010000U ) /*!< Normal interrupt summary flag */
+    #define ETH_DMA_FLAG_AIS                  ( ( uint32_t ) 0x00008000U ) /*!< Abnormal interrupt summary flag */
+    #define ETH_DMA_FLAG_ER                   ( ( uint32_t ) 0x00004000U ) /*!< Early receive flag */
+    #define ETH_DMA_FLAG_FBE                  ( ( uint32_t ) 0x00002000U ) /*!< Fatal bus error flag */
+    #define ETH_DMA_FLAG_ET                   ( ( uint32_t ) 0x00000400U ) /*!< Early transmit flag */
+    #define ETH_DMA_FLAG_RWT                  ( ( uint32_t ) 0x00000200U ) /*!< Receive watchdog timeout flag */
+    #define ETH_DMA_FLAG_RPS                  ( ( uint32_t ) 0x00000100U ) /*!< Receive process stopped flag */
+    #define ETH_DMA_FLAG_RBU                  ( ( uint32_t ) 0x00000080U ) /*!< Receive buffer unavailable flag */
+    #define ETH_DMA_FLAG_R                    ( ( uint32_t ) 0x00000040U ) /*!< Receive flag */
+    #define ETH_DMA_FLAG_TU                   ( ( uint32_t ) 0x00000020U ) /*!< Underflow flag */
+    #define ETH_DMA_FLAG_RO                   ( ( uint32_t ) 0x00000010U ) /*!< Overflow flag */
+    #define ETH_DMA_FLAG_TJT                  ( ( uint32_t ) 0x00000008U ) /*!< Transmit jabber timeout flag */
+    #define ETH_DMA_FLAG_TBU                  ( ( uint32_t ) 0x00000004U ) /*!< Transmit buffer unavailable flag */
+    #define ETH_DMA_FLAG_TPS                  ( ( uint32_t ) 0x00000002U ) /*!< Transmit process stopped flag */
+    #define ETH_DMA_FLAG_T                    ( ( uint32_t ) 0x00000001U ) /*!< Transmit flag */
+
 /**
-  * @}
-  */
+ * @}
+ */
 
 /** @defgroup ETH_MAC_Interrupts ETH MAC Interrupts
-  * @{
-  */
-#define ETH_MAC_IT_TST       ((uint32_t)0x00000200U)  /*!< Time stamp trigger interrupt (on MAC) */
-#define ETH_MAC_IT_MMCT      ((uint32_t)0x00000040U)  /*!< MMC transmit interrupt */
-#define ETH_MAC_IT_MMCR      ((uint32_t)0x00000020U)  /*!< MMC receive interrupt */
-#define ETH_MAC_IT_MMC       ((uint32_t)0x00000010U)  /*!< MMC interrupt (on MAC) */
-#define ETH_MAC_IT_PMT       ((uint32_t)0x00000008U)  /*!< PMT interrupt (on MAC) */
+ * @{
+ */
+    #define ETH_MAC_IT_TST     ( ( uint32_t ) 0x00000200U ) /*!< Time stamp trigger interrupt (on MAC) */
+    #define ETH_MAC_IT_MMCT    ( ( uint32_t ) 0x00000040U ) /*!< MMC transmit interrupt */
+    #define ETH_MAC_IT_MMCR    ( ( uint32_t ) 0x00000020U ) /*!< MMC receive interrupt */
+    #define ETH_MAC_IT_MMC     ( ( uint32_t ) 0x00000010U ) /*!< MMC interrupt (on MAC) */
+    #define ETH_MAC_IT_PMT     ( ( uint32_t ) 0x00000008U ) /*!< PMT interrupt (on MAC) */
+
 /**
-  * @}
-  */
+ * @}
+ */
 
 /** @defgroup ETH_DMA_Interrupts ETH DMA Interrupts
-  * @{
-  */
-#define ETH_DMA_IT_TST       ((uint32_t)0x20000000U)  /*!< Time-stamp trigger interrupt (on DMA) */
-#define ETH_DMA_IT_PMT       ((uint32_t)0x10000000U)  /*!< PMT interrupt (on DMA) */
-#define ETH_DMA_IT_MMC       ((uint32_t)0x08000000U)  /*!< MMC interrupt (on DMA) */
-#define ETH_DMA_IT_NIS       ((uint32_t)0x00010000U)  /*!< Normal interrupt summary */
-#define ETH_DMA_IT_AIS       ((uint32_t)0x00008000U)  /*!< Abnormal interrupt summary */
-#define ETH_DMA_IT_ER        ((uint32_t)0x00004000U)  /*!< Early receive interrupt */
-#define ETH_DMA_IT_FBE       ((uint32_t)0x00002000U)  /*!< Fatal bus error interrupt */
-#define ETH_DMA_IT_ET        ((uint32_t)0x00000400U)  /*!< Early transmit interrupt */
-#define ETH_DMA_IT_RWT       ((uint32_t)0x00000200U)  /*!< Receive watchdog timeout interrupt */
-#define ETH_DMA_IT_RPS       ((uint32_t)0x00000100U)  /*!< Receive process stopped interrupt */
-#define ETH_DMA_IT_RBU       ((uint32_t)0x00000080U)  /*!< Receive buffer unavailable interrupt */
-#define ETH_DMA_IT_R         ((uint32_t)0x00000040U)  /*!< Receive interrupt */
-#define ETH_DMA_IT_TU        ((uint32_t)0x00000020U)  /*!< Underflow interrupt */
-#define ETH_DMA_IT_RO        ((uint32_t)0x00000010U)  /*!< Overflow interrupt */
-#define ETH_DMA_IT_TJT       ((uint32_t)0x00000008U)  /*!< Transmit jabber timeout interrupt */
-#define ETH_DMA_IT_TBU       ((uint32_t)0x00000004U)  /*!< Transmit buffer unavailable interrupt */
-#define ETH_DMA_IT_TPS       ((uint32_t)0x00000002U)  /*!< Transmit process stopped interrupt */
-#define ETH_DMA_IT_T         ((uint32_t)0x00000001U)  /*!< Transmit interrupt */
+ * @{
+ */
+    #define ETH_DMA_IT_TST    ( ( uint32_t ) 0x20000000U ) /*!< Time-stamp trigger interrupt (on DMA) */
+    #define ETH_DMA_IT_PMT    ( ( uint32_t ) 0x10000000U ) /*!< PMT interrupt (on DMA) */
+    #define ETH_DMA_IT_MMC    ( ( uint32_t ) 0x08000000U ) /*!< MMC interrupt (on DMA) */
+    #define ETH_DMA_IT_NIS    ( ( uint32_t ) 0x00010000U ) /*!< Normal interrupt summary */
+    #define ETH_DMA_IT_AIS    ( ( uint32_t ) 0x00008000U ) /*!< Abnormal interrupt summary */
+    #define ETH_DMA_IT_ER     ( ( uint32_t ) 0x00004000U ) /*!< Early receive interrupt */
+    #define ETH_DMA_IT_FBE    ( ( uint32_t ) 0x00002000U ) /*!< Fatal bus error interrupt */
+    #define ETH_DMA_IT_ET     ( ( uint32_t ) 0x00000400U ) /*!< Early transmit interrupt */
+    #define ETH_DMA_IT_RWT    ( ( uint32_t ) 0x00000200U ) /*!< Receive watchdog timeout interrupt */
+    #define ETH_DMA_IT_RPS    ( ( uint32_t ) 0x00000100U ) /*!< Receive process stopped interrupt */
+    #define ETH_DMA_IT_RBU    ( ( uint32_t ) 0x00000080U ) /*!< Receive buffer unavailable interrupt */
+    #define ETH_DMA_IT_R      ( ( uint32_t ) 0x00000040U ) /*!< Receive interrupt */
+    #define ETH_DMA_IT_TU     ( ( uint32_t ) 0x00000020U ) /*!< Underflow interrupt */
+    #define ETH_DMA_IT_RO     ( ( uint32_t ) 0x00000010U ) /*!< Overflow interrupt */
+    #define ETH_DMA_IT_TJT    ( ( uint32_t ) 0x00000008U ) /*!< Transmit jabber timeout interrupt */
+    #define ETH_DMA_IT_TBU    ( ( uint32_t ) 0x00000004U ) /*!< Transmit buffer unavailable interrupt */
+    #define ETH_DMA_IT_TPS    ( ( uint32_t ) 0x00000002U ) /*!< Transmit process stopped interrupt */
+    #define ETH_DMA_IT_T      ( ( uint32_t ) 0x00000001U ) /*!< Transmit interrupt */
+
 /**
-  * @}
-  */
+ * @}
+ */
 
 /** @defgroup ETH_DMA_transmit_process_state ETH DMA transmit process state
-  * @{
-  */
-#define ETH_DMA_TRANSMITPROCESS_STOPPED     ((uint32_t)0x00000000U)  /*!< Stopped - Reset or Stop Tx Command issued */
-#define ETH_DMA_TRANSMITPROCESS_FETCHING    ((uint32_t)0x00100000U)  /*!< Running - fetching the Tx descriptor */
-#define ETH_DMA_TRANSMITPROCESS_WAITING     ((uint32_t)0x00200000U)  /*!< Running - waiting for status */
-#define ETH_DMA_TRANSMITPROCESS_READING     ((uint32_t)0x00300000U)  /*!< Running - reading the data from host memory */
-#define ETH_DMA_TRANSMITPROCESS_SUSPENDED   ((uint32_t)0x00600000U)  /*!< Suspended - Tx Descriptor unavailable */
-#define ETH_DMA_TRANSMITPROCESS_CLOSING     ((uint32_t)0x00700000U)  /*!< Running - closing Rx descriptor */
+ * @{
+ */
+    #define ETH_DMA_TRANSMITPROCESS_STOPPED      ( ( uint32_t ) 0x00000000U ) /*!< Stopped - Reset or Stop Tx Command issued */
+    #define ETH_DMA_TRANSMITPROCESS_FETCHING     ( ( uint32_t ) 0x00100000U ) /*!< Running - fetching the Tx descriptor */
+    #define ETH_DMA_TRANSMITPROCESS_WAITING      ( ( uint32_t ) 0x00200000U ) /*!< Running - waiting for status */
+    #define ETH_DMA_TRANSMITPROCESS_READING      ( ( uint32_t ) 0x00300000U ) /*!< Running - reading the data from host memory */
+    #define ETH_DMA_TRANSMITPROCESS_SUSPENDED    ( ( uint32_t ) 0x00600000U ) /*!< Suspended - Tx Descriptor unavailable */
+    #define ETH_DMA_TRANSMITPROCESS_CLOSING      ( ( uint32_t ) 0x00700000U ) /*!< Running - closing Rx descriptor */
 
 /**
-  * @}
-  */
+ * @}
+ */
 
 
 /** @defgroup ETH_DMA_receive_process_state ETH DMA receive process state
-  * @{
-  */
-#define ETH_DMA_RECEIVEPROCESS_STOPPED      ((uint32_t)0x00000000U)  /*!< Stopped - Reset or Stop Rx Command issued */
-#define ETH_DMA_RECEIVEPROCESS_FETCHING     ((uint32_t)0x00020000U)  /*!< Running - fetching the Rx descriptor */
-#define ETH_DMA_RECEIVEPROCESS_WAITING      ((uint32_t)0x00060000U)  /*!< Running - waiting for packet */
-#define ETH_DMA_RECEIVEPROCESS_SUSPENDED    ((uint32_t)0x00080000U)  /*!< Suspended - Rx Descriptor unavailable */
-#define ETH_DMA_RECEIVEPROCESS_CLOSING      ((uint32_t)0x000A0000U)  /*!< Running - closing descriptor */
-#define ETH_DMA_RECEIVEPROCESS_QUEUING      ((uint32_t)0x000E0000U)  /*!< Running - queuing the receive frame into host memory */
+ * @{
+ */
+    #define ETH_DMA_RECEIVEPROCESS_STOPPED      ( ( uint32_t ) 0x00000000U ) /*!< Stopped - Reset or Stop Rx Command issued */
+    #define ETH_DMA_RECEIVEPROCESS_FETCHING     ( ( uint32_t ) 0x00020000U ) /*!< Running - fetching the Rx descriptor */
+    #define ETH_DMA_RECEIVEPROCESS_WAITING      ( ( uint32_t ) 0x00060000U ) /*!< Running - waiting for packet */
+    #define ETH_DMA_RECEIVEPROCESS_SUSPENDED    ( ( uint32_t ) 0x00080000U ) /*!< Suspended - Rx Descriptor unavailable */
+    #define ETH_DMA_RECEIVEPROCESS_CLOSING      ( ( uint32_t ) 0x000A0000U ) /*!< Running - closing descriptor */
+    #define ETH_DMA_RECEIVEPROCESS_QUEUING      ( ( uint32_t ) 0x000E0000U ) /*!< Running - queuing the receive frame into host memory */
 
 /**
-  * @}
-  */
+ * @}
+ */
 
 /** @defgroup ETH_DMA_overflow ETH DMA overflow
-  * @{
-  */
-#define ETH_DMA_OVERFLOW_RXFIFOCOUNTER      ((uint32_t)0x10000000U)  /*!< Overflow bit for FIFO overflow counter */
-#define ETH_DMA_OVERFLOW_MISSEDFRAMECOUNTER ((uint32_t)0x00010000U)  /*!< Overflow bit for missed frame counter */
+ * @{
+ */
+    #define ETH_DMA_OVERFLOW_RXFIFOCOUNTER         ( ( uint32_t ) 0x10000000U ) /*!< Overflow bit for FIFO overflow counter */
+    #define ETH_DMA_OVERFLOW_MISSEDFRAMECOUNTER    ( ( uint32_t ) 0x00010000U ) /*!< Overflow bit for missed frame counter */
+
 /**
-  * @}
-  */
+ * @}
+ */
 
 /** @defgroup ETH_EXTI_LINE_WAKEUP ETH EXTI LINE WAKEUP
-  * @{
-  */
-#define ETH_EXTI_LINE_WAKEUP              ((uint32_t)0x00080000U)  /*!< External interrupt line 19 Connected to the ETH EXTI Line */
+ * @{
+ */
+    #define ETH_EXTI_LINE_WAKEUP    ( ( uint32_t ) 0x00080000U )   /*!< External interrupt line 19 Connected to the ETH EXTI Line */
 
 /**
-  * @}
-  */
+ * @}
+ */
 
 /**
-  * @}
-  */
+ * @}
+ */
 
 /* Exported macro ------------------------------------------------------------*/
+
 /** @defgroup ETH_Exported_Macros ETH Exported Macros
  *  @brief macros to handle interrupts and specific clock configurations
  * @{
  */
 
 /** @brief Reset ETH handle state
-  * @param  __HANDLE__: specifies the ETH handle.
-  * @retval None
-  */
-#define __HAL_ETH_RESET_HANDLE_STATE(__HANDLE__) ((__HANDLE__)->State = HAL_ETH_STATE_RESET)
+ * @param  __HANDLE__: specifies the ETH handle.
+ * @retval None
+ */
+    #define __HAL_ETH_RESET_HANDLE_STATE( __HANDLE__ )                            ( ( __HANDLE__ )->State = HAL_ETH_STATE_RESET )
 
 /**
-  * @brief  Checks whether the specified Ethernet DMA Tx Desc flag is set or not.
-  * @param  __HANDLE__: ETH Handle
-  * @param  __FLAG__: specifies the flag of TDES0 to check.
-  * @retval the ETH_DMATxDescFlag (SET or RESET).
-  */
-#define __HAL_ETH_DMATXDESC_GET_FLAG(__HANDLE__, __FLAG__)             ((__HANDLE__)->TxDesc->Status & (__FLAG__) == (__FLAG__))
+ * @brief  Checks whether the specified Ethernet DMA Tx Desc flag is set or not.
+ * @param  __HANDLE__: ETH Handle
+ * @param  __FLAG__: specifies the flag of TDES0 to check.
+ * @retval the ETH_DMATxDescFlag (SET or RESET).
+ */
+    #define __HAL_ETH_DMATXDESC_GET_FLAG( __HANDLE__, __FLAG__ )                  ( ( __HANDLE__ )->TxDesc->Status & ( __FLAG__ ) == ( __FLAG__ ) )
 
 /**
-  * @brief  Checks whether the specified Ethernet DMA Rx Desc flag is set or not.
-  * @param  __HANDLE__: ETH Handle
-  * @param  __FLAG__: specifies the flag of RDES0 to check.
-  * @retval the ETH_DMATxDescFlag (SET or RESET).
-  */
-#define __HAL_ETH_DMARXDESC_GET_FLAG(__HANDLE__, __FLAG__)             ((__HANDLE__)->RxDesc->Status & (__FLAG__) == (__FLAG__))
+ * @brief  Checks whether the specified Ethernet DMA Rx Desc flag is set or not.
+ * @param  __HANDLE__: ETH Handle
+ * @param  __FLAG__: specifies the flag of RDES0 to check.
+ * @retval the ETH_DMATxDescFlag (SET or RESET).
+ */
+    #define __HAL_ETH_DMARXDESC_GET_FLAG( __HANDLE__, __FLAG__ )                  ( ( __HANDLE__ )->RxDesc->Status & ( __FLAG__ ) == ( __FLAG__ ) )
 
 /**
-  * @brief  Enables the specified DMA Rx Desc receive interrupt.
-  * @param  __HANDLE__: ETH Handle
-  * @retval None
-  */
-#define __HAL_ETH_DMARXDESC_ENABLE_IT(__HANDLE__)                          ((__HANDLE__)->RxDesc->ControlBufferSize &=(~(uint32_t)ETH_DMARXDESC_DIC))
+ * @brief  Enables the specified DMA Rx Desc receive interrupt.
+ * @param  __HANDLE__: ETH Handle
+ * @retval None
+ */
+    #define __HAL_ETH_DMARXDESC_ENABLE_IT( __HANDLE__ )                           ( ( __HANDLE__ )->RxDesc->ControlBufferSize &= ( ~( uint32_t ) ETH_DMARXDESC_DIC ) )
 
 /**
-  * @brief  Disables the specified DMA Rx Desc receive interrupt.
-  * @param  __HANDLE__: ETH Handle
-  * @retval None
-  */
-#define __HAL_ETH_DMARXDESC_DISABLE_IT(__HANDLE__)                         ((__HANDLE__)->RxDesc->ControlBufferSize |= ETH_DMARXDESC_DIC)
+ * @brief  Disables the specified DMA Rx Desc receive interrupt.
+ * @param  __HANDLE__: ETH Handle
+ * @retval None
+ */
+    #define __HAL_ETH_DMARXDESC_DISABLE_IT( __HANDLE__ )                          ( ( __HANDLE__ )->RxDesc->ControlBufferSize |= ETH_DMARXDESC_DIC )
 
 /**
-  * @brief  Set the specified DMA Rx Desc Own bit.
-  * @param  __HANDLE__: ETH Handle
-  * @retval None
-  */
-#define __HAL_ETH_DMARXDESC_SET_OWN_BIT(__HANDLE__)                           ((__HANDLE__)->RxDesc->Status |= ETH_DMARXDESC_OWN)
+ * @brief  Set the specified DMA Rx Desc Own bit.
+ * @param  __HANDLE__: ETH Handle
+ * @retval None
+ */
+    #define __HAL_ETH_DMARXDESC_SET_OWN_BIT( __HANDLE__ )                         ( ( __HANDLE__ )->RxDesc->Status |= ETH_DMARXDESC_OWN )
 
 /**
-  * @brief  Returns the specified Ethernet DMA Tx Desc collision count.
-  * @param  __HANDLE__: ETH Handle
-  * @retval The Transmit descriptor collision counter value.
-  */
-#define __HAL_ETH_DMATXDESC_GET_COLLISION_COUNT(__HANDLE__)                   (((__HANDLE__)->TxDesc->Status & ETH_DMATXDESC_CC) >> ETH_DMATXDESC_COLLISION_COUNTSHIFT)
+ * @brief  Returns the specified Ethernet DMA Tx Desc collision count.
+ * @param  __HANDLE__: ETH Handle
+ * @retval The Transmit descriptor collision counter value.
+ */
+    #define __HAL_ETH_DMATXDESC_GET_COLLISION_COUNT( __HANDLE__ )                 ( ( ( __HANDLE__ )->TxDesc->Status & ETH_DMATXDESC_CC ) >> ETH_DMATXDESC_COLLISION_COUNTSHIFT )
 
 /**
-  * @brief  Set the specified DMA Tx Desc Own bit.
-  * @param  __HANDLE__: ETH Handle
-  * @retval None
-  */
-#define __HAL_ETH_DMATXDESC_SET_OWN_BIT(__HANDLE__)                       ((__HANDLE__)->TxDesc->Status |= ETH_DMATXDESC_OWN)
+ * @brief  Set the specified DMA Tx Desc Own bit.
+ * @param  __HANDLE__: ETH Handle
+ * @retval None
+ */
+    #define __HAL_ETH_DMATXDESC_SET_OWN_BIT( __HANDLE__ )                         ( ( __HANDLE__ )->TxDesc->Status |= ETH_DMATXDESC_OWN )
 
 /**
-  * @brief  Enables the specified DMA Tx Desc Transmit interrupt.
-  * @param  __HANDLE__: ETH Handle
-  * @retval None
-  */
-#define __HAL_ETH_DMATXDESC_ENABLE_IT(__HANDLE__)                          ((__HANDLE__)->TxDesc->Status |= ETH_DMATXDESC_IC)
+ * @brief  Enables the specified DMA Tx Desc Transmit interrupt.
+ * @param  __HANDLE__: ETH Handle
+ * @retval None
+ */
+    #define __HAL_ETH_DMATXDESC_ENABLE_IT( __HANDLE__ )                           ( ( __HANDLE__ )->TxDesc->Status |= ETH_DMATXDESC_IC )
 
 /**
-  * @brief  Disables the specified DMA Tx Desc Transmit interrupt.
-  * @param  __HANDLE__: ETH Handle
-  * @retval None
-  */
-#define __HAL_ETH_DMATXDESC_DISABLE_IT(__HANDLE__)                          ((__HANDLE__)->TxDesc->Status &= ~ETH_DMATXDESC_IC)
+ * @brief  Disables the specified DMA Tx Desc Transmit interrupt.
+ * @param  __HANDLE__: ETH Handle
+ * @retval None
+ */
+    #define __HAL_ETH_DMATXDESC_DISABLE_IT( __HANDLE__ )                          ( ( __HANDLE__ )->TxDesc->Status &= ~ETH_DMATXDESC_IC )
 
 /**
-  * @brief  Selects the specified Ethernet DMA Tx Desc Checksum Insertion.
-  * @param  __HANDLE__: ETH Handle
-  * @param  __CHECKSUM__: specifies is the DMA Tx desc checksum insertion.
-  *   This parameter can be one of the following values:
-  *     @arg ETH_DMATXDESC_CHECKSUMBYPASS : Checksum bypass
-  *     @arg ETH_DMATXDESC_CHECKSUMIPV4HEADER : IPv4 header checksum
-  *     @arg ETH_DMATXDESC_CHECKSUMTCPUDPICMPSEGMENT : TCP/UDP/ICMP checksum. Pseudo header checksum is assumed to be present
-  *     @arg ETH_DMATXDESC_CHECKSUMTCPUDPICMPFULL : TCP/UDP/ICMP checksum fully in hardware including pseudo header
-  * @retval None
-  */
-#define __HAL_ETH_DMATXDESC_CHECKSUM_INSERTION(__HANDLE__, __CHECKSUM__)     ((__HANDLE__)->TxDesc->Status |= (__CHECKSUM__))
+ * @brief  Selects the specified Ethernet DMA Tx Desc Checksum Insertion.
+ * @param  __HANDLE__: ETH Handle
+ * @param  __CHECKSUM__: specifies is the DMA Tx desc checksum insertion.
+ *   This parameter can be one of the following values:
+ *     @arg ETH_DMATXDESC_CHECKSUMBYPASS : Checksum bypass
+ *     @arg ETH_DMATXDESC_CHECKSUMIPV4HEADER : IPv4 header checksum
+ *     @arg ETH_DMATXDESC_CHECKSUMTCPUDPICMPSEGMENT : TCP/UDP/ICMP checksum. Pseudo header checksum is assumed to be present
+ *     @arg ETH_DMATXDESC_CHECKSUMTCPUDPICMPFULL : TCP/UDP/ICMP checksum fully in hardware including pseudo header
+ * @retval None
+ */
+    #define __HAL_ETH_DMATXDESC_CHECKSUM_INSERTION( __HANDLE__, __CHECKSUM__ )    ( ( __HANDLE__ )->TxDesc->Status |= ( __CHECKSUM__ ) )
 
 /**
-  * @brief  Enables the DMA Tx Desc CRC.
-  * @param  __HANDLE__: ETH Handle
-  * @retval None
-  */
-#define __HAL_ETH_DMATXDESC_CRC_ENABLE(__HANDLE__)                          ((__HANDLE__)->TxDesc->Status &= ~ETH_DMATXDESC_DC)
+ * @brief  Enables the DMA Tx Desc CRC.
+ * @param  __HANDLE__: ETH Handle
+ * @retval None
+ */
+    #define __HAL_ETH_DMATXDESC_CRC_ENABLE( __HANDLE__ )                          ( ( __HANDLE__ )->TxDesc->Status &= ~ETH_DMATXDESC_DC )
 
 /**
-  * @brief  Disables the DMA Tx Desc CRC.
-  * @param  __HANDLE__: ETH Handle
-  * @retval None
-  */
-#define __HAL_ETH_DMATXDESC_CRC_DISABLE(__HANDLE__)                         ((__HANDLE__)->TxDesc->Status |= ETH_DMATXDESC_DC)
+ * @brief  Disables the DMA Tx Desc CRC.
+ * @param  __HANDLE__: ETH Handle
+ * @retval None
+ */
+    #define __HAL_ETH_DMATXDESC_CRC_DISABLE( __HANDLE__ )                         ( ( __HANDLE__ )->TxDesc->Status |= ETH_DMATXDESC_DC )
 
 /**
-  * @brief  Enables the DMA Tx Desc padding for frame shorter than 64 bytes.
-  * @param  __HANDLE__: ETH Handle
-  * @retval None
-  */
-#define __HAL_ETH_DMATXDESC_SHORT_FRAME_PADDING_ENABLE(__HANDLE__)            ((__HANDLE__)->TxDesc->Status &= ~ETH_DMATXDESC_DP)
+ * @brief  Enables the DMA Tx Desc padding for frame shorter than 64 bytes.
+ * @param  __HANDLE__: ETH Handle
+ * @retval None
+ */
+    #define __HAL_ETH_DMATXDESC_SHORT_FRAME_PADDING_ENABLE( __HANDLE__ )          ( ( __HANDLE__ )->TxDesc->Status &= ~ETH_DMATXDESC_DP )
 
 /**
-  * @brief  Disables the DMA Tx Desc padding for frame shorter than 64 bytes.
-  * @param  __HANDLE__: ETH Handle
-  * @retval None
-  */
-#define __HAL_ETH_DMATXDESC_SHORT_FRAME_PADDING_DISABLE(__HANDLE__)           ((__HANDLE__)->TxDesc->Status |= ETH_DMATXDESC_DP)
+ * @brief  Disables the DMA Tx Desc padding for frame shorter than 64 bytes.
+ * @param  __HANDLE__: ETH Handle
+ * @retval None
+ */
+    #define __HAL_ETH_DMATXDESC_SHORT_FRAME_PADDING_DISABLE( __HANDLE__ )         ( ( __HANDLE__ )->TxDesc->Status |= ETH_DMATXDESC_DP )
 
 /**
  * @brief  Enables the specified Ethernet MAC interrupts.
-  * @param  __HANDLE__   : ETH Handle
-  * @param  __INTERRUPT__: specifies the Ethernet MAC interrupt sources to be
-  *   enabled or disabled.
-  *   This parameter can be any combination of the following values:
-  *     @arg ETH_MAC_IT_TST : Time stamp trigger interrupt
-  *     @arg ETH_MAC_IT_PMT : PMT interrupt
-  * @retval None
-  */
-#define __HAL_ETH_MAC_ENABLE_IT(__HANDLE__, __INTERRUPT__)                 ((__HANDLE__)->Instance->MACIMR |= (__INTERRUPT__))
+ * @param  __HANDLE__   : ETH Handle
+ * @param  __INTERRUPT__: specifies the Ethernet MAC interrupt sources to be
+ *   enabled or disabled.
+ *   This parameter can be any combination of the following values:
+ *     @arg ETH_MAC_IT_TST : Time stamp trigger interrupt
+ *     @arg ETH_MAC_IT_PMT : PMT interrupt
+ * @retval None
+ */
+    #define __HAL_ETH_MAC_ENABLE_IT( __HANDLE__, __INTERRUPT__ )                  ( ( __HANDLE__ )->Instance->MACIMR |= ( __INTERRUPT__ ) )
 
 /**
-  * @brief  Disables the specified Ethernet MAC interrupts.
-  * @param  __HANDLE__   : ETH Handle
-  * @param  __INTERRUPT__: specifies the Ethernet MAC interrupt sources to be
-  *   enabled or disabled.
-  *   This parameter can be any combination of the following values:
-  *     @arg ETH_MAC_IT_TST : Time stamp trigger interrupt
-  *     @arg ETH_MAC_IT_PMT : PMT interrupt
-  * @retval None
-  */
-#define __HAL_ETH_MAC_DISABLE_IT(__HANDLE__, __INTERRUPT__)                ((__HANDLE__)->Instance->MACIMR &= ~(__INTERRUPT__))
+ * @brief  Disables the specified Ethernet MAC interrupts.
+ * @param  __HANDLE__   : ETH Handle
+ * @param  __INTERRUPT__: specifies the Ethernet MAC interrupt sources to be
+ *   enabled or disabled.
+ *   This parameter can be any combination of the following values:
+ *     @arg ETH_MAC_IT_TST : Time stamp trigger interrupt
+ *     @arg ETH_MAC_IT_PMT : PMT interrupt
+ * @retval None
+ */
+    #define __HAL_ETH_MAC_DISABLE_IT( __HANDLE__, __INTERRUPT__ )                 ( ( __HANDLE__ )->Instance->MACIMR &= ~( __INTERRUPT__ ) )
 
 /**
-  * @brief  Initiate a Pause Control Frame (Full-duplex only).
-  * @param  __HANDLE__: ETH Handle
-  * @retval None
-  */
-#define __HAL_ETH_INITIATE_PAUSE_CONTROL_FRAME(__HANDLE__)              ((__HANDLE__)->Instance->MACFCR |= ETH_MACFCR_FCBBPA)
+ * @brief  Initiate a Pause Control Frame (Full-duplex only).
+ * @param  __HANDLE__: ETH Handle
+ * @retval None
+ */
+    #define __HAL_ETH_INITIATE_PAUSE_CONTROL_FRAME( __HANDLE__ )                  ( ( __HANDLE__ )->Instance->MACFCR |= ETH_MACFCR_FCBBPA )
 
 /**
-  * @brief  Checks whether the Ethernet flow control busy bit is set or not.
-  * @param  __HANDLE__: ETH Handle
-  * @retval The new state of flow control busy status bit (SET or RESET).
-  */
-#define __HAL_ETH_GET_FLOW_CONTROL_BUSY_STATUS(__HANDLE__)               (((__HANDLE__)->Instance->MACFCR & ETH_MACFCR_FCBBPA) == ETH_MACFCR_FCBBPA)
+ * @brief  Checks whether the Ethernet flow control busy bit is set or not.
+ * @param  __HANDLE__: ETH Handle
+ * @retval The new state of flow control busy status bit (SET or RESET).
+ */
+    #define __HAL_ETH_GET_FLOW_CONTROL_BUSY_STATUS( __HANDLE__ )                  ( ( ( __HANDLE__ )->Instance->MACFCR & ETH_MACFCR_FCBBPA ) == ETH_MACFCR_FCBBPA )
 
 /**
-  * @brief  Enables the MAC Back Pressure operation activation (Half-duplex only).
-  * @param  __HANDLE__: ETH Handle
-  * @retval None
-  */
-#define __HAL_ETH_BACK_PRESSURE_ACTIVATION_ENABLE(__HANDLE__)          ((__HANDLE__)->Instance->MACFCR |= ETH_MACFCR_FCBBPA)
+ * @brief  Enables the MAC Back Pressure operation activation (Half-duplex only).
+ * @param  __HANDLE__: ETH Handle
+ * @retval None
+ */
+    #define __HAL_ETH_BACK_PRESSURE_ACTIVATION_ENABLE( __HANDLE__ )               ( ( __HANDLE__ )->Instance->MACFCR |= ETH_MACFCR_FCBBPA )
 
 /**
-  * @brief  Disables the MAC BackPressure operation activation (Half-duplex only).
-  * @param  __HANDLE__: ETH Handle
-  * @retval None
-  */
-#define __HAL_ETH_BACK_PRESSURE_ACTIVATION_DISABLE(__HANDLE__)         ((__HANDLE__)->Instance->MACFCR &= ~ETH_MACFCR_FCBBPA)
+ * @brief  Disables the MAC BackPressure operation activation (Half-duplex only).
+ * @param  __HANDLE__: ETH Handle
+ * @retval None
+ */
+    #define __HAL_ETH_BACK_PRESSURE_ACTIVATION_DISABLE( __HANDLE__ )              ( ( __HANDLE__ )->Instance->MACFCR &= ~ETH_MACFCR_FCBBPA )
 
 /**
-  * @brief  Checks whether the specified Ethernet MAC flag is set or not.
-  * @param  __HANDLE__: ETH Handle
-  * @param  __FLAG__: specifies the flag to check.
-  *   This parameter can be one of the following values:
-  *     @arg ETH_MAC_FLAG_TST  : Time stamp trigger flag
-  *     @arg ETH_MAC_FLAG_MMCT : MMC transmit flag
-  *     @arg ETH_MAC_FLAG_MMCR : MMC receive flag
-  *     @arg ETH_MAC_FLAG_MMC  : MMC flag
-  *     @arg ETH_MAC_FLAG_PMT  : PMT flag
-  * @retval The state of Ethernet MAC flag.
-  */
-#define __HAL_ETH_MAC_GET_FLAG(__HANDLE__, __FLAG__)                   (((__HANDLE__)->Instance->MACSR &( __FLAG__)) == ( __FLAG__))
+ * @brief  Checks whether the specified Ethernet MAC flag is set or not.
+ * @param  __HANDLE__: ETH Handle
+ * @param  __FLAG__: specifies the flag to check.
+ *   This parameter can be one of the following values:
+ *     @arg ETH_MAC_FLAG_TST  : Time stamp trigger flag
+ *     @arg ETH_MAC_FLAG_MMCT : MMC transmit flag
+ *     @arg ETH_MAC_FLAG_MMCR : MMC receive flag
+ *     @arg ETH_MAC_FLAG_MMC  : MMC flag
+ *     @arg ETH_MAC_FLAG_PMT  : PMT flag
+ * @retval The state of Ethernet MAC flag.
+ */
+    #define __HAL_ETH_MAC_GET_FLAG( __HANDLE__, __FLAG__ )                        ( ( ( __HANDLE__ )->Instance->MACSR & ( __FLAG__ ) ) == ( __FLAG__ ) )
 
 /**
-  * @brief  Enables the specified Ethernet DMA interrupts.
-  * @param  __HANDLE__   : ETH Handle
-  * @param  __INTERRUPT__: specifies the Ethernet DMA interrupt sources to be
-  *   enabled @ref ETH_DMA_Interrupts
-  * @retval None
-  */
-#define __HAL_ETH_DMA_ENABLE_IT(__HANDLE__, __INTERRUPT__)                 ((__HANDLE__)->Instance->DMAIER |= (__INTERRUPT__))
+ * @brief  Enables the specified Ethernet DMA interrupts.
+ * @param  __HANDLE__   : ETH Handle
+ * @param  __INTERRUPT__: specifies the Ethernet DMA interrupt sources to be
+ *   enabled @ref ETH_DMA_Interrupts
+ * @retval None
+ */
+    #define __HAL_ETH_DMA_ENABLE_IT( __HANDLE__, __INTERRUPT__ )                  ( ( __HANDLE__ )->Instance->DMAIER |= ( __INTERRUPT__ ) )
 
 /**
-  * @brief  Disables the specified Ethernet DMA interrupts.
-  * @param  __HANDLE__   : ETH Handle
-  * @param  __INTERRUPT__: specifies the Ethernet DMA interrupt sources to be
-  *   disabled. @ref ETH_DMA_Interrupts
-  * @retval None
-  */
-#define __HAL_ETH_DMA_DISABLE_IT(__HANDLE__, __INTERRUPT__)                ((__HANDLE__)->Instance->DMAIER &= ~(__INTERRUPT__))
+ * @brief  Disables the specified Ethernet DMA interrupts.
+ * @param  __HANDLE__   : ETH Handle
+ * @param  __INTERRUPT__: specifies the Ethernet DMA interrupt sources to be
+ *   disabled. @ref ETH_DMA_Interrupts
+ * @retval None
+ */
+    #define __HAL_ETH_DMA_DISABLE_IT( __HANDLE__, __INTERRUPT__ )                 ( ( __HANDLE__ )->Instance->DMAIER &= ~( __INTERRUPT__ ) )
 
 /**
-  * @brief  Clears the Ethernet DMA IT pending bit.
-  * @param  __HANDLE__   : ETH Handle
-  * @param  __INTERRUPT__: specifies the interrupt pending bit to clear. @ref ETH_DMA_Interrupts
-  * @retval None
-  */
-#define __HAL_ETH_DMA_CLEAR_IT(__HANDLE__, __INTERRUPT__)      ((__HANDLE__)->Instance->DMASR =(__INTERRUPT__))
+ * @brief  Clears the Ethernet DMA IT pending bit.
+ * @param  __HANDLE__   : ETH Handle
+ * @param  __INTERRUPT__: specifies the interrupt pending bit to clear. @ref ETH_DMA_Interrupts
+ * @retval None
+ */
+    #define __HAL_ETH_DMA_CLEAR_IT( __HANDLE__, __INTERRUPT__ )                   ( ( __HANDLE__ )->Instance->DMASR = ( __INTERRUPT__ ) )
 
 /**
-  * @brief  Checks whether the specified Ethernet DMA flag is set or not.
-* @param  __HANDLE__: ETH Handle
-  * @param  __FLAG__: specifies the flag to check. @ref ETH_DMA_Flags
-  * @retval The new state of ETH_DMA_FLAG (SET or RESET).
-  */
-#define __HAL_ETH_DMA_GET_FLAG(__HANDLE__, __FLAG__)                   (((__HANDLE__)->Instance->DMASR &( __FLAG__)) == ( __FLAG__))
+ * @brief  Checks whether the specified Ethernet DMA flag is set or not.
+ * @param  __HANDLE__: ETH Handle
+ * @param  __FLAG__: specifies the flag to check. @ref ETH_DMA_Flags
+ * @retval The new state of ETH_DMA_FLAG (SET or RESET).
+ */
+    #define __HAL_ETH_DMA_GET_FLAG( __HANDLE__, __FLAG__ )                        ( ( ( __HANDLE__ )->Instance->DMASR & ( __FLAG__ ) ) == ( __FLAG__ ) )
 
 /**
-  * @brief  Checks whether the specified Ethernet DMA flag is set or not.
-  * @param  __HANDLE__: ETH Handle
-  * @param  __FLAG__: specifies the flag to clear. @ref ETH_DMA_Flags
-  * @retval The new state of ETH_DMA_FLAG (SET or RESET).
-  */
-#define __HAL_ETH_DMA_CLEAR_FLAG(__HANDLE__, __FLAG__)                 ((__HANDLE__)->Instance->DMASR = (__FLAG__))
+ * @brief  Checks whether the specified Ethernet DMA flag is set or not.
+ * @param  __HANDLE__: ETH Handle
+ * @param  __FLAG__: specifies the flag to clear. @ref ETH_DMA_Flags
+ * @retval The new state of ETH_DMA_FLAG (SET or RESET).
+ */
+    #define __HAL_ETH_DMA_CLEAR_FLAG( __HANDLE__, __FLAG__ )                      ( ( __HANDLE__ )->Instance->DMASR = ( __FLAG__ ) )
 
 /**
-  * @brief  Checks whether the specified Ethernet DMA overflow flag is set or not.
-  * @param  __HANDLE__: ETH Handle
-  * @param  __OVERFLOW__: specifies the DMA overflow flag to check.
-  *   This parameter can be one of the following values:
-  *     @arg ETH_DMA_OVERFLOW_RXFIFOCOUNTER : Overflow for FIFO Overflows Counter
-  *     @arg ETH_DMA_OVERFLOW_MISSEDFRAMECOUNTER : Overflow for Buffer Unavailable Missed Frame Counter
-  * @retval The state of Ethernet DMA overflow Flag (SET or RESET).
-  */
-#define __HAL_ETH_GET_DMA_OVERFLOW_STATUS(__HANDLE__, __OVERFLOW__)       (((__HANDLE__)->Instance->DMAMFBOCR & (__OVERFLOW__)) == (__OVERFLOW__))
+ * @brief  Checks whether the specified Ethernet DMA overflow flag is set or not.
+ * @param  __HANDLE__: ETH Handle
+ * @param  __OVERFLOW__: specifies the DMA overflow flag to check.
+ *   This parameter can be one of the following values:
+ *     @arg ETH_DMA_OVERFLOW_RXFIFOCOUNTER : Overflow for FIFO Overflows Counter
+ *     @arg ETH_DMA_OVERFLOW_MISSEDFRAMECOUNTER : Overflow for Buffer Unavailable Missed Frame Counter
+ * @retval The state of Ethernet DMA overflow Flag (SET or RESET).
+ */
+    #define __HAL_ETH_GET_DMA_OVERFLOW_STATUS( __HANDLE__, __OVERFLOW__ )         ( ( ( __HANDLE__ )->Instance->DMAMFBOCR & ( __OVERFLOW__ ) ) == ( __OVERFLOW__ ) )
 
 /**
-  * @brief  Set the DMA Receive status watchdog timer register value
-  * @param  __HANDLE__: ETH Handle
-  * @param  __VALUE__: DMA Receive status watchdog timer register value
-  * @retval None
-  */
-#define __HAL_ETH_SET_RECEIVE_WATCHDOG_TIMER(__HANDLE__, __VALUE__)       ((__HANDLE__)->Instance->DMARSWTR = (__VALUE__))
+ * @brief  Set the DMA Receive status watchdog timer register value
+ * @param  __HANDLE__: ETH Handle
+ * @param  __VALUE__: DMA Receive status watchdog timer register value
+ * @retval None
+ */
+    #define __HAL_ETH_SET_RECEIVE_WATCHDOG_TIMER( __HANDLE__, __VALUE__ )         ( ( __HANDLE__ )->Instance->DMARSWTR = ( __VALUE__ ) )
 
 /**
-  * @brief  Enables any unicast packet filtered by the MAC address
-  *   recognition to be a wake-up frame.
-  * @param  __HANDLE__: ETH Handle.
-  * @retval None
-  */
-#define __HAL_ETH_GLOBAL_UNICAST_WAKEUP_ENABLE(__HANDLE__)               ((__HANDLE__)->Instance->MACPMTCSR |= ETH_MACPMTCSR_GU)
+ * @brief  Enables any unicast packet filtered by the MAC address
+ *   recognition to be a wake-up frame.
+ * @param  __HANDLE__: ETH Handle.
+ * @retval None
+ */
+    #define __HAL_ETH_GLOBAL_UNICAST_WAKEUP_ENABLE( __HANDLE__ )                  ( ( __HANDLE__ )->Instance->MACPMTCSR |= ETH_MACPMTCSR_GU )
 
 /**
-  * @brief  Disables any unicast packet filtered by the MAC address
-  *   recognition to be a wake-up frame.
-  * @param  __HANDLE__: ETH Handle.
-  * @retval None
-  */
-#define __HAL_ETH_GLOBAL_UNICAST_WAKEUP_DISABLE(__HANDLE__)              ((__HANDLE__)->Instance->MACPMTCSR &= ~ETH_MACPMTCSR_GU)
+ * @brief  Disables any unicast packet filtered by the MAC address
+ *   recognition to be a wake-up frame.
+ * @param  __HANDLE__: ETH Handle.
+ * @retval None
+ */
+    #define __HAL_ETH_GLOBAL_UNICAST_WAKEUP_DISABLE( __HANDLE__ )                 ( ( __HANDLE__ )->Instance->MACPMTCSR &= ~ETH_MACPMTCSR_GU )
 
 /**
-  * @brief  Enables the MAC Wake-Up Frame Detection.
-  * @param  __HANDLE__: ETH Handle.
-  * @retval None
-  */
-#define __HAL_ETH_WAKEUP_FRAME_DETECTION_ENABLE(__HANDLE__)              ((__HANDLE__)->Instance->MACPMTCSR |= ETH_MACPMTCSR_WFE)
+ * @brief  Enables the MAC Wake-Up Frame Detection.
+ * @param  __HANDLE__: ETH Handle.
+ * @retval None
+ */
+    #define __HAL_ETH_WAKEUP_FRAME_DETECTION_ENABLE( __HANDLE__ )                 ( ( __HANDLE__ )->Instance->MACPMTCSR |= ETH_MACPMTCSR_WFE )
 
 /**
-  * @brief  Disables the MAC Wake-Up Frame Detection.
-  * @param  __HANDLE__: ETH Handle.
-  * @retval None
-  */
-#define __HAL_ETH_WAKEUP_FRAME_DETECTION_DISABLE(__HANDLE__)             ((__HANDLE__)->Instance->MACPMTCSR &= ~ETH_MACPMTCSR_WFE)
+ * @brief  Disables the MAC Wake-Up Frame Detection.
+ * @param  __HANDLE__: ETH Handle.
+ * @retval None
+ */
+    #define __HAL_ETH_WAKEUP_FRAME_DETECTION_DISABLE( __HANDLE__ )                ( ( __HANDLE__ )->Instance->MACPMTCSR &= ~ETH_MACPMTCSR_WFE )
 
 /**
-  * @brief  Enables the MAC Magic Packet Detection.
-  * @param  __HANDLE__: ETH Handle.
-  * @retval None
-  */
-#define __HAL_ETH_MAGIC_PACKET_DETECTION_ENABLE(__HANDLE__)              ((__HANDLE__)->Instance->MACPMTCSR |= ETH_MACPMTCSR_MPE)
+ * @brief  Enables the MAC Magic Packet Detection.
+ * @param  __HANDLE__: ETH Handle.
+ * @retval None
+ */
+    #define __HAL_ETH_MAGIC_PACKET_DETECTION_ENABLE( __HANDLE__ )                 ( ( __HANDLE__ )->Instance->MACPMTCSR |= ETH_MACPMTCSR_MPE )
 
 /**
-  * @brief  Disables the MAC Magic Packet Detection.
-  * @param  __HANDLE__: ETH Handle.
-  * @retval None
-  */
-#define __HAL_ETH_MAGIC_PACKET_DETECTION_DISABLE(__HANDLE__)             ((__HANDLE__)->Instance->MACPMTCSR &= ~ETH_MACPMTCSR_WFE)
+ * @brief  Disables the MAC Magic Packet Detection.
+ * @param  __HANDLE__: ETH Handle.
+ * @retval None
+ */
+    #define __HAL_ETH_MAGIC_PACKET_DETECTION_DISABLE( __HANDLE__ )                ( ( __HANDLE__ )->Instance->MACPMTCSR &= ~ETH_MACPMTCSR_WFE )
 
 /**
-  * @brief  Enables the MAC Power Down.
-  * @param  __HANDLE__: ETH Handle
-  * @retval None
-  */
-#define __HAL_ETH_POWER_DOWN_ENABLE(__HANDLE__)                         ((__HANDLE__)->Instance->MACPMTCSR |= ETH_MACPMTCSR_PD)
+ * @brief  Enables the MAC Power Down.
+ * @param  __HANDLE__: ETH Handle
+ * @retval None
+ */
+    #define __HAL_ETH_POWER_DOWN_ENABLE( __HANDLE__ )                             ( ( __HANDLE__ )->Instance->MACPMTCSR |= ETH_MACPMTCSR_PD )
 
 /**
-  * @brief  Disables the MAC Power Down.
-  * @param  __HANDLE__: ETH Handle
-  * @retval None
-  */
-#define __HAL_ETH_POWER_DOWN_DISABLE(__HANDLE__)                        ((__HANDLE__)->Instance->MACPMTCSR &= ~ETH_MACPMTCSR_PD)
+ * @brief  Disables the MAC Power Down.
+ * @param  __HANDLE__: ETH Handle
+ * @retval None
+ */
+    #define __HAL_ETH_POWER_DOWN_DISABLE( __HANDLE__ )                            ( ( __HANDLE__ )->Instance->MACPMTCSR &= ~ETH_MACPMTCSR_PD )
 
 /**
-  * @brief  Checks whether the specified Ethernet PMT flag is set or not.
-  * @param  __HANDLE__: ETH Handle.
-  * @param  __FLAG__: specifies the flag to check.
-  *   This parameter can be one of the following values:
-  *     @arg ETH_PMT_FLAG_WUFFRPR : Wake-Up Frame Filter Register Pointer Reset
-  *     @arg ETH_PMT_FLAG_WUFR    : Wake-Up Frame Received
-  *     @arg ETH_PMT_FLAG_MPR     : Magic Packet Received
-  * @retval The new state of Ethernet PMT Flag (SET or RESET).
-  */
-#define __HAL_ETH_GET_PMT_FLAG_STATUS(__HANDLE__, __FLAG__)               (((__HANDLE__)->Instance->MACPMTCSR &( __FLAG__)) == ( __FLAG__))
+ * @brief  Checks whether the specified Ethernet PMT flag is set or not.
+ * @param  __HANDLE__: ETH Handle.
+ * @param  __FLAG__: specifies the flag to check.
+ *   This parameter can be one of the following values:
+ *     @arg ETH_PMT_FLAG_WUFFRPR : Wake-Up Frame Filter Register Pointer Reset
+ *     @arg ETH_PMT_FLAG_WUFR    : Wake-Up Frame Received
+ *     @arg ETH_PMT_FLAG_MPR     : Magic Packet Received
+ * @retval The new state of Ethernet PMT Flag (SET or RESET).
+ */
+    #define __HAL_ETH_GET_PMT_FLAG_STATUS( __HANDLE__, __FLAG__ )                 ( ( ( __HANDLE__ )->Instance->MACPMTCSR & ( __FLAG__ ) ) == ( __FLAG__ ) )
 
 /**
-  * @brief  Preset and Initialize the MMC counters to almost-full value: 0xFFFF_FFF0 (full - 16)
-  * @param   __HANDLE__: ETH Handle.
-  * @retval None
-  */
-#define __HAL_ETH_MMC_COUNTER_FULL_PRESET(__HANDLE__)                     ((__HANDLE__)->Instance->MMCCR |= (ETH_MMCCR_MCFHP | ETH_MMCCR_MCP))
+ * @brief  Preset and Initialize the MMC counters to almost-full value: 0xFFFF_FFF0 (full - 16)
+ * @param   __HANDLE__: ETH Handle.
+ * @retval None
+ */
+    #define __HAL_ETH_MMC_COUNTER_FULL_PRESET( __HANDLE__ )                       ( ( __HANDLE__ )->Instance->MMCCR |= ( ETH_MMCCR_MCFHP | ETH_MMCCR_MCP ) )
 
 /**
-  * @brief  Preset and Initialize the MMC counters to almost-half value: 0x7FFF_FFF0 (half - 16)
-  * @param  __HANDLE__: ETH Handle.
-  * @retval None
-  */
-#define __HAL_ETH_MMC_COUNTER_HALF_PRESET(__HANDLE__)                     do{(__HANDLE__)->Instance->MMCCR &= ~ETH_MMCCR_MCFHP;\
-                                                                          (__HANDLE__)->Instance->MMCCR |= ETH_MMCCR_MCP;} while (0)
+ * @brief  Preset and Initialize the MMC counters to almost-half value: 0x7FFF_FFF0 (half - 16)
+ * @param  __HANDLE__: ETH Handle.
+ * @retval None
+ */
+    #define __HAL_ETH_MMC_COUNTER_HALF_PRESET( __HANDLE__ )  \
+    do{ ( __HANDLE__ )->Instance->MMCCR &= ~ETH_MMCCR_MCFHP; \
+        ( __HANDLE__ )->Instance->MMCCR |= ETH_MMCCR_MCP; } while ( 0 )
 
 /**
-  * @brief  Enables the MMC Counter Freeze.
-  * @param  __HANDLE__: ETH Handle.
-  * @retval None
-  */
-#define __HAL_ETH_MMC_COUNTER_FREEZE_ENABLE(__HANDLE__)                  ((__HANDLE__)->Instance->MMCCR |= ETH_MMCCR_MCF)
+ * @brief  Enables the MMC Counter Freeze.
+ * @param  __HANDLE__: ETH Handle.
+ * @retval None
+ */
+    #define __HAL_ETH_MMC_COUNTER_FREEZE_ENABLE( __HANDLE__ )           ( ( __HANDLE__ )->Instance->MMCCR |= ETH_MMCCR_MCF )
 
 /**
-  * @brief  Disables the MMC Counter Freeze.
-  * @param  __HANDLE__: ETH Handle.
-  * @retval None
-  */
-#define __HAL_ETH_MMC_COUNTER_FREEZE_DISABLE(__HANDLE__)                 ((__HANDLE__)->Instance->MMCCR &= ~ETH_MMCCR_MCF)
+ * @brief  Disables the MMC Counter Freeze.
+ * @param  __HANDLE__: ETH Handle.
+ * @retval None
+ */
+    #define __HAL_ETH_MMC_COUNTER_FREEZE_DISABLE( __HANDLE__ )          ( ( __HANDLE__ )->Instance->MMCCR &= ~ETH_MMCCR_MCF )
 
 /**
-  * @brief  Enables the MMC Reset On Read.
-  * @param  __HANDLE__: ETH Handle.
-  * @retval None
-  */
-#define __HAL_ETH_ETH_MMC_RESET_ONREAD_ENABLE(__HANDLE__)                ((__HANDLE__)->Instance->MMCCR |= ETH_MMCCR_ROR)
+ * @brief  Enables the MMC Reset On Read.
+ * @param  __HANDLE__: ETH Handle.
+ * @retval None
+ */
+    #define __HAL_ETH_ETH_MMC_RESET_ONREAD_ENABLE( __HANDLE__ )         ( ( __HANDLE__ )->Instance->MMCCR |= ETH_MMCCR_ROR )
 
 /**
-  * @brief  Disables the MMC Reset On Read.
-  * @param  __HANDLE__: ETH Handle.
-  * @retval None
-  */
-#define __HAL_ETH_ETH_MMC_RESET_ONREAD_DISABLE(__HANDLE__)               ((__HANDLE__)->Instance->MMCCR &= ~ETH_MMCCR_ROR)
+ * @brief  Disables the MMC Reset On Read.
+ * @param  __HANDLE__: ETH Handle.
+ * @retval None
+ */
+    #define __HAL_ETH_ETH_MMC_RESET_ONREAD_DISABLE( __HANDLE__ )        ( ( __HANDLE__ )->Instance->MMCCR &= ~ETH_MMCCR_ROR )
 
 /**
-  * @brief  Enables the MMC Counter Stop Rollover.
-  * @param  __HANDLE__: ETH Handle.
-  * @retval None
-  */
-#define __HAL_ETH_ETH_MMC_COUNTER_ROLLOVER_ENABLE(__HANDLE__)            ((__HANDLE__)->Instance->MMCCR &= ~ETH_MMCCR_CSR)
+ * @brief  Enables the MMC Counter Stop Rollover.
+ * @param  __HANDLE__: ETH Handle.
+ * @retval None
+ */
+    #define __HAL_ETH_ETH_MMC_COUNTER_ROLLOVER_ENABLE( __HANDLE__ )     ( ( __HANDLE__ )->Instance->MMCCR &= ~ETH_MMCCR_CSR )
 
 /**
-  * @brief  Disables the MMC Counter Stop Rollover.
-  * @param  __HANDLE__: ETH Handle.
-  * @retval None
-  */
-#define __HAL_ETH_ETH_MMC_COUNTER_ROLLOVER_DISABLE(__HANDLE__)           ((__HANDLE__)->Instance->MMCCR |= ETH_MMCCR_CSR)
+ * @brief  Disables the MMC Counter Stop Rollover.
+ * @param  __HANDLE__: ETH Handle.
+ * @retval None
+ */
+    #define __HAL_ETH_ETH_MMC_COUNTER_ROLLOVER_DISABLE( __HANDLE__ )    ( ( __HANDLE__ )->Instance->MMCCR |= ETH_MMCCR_CSR )
 
 /**
-  * @brief  Resets the MMC Counters.
-  * @param   __HANDLE__: ETH Handle.
-  * @retval None
-  */
-#define __HAL_ETH_MMC_COUNTERS_RESET(__HANDLE__)                         ((__HANDLE__)->Instance->MMCCR |= ETH_MMCCR_CR)
+ * @brief  Resets the MMC Counters.
+ * @param   __HANDLE__: ETH Handle.
+ * @retval None
+ */
+    #define __HAL_ETH_MMC_COUNTERS_RESET( __HANDLE__ )                  ( ( __HANDLE__ )->Instance->MMCCR |= ETH_MMCCR_CR )
 
 /**
-  * @brief  Enables the specified Ethernet MMC Rx interrupts.
-  * @param   __HANDLE__: ETH Handle.
-  * @param  __INTERRUPT__: specifies the Ethernet MMC interrupt sources to be enabled or disabled.
-  *   This parameter can be one of the following values:
-  *     @arg ETH_MMC_IT_RGUF  : When Rx good unicast frames counter reaches half the maximum value
-  *     @arg ETH_MMC_IT_RFAE  : When Rx alignment error counter reaches half the maximum value
-  *     @arg ETH_MMC_IT_RFCE  : When Rx crc error counter reaches half the maximum value
-  * @retval None
-  */
-#define __HAL_ETH_MMC_RX_IT_ENABLE(__HANDLE__, __INTERRUPT__)               (__HANDLE__)->Instance->MMCRIMR &= ~((__INTERRUPT__) & 0xEFFFFFFF)
-/**
-  * @brief  Disables the specified Ethernet MMC Rx interrupts.
-  * @param   __HANDLE__: ETH Handle.
-  * @param  __INTERRUPT__: specifies the Ethernet MMC interrupt sources to be enabled or disabled.
-  *   This parameter can be one of the following values:
-  *     @arg ETH_MMC_IT_RGUF  : When Rx good unicast frames counter reaches half the maximum value
-  *     @arg ETH_MMC_IT_RFAE  : When Rx alignment error counter reaches half the maximum value
-  *     @arg ETH_MMC_IT_RFCE  : When Rx crc error counter reaches half the maximum value
-  * @retval None
-  */
-#define __HAL_ETH_MMC_RX_IT_DISABLE(__HANDLE__, __INTERRUPT__)              (__HANDLE__)->Instance->MMCRIMR |= ((__INTERRUPT__) & 0xEFFFFFFF)
-/**
-  * @brief  Enables the specified Ethernet MMC Tx interrupts.
-  * @param   __HANDLE__: ETH Handle.
-  * @param  __INTERRUPT__: specifies the Ethernet MMC interrupt sources to be enabled or disabled.
-  *   This parameter can be one of the following values:
-  *     @arg ETH_MMC_IT_TGF   : When Tx good frame counter reaches half the maximum value
-  *     @arg ETH_MMC_IT_TGFMSC: When Tx good multi col counter reaches half the maximum value
-  *     @arg ETH_MMC_IT_TGFSC : When Tx good single col counter reaches half the maximum value
-  * @retval None
-  */
-#define __HAL_ETH_MMC_TX_IT_ENABLE(__HANDLE__, __INTERRUPT__)            ((__HANDLE__)->Instance->MMCRIMR &= ~ (__INTERRUPT__))
+ * @brief  Enables the specified Ethernet MMC Rx interrupts.
+ * @param   __HANDLE__: ETH Handle.
+ * @param  __INTERRUPT__: specifies the Ethernet MMC interrupt sources to be enabled or disabled.
+ *   This parameter can be one of the following values:
+ *     @arg ETH_MMC_IT_RGUF  : When Rx good unicast frames counter reaches half the maximum value
+ *     @arg ETH_MMC_IT_RFAE  : When Rx alignment error counter reaches half the maximum value
+ *     @arg ETH_MMC_IT_RFCE  : When Rx crc error counter reaches half the maximum value
+ * @retval None
+ */
+    #define __HAL_ETH_MMC_RX_IT_ENABLE( __HANDLE__, __INTERRUPT__ )     ( __HANDLE__ )->Instance->MMCRIMR &= ~( ( __INTERRUPT__ ) & 0xEFFFFFFF )
 
 /**
-  * @brief  Disables the specified Ethernet MMC Tx interrupts.
-  * @param   __HANDLE__: ETH Handle.
-  * @param  __INTERRUPT__: specifies the Ethernet MMC interrupt sources to be enabled or disabled.
-  *   This parameter can be one of the following values:
-  *     @arg ETH_MMC_IT_TGF   : When Tx good frame counter reaches half the maximum value
-  *     @arg ETH_MMC_IT_TGFMSC: When Tx good multi col counter reaches half the maximum value
-  *     @arg ETH_MMC_IT_TGFSC : When Tx good single col counter reaches half the maximum value
-  * @retval None
-  */
-#define __HAL_ETH_MMC_TX_IT_DISABLE(__HANDLE__, __INTERRUPT__)           ((__HANDLE__)->Instance->MMCRIMR |= (__INTERRUPT__))
+ * @brief  Disables the specified Ethernet MMC Rx interrupts.
+ * @param   __HANDLE__: ETH Handle.
+ * @param  __INTERRUPT__: specifies the Ethernet MMC interrupt sources to be enabled or disabled.
+ *   This parameter can be one of the following values:
+ *     @arg ETH_MMC_IT_RGUF  : When Rx good unicast frames counter reaches half the maximum value
+ *     @arg ETH_MMC_IT_RFAE  : When Rx alignment error counter reaches half the maximum value
+ *     @arg ETH_MMC_IT_RFCE  : When Rx crc error counter reaches half the maximum value
+ * @retval None
+ */
+    #define __HAL_ETH_MMC_RX_IT_DISABLE( __HANDLE__, __INTERRUPT__ )    ( __HANDLE__ )->Instance->MMCRIMR |= ( ( __INTERRUPT__ ) & 0xEFFFFFFF )
 
 /**
-  * @brief  Enables the ETH External interrupt line.
-  * @retval None
-  */
-#define __HAL_ETH_WAKEUP_EXTI_ENABLE_IT()    EXTI->IMR |= (ETH_EXTI_LINE_WAKEUP)
+ * @brief  Enables the specified Ethernet MMC Tx interrupts.
+ * @param   __HANDLE__: ETH Handle.
+ * @param  __INTERRUPT__: specifies the Ethernet MMC interrupt sources to be enabled or disabled.
+ *   This parameter can be one of the following values:
+ *     @arg ETH_MMC_IT_TGF   : When Tx good frame counter reaches half the maximum value
+ *     @arg ETH_MMC_IT_TGFMSC: When Tx good multi col counter reaches half the maximum value
+ *     @arg ETH_MMC_IT_TGFSC : When Tx good single col counter reaches half the maximum value
+ * @retval None
+ */
+    #define __HAL_ETH_MMC_TX_IT_ENABLE( __HANDLE__, __INTERRUPT__ )     ( ( __HANDLE__ )->Instance->MMCRIMR &= ~( __INTERRUPT__ ) )
 
 /**
-  * @brief  Disables the ETH External interrupt line.
-  * @retval None
-  */
-#define __HAL_ETH_WAKEUP_EXTI_DISABLE_IT()   EXTI->IMR &= ~(ETH_EXTI_LINE_WAKEUP)
+ * @brief  Disables the specified Ethernet MMC Tx interrupts.
+ * @param   __HANDLE__: ETH Handle.
+ * @param  __INTERRUPT__: specifies the Ethernet MMC interrupt sources to be enabled or disabled.
+ *   This parameter can be one of the following values:
+ *     @arg ETH_MMC_IT_TGF   : When Tx good frame counter reaches half the maximum value
+ *     @arg ETH_MMC_IT_TGFMSC: When Tx good multi col counter reaches half the maximum value
+ *     @arg ETH_MMC_IT_TGFSC : When Tx good single col counter reaches half the maximum value
+ * @retval None
+ */
+    #define __HAL_ETH_MMC_TX_IT_DISABLE( __HANDLE__, __INTERRUPT__ )    ( ( __HANDLE__ )->Instance->MMCRIMR |= ( __INTERRUPT__ ) )
 
 /**
-  * @brief Enable event on ETH External event line.
-  * @retval None.
-  */
-#define __HAL_ETH_WAKEUP_EXTI_ENABLE_EVENT()  EXTI->EMR |= (ETH_EXTI_LINE_WAKEUP)
+ * @brief  Enables the ETH External interrupt line.
+ * @retval None
+ */
+    #define __HAL_ETH_WAKEUP_EXTI_ENABLE_IT()                           EXTI->IMR |= ( ETH_EXTI_LINE_WAKEUP )
 
 /**
-  * @brief Disable event on ETH External event line
-  * @retval None.
-  */
-#define __HAL_ETH_WAKEUP_EXTI_DISABLE_EVENT() EXTI->EMR &= ~(ETH_EXTI_LINE_WAKEUP)
+ * @brief  Disables the ETH External interrupt line.
+ * @retval None
+ */
+    #define __HAL_ETH_WAKEUP_EXTI_DISABLE_IT()                          EXTI->IMR &= ~( ETH_EXTI_LINE_WAKEUP )
 
 /**
-  * @brief  Get flag of the ETH External interrupt line.
-  * @retval None
-  */
-#define __HAL_ETH_WAKEUP_EXTI_GET_FLAG()     EXTI->PR & (ETH_EXTI_LINE_WAKEUP)
+ * @brief Enable event on ETH External event line.
+ * @retval None.
+ */
+    #define __HAL_ETH_WAKEUP_EXTI_ENABLE_EVENT()                        EXTI->EMR |= ( ETH_EXTI_LINE_WAKEUP )
 
 /**
-  * @brief  Clear flag of the ETH External interrupt line.
-  * @retval None
-  */
-#define __HAL_ETH_WAKEUP_EXTI_CLEAR_FLAG()   EXTI->PR = (ETH_EXTI_LINE_WAKEUP)
+ * @brief Disable event on ETH External event line
+ * @retval None.
+ */
+    #define __HAL_ETH_WAKEUP_EXTI_DISABLE_EVENT()                       EXTI->EMR &= ~( ETH_EXTI_LINE_WAKEUP )
 
 /**
-  * @brief  Enables rising edge trigger to the ETH External interrupt line.
-  * @retval None
-  */
-#define __HAL_ETH_WAKEUP_EXTI_ENABLE_RISING_EDGE_TRIGGER()  EXTI->RTSR |= ETH_EXTI_LINE_WAKEUP
+ * @brief  Get flag of the ETH External interrupt line.
+ * @retval None
+ */
+    #define __HAL_ETH_WAKEUP_EXTI_GET_FLAG()                            EXTI->PR & ( ETH_EXTI_LINE_WAKEUP )
 
 /**
-  * @brief  Disables the rising edge trigger to the ETH External interrupt line.
-  * @retval None
-  */
-#define __HAL_ETH_WAKEUP_EXTI_DISABLE_RISING_EDGE_TRIGGER()  EXTI->RTSR &= ~(ETH_EXTI_LINE_WAKEUP)
+ * @brief  Clear flag of the ETH External interrupt line.
+ * @retval None
+ */
+    #define __HAL_ETH_WAKEUP_EXTI_CLEAR_FLAG()                          EXTI->PR = ( ETH_EXTI_LINE_WAKEUP )
 
 /**
-  * @brief  Enables falling edge trigger to the ETH External interrupt line.
-  * @retval None
-  */
-#define __HAL_ETH_WAKEUP_EXTI_ENABLE_FALLING_EDGE_TRIGGER()  EXTI->FTSR |= (ETH_EXTI_LINE_WAKEUP)
+ * @brief  Enables rising edge trigger to the ETH External interrupt line.
+ * @retval None
+ */
+    #define __HAL_ETH_WAKEUP_EXTI_ENABLE_RISING_EDGE_TRIGGER()          EXTI->RTSR |= ETH_EXTI_LINE_WAKEUP
 
 /**
-  * @brief  Disables falling edge trigger to the ETH External interrupt line.
-  * @retval None
-  */
-#define __HAL_ETH_WAKEUP_EXTI_DISABLE_FALLING_EDGE_TRIGGER()  EXTI->FTSR &= ~(ETH_EXTI_LINE_WAKEUP)
+ * @brief  Disables the rising edge trigger to the ETH External interrupt line.
+ * @retval None
+ */
+    #define __HAL_ETH_WAKEUP_EXTI_DISABLE_RISING_EDGE_TRIGGER()         EXTI->RTSR &= ~( ETH_EXTI_LINE_WAKEUP )
 
 /**
-  * @brief  Enables rising/falling edge trigger to the ETH External interrupt line.
-  * @retval None
-  */
-#define __HAL_ETH_WAKEUP_EXTI_ENABLE_FALLINGRISING_TRIGGER()  EXTI->RTSR |= ETH_EXTI_LINE_WAKEUP;\
-                                                              EXTI->FTSR |= ETH_EXTI_LINE_WAKEUP
+ * @brief  Enables falling edge trigger to the ETH External interrupt line.
+ * @retval None
+ */
+    #define __HAL_ETH_WAKEUP_EXTI_ENABLE_FALLING_EDGE_TRIGGER()         EXTI->FTSR |= ( ETH_EXTI_LINE_WAKEUP )
 
 /**
-  * @brief  Disables rising/falling edge trigger to the ETH External interrupt line.
-  * @retval None
-  */
-#define __HAL_ETH_WAKEUP_EXTI_DISABLE_FALLINGRISING_TRIGGER()  EXTI->RTSR &= ~(ETH_EXTI_LINE_WAKEUP);\
-                                                               EXTI->FTSR &= ~(ETH_EXTI_LINE_WAKEUP)
+ * @brief  Disables falling edge trigger to the ETH External interrupt line.
+ * @retval None
+ */
+    #define __HAL_ETH_WAKEUP_EXTI_DISABLE_FALLING_EDGE_TRIGGER()        EXTI->FTSR &= ~( ETH_EXTI_LINE_WAKEUP )
 
 /**
-  * @brief Generate a Software interrupt on selected EXTI line.
-  * @retval None.
-  */
-#define __HAL_ETH_WAKEUP_EXTI_GENERATE_SWIT()                  EXTI->SWIER|= ETH_EXTI_LINE_WAKEUP
+ * @brief  Enables rising/falling edge trigger to the ETH External interrupt line.
+ * @retval None
+ */
+    #define __HAL_ETH_WAKEUP_EXTI_ENABLE_FALLINGRISING_TRIGGER() \
+    EXTI->RTSR |= ETH_EXTI_LINE_WAKEUP;                          \
+    EXTI->FTSR |= ETH_EXTI_LINE_WAKEUP
 
 /**
-  * @}
-  */
+ * @brief  Disables rising/falling edge trigger to the ETH External interrupt line.
+ * @retval None
+ */
+    #define __HAL_ETH_WAKEUP_EXTI_DISABLE_FALLINGRISING_TRIGGER() \
+    EXTI->RTSR &= ~( ETH_EXTI_LINE_WAKEUP );                      \
+    EXTI->FTSR &= ~( ETH_EXTI_LINE_WAKEUP )
+
+/**
+ * @brief Generate a Software interrupt on selected EXTI line.
+ * @retval None.
+ */
+    #define __HAL_ETH_WAKEUP_EXTI_GENERATE_SWIT()    EXTI->SWIER |= ETH_EXTI_LINE_WAKEUP
+
+/**
+ * @}
+ */
 /* Exported functions --------------------------------------------------------*/
 
 /** @addtogroup ETH_Exported_Functions
-  * @{
-  */
+ * @{
+ */
 
 /* Initialization and de-initialization functions  ****************************/
 
 /** @addtogroup ETH_Exported_Functions_Group1
-  * @{
-  */
-HAL_StatusTypeDef HAL_ETH_Init(ETH_HandleTypeDef *heth);
-HAL_StatusTypeDef HAL_ETH_DeInit(ETH_HandleTypeDef *heth);
-void HAL_ETH_MspInit(ETH_HandleTypeDef *heth);
-void HAL_ETH_MspDeInit(ETH_HandleTypeDef *heth);
-HAL_StatusTypeDef HAL_ETH_DMATxDescListInit(ETH_HandleTypeDef *heth, ETH_DMADescTypeDef *DMATxDescTab, uint8_t* TxBuff, uint32_t TxBuffCount);
-HAL_StatusTypeDef HAL_ETH_DMARxDescListInit(ETH_HandleTypeDef *heth, ETH_DMADescTypeDef *DMARxDescTab, uint8_t *RxBuff, uint32_t RxBuffCount);
+ * @{
+ */
+    HAL_StatusTypeDef HAL_ETH_Init( ETH_HandleTypeDef * heth );
+    HAL_StatusTypeDef HAL_ETH_DeInit( ETH_HandleTypeDef * heth );
+    void HAL_ETH_MspInit( ETH_HandleTypeDef * heth );
+    void HAL_ETH_MspDeInit( ETH_HandleTypeDef * heth );
+    HAL_StatusTypeDef HAL_ETH_DMATxDescListInit( ETH_HandleTypeDef * heth,
+                                                 ETH_DMADescTypeDef * DMATxDescTab,
+                                                 uint8_t * TxBuff,
+                                                 uint32_t TxBuffCount );
+    HAL_StatusTypeDef HAL_ETH_DMARxDescListInit( ETH_HandleTypeDef * heth,
+                                                 ETH_DMADescTypeDef * DMARxDescTab,
+                                                 uint8_t * RxBuff,
+                                                 uint32_t RxBuffCount );
 
 /**
-  * @}
-  */
+ * @}
+ */
 /* IO operation functions  ****************************************************/
 
 /** @addtogroup ETH_Exported_Functions_Group2
-  * @{
-  */
-HAL_StatusTypeDef HAL_ETH_TransmitFrame(ETH_HandleTypeDef *heth, uint32_t FrameLength);
-HAL_StatusTypeDef HAL_ETH_GetReceivedFrame(ETH_HandleTypeDef *heth);
+ * @{
+ */
+    HAL_StatusTypeDef HAL_ETH_TransmitFrame( ETH_HandleTypeDef * heth,
+                                             uint32_t FrameLength );
+    HAL_StatusTypeDef HAL_ETH_GetReceivedFrame( ETH_HandleTypeDef * heth );
 /* Communication with PHY functions*/
-HAL_StatusTypeDef HAL_ETH_ReadPHYRegister(ETH_HandleTypeDef *heth, uint16_t PHYReg, uint32_t *RegValue);
-HAL_StatusTypeDef HAL_ETH_WritePHYRegister(ETH_HandleTypeDef *heth, uint16_t PHYReg, uint32_t RegValue);
+    HAL_StatusTypeDef HAL_ETH_ReadPHYRegister( ETH_HandleTypeDef * heth,
+                                               uint16_t PHYReg,
+                                               uint32_t * RegValue );
+    HAL_StatusTypeDef HAL_ETH_WritePHYRegister( ETH_HandleTypeDef * heth,
+                                                uint16_t PHYReg,
+                                                uint32_t RegValue );
 /* Non-Blocking mode: Interrupt */
-HAL_StatusTypeDef HAL_ETH_GetReceivedFrame_IT(ETH_HandleTypeDef *heth);
-void HAL_ETH_IRQHandler(ETH_HandleTypeDef *heth);
+    HAL_StatusTypeDef HAL_ETH_GetReceivedFrame_IT( ETH_HandleTypeDef * heth );
+    void HAL_ETH_IRQHandler( ETH_HandleTypeDef * heth );
 /* Callback in non blocking modes (Interrupt) */
-void HAL_ETH_TxCpltCallback(ETH_HandleTypeDef *heth);
-void HAL_ETH_RxCpltCallback(ETH_HandleTypeDef *heth);
-void HAL_ETH_ErrorCallback(ETH_HandleTypeDef *heth);
+    void HAL_ETH_TxCpltCallback( ETH_HandleTypeDef * heth );
+    void HAL_ETH_RxCpltCallback( ETH_HandleTypeDef * heth );
+    void HAL_ETH_ErrorCallback( ETH_HandleTypeDef * heth );
+
 /**
-  * @}
-  */
+ * @}
+ */
 
 /* Peripheral Control functions  **********************************************/
 
 /** @addtogroup ETH_Exported_Functions_Group3
-  * @{
-  */
+ * @{
+ */
 
-HAL_StatusTypeDef HAL_ETH_Start(ETH_HandleTypeDef *heth);
-HAL_StatusTypeDef HAL_ETH_Stop(ETH_HandleTypeDef *heth);
-HAL_StatusTypeDef HAL_ETH_ConfigMAC(ETH_HandleTypeDef *heth, ETH_MACInitTypeDef *macconf);
-HAL_StatusTypeDef HAL_ETH_ConfigDMA(ETH_HandleTypeDef *heth, ETH_DMAInitTypeDef *dmaconf);
+    HAL_StatusTypeDef HAL_ETH_Start( ETH_HandleTypeDef * heth );
+    HAL_StatusTypeDef HAL_ETH_Stop( ETH_HandleTypeDef * heth );
+    HAL_StatusTypeDef HAL_ETH_ConfigMAC( ETH_HandleTypeDef * heth,
+                                         ETH_MACInitTypeDef * macconf );
+    HAL_StatusTypeDef HAL_ETH_ConfigDMA( ETH_HandleTypeDef * heth,
+                                         ETH_DMAInitTypeDef * dmaconf );
+
 /**
-  * @}
-  */
+ * @}
+ */
 
 /* Peripheral State functions  ************************************************/
 
 /** @addtogroup ETH_Exported_Functions_Group4
-  * @{
-  */
-HAL_ETH_StateTypeDef HAL_ETH_GetState(ETH_HandleTypeDef *heth);
-/**
-  * @}
-  */
+ * @{
+ */
+    HAL_ETH_StateTypeDef HAL_ETH_GetState( ETH_HandleTypeDef * heth );
 
 /**
-  * @}
-  */
+ * @}
+ */
 
 /**
-  * @}
-  */
+ * @}
+ */
 
 /**
-  * @}
-  */
-#ifdef __cplusplus
-}
-#endif
+ * @}
+ */
+
+/**
+ * @}
+ */
+    #ifdef __cplusplus
+        }
+    #endif
 
 #endif /* __STM32Fxx_HAL_ETH_H */
 

--- a/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/portable/NetworkInterface/WinPCap/FaultInjection.c
+++ b/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/portable/NetworkInterface/WinPCap/FaultInjection.c
@@ -1,175 +1,188 @@
-#define xBUFFER_CACHE_SIZE			10
-#define xMAX_FAULT_INJECTION_RATE	15
-#define xMIN_FAULT_INJECTION_RATE	3
-#define xNUM_FAULT_TYPES			1
+#define xBUFFER_CACHE_SIZE           10
+#define xMAX_FAULT_INJECTION_RATE    15
+#define xMIN_FAULT_INJECTION_RATE    3
+#define xNUM_FAULT_TYPES             1
 
-static NetworkBufferDescriptor_t *xNetworkBufferCache[ xBUFFER_CACHE_SIZE ] = { 0 };
+static NetworkBufferDescriptor_t * xNetworkBufferCache[ xBUFFER_CACHE_SIZE ] = { 0 };
 
-#define xFAULT_LOG_SIZE 2048
+#define xFAULT_LOG_SIZE    2048
 uint32_t ulInjectedFault[ xFAULT_LOG_SIZE ];
 uint32_t ulFaultLogIndex = 0;
 
-static BaseType_t prvCachePacket( NetworkBufferDescriptor_t *pxNetworkBufferIn )
+static BaseType_t prvCachePacket( NetworkBufferDescriptor_t * pxNetworkBufferIn )
 {
-BaseType_t x, xReturn = pdFALSE;
+    BaseType_t x, xReturn = pdFALSE;
 
-	for( x = 0; x < xBUFFER_CACHE_SIZE; x++ )
-	{
-		if( xNetworkBufferCache[ x ] == NULL )
-		{
-			xNetworkBufferCache[ x ] = pxNetworkBufferIn;
-			xReturn = pdTRUE;
-			break;
-		}
-	}
+    for( x = 0; x < xBUFFER_CACHE_SIZE; x++ )
+    {
+        if( xNetworkBufferCache[ x ] == NULL )
+        {
+            xNetworkBufferCache[ x ] = pxNetworkBufferIn;
+            xReturn = pdTRUE;
+            break;
+        }
+    }
 
-	return xReturn;
+    return xReturn;
 }
 /*-----------------------------------------------------------*/
 
-static NetworkBufferDescriptor_t *prvGetCachedPacket( void )
+static NetworkBufferDescriptor_t * prvGetCachedPacket( void )
 {
-BaseType_t x;
-NetworkBufferDescriptor_t *pxReturn = NULL;
+    BaseType_t x;
+    NetworkBufferDescriptor_t * pxReturn = NULL;
 
-	for( x = ( xBUFFER_CACHE_SIZE - 1 ); x >= 0; x-- )
-	{
-		if( xNetworkBufferCache[ x ] != NULL )
-		{
-			pxReturn = xNetworkBufferCache[ x ];
-			xNetworkBufferCache[ x ] = NULL;
-			break;
-		}
-	}
+    for( x = ( xBUFFER_CACHE_SIZE - 1 ); x >= 0; x-- )
+    {
+        if( xNetworkBufferCache[ x ] != NULL )
+        {
+            pxReturn = xNetworkBufferCache[ x ];
+            xNetworkBufferCache[ x ] = NULL;
+            break;
+        }
+    }
 
-	return pxReturn;
+    return pxReturn;
 }
 /*-----------------------------------------------------------*/
 
-static NetworkBufferDescriptor_t *prvDuplicatePacket( NetworkBufferDescriptor_t * pxOriginalPacket, const uint8_t *pucPacketData )
+static NetworkBufferDescriptor_t * prvDuplicatePacket( NetworkBufferDescriptor_t * pxOriginalPacket,
+                                                       const uint8_t * pucPacketData )
 {
-NetworkBufferDescriptor_t *pxReturn;
+    NetworkBufferDescriptor_t * pxReturn;
 
-	/* Obtain a new descriptor. */
-	pxReturn = pxGetNetworkBufferWithDescriptor( pxOriginalPacket->xDataLength, 0 );
+    /* Obtain a new descriptor. */
+    pxReturn = pxGetNetworkBufferWithDescriptor( pxOriginalPacket->xDataLength, 0 );
 
-	if( pxReturn != NULL )
-	{
-		/* Copy in the packet data. */
-		pxReturn->xDataLength = pxOriginalPacket->xDataLength;
-		memcpy( pxReturn->pucEthernetBuffer, pucPacketData, pxOriginalPacket->xDataLength );
-	}
+    if( pxReturn != NULL )
+    {
+        /* Copy in the packet data. */
+        pxReturn->xDataLength = pxOriginalPacket->xDataLength;
+        memcpy( pxReturn->pucEthernetBuffer, pucPacketData, pxOriginalPacket->xDataLength );
+    }
 
-	return pxReturn;
+    return pxReturn;
 }
 /*-----------------------------------------------------------*/
 
-static NetworkBufferDescriptor_t *prvRxFaultInjection( NetworkBufferDescriptor_t *pxNetworkBufferIn, const uint8_t *pucPacketData )
+static NetworkBufferDescriptor_t * prvRxFaultInjection( NetworkBufferDescriptor_t * pxNetworkBufferIn,
+                                                        const uint8_t * pucPacketData )
 {
-static uint32_t ulCallCount = 0, ulNextFaultCallCount = 0;
-NetworkBufferDescriptor_t *pxReturn = pxNetworkBufferIn;
-IPStackEvent_t xRxEvent = { eNetworkRxEvent, NULL };
-uint32_t ulFault;
+    static uint32_t ulCallCount = 0, ulNextFaultCallCount = 0;
+    NetworkBufferDescriptor_t * pxReturn = pxNetworkBufferIn;
+    IPStackEvent_t xRxEvent = { eNetworkRxEvent, NULL };
+    uint32_t ulFault;
 
-return pxNetworkBufferIn;
+    return pxNetworkBufferIn;
 
-	ulCallCount++;
+    ulCallCount++;
 
-	if( ulCallCount > ulNextFaultCallCount )
-	{
-		xApplicationGetRandomNumber( &( ulNextFaultCallCount ) );
-		ulNextFaultCallCount = ulNextFaultCallCount % xMAX_FAULT_INJECTION_RATE;
-		if( ulNextFaultCallCount < xMIN_FAULT_INJECTION_RATE )
-		{
-			ulNextFaultCallCount = xMIN_FAULT_INJECTION_RATE;
-		}
+    if( ulCallCount > ulNextFaultCallCount )
+    {
+        xApplicationGetRandomNumber( &( ulNextFaultCallCount ) );
+        ulNextFaultCallCount = ulNextFaultCallCount % xMAX_FAULT_INJECTION_RATE;
 
-		ulCallCount = 0;
+        if( ulNextFaultCallCount < xMIN_FAULT_INJECTION_RATE )
+        {
+            ulNextFaultCallCount = xMIN_FAULT_INJECTION_RATE;
+        }
 
-		xApplicationGetRandomNumber( &( ulFault ) );
-		ulFault = ulFault % xNUM_FAULT_TYPES;
+        ulCallCount = 0;
 
-		if( ulFaultLogIndex < xFAULT_LOG_SIZE )
-		{
-			ulInjectedFault[ ulFaultLogIndex ] = ulFault;
-			ulFaultLogIndex++;
-		}
+        xApplicationGetRandomNumber( &( ulFault ) );
+        ulFault = ulFault % xNUM_FAULT_TYPES;
 
-		switch( ulFault )
-		{
-			case 0:
-				/* Just drop the packet. */
-				vReleaseNetworkBufferAndDescriptor( pxNetworkBufferIn );
-				pxReturn = NULL;
-				break;
+        if( ulFaultLogIndex < xFAULT_LOG_SIZE )
+        {
+            ulInjectedFault[ ulFaultLogIndex ] = ulFault;
+            ulFaultLogIndex++;
+        }
 
-			case 1:
-				/* Store the packet in the cache for later. */
-				if( prvCachePacket( pxNetworkBufferIn ) == pdTRUE )
-				{
-					/* The packet may get sent later, it is not being sent
-					now. */
-					pxReturn = NULL;
-				}
-				break;
+        switch( ulFault )
+        {
+            case 0:
+                /* Just drop the packet. */
+                vReleaseNetworkBufferAndDescriptor( pxNetworkBufferIn );
+                pxReturn = NULL;
+                break;
 
-			case 2:
-				/* Send a cached packet. */
-				pxReturn = prvGetCachedPacket();
-				if( pxReturn != NULL )
-				{
-					/* A cached packet was obtained so drop the original
-					packet. */
-					vReleaseNetworkBufferAndDescriptor( pxNetworkBufferIn );
-				}
-				else
-				{
-					/* Could not obtain a packet from the cache so just return
-					the packet that was passed in. */
-					pxReturn = pxNetworkBufferIn;
-				}
-				break;
+            case 1:
 
-			case 4:
+                /* Store the packet in the cache for later. */
+                if( prvCachePacket( pxNetworkBufferIn ) == pdTRUE )
+                {
+                    /* The packet may get sent later, it is not being sent
+                     * now. */
+                    pxReturn = NULL;
+                }
 
-				/* Send a duplicate of the packet right away. */
-				pxReturn = prvDuplicatePacket( pxNetworkBufferIn, pucPacketData );
+                break;
 
-				/* Send the original packet to the stack. */
-				xRxEvent.pvData = ( void * ) pxNetworkBufferIn;
-				if( xSendEventStructToIPTask( &xRxEvent, ( TickType_t ) 0 ) == pdFAIL )
-				{
-					vReleaseNetworkBufferAndDescriptor( pxNetworkBufferIn );
-				}
-				break;
+            case 2:
+                /* Send a cached packet. */
+                pxReturn = prvGetCachedPacket();
 
-			case 5:
+                if( pxReturn != NULL )
+                {
+                    /* A cached packet was obtained so drop the original
+                     * packet. */
+                    vReleaseNetworkBufferAndDescriptor( pxNetworkBufferIn );
+                }
+                else
+                {
+                    /* Could not obtain a packet from the cache so just return
+                     * the packet that was passed in. */
+                    pxReturn = pxNetworkBufferIn;
+                }
 
-				/* Send both a cached packet and the current packet. */
-				xRxEvent.pvData = ( void * ) prvGetCachedPacket();
-				if( xRxEvent.pvData != NULL )
-				{
-					if( xSendEventStructToIPTask( &xRxEvent, ( TickType_t ) 0 ) == pdFAIL )
-					{
-						vReleaseNetworkBufferAndDescriptor( pxNetworkBufferIn );
-					}
-				}
-				break;
+                break;
 
-			case 6:
-			case 7:
-			case 8:
-				/* Store the packet in the cache for later. */
-				if( prvCachePacket( pxNetworkBufferIn ) == pdTRUE )
-				{
-					/* The packet may get sent later, it is not being sent
-					now. */
-					pxReturn = NULL;
-				}
-				break;
-		}
-	}
+            case 4:
 
-	return pxReturn;
+                /* Send a duplicate of the packet right away. */
+                pxReturn = prvDuplicatePacket( pxNetworkBufferIn, pucPacketData );
+
+                /* Send the original packet to the stack. */
+                xRxEvent.pvData = ( void * ) pxNetworkBufferIn;
+
+                if( xSendEventStructToIPTask( &xRxEvent, ( TickType_t ) 0 ) == pdFAIL )
+                {
+                    vReleaseNetworkBufferAndDescriptor( pxNetworkBufferIn );
+                }
+
+                break;
+
+            case 5:
+
+                /* Send both a cached packet and the current packet. */
+                xRxEvent.pvData = ( void * ) prvGetCachedPacket();
+
+                if( xRxEvent.pvData != NULL )
+                {
+                    if( xSendEventStructToIPTask( &xRxEvent, ( TickType_t ) 0 ) == pdFAIL )
+                    {
+                        vReleaseNetworkBufferAndDescriptor( pxNetworkBufferIn );
+                    }
+                }
+
+                break;
+
+            case 6:
+            case 7:
+            case 8:
+
+                /* Store the packet in the cache for later. */
+                if( prvCachePacket( pxNetworkBufferIn ) == pdTRUE )
+                {
+                    /* The packet may get sent later, it is not being sent
+                     * now. */
+                    pxReturn = NULL;
+                }
+
+                break;
+        }
+    }
+
+    return pxReturn;
 }
 /*-----------------------------------------------------------*/

--- a/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/portable/NetworkInterface/WinPCap/NetworkInterface.c
+++ b/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/portable/NetworkInterface/WinPCap/NetworkInterface.c
@@ -1,27 +1,27 @@
 /*
-FreeRTOS+TCP V2.2.1
-Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of
-this software and associated documentation files (the "Software"), to deal in
-the Software without restriction, including without limitation the rights to
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
-the Software, and to permit persons to whom the Software is furnished to do so,
-subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
-COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
-IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
- http://aws.amazon.com/freertos
- http://www.FreeRTOS.org
-*/
+ * FreeRTOS+TCP V2.2.1
+ * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
 
 /* WinPCap includes. */
 #define HAVE_REMOTE
@@ -38,26 +38,26 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "NetworkBufferManagement.h"
 
 /* Thread-safe circular buffers are being used to pass data to and from the PCAP
-access functions. */
+ * access functions. */
 #include "Win32-Extensions.h"
 #include "FreeRTOS_Stream_Buffer.h"
 
 /* Sizes of the thread safe circular buffers used to pass data to and from the
-WinPCAP Windows threads. */
-#define xSEND_BUFFER_SIZE  32768
-#define xRECV_BUFFER_SIZE  32768
+ * WinPCAP Windows threads. */
+#define xSEND_BUFFER_SIZE    32768
+#define xRECV_BUFFER_SIZE    32768
 
 /* If ipconfigETHERNET_DRIVER_FILTERS_FRAME_TYPES is set to 1, then the Ethernet
-driver will filter incoming packets and only pass the stack those packets it
-considers need processing. */
-#if( ipconfigETHERNET_DRIVER_FILTERS_FRAME_TYPES == 0 )
-	#define ipCONSIDER_FRAME_FOR_PROCESSING( pucEthernetBuffer ) eProcessBuffer
+ * driver will filter incoming packets and only pass the stack those packets it
+ * considers need processing. */
+#if ( ipconfigETHERNET_DRIVER_FILTERS_FRAME_TYPES == 0 )
+    #define ipCONSIDER_FRAME_FOR_PROCESSING( pucEthernetBuffer )    eProcessBuffer
 #else
-	#define ipCONSIDER_FRAME_FOR_PROCESSING( pucEthernetBuffer ) eConsiderFrameForProcessing( ( pucEthernetBuffer ) )
+    #define ipCONSIDER_FRAME_FOR_PROCESSING( pucEthernetBuffer )    eConsiderFrameForProcessing( ( pucEthernetBuffer ) )
 #endif
 
 /* Used to insert test code only. */
-#define niDISRUPT_PACKETS	0
+#define niDISRUPT_PACKETS    0
 
 /*-----------------------------------------------------------*/
 
@@ -65,8 +65,8 @@ considers need processing. */
  * Windows threads that are outside of the control of the FreeRTOS simulator are
  * used to interface with the WinPCAP libraries.
  */
-DWORD WINAPI prvWinPcapRecvThread( void *pvParam );
-DWORD WINAPI prvWinPcapSendThread( void *pvParam );
+DWORD WINAPI prvWinPcapRecvThread( void * pvParam );
+DWORD WINAPI prvWinPcapSendThread( void * pvParam );
 
 /*
  * Print out a numbered list of network interfaces that are available on the
@@ -78,8 +78,8 @@ static pcap_if_t * prvPrintAvailableNetworkInterfaces( void );
  * Open the network interface.  The number of the interface to be opened is set
  * by the configNETWORK_INTERFACE_TO_USE constant in FreeRTOSConfig.h.
  */
-static void prvOpenSelectedNetworkInterface( pcap_if_t *pxAllNetworkInterfaces );
-static int prvOpenInterface( const char *pucName );
+static void prvOpenSelectedNetworkInterface( pcap_if_t * pxAllNetworkInterfaces );
+static int prvOpenInterface( const char * pucName );
 
 /*
  * Configure the capture filter to allow blocking reads, and to filter out
@@ -91,7 +91,7 @@ static void prvConfigureCaptureBehaviour( void );
  * A function that simulates Ethernet interrupts by periodically polling the
  * WinPCap interface for new data.
  */
-static void prvInterruptSimulatorTask( void *pvParameters );
+static void prvInterruptSimulatorTask( void * pvParameters );
 
 /*
  * Create the buffers that are used to pass data between the FreeRTOS simulator
@@ -102,7 +102,9 @@ static void prvCreateThreadSafeBuffers( void );
 /*
  * Utility function used to format print messages only.
  */
-static const char *prvRemoveSpaces( char *pcBuffer, int aBuflen, const char *pcMessage );
+static const char * prvRemoveSpaces( char * pcBuffer,
+                                     int aBuflen,
+                                     const char * pcMessage );
 
 /*-----------------------------------------------------------*/
 
@@ -110,23 +112,23 @@ static const char *prvRemoveSpaces( char *pcBuffer, int aBuflen, const char *pcM
 static char cErrorBuffer[ PCAP_ERRBUF_SIZE ];
 
 /* An event used to wake up the Win32 thread that sends data through the WinPCAP
-library. */
-static void *pvSendEvent = NULL;
+ * library. */
+static void * pvSendEvent = NULL;
 
 /* _HT_ made the PCAP interface number configurable through the program's
-parameters in order to test in different machines. */
+ * parameters in order to test in different machines. */
 static BaseType_t xConfigNetworkInterfaceToUse = configNETWORK_INTERFACE_TO_USE;
 
 /* Handles to the Windows threads that handle the PCAP IO. */
 static HANDLE vWinPcapRecvThreadHandle = NULL;
-static HANDLE vWinPcapSendThreadHandle = NULL;;
+static HANDLE vWinPcapSendThreadHandle = NULL;
 
 /* The interface being used by WinPCap. */
-static pcap_t *pxOpenedInterfaceHandle = NULL;
+static pcap_t * pxOpenedInterfaceHandle = NULL;
 
 /* Circular buffers used by the PCAP Win32 threads. */
-static StreamBuffer_t *xSendBuffer = NULL;
-static StreamBuffer_t *xRecvBuffer = NULL;
+static StreamBuffer_t * xSendBuffer = NULL;
+static StreamBuffer_t * xRecvBuffer = NULL;
 
 /* The MAC address initially set to the constants defined in FreeRTOSConfig.h. */
 extern uint8_t ucMACAddress[ 6 ];
@@ -138,538 +140,550 @@ static volatile uint32_t ulWinPCAPSendFailures = 0;
 
 BaseType_t xNetworkInterfaceInitialise( void )
 {
-BaseType_t xReturn = pdFALSE;
-pcap_if_t *pxAllNetworkInterfaces;
+    BaseType_t xReturn = pdFALSE;
+    pcap_if_t * pxAllNetworkInterfaces;
 
-	/* Query the computer the simulation is being executed on to find the
-	network interfaces it has installed. */
-	pxAllNetworkInterfaces = prvPrintAvailableNetworkInterfaces();
+    /* Query the computer the simulation is being executed on to find the
+     * network interfaces it has installed. */
+    pxAllNetworkInterfaces = prvPrintAvailableNetworkInterfaces();
 
-	/* Open the network interface.  The number of the interface to be opened is
-	set by the configNETWORK_INTERFACE_TO_USE constant in FreeRTOSConfig.h.
-	Calling this function will set the pxOpenedInterfaceHandle variable.  If,
-	after calling this function, pxOpenedInterfaceHandle is equal to NULL, then
-	the interface could not be opened. */
-	if( pxAllNetworkInterfaces != NULL )
-	{
-		prvOpenSelectedNetworkInterface( pxAllNetworkInterfaces );
-	}
+    /* Open the network interface.  The number of the interface to be opened is
+     * set by the configNETWORK_INTERFACE_TO_USE constant in FreeRTOSConfig.h.
+     * Calling this function will set the pxOpenedInterfaceHandle variable.  If,
+     * after calling this function, pxOpenedInterfaceHandle is equal to NULL, then
+     * the interface could not be opened. */
+    if( pxAllNetworkInterfaces != NULL )
+    {
+        prvOpenSelectedNetworkInterface( pxAllNetworkInterfaces );
+    }
 
-	if( pxOpenedInterfaceHandle != NULL )
-	{
-		xReturn = pdPASS;
-	}
+    if( pxOpenedInterfaceHandle != NULL )
+    {
+        xReturn = pdPASS;
+    }
 
-	return xReturn;
+    return xReturn;
 }
 /*-----------------------------------------------------------*/
 
 static void prvCreateThreadSafeBuffers( void )
 {
-	/* The buffer used to pass data to be transmitted from a FreeRTOS task to
-	the Win32 thread that sends via the WinPCAP library. */
-	if( xSendBuffer == NULL)
-	{
-		xSendBuffer = ( StreamBuffer_t * ) malloc( sizeof( *xSendBuffer ) - sizeof( xSendBuffer->ucArray ) + xSEND_BUFFER_SIZE + 1 );
-		configASSERT( xSendBuffer );
-		memset( xSendBuffer, '\0', sizeof( *xSendBuffer ) - sizeof( xSendBuffer->ucArray ) );
-		xSendBuffer->LENGTH = xSEND_BUFFER_SIZE + 1;
-	}
+    /* The buffer used to pass data to be transmitted from a FreeRTOS task to
+     * the Win32 thread that sends via the WinPCAP library. */
+    if( xSendBuffer == NULL )
+    {
+        xSendBuffer = ( StreamBuffer_t * ) malloc( sizeof( *xSendBuffer ) - sizeof( xSendBuffer->ucArray ) + xSEND_BUFFER_SIZE + 1 );
+        configASSERT( xSendBuffer );
+        memset( xSendBuffer, '\0', sizeof( *xSendBuffer ) - sizeof( xSendBuffer->ucArray ) );
+        xSendBuffer->LENGTH = xSEND_BUFFER_SIZE + 1;
+    }
 
-	/* The buffer used to pass received data from the Win32 thread that receives
-	via the WinPCAP library to the FreeRTOS task. */
-	if( xRecvBuffer == NULL)
-	{
-		xRecvBuffer = ( StreamBuffer_t * ) malloc( sizeof( *xRecvBuffer ) - sizeof( xRecvBuffer->ucArray ) + xRECV_BUFFER_SIZE + 1 );
-		configASSERT( xRecvBuffer );
-		memset( xRecvBuffer, '\0', sizeof( *xRecvBuffer ) - sizeof( xRecvBuffer->ucArray ) );
-		xRecvBuffer->LENGTH = xRECV_BUFFER_SIZE + 1;
-	}
+    /* The buffer used to pass received data from the Win32 thread that receives
+     * via the WinPCAP library to the FreeRTOS task. */
+    if( xRecvBuffer == NULL )
+    {
+        xRecvBuffer = ( StreamBuffer_t * ) malloc( sizeof( *xRecvBuffer ) - sizeof( xRecvBuffer->ucArray ) + xRECV_BUFFER_SIZE + 1 );
+        configASSERT( xRecvBuffer );
+        memset( xRecvBuffer, '\0', sizeof( *xRecvBuffer ) - sizeof( xRecvBuffer->ucArray ) );
+        xRecvBuffer->LENGTH = xRECV_BUFFER_SIZE + 1;
+    }
 }
 /*-----------------------------------------------------------*/
 
-BaseType_t xNetworkInterfaceOutput( NetworkBufferDescriptor_t * const pxNetworkBuffer, BaseType_t bReleaseAfterSend )
+BaseType_t xNetworkInterfaceOutput( NetworkBufferDescriptor_t * const pxNetworkBuffer,
+                                    BaseType_t bReleaseAfterSend )
 {
-size_t xSpace;
+    size_t xSpace;
 
-	iptraceNETWORK_INTERFACE_TRANSMIT();
-	configASSERT( xIsCallingFromIPTask() == pdTRUE );
+    iptraceNETWORK_INTERFACE_TRANSMIT();
+    configASSERT( xIsCallingFromIPTask() == pdTRUE );
 
-	/* Both the length of the data being sent and the actual data being sent
-	are placed in the thread safe buffer used to pass data between the FreeRTOS
-	tasks and the Win32 thread that sends data via the WinPCAP library.  Drop
-	the packet if there is insufficient space in the buffer to hold both. */
-	xSpace = uxStreamBufferGetSpace( xSendBuffer );
+    /* Both the length of the data being sent and the actual data being sent
+     *  are placed in the thread safe buffer used to pass data between the FreeRTOS
+     *  tasks and the Win32 thread that sends data via the WinPCAP library.  Drop
+     *  the packet if there is insufficient space in the buffer to hold both. */
+    xSpace = uxStreamBufferGetSpace( xSendBuffer );
 
-	if( ( pxNetworkBuffer->xDataLength <= ( ipconfigNETWORK_MTU + ipSIZE_OF_ETH_HEADER ) ) &&
-		( xSpace >= ( pxNetworkBuffer->xDataLength + sizeof( pxNetworkBuffer->xDataLength ) ) ) )
-	{
-		/* First write in the length of the data, then write in the data
-		itself. */
-		uxStreamBufferAdd( xSendBuffer, 0, ( const uint8_t * ) &( pxNetworkBuffer->xDataLength ), sizeof( pxNetworkBuffer->xDataLength ) );
-		uxStreamBufferAdd( xSendBuffer, 0, ( const uint8_t * ) pxNetworkBuffer->pucEthernetBuffer, pxNetworkBuffer->xDataLength );
-	}
-	else
-	{
-		FreeRTOS_debug_printf( ( "xNetworkInterfaceOutput: send buffers full to store %lu\n", pxNetworkBuffer->xDataLength ) );
-	}
+    if( ( pxNetworkBuffer->xDataLength <= ( ipconfigNETWORK_MTU + ipSIZE_OF_ETH_HEADER ) ) &&
+        ( xSpace >= ( pxNetworkBuffer->xDataLength + sizeof( pxNetworkBuffer->xDataLength ) ) ) )
+    {
+        /* First write in the length of the data, then write in the data
+         * itself. */
+        uxStreamBufferAdd( xSendBuffer, 0, ( const uint8_t * ) &( pxNetworkBuffer->xDataLength ), sizeof( pxNetworkBuffer->xDataLength ) );
+        uxStreamBufferAdd( xSendBuffer, 0, ( const uint8_t * ) pxNetworkBuffer->pucEthernetBuffer, pxNetworkBuffer->xDataLength );
+    }
+    else
+    {
+        FreeRTOS_debug_printf( ( "xNetworkInterfaceOutput: send buffers full to store %lu\n", pxNetworkBuffer->xDataLength ) );
+    }
 
-	/* Kick the Tx task in either case in case it doesn't know the buffer is
-	full. */
-	SetEvent( pvSendEvent );
+    /* Kick the Tx task in either case in case it doesn't know the buffer is
+     * full. */
+    SetEvent( pvSendEvent );
 
-	/* The buffer has been sent so can be released. */
-	if( bReleaseAfterSend != pdFALSE )
-	{
-		vReleaseNetworkBufferAndDescriptor( pxNetworkBuffer );
-	}
+    /* The buffer has been sent so can be released. */
+    if( bReleaseAfterSend != pdFALSE )
+    {
+        vReleaseNetworkBufferAndDescriptor( pxNetworkBuffer );
+    }
 
-	return pdPASS;
+    return pdPASS;
 }
 /*-----------------------------------------------------------*/
 
 static pcap_if_t * prvPrintAvailableNetworkInterfaces( void )
 {
-pcap_if_t * pxAllNetworkInterfaces = NULL, *xInterface;
-int32_t lInterfaceNumber = 1;
-char cBuffer[ 512 ];
-static BaseType_t xInvalidInterfaceDetected = pdFALSE;
+    pcap_if_t * pxAllNetworkInterfaces = NULL, * xInterface;
+    int32_t lInterfaceNumber = 1;
+    char cBuffer[ 512 ];
+    static BaseType_t xInvalidInterfaceDetected = pdFALSE;
 
-	if( xInvalidInterfaceDetected == pdFALSE )
-	{
-		if( pcap_findalldevs_ex( PCAP_SRC_IF_STRING, NULL, &pxAllNetworkInterfaces, cErrorBuffer ) == -1 )
-		{
-			printf( "Could not obtain a list of network interfaces\n%s\n", cErrorBuffer );
-			pxAllNetworkInterfaces = NULL;
-		}
-		else
-		{
-			printf( "\r\n\r\nThe following network interfaces are available:\r\n\r\n" );
-		}
+    if( xInvalidInterfaceDetected == pdFALSE )
+    {
+        if( pcap_findalldevs_ex( PCAP_SRC_IF_STRING, NULL, &pxAllNetworkInterfaces, cErrorBuffer ) == -1 )
+        {
+            printf( "Could not obtain a list of network interfaces\n%s\n", cErrorBuffer );
+            pxAllNetworkInterfaces = NULL;
+        }
+        else
+        {
+            printf( "\r\n\r\nThe following network interfaces are available:\r\n\r\n" );
+        }
 
-		if( pxAllNetworkInterfaces != NULL )
-		{
-			/* Print out the list of network interfaces.  The first in the list
-			is interface '1', not interface '0'. */
-			for( xInterface = pxAllNetworkInterfaces; xInterface != NULL; xInterface = xInterface->next )
-			{
-				/* The descriptions of the devices can be full of spaces, clean them
-				a little.  printf() can only be used here because the network is not
-				up yet - so no other network tasks will be running. */
-				printf( "Interface %d - %s\n", lInterfaceNumber, prvRemoveSpaces( cBuffer, sizeof( cBuffer ), xInterface->name ) );
-				printf( "              (%s)\n", prvRemoveSpaces(cBuffer, sizeof( cBuffer ), xInterface->description ? xInterface->description : "No description" ) );
-				printf( "\n" );
-				lInterfaceNumber++;
-			}
-		}
+        if( pxAllNetworkInterfaces != NULL )
+        {
+            /* Print out the list of network interfaces.  The first in the list
+             * is interface '1', not interface '0'. */
+            for( xInterface = pxAllNetworkInterfaces; xInterface != NULL; xInterface = xInterface->next )
+            {
+                /* The descriptions of the devices can be full of spaces, clean them
+                 * a little.  printf() can only be used here because the network is not
+                 * up yet - so no other network tasks will be running. */
+                printf( "Interface %d - %s\n", lInterfaceNumber, prvRemoveSpaces( cBuffer, sizeof( cBuffer ), xInterface->name ) );
+                printf( "              (%s)\n", prvRemoveSpaces( cBuffer, sizeof( cBuffer ), xInterface->description ? xInterface->description : "No description" ) );
+                printf( "\n" );
+                lInterfaceNumber++;
+            }
+        }
 
-		if( lInterfaceNumber == 1 )
-		{
-			/* The interface number was never incremented, so the above for() loop
-			did not execute meaning no interfaces were found. */
-			printf( " \nNo network interfaces were found.\n" );
-			pxAllNetworkInterfaces = NULL;
-		}
+        if( lInterfaceNumber == 1 )
+        {
+            /* The interface number was never incremented, so the above for() loop
+             * did not execute meaning no interfaces were found. */
+            printf( " \nNo network interfaces were found.\n" );
+            pxAllNetworkInterfaces = NULL;
+        }
 
-		printf( "\r\nThe interface that will be opened is set by " );
-		printf( "\"configNETWORK_INTERFACE_TO_USE\", which\r\nshould be defined in FreeRTOSConfig.h\r\n" );
+        printf( "\r\nThe interface that will be opened is set by " );
+        printf( "\"configNETWORK_INTERFACE_TO_USE\", which\r\nshould be defined in FreeRTOSConfig.h\r\n" );
 
-		if( ( xConfigNetworkInterfaceToUse < 1L ) || ( xConfigNetworkInterfaceToUse >= lInterfaceNumber ) )
-		{
-			printf( "\r\nERROR:  configNETWORK_INTERFACE_TO_USE is set to %d, which is an invalid value.\r\n", xConfigNetworkInterfaceToUse );
-			printf( "Please set configNETWORK_INTERFACE_TO_USE to one of the interface numbers listed above,\r\n" );
-			printf( "then re-compile and re-start the application.  Only Ethernet (as opposed to WiFi)\r\n" );
-			printf( "interfaces are supported.\r\n\r\nHALTING\r\n\r\n\r\n" );
-			xInvalidInterfaceDetected = pdTRUE;
+        if( ( xConfigNetworkInterfaceToUse < 1L ) || ( xConfigNetworkInterfaceToUse >= lInterfaceNumber ) )
+        {
+            printf( "\r\nERROR:  configNETWORK_INTERFACE_TO_USE is set to %d, which is an invalid value.\r\n", xConfigNetworkInterfaceToUse );
+            printf( "Please set configNETWORK_INTERFACE_TO_USE to one of the interface numbers listed above,\r\n" );
+            printf( "then re-compile and re-start the application.  Only Ethernet (as opposed to WiFi)\r\n" );
+            printf( "interfaces are supported.\r\n\r\nHALTING\r\n\r\n\r\n" );
+            xInvalidInterfaceDetected = pdTRUE;
 
-			if( pxAllNetworkInterfaces != NULL )
-			{
-				/* Free the device list, as no devices are going to be opened. */
-				pcap_freealldevs( pxAllNetworkInterfaces );
-				pxAllNetworkInterfaces = NULL;
-			}
-		}
-		else
-		{
-			printf( "Attempting to open interface number %d.\n", xConfigNetworkInterfaceToUse );
-		}
-	}
+            if( pxAllNetworkInterfaces != NULL )
+            {
+                /* Free the device list, as no devices are going to be opened. */
+                pcap_freealldevs( pxAllNetworkInterfaces );
+                pxAllNetworkInterfaces = NULL;
+            }
+        }
+        else
+        {
+            printf( "Attempting to open interface number %d.\n", xConfigNetworkInterfaceToUse );
+        }
+    }
 
-	return pxAllNetworkInterfaces;
+    return pxAllNetworkInterfaces;
 }
 /*-----------------------------------------------------------*/
 
-static int prvOpenInterface( const char *pucName )
+static int prvOpenInterface( const char * pucName )
 {
-static char pucInterfaceName[ 256 ];
+    static char pucInterfaceName[ 256 ];
 
-	if( pucName != NULL )
-	{
-		strncpy( pucInterfaceName, pucName, sizeof( pucInterfaceName ) );
-	}
+    if( pucName != NULL )
+    {
+        strncpy( pucInterfaceName, pucName, sizeof( pucInterfaceName ) );
+    }
 
-	pxOpenedInterfaceHandle = pcap_open(	pucInterfaceName,          	/* The name of the selected interface. */
-											ipTOTAL_ETHERNET_FRAME_SIZE, /* The size of the packet to capture. */
-											PCAP_OPENFLAG_PROMISCUOUS,	/* Open in promiscuous mode as the MAC and
-																		IP address is going to be "simulated", and
-																		not be the real MAC and IP address.  This allows
-																		traffic to the simulated IP address to be routed
-																		to uIP, and traffic to the real IP address to be
-																		routed to the Windows TCP/IP stack. */
-											100,
-											NULL,             			/* No authentication is required as this is
-																		not a remote capture session. */
-											cErrorBuffer
-									   );
+    pxOpenedInterfaceHandle = pcap_open( pucInterfaceName,            /* The name of the selected interface. */
+                                         ipTOTAL_ETHERNET_FRAME_SIZE, /* The size of the packet to capture. */
+                                         PCAP_OPENFLAG_PROMISCUOUS,   /* Open in promiscuous mode as the MAC and
+                                                                       * IP address is going to be "simulated", and
+                                                                       * not be the real MAC and IP address.  This allows
+                                                                       * traffic to the simulated IP address to be routed
+                                                                       * to uIP, and traffic to the real IP address to be
+                                                                       * routed to the Windows TCP/IP stack. */
+                                         100,
+                                         NULL,                        /* No authentication is required as this is
+                                                                       * not a remote capture session. */
+                                         cErrorBuffer
+                                         );
 
-	if ( pxOpenedInterfaceHandle == NULL )
-	{
-		printf( "\n%s is not supported by WinPcap and cannot be opened\n", pucInterfaceName );
-		return 1;
-	}
-	else
-	{
-		/* Configure the capture filter to allow blocking reads, and to filter
-		out packets that are not of interest to this demo. */
-		prvConfigureCaptureBehaviour();
-	}
-	return 0;
+    if( pxOpenedInterfaceHandle == NULL )
+    {
+        printf( "\n%s is not supported by WinPcap and cannot be opened\n", pucInterfaceName );
+        return 1;
+    }
+    else
+    {
+        /* Configure the capture filter to allow blocking reads, and to filter
+         * out packets that are not of interest to this demo. */
+        prvConfigureCaptureBehaviour();
+    }
+
+    return 0;
 }
 /*-----------------------------------------------------------*/
 
-static void prvOpenSelectedNetworkInterface( pcap_if_t *pxAllNetworkInterfaces )
+static void prvOpenSelectedNetworkInterface( pcap_if_t * pxAllNetworkInterfaces )
 {
-pcap_if_t *pxInterface;
-int32_t x;
+    pcap_if_t * pxInterface;
+    int32_t x;
 
-	/* Walk the list of devices until the selected device is located. */
-	pxInterface = pxAllNetworkInterfaces;
-	for( x = 0L; x < ( xConfigNetworkInterfaceToUse - 1L ); x++ )
-	{
-		pxInterface = pxInterface->next;
-	}
+    /* Walk the list of devices until the selected device is located. */
+    pxInterface = pxAllNetworkInterfaces;
 
-	/* Open the selected interface. */
-	if( prvOpenInterface( pxInterface->name ) == 0 )
-	{
-		printf( "Successfully opened interface number %d.\n", x + 1 );
-	}
-	else
-	{
-		printf( "Failed to open interface number %d.\n", x + 1 );
-	}
+    for( x = 0L; x < ( xConfigNetworkInterfaceToUse - 1L ); x++ )
+    {
+        pxInterface = pxInterface->next;
+    }
 
-	/* The device list is no longer required. */
-	pcap_freealldevs( pxAllNetworkInterfaces );
+    /* Open the selected interface. */
+    if( prvOpenInterface( pxInterface->name ) == 0 )
+    {
+        printf( "Successfully opened interface number %d.\n", x + 1 );
+    }
+    else
+    {
+        printf( "Failed to open interface number %d.\n", x + 1 );
+    }
+
+    /* The device list is no longer required. */
+    pcap_freealldevs( pxAllNetworkInterfaces );
 }
 /*-----------------------------------------------------------*/
 
 static void prvConfigureCaptureBehaviour( void )
 {
-struct bpf_program xFilterCode;
-uint32_t ulNetMask;
+    struct bpf_program xFilterCode;
+    uint32_t ulNetMask;
 
-	/* Set up a filter so only the packets of interest are passed to the IP
-	stack.  cErrorBuffer is used for convenience to create the string.  Don't
-	confuse this with an error message. */
-	sprintf( cErrorBuffer, "broadcast or multicast or ether host %x:%x:%x:%x:%x:%x",
-		ucMACAddress[0], ucMACAddress[1], ucMACAddress[2], ucMACAddress[3], ucMACAddress[4], ucMACAddress[5] );
+    /* Set up a filter so only the packets of interest are passed to the IP
+     * stack.  cErrorBuffer is used for convenience to create the string.  Don't
+     * confuse this with an error message. */
+    sprintf( cErrorBuffer, "broadcast or multicast or ether host %x:%x:%x:%x:%x:%x",
+             ucMACAddress[ 0 ], ucMACAddress[ 1 ], ucMACAddress[ 2 ], ucMACAddress[ 3 ], ucMACAddress[ 4 ], ucMACAddress[ 5 ] );
 
-	ulNetMask = ( configNET_MASK3 << 24UL ) | ( configNET_MASK2 << 16UL ) | ( configNET_MASK1 << 8L ) | configNET_MASK0;
+    ulNetMask = ( configNET_MASK3 << 24UL ) | ( configNET_MASK2 << 16UL ) | ( configNET_MASK1 << 8L ) | configNET_MASK0;
 
-	if( pcap_compile( pxOpenedInterfaceHandle, &xFilterCode, cErrorBuffer, 1, ulNetMask ) < 0 )
-	{
-		printf( "\nThe packet filter string is invalid\n" );
-	}
-	else
-	{
-		if( pcap_setfilter( pxOpenedInterfaceHandle, &xFilterCode ) < 0 )
-		{
-			printf( "\nAn error occurred setting the packet filter.\n" );
-		}
-		/* When pcap_compile() succeeds, it allocates memory for the memory pointed to by the bpf_program struct 
-		parameter.pcap_freecode() will free that memory. */
-		pcap_freecode( &xFilterCode );
-	}
+    if( pcap_compile( pxOpenedInterfaceHandle, &xFilterCode, cErrorBuffer, 1, ulNetMask ) < 0 )
+    {
+        printf( "\nThe packet filter string is invalid\n" );
+    }
+    else
+    {
+        if( pcap_setfilter( pxOpenedInterfaceHandle, &xFilterCode ) < 0 )
+        {
+            printf( "\nAn error occurred setting the packet filter.\n" );
+        }
 
-	/* Create the buffers used to pass packets between the FreeRTOS simulator
-	and the Win32 threads that are handling WinPCAP. */
-	prvCreateThreadSafeBuffers();
+        /* When pcap_compile() succeeds, it allocates memory for the memory pointed to by the bpf_program struct
+         * parameter.pcap_freecode() will free that memory. */
+        pcap_freecode( &xFilterCode );
+    }
 
-	if( pvSendEvent == NULL )
-	{
-		/* Create event used to signal the Win32 WinPCAP Tx thread. */
-		pvSendEvent = CreateEvent( NULL, FALSE, TRUE, NULL );
+    /* Create the buffers used to pass packets between the FreeRTOS simulator
+     * and the Win32 threads that are handling WinPCAP. */
+    prvCreateThreadSafeBuffers();
 
-		/* Create the Win32 thread that handles WinPCAP Rx. */
-		vWinPcapRecvThreadHandle = CreateThread(
-			NULL,	/* Pointer to thread security attributes. */
-			0,		/* Initial thread stack size, in bytes. */
-			prvWinPcapRecvThread,	/* Pointer to thread function. */
-			NULL,	/* Argument for new thread. */
-			0,		/* Creation flags. */
-			NULL );
+    if( pvSendEvent == NULL )
+    {
+        /* Create event used to signal the Win32 WinPCAP Tx thread. */
+        pvSendEvent = CreateEvent( NULL, FALSE, TRUE, NULL );
 
-		/* Use the cores that are not used by the FreeRTOS tasks. */
-		SetThreadAffinityMask( vWinPcapRecvThreadHandle, ~0x01u );
+        /* Create the Win32 thread that handles WinPCAP Rx. */
+        vWinPcapRecvThreadHandle = CreateThread(
+            NULL,                 /* Pointer to thread security attributes. */
+            0,                    /* Initial thread stack size, in bytes. */
+            prvWinPcapRecvThread, /* Pointer to thread function. */
+            NULL,                 /* Argument for new thread. */
+            0,                    /* Creation flags. */
+            NULL );
 
-		/* Create the Win32 thread that handlers WinPCAP Tx. */
-		vWinPcapSendThreadHandle = CreateThread(
-			NULL,	/* Pointer to thread security attributes. */
-			0,		/* initial thread stack size, in bytes. */
-			prvWinPcapSendThread,	/* Pointer to thread function. */
-			NULL,	/* Argument for new thread. */
-			0,		/* Creation flags. */
-			NULL );
+        /* Use the cores that are not used by the FreeRTOS tasks. */
+        SetThreadAffinityMask( vWinPcapRecvThreadHandle, ~0x01u );
 
-		/* Use the cores that are not used by the FreeRTOS tasks. */
-		SetThreadAffinityMask( vWinPcapSendThreadHandle, ~0x01u );
+        /* Create the Win32 thread that handlers WinPCAP Tx. */
+        vWinPcapSendThreadHandle = CreateThread(
+            NULL,                 /* Pointer to thread security attributes. */
+            0,                    /* initial thread stack size, in bytes. */
+            prvWinPcapSendThread, /* Pointer to thread function. */
+            NULL,                 /* Argument for new thread. */
+            0,                    /* Creation flags. */
+            NULL );
 
-		/* Create a task that simulates an interrupt in a real system.  This will
-		block waiting for packets, then send a message to the IP task when data
-		is available. */
-		xTaskCreate( prvInterruptSimulatorTask, "MAC_ISR", configMINIMAL_STACK_SIZE, NULL, configMAC_ISR_SIMULATOR_PRIORITY, NULL );
-	}
+        /* Use the cores that are not used by the FreeRTOS tasks. */
+        SetThreadAffinityMask( vWinPcapSendThreadHandle, ~0x01u );
+
+        /* Create a task that simulates an interrupt in a real system.  This will
+         * block waiting for packets, then send a message to the IP task when data
+         * is available. */
+        xTaskCreate( prvInterruptSimulatorTask, "MAC_ISR", configMINIMAL_STACK_SIZE, NULL, configMAC_ISR_SIMULATOR_PRIORITY, NULL );
+    }
 }
 /*-----------------------------------------------------------*/
 
 /* WinPCAP function. */
-void pcap_callback( u_char *user, const struct pcap_pkthdr *pkt_header, const u_char *pkt_data )
+void pcap_callback( u_char * user,
+                    const struct pcap_pkthdr * pkt_header,
+                    const u_char * pkt_data )
 {
-	(void)user;
+    ( void ) user;
 
-	/* THIS IS CALLED FROM A WINDOWS THREAD - DO NOT ATTEMPT ANY FREERTOS CALLS
-	OR TO PRINT OUT MESSAGES HERE. */
+    /* THIS IS CALLED FROM A WINDOWS THREAD - DO NOT ATTEMPT ANY FREERTOS CALLS
+     * OR TO PRINT OUT MESSAGES HERE. */
 
-	/* Pass data to the FreeRTOS simulator on a thread safe circular buffer. */
-	if( ( pkt_header->caplen <= ( ipconfigNETWORK_MTU + ipSIZE_OF_ETH_HEADER ) ) &&
-		( uxStreamBufferGetSpace( xRecvBuffer ) >= ( ( ( size_t ) pkt_header->caplen ) + sizeof( *pkt_header ) ) ) )
-	{
-		/* The received packets will be written to a C source file,
-		only if 'ipconfigUSE_DUMP_PACKETS' is defined.
-		Otherwise, there is no action. */
-		iptraceDUMP_PACKET( ( const uint8_t* ) pkt_data, ( size_t ) pkt_header->caplen, pdTRUE );
+    /* Pass data to the FreeRTOS simulator on a thread safe circular buffer. */
+    if( ( pkt_header->caplen <= ( ipconfigNETWORK_MTU + ipSIZE_OF_ETH_HEADER ) ) &&
+        ( uxStreamBufferGetSpace( xRecvBuffer ) >= ( ( ( size_t ) pkt_header->caplen ) + sizeof( *pkt_header ) ) ) )
+    {
+        /* The received packets will be written to a C source file,
+         * only if 'ipconfigUSE_DUMP_PACKETS' is defined.
+         * Otherwise, there is no action. */
+        iptraceDUMP_PACKET( ( const uint8_t * ) pkt_data, ( size_t ) pkt_header->caplen, pdTRUE );
 
-		uxStreamBufferAdd( xRecvBuffer, 0, ( const uint8_t* ) pkt_header, sizeof( *pkt_header ) );
-		uxStreamBufferAdd( xRecvBuffer, 0, ( const uint8_t* ) pkt_data, ( size_t ) pkt_header->caplen );
-	}
+        uxStreamBufferAdd( xRecvBuffer, 0, ( const uint8_t * ) pkt_header, sizeof( *pkt_header ) );
+        uxStreamBufferAdd( xRecvBuffer, 0, ( const uint8_t * ) pkt_data, ( size_t ) pkt_header->caplen );
+    }
 }
 /*-----------------------------------------------------------*/
 
-DWORD WINAPI prvWinPcapRecvThread ( void *pvParam )
+DWORD WINAPI prvWinPcapRecvThread( void * pvParam )
 {
-	( void ) pvParam;
+    ( void ) pvParam;
 
-	/* THIS IS A WINDOWS THREAD - DO NOT ATTEMPT ANY FREERTOS CALLS	OR TO PRINT
-	OUT MESSAGES HERE. */
+    /* THIS IS A WINDOWS THREAD - DO NOT ATTEMPT ANY FREERTOS CALLS	OR TO PRINT
+     * OUT MESSAGES HERE. */
 
-	for( ;; )
-	{
-		pcap_dispatch( pxOpenedInterfaceHandle, 1, pcap_callback, ( u_char * ) "mydata" );
-	}
+    for( ; ; )
+    {
+        pcap_dispatch( pxOpenedInterfaceHandle, 1, pcap_callback, ( u_char * ) "mydata" );
+    }
 }
 /*-----------------------------------------------------------*/
 
-DWORD WINAPI prvWinPcapSendThread( void *pvParam )
+DWORD WINAPI prvWinPcapSendThread( void * pvParam )
 {
-size_t xLength;
-uint8_t ucBuffer[ ipconfigNETWORK_MTU + ipSIZE_OF_ETH_HEADER ];
-static char cErrorMessage[ 1024 ];
-const DWORD xMaxMSToWait = 1000;
+    size_t xLength;
+    uint8_t ucBuffer[ ipconfigNETWORK_MTU + ipSIZE_OF_ETH_HEADER ];
+    static char cErrorMessage[ 1024 ];
+    const DWORD xMaxMSToWait = 1000;
 
-	/* THIS IS A WINDOWS THREAD - DO NOT ATTEMPT ANY FREERTOS CALLS	OR TO PRINT
-	OUT MESSAGES HERE. */
+    /* THIS IS A WINDOWS THREAD - DO NOT ATTEMPT ANY FREERTOS CALLS	OR TO PRINT
+     * OUT MESSAGES HERE. */
 
-	/* Remove compiler warnings about unused parameters. */
-	( void ) pvParam;
+    /* Remove compiler warnings about unused parameters. */
+    ( void ) pvParam;
 
-	for( ;; )
-	{
-		/* Wait until notified of something to send. */
-		WaitForSingleObject( pvSendEvent, xMaxMSToWait );
+    for( ; ; )
+    {
+        /* Wait until notified of something to send. */
+        WaitForSingleObject( pvSendEvent, xMaxMSToWait );
 
-		/* Is there more than the length value stored in the circular buffer
-		used to pass data from the FreeRTOS simulator into this Win32 thread? */
-		while( uxStreamBufferGetSize( xSendBuffer ) > sizeof( xLength ) )
-		{
-			uxStreamBufferGet( xSendBuffer, 0, ( uint8_t * ) &xLength, sizeof( xLength ), pdFALSE );
-			uxStreamBufferGet( xSendBuffer, 0, ( uint8_t* ) ucBuffer, xLength, pdFALSE );
-			/* The packets sent will be written to a C source file,
-			only if 'ipconfigUSE_DUMP_PACKETS' is defined.
-			Otherwise, there is no action. */
-			iptraceDUMP_PACKET( ucBuffer, xLength, pdFALSE );
-			if( pcap_sendpacket( pxOpenedInterfaceHandle, ucBuffer, xLength  ) != 0 )
-			{
-				ulWinPCAPSendFailures++;
-			}
-		}
-	}
+        /* Is there more than the length value stored in the circular buffer
+         * used to pass data from the FreeRTOS simulator into this Win32 thread? */
+        while( uxStreamBufferGetSize( xSendBuffer ) > sizeof( xLength ) )
+        {
+            uxStreamBufferGet( xSendBuffer, 0, ( uint8_t * ) &xLength, sizeof( xLength ), pdFALSE );
+            uxStreamBufferGet( xSendBuffer, 0, ( uint8_t * ) ucBuffer, xLength, pdFALSE );
+
+            /* The packets sent will be written to a C source file,
+             * only if 'ipconfigUSE_DUMP_PACKETS' is defined.
+             * Otherwise, there is no action. */
+            iptraceDUMP_PACKET( ucBuffer, xLength, pdFALSE );
+
+            if( pcap_sendpacket( pxOpenedInterfaceHandle, ucBuffer, xLength ) != 0 )
+            {
+                ulWinPCAPSendFailures++;
+            }
+        }
+    }
 }
 /*-----------------------------------------------------------*/
 
-static BaseType_t xPacketBouncedBack( const uint8_t *pucBuffer )
+static BaseType_t xPacketBouncedBack( const uint8_t * pucBuffer )
 {
-EthernetHeader_t *pxEtherHeader;
-BaseType_t xResult;
+    EthernetHeader_t * pxEtherHeader;
+    BaseType_t xResult;
 
-	pxEtherHeader = ( EthernetHeader_t * ) pucBuffer;
-	if( memcmp( ucMACAddress, pxEtherHeader->xSourceAddress.ucBytes, ipMAC_ADDRESS_LENGTH_BYTES ) == 0 )
-	{
-		FreeRTOS_printf( ( "Bounced back: %02x:%02x:%02x:%02x:%02x:%02x\n",
-			pxEtherHeader->xSourceAddress.ucBytes[ 0 ],
-			pxEtherHeader->xSourceAddress.ucBytes[ 1 ],
-			pxEtherHeader->xSourceAddress.ucBytes[ 2 ],
-			pxEtherHeader->xSourceAddress.ucBytes[ 3 ],
-			pxEtherHeader->xSourceAddress.ucBytes[ 4 ],
-			pxEtherHeader->xSourceAddress.ucBytes[ 5 ] ) );
-		xResult = pdTRUE;
-	}
-	else
-	{
-		xResult = pdFALSE;
-	}
-	return xResult;
+    pxEtherHeader = ( EthernetHeader_t * ) pucBuffer;
+
+    if( memcmp( ucMACAddress, pxEtherHeader->xSourceAddress.ucBytes, ipMAC_ADDRESS_LENGTH_BYTES ) == 0 )
+    {
+        FreeRTOS_printf( ( "Bounced back: %02x:%02x:%02x:%02x:%02x:%02x\n",
+                           pxEtherHeader->xSourceAddress.ucBytes[ 0 ],
+                           pxEtherHeader->xSourceAddress.ucBytes[ 1 ],
+                           pxEtherHeader->xSourceAddress.ucBytes[ 2 ],
+                           pxEtherHeader->xSourceAddress.ucBytes[ 3 ],
+                           pxEtherHeader->xSourceAddress.ucBytes[ 4 ],
+                           pxEtherHeader->xSourceAddress.ucBytes[ 5 ] ) );
+        xResult = pdTRUE;
+    }
+    else
+    {
+        xResult = pdFALSE;
+    }
+
+    return xResult;
 }
 /*-----------------------------------------------------------*/
 
-static void prvInterruptSimulatorTask( void *pvParameters )
+static void prvInterruptSimulatorTask( void * pvParameters )
 {
-struct pcap_pkthdr xHeader;
-static struct pcap_pkthdr *pxHeader;
-const uint8_t *pucPacketData;
-uint8_t ucRecvBuffer[ ipconfigNETWORK_MTU + ipSIZE_OF_ETH_HEADER ];
-NetworkBufferDescriptor_t *pxNetworkBuffer;
-IPStackEvent_t xRxEvent = { eNetworkRxEvent, NULL };
-eFrameProcessingResult_t eResult;
+    struct pcap_pkthdr xHeader;
+    static struct pcap_pkthdr * pxHeader;
+    const uint8_t * pucPacketData;
+    uint8_t ucRecvBuffer[ ipconfigNETWORK_MTU + ipSIZE_OF_ETH_HEADER ];
+    NetworkBufferDescriptor_t * pxNetworkBuffer;
+    IPStackEvent_t xRxEvent = { eNetworkRxEvent, NULL };
+    eFrameProcessingResult_t eResult;
 
-	/* Remove compiler warnings about unused parameters. */
-	( void ) pvParameters;
+    /* Remove compiler warnings about unused parameters. */
+    ( void ) pvParameters;
 
-	for( ;; )
-	{
-		/* Does the circular buffer used to pass data from the Win32 thread that
-		handles WinPCAP Rx into the FreeRTOS simulator contain another packet? */
-		if( uxStreamBufferGetSize( xRecvBuffer ) > sizeof( xHeader ) )
-		{
-			/* Get the next packet. */
-			uxStreamBufferGet( xRecvBuffer, 0, (uint8_t*)&xHeader, sizeof( xHeader ), pdFALSE );
-			uxStreamBufferGet( xRecvBuffer, 0, (uint8_t*)ucRecvBuffer, ( size_t ) xHeader.len, pdFALSE );
-			pucPacketData = ucRecvBuffer;
-			pxHeader = &xHeader;
+    for( ; ; )
+    {
+        /* Does the circular buffer used to pass data from the Win32 thread that
+         * handles WinPCAP Rx into the FreeRTOS simulator contain another packet? */
+        if( uxStreamBufferGetSize( xRecvBuffer ) > sizeof( xHeader ) )
+        {
+            /* Get the next packet. */
+            uxStreamBufferGet( xRecvBuffer, 0, ( uint8_t * ) &xHeader, sizeof( xHeader ), pdFALSE );
+            uxStreamBufferGet( xRecvBuffer, 0, ( uint8_t * ) ucRecvBuffer, ( size_t ) xHeader.len, pdFALSE );
+            pucPacketData = ucRecvBuffer;
+            pxHeader = &xHeader;
 
-			iptraceNETWORK_INTERFACE_RECEIVE();
+            iptraceNETWORK_INTERFACE_RECEIVE();
 
-			/* Check for minimal size. */
-			if( pxHeader->len >= sizeof( EthernetHeader_t ) )
-			{
-				eResult = ipCONSIDER_FRAME_FOR_PROCESSING( pucPacketData );
-			}
-			else
-			{
-				eResult = eReleaseBuffer;
-			}
+            /* Check for minimal size. */
+            if( pxHeader->len >= sizeof( EthernetHeader_t ) )
+            {
+                eResult = ipCONSIDER_FRAME_FOR_PROCESSING( pucPacketData );
+            }
+            else
+            {
+                eResult = eReleaseBuffer;
+            }
 
-			if( eResult == eProcessBuffer )
-			{
-				/* Will the data fit into the frame buffer? */
-				if( pxHeader->len <= ipTOTAL_ETHERNET_FRAME_SIZE )
-				{
-					/* Obtain a buffer into which the data can be placed.  This
-					is only	an interrupt simulator, not a real interrupt, so it
-					is ok to call the task level function here, but note that
-					some buffer implementations cannot be called from a real
-					interrupt. */
-					if( xPacketBouncedBack( pucPacketData ) == pdFALSE )
-					{
-						pxNetworkBuffer = pxGetNetworkBufferWithDescriptor( pxHeader->len, 0 );
-					}
-					else
-					{
-						pxNetworkBuffer = NULL;
-					}
+            if( eResult == eProcessBuffer )
+            {
+                /* Will the data fit into the frame buffer? */
+                if( pxHeader->len <= ipTOTAL_ETHERNET_FRAME_SIZE )
+                {
+                    /* Obtain a buffer into which the data can be placed.  This
+                     * is only	an interrupt simulator, not a real interrupt, so it
+                     * is ok to call the task level function here, but note that
+                     * some buffer implementations cannot be called from a real
+                     * interrupt. */
+                    if( xPacketBouncedBack( pucPacketData ) == pdFALSE )
+                    {
+                        pxNetworkBuffer = pxGetNetworkBufferWithDescriptor( pxHeader->len, 0 );
+                    }
+                    else
+                    {
+                        pxNetworkBuffer = NULL;
+                    }
 
-					if( pxNetworkBuffer != NULL )
-					{
-						memcpy( pxNetworkBuffer->pucEthernetBuffer, pucPacketData, pxHeader->len );
-						pxNetworkBuffer->xDataLength = ( size_t ) pxHeader->len;
+                    if( pxNetworkBuffer != NULL )
+                    {
+                        memcpy( pxNetworkBuffer->pucEthernetBuffer, pucPacketData, pxHeader->len );
+                        pxNetworkBuffer->xDataLength = ( size_t ) pxHeader->len;
 
-						#if( niDISRUPT_PACKETS == 1 )
-						{
-							pxNetworkBuffer = vRxFaultInjection( pxNetworkBuffer, pucPacketData );
-						}
-						#endif /* niDISRUPT_PACKETS */
+                        #if ( niDISRUPT_PACKETS == 1 )
+                            {
+                                pxNetworkBuffer = vRxFaultInjection( pxNetworkBuffer, pucPacketData );
+                            }
+                        #endif /* niDISRUPT_PACKETS */
 
-						if( pxNetworkBuffer != NULL )
-						{
-							xRxEvent.pvData = ( void * ) pxNetworkBuffer;
+                        if( pxNetworkBuffer != NULL )
+                        {
+                            xRxEvent.pvData = ( void * ) pxNetworkBuffer;
 
-							/* Data was received and stored.  Send a message to
-							the IP task to let it know. */
-							if( xSendEventStructToIPTask( &xRxEvent, ( TickType_t ) 0 ) == pdFAIL )
-							{
-								/* The buffer could not be sent to the stack so
-								must be released again.  This is only an
-								interrupt simulator, not a real interrupt, so it
-								is ok to use the task level function here, but
-								note no all buffer implementations will allow
-								this function to be executed from a real
-								interrupt. */
-								vReleaseNetworkBufferAndDescriptor( pxNetworkBuffer );
-								iptraceETHERNET_RX_EVENT_LOST();
-							}
-						}
-						else
-						{
-							/* The packet was already released or stored inside
-							vRxFaultInjection().  Don't release it here. */
-						}
-					}
-					else
-					{
-						iptraceETHERNET_RX_EVENT_LOST();
-					}
-				}
-				else
-				{
-					/* Log that a packet was dropped because it would have
-					overflowed the buffer, but there may be more buffers to
-					process. */
-				}
-			}
-		}
-		else
-		{
-			/* There is no real way of simulating an interrupt.  Make sure
-			other tasks can run. */
-			vTaskDelay( configWINDOWS_MAC_INTERRUPT_SIMULATOR_DELAY );
-		}
-	}
+                            /* Data was received and stored.  Send a message to
+                             * the IP task to let it know. */
+                            if( xSendEventStructToIPTask( &xRxEvent, ( TickType_t ) 0 ) == pdFAIL )
+                            {
+                                /* The buffer could not be sent to the stack so
+                                 * must be released again.  This is only an
+                                 * interrupt simulator, not a real interrupt, so it
+                                 * is ok to use the task level function here, but
+                                 * note no all buffer implementations will allow
+                                 * this function to be executed from a real
+                                 * interrupt. */
+                                vReleaseNetworkBufferAndDescriptor( pxNetworkBuffer );
+                                iptraceETHERNET_RX_EVENT_LOST();
+                            }
+                        }
+                        else
+                        {
+                            /* The packet was already released or stored inside
+                             * vRxFaultInjection().  Don't release it here. */
+                        }
+                    }
+                    else
+                    {
+                        iptraceETHERNET_RX_EVENT_LOST();
+                    }
+                }
+                else
+                {
+                    /* Log that a packet was dropped because it would have
+                     * overflowed the buffer, but there may be more buffers to
+                     * process. */
+                }
+            }
+        }
+        else
+        {
+            /* There is no real way of simulating an interrupt.  Make sure
+             * other tasks can run. */
+            vTaskDelay( configWINDOWS_MAC_INTERRUPT_SIMULATOR_DELAY );
+        }
+    }
 }
 /*-----------------------------------------------------------*/
 
-static const char *prvRemoveSpaces( char *pcBuffer, int aBuflen, const char *pcMessage )
+static const char * prvRemoveSpaces( char * pcBuffer,
+                                     int aBuflen,
+                                     const char * pcMessage )
 {
-	char *pcTarget = pcBuffer;
+    char * pcTarget = pcBuffer;
 
-	/* Utility function used to formap messages being printed only. */
-	while( ( *pcMessage != 0 ) && ( pcTarget < ( pcBuffer + aBuflen - 1 ) ) )
-	{
-		*( pcTarget++ ) = *pcMessage;
+    /* Utility function used to formap messages being printed only. */
+    while( ( *pcMessage != 0 ) && ( pcTarget < ( pcBuffer + aBuflen - 1 ) ) )
+    {
+        *( pcTarget++ ) = *pcMessage;
 
-		if( isspace( *pcMessage ) != pdFALSE )
-		{
-			while( isspace( *pcMessage ) != pdFALSE )
-			{
-				pcMessage++;
-			}
-		}
-		else
-		{
-			pcMessage++;
-		}
-	}
+        if( isspace( *pcMessage ) != pdFALSE )
+        {
+            while( isspace( *pcMessage ) != pdFALSE )
+            {
+                pcMessage++;
+            }
+        }
+        else
+        {
+            pcMessage++;
+        }
+    }
 
-	*pcTarget = '\0';
+    *pcTarget = '\0';
 
-	return pcBuffer;
+    return pcBuffer;
 }

--- a/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/portable/NetworkInterface/Zynq/NetworkInterface.c
+++ b/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/portable/NetworkInterface/Zynq/NetworkInterface.c
@@ -52,47 +52,48 @@
 #include "uncached_memory.h"
 
 #ifndef niEMAC_HANDLER_TASK_PRIORITY
-	/* Define the priority of the task prvEMACHandlerTask(). */
-	#define niEMAC_HANDLER_TASK_PRIORITY	configMAX_PRIORITIES - 1
+    /* Define the priority of the task prvEMACHandlerTask(). */
+    #define niEMAC_HANDLER_TASK_PRIORITY    configMAX_PRIORITIES - 1
 #endif
 
-#define niBMSR_LINK_STATUS         0x0004uL
+#define niBMSR_LINK_STATUS                  0x0004uL
 
-#ifndef	PHY_LS_HIGH_CHECK_TIME_MS
-	/* Check if the LinkSStatus in the PHY is still high after 15 seconds of not
-	receiving packets. */
-	#define PHY_LS_HIGH_CHECK_TIME_MS	15000
+#ifndef PHY_LS_HIGH_CHECK_TIME_MS
+
+    /* Check if the LinkSStatus in the PHY is still high after 15 seconds of not
+     * receiving packets. */
+    #define PHY_LS_HIGH_CHECK_TIME_MS    15000
 #endif
 
-#ifndef	PHY_LS_LOW_CHECK_TIME_MS
-	/* Check if the LinkSStatus in the PHY is still low every second. */
-	#define PHY_LS_LOW_CHECK_TIME_MS	1000
+#ifndef PHY_LS_LOW_CHECK_TIME_MS
+    /* Check if the LinkSStatus in the PHY is still low every second. */
+    #define PHY_LS_LOW_CHECK_TIME_MS    1000
 #endif
 
 /* The size of each buffer when BufferAllocation_1 is used:
-http://www.freertos.org/FreeRTOS-Plus/FreeRTOS_Plus_TCP/Embedded_Ethernet_Buffer_Management.html */
-#define niBUFFER_1_PACKET_SIZE		1536
+ * http://www.freertos.org/FreeRTOS-Plus/FreeRTOS_Plus_TCP/Embedded_Ethernet_Buffer_Management.html */
+#define niBUFFER_1_PACKET_SIZE    1536
 
 /* Naming and numbering of PHY registers. */
-#define PHY_REG_01_BMSR			0x01	/* Basic mode status register */
+#define PHY_REG_01_BMSR           0x01  /* Basic mode status register */
 
 #ifndef iptraceEMAC_TASK_STARTING
-	#define iptraceEMAC_TASK_STARTING()	do { } while( 0 )
+    #define iptraceEMAC_TASK_STARTING()    do {} while( 0 )
 #endif
 
 /* Default the size of the stack used by the EMAC deferred handler task to twice
-the size of the stack used by the idle task - but allow this to be overridden in
-FreeRTOSConfig.h as configMINIMAL_STACK_SIZE is a user definable constant. */
+ * the size of the stack used by the idle task - but allow this to be overridden in
+ * FreeRTOSConfig.h as configMINIMAL_STACK_SIZE is a user definable constant. */
 #ifndef configEMAC_TASK_STACK_SIZE
-	#define configEMAC_TASK_STACK_SIZE ( 2 * configMINIMAL_STACK_SIZE )
+    #define configEMAC_TASK_STACK_SIZE    ( 2 * configMINIMAL_STACK_SIZE )
 #endif
 
-#if( ipconfigZERO_COPY_RX_DRIVER == 0 || ipconfigZERO_COPY_TX_DRIVER == 0 )
-	#error Please define both 'ipconfigZERO_COPY_RX_DRIVER' and 'ipconfigZERO_COPY_TX_DRIVER' as 1
+#if ( ipconfigZERO_COPY_RX_DRIVER == 0 || ipconfigZERO_COPY_TX_DRIVER == 0 )
+    #error Please define both 'ipconfigZERO_COPY_RX_DRIVER' and 'ipconfigZERO_COPY_TX_DRIVER' as 1
 #endif
 
-#if( ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM == 0 || ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM == 0 )
-	#warning Please define both 'ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM' and 'ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM' as 1
+#if ( ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM == 0 || ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM == 0 )
+    #warning Please define both 'ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM' and 'ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM' as 1
 #endif
 /*-----------------------------------------------------------*/
 
@@ -105,10 +106,10 @@ static BaseType_t prvGMACWaitLS( TickType_t xMaxTime );
 /*
  * A deferred interrupt handler for all MAC/DMA interrupt sources.
  */
-static void prvEMACHandlerTask( void *pvParameters );
+static void prvEMACHandlerTask( void * pvParameters );
 
 #if ( ipconfigHAS_PRINTF != 0 )
-	static void prvMonitorResources( void );
+    static void prvMonitorResources( void );
 #endif
 
 /*-----------------------------------------------------------*/
@@ -117,18 +118,18 @@ static void prvEMACHandlerTask( void *pvParameters );
 static xemacpsif_s xEMACpsif;
 struct xtopology_t xXTopology =
 {
-	.emac_baseaddr = XPAR_PS7_ETHERNET_0_BASEADDR,
-	.emac_type = xemac_type_emacps,
-	.intc_baseaddr = 0x0,
-	.intc_emac_intr = 0x0,
-	.scugic_baseaddr = XPAR_PS7_SCUGIC_0_BASEADDR,
-	.scugic_emac_intr = 0x36,
+    .emac_baseaddr    = XPAR_PS7_ETHERNET_0_BASEADDR,
+    .emac_type        = xemac_type_emacps,
+    .intc_baseaddr    = 0x0,
+    .intc_emac_intr   = 0x0,
+    .scugic_baseaddr  = XPAR_PS7_SCUGIC_0_BASEADDR,
+    .scugic_emac_intr = 0x36,
 };
 
 XEmacPs_Config mac_config =
 {
-	.DeviceId = XPAR_PS7_ETHERNET_0_DEVICE_ID,	/**< Unique ID  of device */
-	.BaseAddress = XPAR_PS7_ETHERNET_0_BASEADDR /**< Physical base address of IPIF registers */
+    .DeviceId    = XPAR_PS7_ETHERNET_0_DEVICE_ID, /**< Unique ID  of device */
+    .BaseAddress = XPAR_PS7_ETHERNET_0_BASEADDR   /**< Physical base address of IPIF registers */
 };
 
 extern int phy_detected;
@@ -136,329 +137,336 @@ extern int phy_detected;
 /* A copy of PHY register 1: 'PHY_REG_01_BMSR' */
 static uint32_t ulPHYLinkStatus = 0uL;
 
-#if( ipconfigUSE_LLMNR == 1 )
-	static const uint8_t xLLMNR_MACAddress[] = { 0x01, 0x00, 0x5E, 0x00, 0x00, 0xFC };
+#if ( ipconfigUSE_LLMNR == 1 )
+    static const uint8_t xLLMNR_MACAddress[] = { 0x01, 0x00, 0x5E, 0x00, 0x00, 0xFC };
 #endif
 
 /* ucMACAddress as it appears in main.c */
 extern const uint8_t ucMACAddress[ 6 ];
 
 /* Holds the handle of the task used as a deferred interrupt processor.  The
-handle is used so direct notifications can be sent to the task for all EMAC/DMA
-related interrupts. */
+ * handle is used so direct notifications can be sent to the task for all EMAC/DMA
+ * related interrupts. */
 TaskHandle_t xEMACTaskHandle = NULL;
 
 /*-----------------------------------------------------------*/
 
 BaseType_t xNetworkInterfaceInitialise( void )
 {
-uint32_t ulLinkSpeed, ulDMAReg;
-BaseType_t xStatus, xLinkStatus;
-XEmacPs *pxEMAC_PS;
-const TickType_t xWaitLinkDelay = pdMS_TO_TICKS( 7000UL ), xWaitRelinkDelay = pdMS_TO_TICKS( 1000UL );
+    uint32_t ulLinkSpeed, ulDMAReg;
+    BaseType_t xStatus, xLinkStatus;
+    XEmacPs * pxEMAC_PS;
+    const TickType_t xWaitLinkDelay = pdMS_TO_TICKS( 7000UL ), xWaitRelinkDelay = pdMS_TO_TICKS( 1000UL );
 
-	/* Guard against the init function being called more than once. */
-	if( xEMACTaskHandle == NULL )
-	{
-		pxEMAC_PS = &( xEMACpsif.emacps );
-		memset( &xEMACpsif, '\0', sizeof( xEMACpsif ) );
+    /* Guard against the init function being called more than once. */
+    if( xEMACTaskHandle == NULL )
+    {
+        pxEMAC_PS = &( xEMACpsif.emacps );
+        memset( &xEMACpsif, '\0', sizeof( xEMACpsif ) );
 
-		xStatus = XEmacPs_CfgInitialize( pxEMAC_PS, &mac_config, mac_config.BaseAddress);
-		if( xStatus != XST_SUCCESS )
-		{
-			FreeRTOS_printf( ( "xEMACInit: EmacPs Configuration Failed....\n" ) );
-		}
+        xStatus = XEmacPs_CfgInitialize( pxEMAC_PS, &mac_config, mac_config.BaseAddress );
 
-		/* Initialize the mac and set the MAC address. */
-		XEmacPs_SetMacAddress( pxEMAC_PS, ( void * ) ucMACAddress, 1 );
+        if( xStatus != XST_SUCCESS )
+        {
+            FreeRTOS_printf( ( "xEMACInit: EmacPs Configuration Failed....\n" ) );
+        }
 
-		#if( ipconfigUSE_LLMNR == 1 )
-		{
-			/* Also add LLMNR multicast MAC address. */
-			XEmacPs_SetMacAddress( pxEMAC_PS, ( void * )xLLMNR_MACAddress, 2 );
-		}
-		#endif	/* ipconfigUSE_LLMNR == 1 */
+        /* Initialize the mac and set the MAC address. */
+        XEmacPs_SetMacAddress( pxEMAC_PS, ( void * ) ucMACAddress, 1 );
 
-		XEmacPs_SetMdioDivisor( pxEMAC_PS, MDC_DIV_224 );
-		ulLinkSpeed = Phy_Setup( pxEMAC_PS );
-		XEmacPs_SetOperatingSpeed( pxEMAC_PS, ulLinkSpeed);
+        #if ( ipconfigUSE_LLMNR == 1 )
+            {
+                /* Also add LLMNR multicast MAC address. */
+                XEmacPs_SetMacAddress( pxEMAC_PS, ( void * ) xLLMNR_MACAddress, 2 );
+            }
+        #endif /* ipconfigUSE_LLMNR == 1 */
 
-		/* Setting the operating speed of the MAC needs a delay. */
-		vTaskDelay( pdMS_TO_TICKS( 25UL ) );
+        XEmacPs_SetMdioDivisor( pxEMAC_PS, MDC_DIV_224 );
+        ulLinkSpeed = Phy_Setup( pxEMAC_PS );
+        XEmacPs_SetOperatingSpeed( pxEMAC_PS, ulLinkSpeed );
 
-		ulDMAReg = XEmacPs_ReadReg( pxEMAC_PS->Config.BaseAddress, XEMACPS_DMACR_OFFSET);
+        /* Setting the operating speed of the MAC needs a delay. */
+        vTaskDelay( pdMS_TO_TICKS( 25UL ) );
 
-		/* DISC_WHEN_NO_AHB: when set, the GEM DMA will automatically discard receive
-		packets from the receiver packet buffer memory when no AHB resource is available. */
-		XEmacPs_WriteReg( pxEMAC_PS->Config.BaseAddress, XEMACPS_DMACR_OFFSET,
-			ulDMAReg | XEMACPS_DMACR_DISC_WHEN_NO_AHB_MASK);
+        ulDMAReg = XEmacPs_ReadReg( pxEMAC_PS->Config.BaseAddress, XEMACPS_DMACR_OFFSET );
 
-		setup_isr( &xEMACpsif );
-		init_dma( &xEMACpsif );
-		start_emacps( &xEMACpsif );
+        /* DISC_WHEN_NO_AHB: when set, the GEM DMA will automatically discard receive
+         * packets from the receiver packet buffer memory when no AHB resource is available. */
+        XEmacPs_WriteReg( pxEMAC_PS->Config.BaseAddress, XEMACPS_DMACR_OFFSET,
+                          ulDMAReg | XEMACPS_DMACR_DISC_WHEN_NO_AHB_MASK );
 
-		prvGMACWaitLS( xWaitLinkDelay );
+        setup_isr( &xEMACpsif );
+        init_dma( &xEMACpsif );
+        start_emacps( &xEMACpsif );
 
-		/* The deferred interrupt handler task is created at the highest
-		possible priority to ensure the interrupt handler can return directly
-		to it.  The task's handle is stored in xEMACTaskHandle so interrupts can
-		notify the task when there is something to process. */
-		xTaskCreate( prvEMACHandlerTask, "EMAC", configEMAC_TASK_STACK_SIZE, NULL, niEMAC_HANDLER_TASK_PRIORITY, &xEMACTaskHandle );
-	}
-	else
-	{
-		/* Initialisation was already performed, just wait for the link. */
-		prvGMACWaitLS( xWaitRelinkDelay );
-	}
+        prvGMACWaitLS( xWaitLinkDelay );
 
-	/* Only return pdTRUE when the Link Status of the PHY is high, otherwise the
-	DHCP process and all other communication will fail. */
-	xLinkStatus = xGetPhyLinkStatus();
+        /* The deferred interrupt handler task is created at the highest
+         * possible priority to ensure the interrupt handler can return directly
+         * to it.  The task's handle is stored in xEMACTaskHandle so interrupts can
+         * notify the task when there is something to process. */
+        xTaskCreate( prvEMACHandlerTask, "EMAC", configEMAC_TASK_STACK_SIZE, NULL, niEMAC_HANDLER_TASK_PRIORITY, &xEMACTaskHandle );
+    }
+    else
+    {
+        /* Initialisation was already performed, just wait for the link. */
+        prvGMACWaitLS( xWaitRelinkDelay );
+    }
 
-	return ( xLinkStatus != pdFALSE );
+    /* Only return pdTRUE when the Link Status of the PHY is high, otherwise the
+     * DHCP process and all other communication will fail. */
+    xLinkStatus = xGetPhyLinkStatus();
+
+    return( xLinkStatus != pdFALSE );
 }
 /*-----------------------------------------------------------*/
 
-BaseType_t xNetworkInterfaceOutput( NetworkBufferDescriptor_t * const pxBuffer, BaseType_t bReleaseAfterSend )
+BaseType_t xNetworkInterfaceOutput( NetworkBufferDescriptor_t * const pxBuffer,
+                                    BaseType_t bReleaseAfterSend )
 {
-	#if( ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM != 0 )
-	{
-	ProtocolPacket_t *pxPacket;
+    #if ( ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM != 0 )
+        {
+            ProtocolPacket_t * pxPacket;
 
-		/* If the peripheral must calculate the checksum, it wants
-		the protocol checksum to have a value of zero. */
-		pxPacket = ( ProtocolPacket_t * ) ( pxBuffer->pucEthernetBuffer );
-		if( ( pxPacket->xICMPPacket.xIPHeader.ucProtocol != ipPROTOCOL_UDP ) &&
-			( pxPacket->xICMPPacket.xIPHeader.ucProtocol != ipPROTOCOL_TCP ) )
-		{
-			/* The EMAC will calculate the checksum of the IP-header.
-			It can only calculate protocol checksums of UDP and TCP,
-			so for ICMP and other protocols it must be done manually. */
-			usGenerateProtocolChecksum( (uint8_t*)&( pxPacket->xUDPPacket ), pxBuffer->xDataLength, pdTRUE );
-		}
-	}
-	#endif /* ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM */
-	if( ( ulPHYLinkStatus & niBMSR_LINK_STATUS ) != 0UL )
-	{
-		iptraceNETWORK_INTERFACE_TRANSMIT();
-		emacps_send_message( &xEMACpsif, pxBuffer, bReleaseAfterSend );
-	}
-	else if( bReleaseAfterSend != pdFALSE )
-	{
-		/* No link. */
-		vReleaseNetworkBufferAndDescriptor( pxBuffer );
-	}
+            /* If the peripheral must calculate the checksum, it wants
+             * the protocol checksum to have a value of zero. */
+            pxPacket = ( ProtocolPacket_t * ) ( pxBuffer->pucEthernetBuffer );
 
-	return pdTRUE;
+            if( ( pxPacket->xICMPPacket.xIPHeader.ucProtocol != ipPROTOCOL_UDP ) &&
+                ( pxPacket->xICMPPacket.xIPHeader.ucProtocol != ipPROTOCOL_TCP ) )
+            {
+                /* The EMAC will calculate the checksum of the IP-header.
+                 * It can only calculate protocol checksums of UDP and TCP,
+                 * so for ICMP and other protocols it must be done manually. */
+                usGenerateProtocolChecksum( ( uint8_t * ) &( pxPacket->xUDPPacket ), pxBuffer->xDataLength, pdTRUE );
+            }
+        }
+    #endif /* ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM */
+
+    if( ( ulPHYLinkStatus & niBMSR_LINK_STATUS ) != 0UL )
+    {
+        iptraceNETWORK_INTERFACE_TRANSMIT();
+        emacps_send_message( &xEMACpsif, pxBuffer, bReleaseAfterSend );
+    }
+    else if( bReleaseAfterSend != pdFALSE )
+    {
+        /* No link. */
+        vReleaseNetworkBufferAndDescriptor( pxBuffer );
+    }
+
+    return pdTRUE;
 }
 /*-----------------------------------------------------------*/
 
 static inline unsigned long ulReadMDIO( unsigned ulRegister )
 {
-uint16_t usValue;
+    uint16_t usValue;
 
-	XEmacPs_PhyRead( &( xEMACpsif.emacps ), phy_detected, ulRegister, &usValue );
-	return usValue;
+    XEmacPs_PhyRead( &( xEMACpsif.emacps ), phy_detected, ulRegister, &usValue );
+    return usValue;
 }
 /*-----------------------------------------------------------*/
 
 static BaseType_t prvGMACWaitLS( TickType_t xMaxTime )
 {
-TickType_t xStartTime, xEndTime;
-const TickType_t xShortDelay = pdMS_TO_TICKS( 20UL );
-BaseType_t xReturn;
+    TickType_t xStartTime, xEndTime;
+    const TickType_t xShortDelay = pdMS_TO_TICKS( 20UL );
+    BaseType_t xReturn;
 
-	xStartTime = xTaskGetTickCount();
+    xStartTime = xTaskGetTickCount();
 
-	for( ;; )
-	{
-		xEndTime = xTaskGetTickCount();
+    for( ; ; )
+    {
+        xEndTime = xTaskGetTickCount();
 
-		if( xEndTime - xStartTime > xMaxTime )
-		{
-			xReturn = pdFALSE;
-			break;
-		}
-		ulPHYLinkStatus = ulReadMDIO( PHY_REG_01_BMSR );
+        if( xEndTime - xStartTime > xMaxTime )
+        {
+            xReturn = pdFALSE;
+            break;
+        }
 
-		if( ( ulPHYLinkStatus & niBMSR_LINK_STATUS ) != 0uL )
-		{
-			xReturn = pdTRUE;
-			break;
-		}
+        ulPHYLinkStatus = ulReadMDIO( PHY_REG_01_BMSR );
 
-		vTaskDelay( xShortDelay );
-	}
+        if( ( ulPHYLinkStatus & niBMSR_LINK_STATUS ) != 0uL )
+        {
+            xReturn = pdTRUE;
+            break;
+        }
 
-	return xReturn;
+        vTaskDelay( xShortDelay );
+    }
+
+    return xReturn;
 }
 /*-----------------------------------------------------------*/
 
 void vNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
 {
-static uint8_t ucNetworkPackets[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS * niBUFFER_1_PACKET_SIZE ] __attribute__ ( ( aligned( 32 ) ) );
-uint8_t *ucRAMBuffer = ucNetworkPackets;
-uint32_t ul;
+    static uint8_t ucNetworkPackets[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS * niBUFFER_1_PACKET_SIZE ] __attribute__( ( aligned( 32 ) ) );
+    uint8_t * ucRAMBuffer = ucNetworkPackets;
+    uint32_t ul;
 
-	for( ul = 0; ul < ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS; ul++ )
-	{
-		pxNetworkBuffers[ ul ].pucEthernetBuffer = ucRAMBuffer + ipBUFFER_PADDING;
-		*( ( unsigned * ) ucRAMBuffer ) = ( unsigned ) ( &( pxNetworkBuffers[ ul ] ) );
-		ucRAMBuffer += niBUFFER_1_PACKET_SIZE;
-	}
+    for( ul = 0; ul < ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS; ul++ )
+    {
+        pxNetworkBuffers[ ul ].pucEthernetBuffer = ucRAMBuffer + ipBUFFER_PADDING;
+        *( ( unsigned * ) ucRAMBuffer ) = ( unsigned ) ( &( pxNetworkBuffers[ ul ] ) );
+        ucRAMBuffer += niBUFFER_1_PACKET_SIZE;
+    }
 }
 /*-----------------------------------------------------------*/
 
 BaseType_t xGetPhyLinkStatus( void )
 {
-BaseType_t xReturn;
+    BaseType_t xReturn;
 
-	if( ( ulPHYLinkStatus & niBMSR_LINK_STATUS ) == 0uL )
-	{
-		xReturn = pdFALSE;
-	}
-	else
-	{
-		xReturn = pdTRUE;
-	}
+    if( ( ulPHYLinkStatus & niBMSR_LINK_STATUS ) == 0uL )
+    {
+        xReturn = pdFALSE;
+    }
+    else
+    {
+        xReturn = pdTRUE;
+    }
 
-	return xReturn;
+    return xReturn;
 }
 /*-----------------------------------------------------------*/
 
 #if ( ipconfigHAS_PRINTF != 0 )
-	static void prvMonitorResources()
-	{
-	static UBaseType_t uxLastMinBufferCount = 0u;
-	static size_t uxMinLastSize = 0uL;
-	UBaseType_t uxCurrentBufferCount;
-	size_t uxMinSize;
+    static void prvMonitorResources()
+    {
+        static UBaseType_t uxLastMinBufferCount = 0u;
+        static size_t uxMinLastSize = 0uL;
+        UBaseType_t uxCurrentBufferCount;
+        size_t uxMinSize;
 
-		uxCurrentBufferCount = uxGetMinimumFreeNetworkBuffers();
+        uxCurrentBufferCount = uxGetMinimumFreeNetworkBuffers();
 
-		if( uxLastMinBufferCount != uxCurrentBufferCount )
-		{
-			/* The logging produced below may be helpful
-			 * while tuning +TCP: see how many buffers are in use. */
-			uxLastMinBufferCount = uxCurrentBufferCount;
-			FreeRTOS_printf( ( "Network buffers: %lu lowest %lu\n",
-							   uxGetNumberOfFreeNetworkBuffers(),
-							   uxCurrentBufferCount ) );
-		}
+        if( uxLastMinBufferCount != uxCurrentBufferCount )
+        {
+            /* The logging produced below may be helpful
+             * while tuning +TCP: see how many buffers are in use. */
+            uxLastMinBufferCount = uxCurrentBufferCount;
+            FreeRTOS_printf( ( "Network buffers: %lu lowest %lu\n",
+                               uxGetNumberOfFreeNetworkBuffers(),
+                               uxCurrentBufferCount ) );
+        }
 
-		uxMinSize = xPortGetMinimumEverFreeHeapSize();
+        uxMinSize = xPortGetMinimumEverFreeHeapSize();
 
-		if( uxMinLastSize != uxMinSize )
-		{
-			uxMinLastSize = uxMinSize;
-			FreeRTOS_printf( ( "Heap: current %lu lowest %lu\n", xPortGetFreeHeapSize(), uxMinSize ) );
-		}
+        if( uxMinLastSize != uxMinSize )
+        {
+            uxMinLastSize = uxMinSize;
+            FreeRTOS_printf( ( "Heap: current %lu lowest %lu\n", xPortGetFreeHeapSize(), uxMinSize ) );
+        }
 
-		#if ( ipconfigCHECK_IP_QUEUE_SPACE != 0 )
-			{
-				static UBaseType_t uxLastMinQueueSpace = 0;
-				UBaseType_t uxCurrentCount = 0u;
+        #if ( ipconfigCHECK_IP_QUEUE_SPACE != 0 )
+            {
+                static UBaseType_t uxLastMinQueueSpace = 0;
+                UBaseType_t uxCurrentCount = 0u;
 
-				uxCurrentCount = uxGetMinimumIPQueueSpace();
+                uxCurrentCount = uxGetMinimumIPQueueSpace();
 
-				if( uxLastMinQueueSpace != uxCurrentCount )
-				{
-					/* The logging produced below may be helpful
-					 * while tuning +TCP: see how many buffers are in use. */
-					uxLastMinQueueSpace = uxCurrentCount;
-					FreeRTOS_printf( ( "Queue space: lowest %lu\n", uxCurrentCount ) );
-				}
-			}
-		#endif /* ipconfigCHECK_IP_QUEUE_SPACE */
-	}
+                if( uxLastMinQueueSpace != uxCurrentCount )
+                {
+                    /* The logging produced below may be helpful
+                     * while tuning +TCP: see how many buffers are in use. */
+                    uxLastMinQueueSpace = uxCurrentCount;
+                    FreeRTOS_printf( ( "Queue space: lowest %lu\n", uxCurrentCount ) );
+                }
+            }
+        #endif /* ipconfigCHECK_IP_QUEUE_SPACE */
+    }
 #endif /* ( ipconfigHAS_PRINTF != 0 ) */
 /*-----------------------------------------------------------*/
 
-static void prvEMACHandlerTask( void *pvParameters )
+static void prvEMACHandlerTask( void * pvParameters )
 {
-TimeOut_t xPhyTime;
-TickType_t xPhyRemTime;
-BaseType_t xResult = 0;
-uint32_t xStatus;
-const TickType_t ulMaxBlockTime = pdMS_TO_TICKS( 100UL );
+    TimeOut_t xPhyTime;
+    TickType_t xPhyRemTime;
+    BaseType_t xResult = 0;
+    uint32_t xStatus;
+    const TickType_t ulMaxBlockTime = pdMS_TO_TICKS( 100UL );
 
-	/* Remove compiler warnings about unused parameters. */
-	( void ) pvParameters;
+    /* Remove compiler warnings about unused parameters. */
+    ( void ) pvParameters;
 
-	/* A possibility to set some additional task properties like calling
-	portTASK_USES_FLOATING_POINT() */
-	iptraceEMAC_TASK_STARTING();
+    /* A possibility to set some additional task properties like calling
+     * portTASK_USES_FLOATING_POINT() */
+    iptraceEMAC_TASK_STARTING();
 
-	vTaskSetTimeOutState( &xPhyTime );
-	xPhyRemTime = pdMS_TO_TICKS( PHY_LS_LOW_CHECK_TIME_MS );
+    vTaskSetTimeOutState( &xPhyTime );
+    xPhyRemTime = pdMS_TO_TICKS( PHY_LS_LOW_CHECK_TIME_MS );
 
-	for( ;; )
-	{
-		#if ( ipconfigHAS_PRINTF != 0 )
-			{
-				prvMonitorResources();
-			}
-		#endif /* ipconfigHAS_PRINTF != 0 ) */
+    for( ; ; )
+    {
+        #if ( ipconfigHAS_PRINTF != 0 )
+            {
+                prvMonitorResources();
+            }
+        #endif /* ipconfigHAS_PRINTF != 0 ) */
 
-		if( ( xEMACpsif.isr_events & EMAC_IF_ALL_EVENT ) == 0 )
-		{
-			/* No events to process now, wait for the next. */
-			ulTaskNotifyTake( pdFALSE, ulMaxBlockTime );
-		}
+        if( ( xEMACpsif.isr_events & EMAC_IF_ALL_EVENT ) == 0 )
+        {
+            /* No events to process now, wait for the next. */
+            ulTaskNotifyTake( pdFALSE, ulMaxBlockTime );
+        }
 
-		if( ( xEMACpsif.isr_events & EMAC_IF_RX_EVENT ) != 0 )
-		{
-			xEMACpsif.isr_events &= ~EMAC_IF_RX_EVENT;
-			xResult = emacps_check_rx( &xEMACpsif );
-		}
+        if( ( xEMACpsif.isr_events & EMAC_IF_RX_EVENT ) != 0 )
+        {
+            xEMACpsif.isr_events &= ~EMAC_IF_RX_EVENT;
+            xResult = emacps_check_rx( &xEMACpsif );
+        }
 
-		if( ( xEMACpsif.isr_events & EMAC_IF_TX_EVENT ) != 0 )
-		{
-			xEMACpsif.isr_events &= ~EMAC_IF_TX_EVENT;
-			emacps_check_tx( &xEMACpsif );
-		}
+        if( ( xEMACpsif.isr_events & EMAC_IF_TX_EVENT ) != 0 )
+        {
+            xEMACpsif.isr_events &= ~EMAC_IF_TX_EVENT;
+            emacps_check_tx( &xEMACpsif );
+        }
 
-		if( ( xEMACpsif.isr_events & EMAC_IF_ERR_EVENT ) != 0 )
-		{
-			xEMACpsif.isr_events &= ~EMAC_IF_ERR_EVENT;
-			emacps_check_errors( &xEMACpsif );
-		}
+        if( ( xEMACpsif.isr_events & EMAC_IF_ERR_EVENT ) != 0 )
+        {
+            xEMACpsif.isr_events &= ~EMAC_IF_ERR_EVENT;
+            emacps_check_errors( &xEMACpsif );
+        }
 
-		if( xResult > 0 )
-		{
-			/* A packet was received. No need to check for the PHY status now,
-			but set a timer to check it later on. */
-			vTaskSetTimeOutState( &xPhyTime );
-			xPhyRemTime = pdMS_TO_TICKS( PHY_LS_HIGH_CHECK_TIME_MS );
-			xResult = 0;
-			if( ( ulPHYLinkStatus & niBMSR_LINK_STATUS ) == 0uL )
-			{
-				/* Indicate that the Link Status is high, so that
-				xNetworkInterfaceOutput() can send packets. */
-				ulPHYLinkStatus |= niBMSR_LINK_STATUS;
-				FreeRTOS_printf( ( "prvEMACHandlerTask: PHY LS assume 1\n" ) );
-			}
-		}
-		else if( xTaskCheckForTimeOut( &xPhyTime, &xPhyRemTime ) != pdFALSE )
-		{
-			xStatus = ulReadMDIO( PHY_REG_01_BMSR );
+        if( xResult > 0 )
+        {
+            /* A packet was received. No need to check for the PHY status now,
+             * but set a timer to check it later on. */
+            vTaskSetTimeOutState( &xPhyTime );
+            xPhyRemTime = pdMS_TO_TICKS( PHY_LS_HIGH_CHECK_TIME_MS );
+            xResult = 0;
 
-			if( ( ulPHYLinkStatus & niBMSR_LINK_STATUS ) != ( xStatus & niBMSR_LINK_STATUS ) )
-			{
-				ulPHYLinkStatus = xStatus;
-				FreeRTOS_printf( ( "prvEMACHandlerTask: PHY LS now %d\n", ( ulPHYLinkStatus & niBMSR_LINK_STATUS ) != 0uL ) );
-			}
+            if( ( ulPHYLinkStatus & niBMSR_LINK_STATUS ) == 0uL )
+            {
+                /* Indicate that the Link Status is high, so that
+                 * xNetworkInterfaceOutput() can send packets. */
+                ulPHYLinkStatus |= niBMSR_LINK_STATUS;
+                FreeRTOS_printf( ( "prvEMACHandlerTask: PHY LS assume 1\n" ) );
+            }
+        }
+        else if( xTaskCheckForTimeOut( &xPhyTime, &xPhyRemTime ) != pdFALSE )
+        {
+            xStatus = ulReadMDIO( PHY_REG_01_BMSR );
 
-			vTaskSetTimeOutState( &xPhyTime );
-			if( ( ulPHYLinkStatus & niBMSR_LINK_STATUS ) != 0uL )
-			{
-				xPhyRemTime = pdMS_TO_TICKS( PHY_LS_HIGH_CHECK_TIME_MS );
-			}
-			else
-			{
-				xPhyRemTime = pdMS_TO_TICKS( PHY_LS_LOW_CHECK_TIME_MS );
-			}
-		}
-	}
+            if( ( ulPHYLinkStatus & niBMSR_LINK_STATUS ) != ( xStatus & niBMSR_LINK_STATUS ) )
+            {
+                ulPHYLinkStatus = xStatus;
+                FreeRTOS_printf( ( "prvEMACHandlerTask: PHY LS now %d\n", ( ulPHYLinkStatus & niBMSR_LINK_STATUS ) != 0uL ) );
+            }
+
+            vTaskSetTimeOutState( &xPhyTime );
+
+            if( ( ulPHYLinkStatus & niBMSR_LINK_STATUS ) != 0uL )
+            {
+                xPhyRemTime = pdMS_TO_TICKS( PHY_LS_HIGH_CHECK_TIME_MS );
+            }
+            else
+            {
+                xPhyRemTime = pdMS_TO_TICKS( PHY_LS_LOW_CHECK_TIME_MS );
+            }
+        }
+    }
 }
 /*-----------------------------------------------------------*/

--- a/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/portable/NetworkInterface/Zynq/uncached_memory.h
+++ b/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/portable/NetworkInterface/Zynq/uncached_memory.h
@@ -15,9 +15,8 @@
 
 #define UNCACHEMEMORY_H
 
-uint8_t *pucGetUncachedMemory( uint32_t ulSize );
+uint8_t * pucGetUncachedMemory( uint32_t ulSize );
 
-uint8_t ucIsCachedMemory( const uint8_t *pucBuffer );
+uint8_t ucIsCachedMemory( const uint8_t * pucBuffer );
 
 #endif /* UNCACHEMEMORY_H */
-

--- a/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/portable/NetworkInterface/Zynq/x_emacpsif.h
+++ b/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/portable/NetworkInterface/Zynq/x_emacpsif.h
@@ -17,45 +17,47 @@
  */
 
 #ifndef __NETIF_XEMACPSIF_H__
-#define __NETIF_XEMACPSIF_H__
+    #define __NETIF_XEMACPSIF_H__
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+    #ifdef __cplusplus
+        extern "C" {
+    #endif
 
-#include <stdint.h>
+    #include <stdint.h>
 
-#include "xstatus.h"
-#include "xparameters.h"
-#include "xparameters_ps.h"	/* defines XPAR values */
-#include "xil_types.h"
-#include "xil_assert.h"
-#include "xil_io.h"
-#include "xil_exception.h"
-#include "xpseudo_asm.h"
-#include "xil_cache.h"
-#include "xuartps.h"
-#include "xscugic.h"
-#include "xemacps.h"		/* defines XEmacPs API */
+    #include "xstatus.h"
+    #include "xparameters.h"
+    #include "xparameters_ps.h" /* defines XPAR values */
+    #include "xil_types.h"
+    #include "xil_assert.h"
+    #include "xil_io.h"
+    #include "xil_exception.h"
+    #include "xpseudo_asm.h"
+    #include "xil_cache.h"
+    #include "xuartps.h"
+    #include "xscugic.h"
+    #include "xemacps.h" /* defines XEmacPs API */
 
-//#include "netif/xpqueue.h"
-//#include "xlwipconfig.h"
+/*#include "netif/xpqueue.h" */
+/*#include "xlwipconfig.h" */
 
-void 	xemacpsif_setmac(uint32_t index, uint8_t *addr);
-uint8_t*	xemacpsif_getmac(uint32_t index);
-//int 	xemacpsif_init(struct netif *netif);
-//int 	xemacpsif_input(struct netif *netif);
-#ifdef NOTNOW_BHILL
-unsigned get_IEEE_phy_speed(XLlTemac *xlltemacp);
-#endif
+    void xemacpsif_setmac( uint32_t index,
+                           uint8_t * addr );
+    uint8_t * xemacpsif_getmac( uint32_t index );
+/*int   xemacpsif_init(struct netif *netif); */
+/*int   xemacpsif_input(struct netif *netif); */
+    #ifdef NOTNOW_BHILL
+        unsigned get_IEEE_phy_speed( XLlTemac * xlltemacp );
+    #endif
 
 /* xaxiemacif_hw.c */
-void 	xemacps_error_handler(XEmacPs * Temac);
+    void xemacps_error_handler( XEmacPs * Temac );
 
-struct xBD_TYPE {
-	uint32_t address;
-	uint32_t flags;
-};
+    struct xBD_TYPE
+    {
+        uint32_t address;
+        uint32_t flags;
+    };
 
 /*
  * Missing declaration in 'src/xemacps_hw.h' :
@@ -67,76 +69,81 @@ struct xBD_TYPE {
  * stored in the SRAM based packet buffer until
  * AHB buffer resource next becomes available.
  */
-#define XEMACPS_DMACR_DISC_WHEN_NO_AHB_MASK		0x01000000
+    #define XEMACPS_DMACR_DISC_WHEN_NO_AHB_MASK    0x01000000
 
-#define EMAC_IF_RX_EVENT	1
-#define EMAC_IF_TX_EVENT	2
-#define EMAC_IF_ERR_EVENT	4
-#define EMAC_IF_ALL_EVENT	7
+    #define EMAC_IF_RX_EVENT                       1
+    #define EMAC_IF_TX_EVENT                       2
+    #define EMAC_IF_ERR_EVENT                      4
+    #define EMAC_IF_ALL_EVENT                      7
 
 /* structure within each netif, encapsulating all information required for
  * using a particular temac instance
  */
-typedef struct {
-	XEmacPs emacps;
+    typedef struct
+    {
+        XEmacPs emacps;
 
-	/* pointers to memory holding buffer descriptors (used only with SDMA) */
-	struct xBD_TYPE *rxSegments;
-	struct xBD_TYPE *txSegments;
+        /* pointers to memory holding buffer descriptors (used only with SDMA) */
+        struct xBD_TYPE * rxSegments;
+        struct xBD_TYPE * txSegments;
 
-	unsigned char *tx_space;
-	unsigned uTxUnitSize;
+        unsigned char * tx_space;
+        unsigned uTxUnitSize;
 
-	char *remain_mem;
-	unsigned remain_siz;
+        char * remain_mem;
+        unsigned remain_siz;
 
-	volatile int rxHead, rxTail;
-	volatile int txHead, txTail;
+        volatile int rxHead, rxTail;
+        volatile int txHead, txTail;
 
-	volatile int txBusy;
+        volatile int txBusy;
 
-	volatile uint32_t isr_events;
+        volatile uint32_t isr_events;
 
-	unsigned int last_rx_frms_cntr;
+        unsigned int last_rx_frms_cntr;
+    } xemacpsif_s;
 
-} xemacpsif_s;
+/*extern xemacpsif_s xemacpsif; */
 
-//extern xemacpsif_s xemacpsif;
-
-int	is_tx_space_available(xemacpsif_s *emac);
+    int is_tx_space_available( xemacpsif_s * emac );
 
 /* xaxiemacif_dma.c */
 
-struct xNETWORK_BUFFER;
+    struct xNETWORK_BUFFER;
 
-int emacps_check_rx( xemacpsif_s *xemacpsif );
-void emacps_check_tx( xemacpsif_s *xemacpsif );
-int emacps_check_errors( xemacpsif_s *xemacps );
-void emacps_set_rx_buffers( xemacpsif_s *xemacpsif, u32 ulCount );
+    int emacps_check_rx( xemacpsif_s * xemacpsif );
+    void emacps_check_tx( xemacpsif_s * xemacpsif );
+    int emacps_check_errors( xemacpsif_s * xemacps );
+    void emacps_set_rx_buffers( xemacpsif_s * xemacpsif,
+                                u32 ulCount );
 
-extern XStatus emacps_send_message(xemacpsif_s *xemacpsif, struct xNETWORK_BUFFER *pxBuffer, int iReleaseAfterSend );
-extern unsigned Phy_Setup( XEmacPs *xemacpsp );
-extern void setup_isr( xemacpsif_s *xemacpsif );
-extern XStatus init_dma( xemacpsif_s *xemacpsif );
-extern void start_emacps( xemacpsif_s *xemacpsif );
+    extern XStatus emacps_send_message( xemacpsif_s * xemacpsif,
+                                        struct xNETWORK_BUFFER * pxBuffer,
+                                        int iReleaseAfterSend );
+    extern unsigned Phy_Setup( XEmacPs * xemacpsp );
+    extern void setup_isr( xemacpsif_s * xemacpsif );
+    extern XStatus init_dma( xemacpsif_s * xemacpsif );
+    extern void start_emacps( xemacpsif_s * xemacpsif );
 
-void EmacEnableIntr(void);
-void EmacDisableIntr(void);
+    void EmacEnableIntr( void );
+    void EmacDisableIntr( void );
 
-XStatus init_axi_dma(xemacpsif_s *xemacpsif);
-void process_sent_bds( xemacpsif_s *xemacpsif );
+    XStatus init_axi_dma( xemacpsif_s * xemacpsif );
+    void process_sent_bds( xemacpsif_s * xemacpsif );
 
-void emacps_send_handler(void *arg);
-void emacps_recv_handler(void *arg);
-void emacps_error_handler(void *arg,u8 Direction, u32 ErrorWord);
-void HandleTxErrors(xemacpsif_s *xemacpsif);
-XEmacPs_Config *xemacps_lookup_config(unsigned mac_base);
+    void emacps_send_handler( void * arg );
+    void emacps_recv_handler( void * arg );
+    void emacps_error_handler( void * arg,
+                               u8 Direction,
+                               u32 ErrorWord );
+    void HandleTxErrors( xemacpsif_s * xemacpsif );
+    XEmacPs_Config * xemacps_lookup_config( unsigned mac_base );
 
-void clean_dma_txdescs(xemacpsif_s *xemacpsif);
-void resetrx_on_no_rxdata(xemacpsif_s *xemacpsif);
+    void clean_dma_txdescs( xemacpsif_s * xemacpsif );
+    void resetrx_on_no_rxdata( xemacpsif_s * xemacpsif );
 
-#ifdef __cplusplus
-}
-#endif
+    #ifdef __cplusplus
+        }
+    #endif
 
 #endif /* __NETIF_XAXIEMACIF_H__ */

--- a/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/portable/NetworkInterface/Zynq/x_emacpsif_dma.c
+++ b/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/portable/NetworkInterface/Zynq/x_emacpsif_dma.c
@@ -46,550 +46,578 @@
 #include "uncached_memory.h"
 
 /* Two defines used to set or clear the EMAC interrupt */
-#define INTC_BASE_ADDR		XPAR_SCUGIC_CPU_BASEADDR
-#define INTC_DIST_BASE_ADDR	XPAR_SCUGIC_DIST_BASEADDR
+#define INTC_BASE_ADDR         XPAR_SCUGIC_CPU_BASEADDR
+#define INTC_DIST_BASE_ADDR    XPAR_SCUGIC_DIST_BASEADDR
 
 
 
-#if( ipconfigPACKET_FILLER_SIZE != 2 )
-	#error Please define ipconfigPACKET_FILLER_SIZE as the value '2'
+#if ( ipconfigPACKET_FILLER_SIZE != 2 )
+    #error Please define ipconfigPACKET_FILLER_SIZE as the value '2'
 #endif
-#define TX_OFFSET				ipconfigPACKET_FILLER_SIZE
+#define TX_OFFSET               ipconfigPACKET_FILLER_SIZE
 
-#define dmaRX_TX_BUFFER_SIZE			1536
+#define dmaRX_TX_BUFFER_SIZE    1536
 
 /* Defined in NetworkInterface.c */
 extern TaskHandle_t xEMACTaskHandle;
 
 /*
-	pxDMA_tx_buffers: these are character arrays, each one is big enough to hold 1 MTU.
-	The actual TX buffers are located in uncached RAM.
-*/
-static unsigned char *pxDMA_tx_buffers[ ipconfigNIC_N_TX_DESC ] = { NULL };
+ *  pxDMA_tx_buffers: these are character arrays, each one is big enough to hold 1 MTU.
+ *  The actual TX buffers are located in uncached RAM.
+ */
+static unsigned char * pxDMA_tx_buffers[ ipconfigNIC_N_TX_DESC ] = { NULL };
 
 /*
-	pxDMA_rx_buffers: these are pointers to 'NetworkBufferDescriptor_t'.
-	Once a message has been received by the EMAC, the descriptor can be passed
-	immediately to the IP-task.
-*/
-static NetworkBufferDescriptor_t *pxDMA_rx_buffers[ ipconfigNIC_N_RX_DESC ] = { NULL };
+ *  pxDMA_rx_buffers: these are pointers to 'NetworkBufferDescriptor_t'.
+ *  Once a message has been received by the EMAC, the descriptor can be passed
+ *  immediately to the IP-task.
+ */
+static NetworkBufferDescriptor_t * pxDMA_rx_buffers[ ipconfigNIC_N_RX_DESC ] = { NULL };
 
 /*
-	The FreeRTOS+TCP port is using a fixed 'topology', which is declared in
-	./portable/NetworkInterface/Zynq/NetworkInterface.c
-*/
+ *  The FreeRTOS+TCP port is using a fixed 'topology', which is declared in
+ *  ./portable/NetworkInterface/Zynq/NetworkInterface.c
+ */
 extern struct xtopology_t xXTopology;
 
 static SemaphoreHandle_t xTXDescriptorSemaphore = NULL;
 
 /*
-	The FreeRTOS+TCP port does not make use of "src/xemacps_bdring.c".
-	In stead 'struct xemacpsif_s' has a "head" and a "tail" index.
-	"head" is the next index to be written, used.
-	"tail" is the next index to be read, freed.
-*/
+ *  The FreeRTOS+TCP port does not make use of "src/xemacps_bdring.c".
+ *  In stead 'struct xemacpsif_s' has a "head" and a "tail" index.
+ *  "head" is the next index to be written, used.
+ *  "tail" is the next index to be read, freed.
+ */
 
-int is_tx_space_available( xemacpsif_s *xemacpsif )
+int is_tx_space_available( xemacpsif_s * xemacpsif )
 {
-size_t uxCount;
+    size_t uxCount;
 
-	if( xTXDescriptorSemaphore != NULL )
-	{
-		uxCount = ( ( UBaseType_t ) ipconfigNIC_N_TX_DESC ) - uxSemaphoreGetCount( xTXDescriptorSemaphore );
-	}
-	else
-	{
-		uxCount = ( UBaseType_t ) 0u;
-	}
+    if( xTXDescriptorSemaphore != NULL )
+    {
+        uxCount = ( ( UBaseType_t ) ipconfigNIC_N_TX_DESC ) - uxSemaphoreGetCount( xTXDescriptorSemaphore );
+    }
+    else
+    {
+        uxCount = ( UBaseType_t ) 0u;
+    }
 
-	return uxCount;
+    return uxCount;
 }
 
-void emacps_check_tx( xemacpsif_s *xemacpsif )
+void emacps_check_tx( xemacpsif_s * xemacpsif )
 {
-int tail = xemacpsif->txTail;
-int head = xemacpsif->txHead;
-size_t uxCount = ( ( UBaseType_t ) ipconfigNIC_N_TX_DESC ) - uxSemaphoreGetCount( xTXDescriptorSemaphore );
+    int tail = xemacpsif->txTail;
+    int head = xemacpsif->txHead;
+    size_t uxCount = ( ( UBaseType_t ) ipconfigNIC_N_TX_DESC ) - uxSemaphoreGetCount( xTXDescriptorSemaphore );
 
-	/* uxCount is the number of TX descriptors that are in use by the DMA. */
-	/* When done, "TXBUF_USED" will be set. */
+    /* uxCount is the number of TX descriptors that are in use by the DMA. */
+    /* When done, "TXBUF_USED" will be set. */
 
-	while( ( uxCount > 0 ) && ( ( xemacpsif->txSegments[ tail ].flags & XEMACPS_TXBUF_USED_MASK ) != 0 ) )
-	{
-		if( ( tail == head ) && ( uxCount != ipconfigNIC_N_TX_DESC ) )
-		{
-			break;
-		}
-		{
-		void *pvBuffer = pxDMA_tx_buffers[ tail ];
-		NetworkBufferDescriptor_t *pxBuffer;
+    while( ( uxCount > 0 ) && ( ( xemacpsif->txSegments[ tail ].flags & XEMACPS_TXBUF_USED_MASK ) != 0 ) )
+    {
+        if( ( tail == head ) && ( uxCount != ipconfigNIC_N_TX_DESC ) )
+        {
+            break;
+        }
 
-			if( pvBuffer != NULL )
-			{
-				pxDMA_tx_buffers[ tail ] = NULL;
-				pxBuffer = pxPacketBuffer_to_NetworkBuffer( pvBuffer );
-				if( pxBuffer != NULL )
-				{
-					vReleaseNetworkBufferAndDescriptor( pxBuffer );
-				}
-				else
-				{
-					FreeRTOS_printf( ( "emacps_check_tx: Can not find network buffer\n" ) );
-				}
-			}
-		}
-		/* Clear all but the "used" and "wrap" bits. */
-		if( tail < ipconfigNIC_N_TX_DESC - 1 )
-		{
-			xemacpsif->txSegments[ tail ].flags = XEMACPS_TXBUF_USED_MASK;
-		}
-		else
-		{
-			xemacpsif->txSegments[ tail ].flags = XEMACPS_TXBUF_USED_MASK | XEMACPS_TXBUF_WRAP_MASK;
-		}
-		uxCount--;
-		/* Tell the counting semaphore that one more TX descriptor is available. */
-		xSemaphoreGive( xTXDescriptorSemaphore );
-		if( ++tail == ipconfigNIC_N_TX_DESC )
-		{
-			tail = 0;
-		}
-		xemacpsif->txTail = tail;
-	}
+        {
+            void * pvBuffer = pxDMA_tx_buffers[ tail ];
+            NetworkBufferDescriptor_t * pxBuffer;
 
-	return;
+            if( pvBuffer != NULL )
+            {
+                pxDMA_tx_buffers[ tail ] = NULL;
+                pxBuffer = pxPacketBuffer_to_NetworkBuffer( pvBuffer );
+
+                if( pxBuffer != NULL )
+                {
+                    vReleaseNetworkBufferAndDescriptor( pxBuffer );
+                }
+                else
+                {
+                    FreeRTOS_printf( ( "emacps_check_tx: Can not find network buffer\n" ) );
+                }
+            }
+        }
+
+        /* Clear all but the "used" and "wrap" bits. */
+        if( tail < ipconfigNIC_N_TX_DESC - 1 )
+        {
+            xemacpsif->txSegments[ tail ].flags = XEMACPS_TXBUF_USED_MASK;
+        }
+        else
+        {
+            xemacpsif->txSegments[ tail ].flags = XEMACPS_TXBUF_USED_MASK | XEMACPS_TXBUF_WRAP_MASK;
+        }
+
+        uxCount--;
+        /* Tell the counting semaphore that one more TX descriptor is available. */
+        xSemaphoreGive( xTXDescriptorSemaphore );
+
+        if( ++tail == ipconfigNIC_N_TX_DESC )
+        {
+            tail = 0;
+        }
+
+        xemacpsif->txTail = tail;
+    }
+
+    return;
 }
 
-void emacps_send_handler(void *arg)
+void emacps_send_handler( void * arg )
 {
-xemacpsif_s   *xemacpsif;
-BaseType_t xHigherPriorityTaskWoken = pdFALSE;
+    xemacpsif_s * xemacpsif;
+    BaseType_t xHigherPriorityTaskWoken = pdFALSE;
 
-	xemacpsif = (xemacpsif_s *)(arg);
+    xemacpsif = ( xemacpsif_s * ) ( arg );
 
-	/* This function is called from an ISR. The Xilinx ISR-handler has already
-	cleared the TXCOMPL and TXSR_USEDREAD status bits in the XEMACPS_TXSR register.
-	But it forgets to do a read-back. Do so now to avoid ever-returning ISR's. */
-	( void ) XEmacPs_ReadReg(xemacpsif->emacps.Config.BaseAddress, XEMACPS_TXSR_OFFSET);
+    /* This function is called from an ISR. The Xilinx ISR-handler has already
+     * cleared the TXCOMPL and TXSR_USEDREAD status bits in the XEMACPS_TXSR register.
+     * But it forgets to do a read-back. Do so now to avoid ever-returning ISR's. */
+    ( void ) XEmacPs_ReadReg( xemacpsif->emacps.Config.BaseAddress, XEMACPS_TXSR_OFFSET );
 
-	/* In this port for FreeRTOS+TCP, the EMAC interrupts will only set a bit in
-	"isr_events". The task in NetworkInterface will wake-up and do the necessary work.
-	*/
-	xemacpsif->isr_events |= EMAC_IF_TX_EVENT;
-	xemacpsif->txBusy = pdFALSE;
+    /* In this port for FreeRTOS+TCP, the EMAC interrupts will only set a bit in
+     * "isr_events". The task in NetworkInterface will wake-up and do the necessary work.
+     */
+    xemacpsif->isr_events |= EMAC_IF_TX_EVENT;
+    xemacpsif->txBusy = pdFALSE;
 
-	if( xEMACTaskHandle != NULL )
-	{
-		vTaskNotifyGiveFromISR( xEMACTaskHandle, &xHigherPriorityTaskWoken );
-	}
+    if( xEMACTaskHandle != NULL )
+    {
+        vTaskNotifyGiveFromISR( xEMACTaskHandle, &xHigherPriorityTaskWoken );
+    }
 
-	portYIELD_FROM_ISR( xHigherPriorityTaskWoken );
+    portYIELD_FROM_ISR( xHigherPriorityTaskWoken );
 }
 
 static BaseType_t xValidLength( BaseType_t xLength )
 {
-BaseType_t xReturn;
+    BaseType_t xReturn;
 
-	if( ( xLength >= ( BaseType_t ) sizeof( struct xARP_PACKET ) ) && ( ( ( uint32_t ) xLength ) <= dmaRX_TX_BUFFER_SIZE ) )
-	{
-		xReturn = pdTRUE;
-	}
-	else
-	{
-		xReturn =  pdFALSE;
-	}
+    if( ( xLength >= ( BaseType_t ) sizeof( struct xARP_PACKET ) ) && ( ( ( uint32_t ) xLength ) <= dmaRX_TX_BUFFER_SIZE ) )
+    {
+        xReturn = pdTRUE;
+    }
+    else
+    {
+        xReturn = pdFALSE;
+    }
 
-	return xReturn;
+    return xReturn;
 }
 
-XStatus emacps_send_message(xemacpsif_s *xemacpsif, NetworkBufferDescriptor_t *pxBuffer, int iReleaseAfterSend )
+XStatus emacps_send_message( xemacpsif_s * xemacpsif,
+                             NetworkBufferDescriptor_t * pxBuffer,
+                             int iReleaseAfterSend )
 {
-int head = xemacpsif->txHead;
-int iHasSent = 0;
-uint32_t ulBaseAddress = xemacpsif->emacps.Config.BaseAddress;
-TickType_t xBlockTimeTicks = pdMS_TO_TICKS( 5000u );
+    int head = xemacpsif->txHead;
+    int iHasSent = 0;
+    uint32_t ulBaseAddress = xemacpsif->emacps.Config.BaseAddress;
+    TickType_t xBlockTimeTicks = pdMS_TO_TICKS( 5000u );
 
-	/* This driver wants to own all network buffers which are to be transmitted. */
-	configASSERT( iReleaseAfterSend != pdFALSE );
+    /* This driver wants to own all network buffers which are to be transmitted. */
+    configASSERT( iReleaseAfterSend != pdFALSE );
 
-	/* Open a do {} while ( 0 ) loop to be able to call break. */
-	do
-	{
-	uint32_t ulFlags = 0;
+    /* Open a do {} while ( 0 ) loop to be able to call break. */
+    do
+    {
+        uint32_t ulFlags = 0;
 
-		if( xValidLength( pxBuffer->xDataLength ) != pdTRUE )
-		{
-			break;
-		}
+        if( xValidLength( pxBuffer->xDataLength ) != pdTRUE )
+        {
+            break;
+        }
 
-		if( xTXDescriptorSemaphore == NULL )
-		{
-			break;
-		}
+        if( xTXDescriptorSemaphore == NULL )
+        {
+            break;
+        }
 
-		if( xSemaphoreTake( xTXDescriptorSemaphore, xBlockTimeTicks ) != pdPASS )
-		{
-			FreeRTOS_printf( ( "emacps_send_message: Time-out waiting for TX buffer\n" ) );
-			break;
-		}
+        if( xSemaphoreTake( xTXDescriptorSemaphore, xBlockTimeTicks ) != pdPASS )
+        {
+            FreeRTOS_printf( ( "emacps_send_message: Time-out waiting for TX buffer\n" ) );
+            break;
+        }
 
-		/* Pass the pointer (and its ownership) directly to DMA. */
-		pxDMA_tx_buffers[ head ] = pxBuffer->pucEthernetBuffer;
-		if( ucIsCachedMemory( pxBuffer->pucEthernetBuffer ) != 0 )
-		{
-			Xil_DCacheFlushRange( ( unsigned )pxBuffer->pucEthernetBuffer, pxBuffer->xDataLength );
-		}
-		/* Buffer has been transferred, do not release it. */
-		iReleaseAfterSend = pdFALSE;
+        /* Pass the pointer (and its ownership) directly to DMA. */
+        pxDMA_tx_buffers[ head ] = pxBuffer->pucEthernetBuffer;
 
-		/* Packets will be sent one-by-one, so for each packet
-		the TXBUF_LAST bit will be set. */
-		ulFlags |= XEMACPS_TXBUF_LAST_MASK;
-		ulFlags |= ( pxBuffer->xDataLength & XEMACPS_TXBUF_LEN_MASK );
-		if( head == ( ipconfigNIC_N_TX_DESC - 1 ) )
-		{
-			ulFlags |= XEMACPS_TXBUF_WRAP_MASK;
-		}
+        if( ucIsCachedMemory( pxBuffer->pucEthernetBuffer ) != 0 )
+        {
+            Xil_DCacheFlushRange( ( unsigned ) pxBuffer->pucEthernetBuffer, pxBuffer->xDataLength );
+        }
 
-		/* Copy the address of the buffer and set the flags. */
-		xemacpsif->txSegments[ head ].address = ( uint32_t )pxDMA_tx_buffers[ head ];
-		xemacpsif->txSegments[ head ].flags = ulFlags;
+        /* Buffer has been transferred, do not release it. */
+        iReleaseAfterSend = pdFALSE;
 
-		iHasSent = pdTRUE;
-		if( ++head == ipconfigNIC_N_TX_DESC )
-		{
-			head = 0;
-		}
-		/* Update the TX-head index. These variable are declared volatile so they will be
-		accessed as little as possible.	*/
-		xemacpsif->txHead = head;
-	} while( pdFALSE );
+        /* Packets will be sent one-by-one, so for each packet
+         * the TXBUF_LAST bit will be set. */
+        ulFlags |= XEMACPS_TXBUF_LAST_MASK;
+        ulFlags |= ( pxBuffer->xDataLength & XEMACPS_TXBUF_LEN_MASK );
 
-	if( iReleaseAfterSend != pdFALSE )
-	{
-		vReleaseNetworkBufferAndDescriptor( pxBuffer );
-		pxBuffer = NULL;
-	}
+        if( head == ( ipconfigNIC_N_TX_DESC - 1 ) )
+        {
+            ulFlags |= XEMACPS_TXBUF_WRAP_MASK;
+        }
 
-	/* Data Synchronization Barrier */
-	dsb();
+        /* Copy the address of the buffer and set the flags. */
+        xemacpsif->txSegments[ head ].address = ( uint32_t ) pxDMA_tx_buffers[ head ];
+        xemacpsif->txSegments[ head ].flags = ulFlags;
 
-	if( iHasSent != pdFALSE )
-	{
-		/* Make STARTTX high */
-		uint32_t ulValue = XEmacPs_ReadReg( ulBaseAddress, XEMACPS_NWCTRL_OFFSET);
-		/* Start transmit */
-		xemacpsif->txBusy = pdTRUE;
-		XEmacPs_WriteReg( ulBaseAddress, XEMACPS_NWCTRL_OFFSET, ( ulValue | XEMACPS_NWCTRL_STARTTX_MASK ) );
-		/* Read back the register to make sure the data is flushed. */
-		( void ) XEmacPs_ReadReg( ulBaseAddress, XEMACPS_NWCTRL_OFFSET );
-	}
-	dsb();
+        iHasSent = pdTRUE;
 
-	return 0;
+        if( ++head == ipconfigNIC_N_TX_DESC )
+        {
+            head = 0;
+        }
+
+        /* Update the TX-head index. These variable are declared volatile so they will be
+         * accessed as little as possible.	*/
+        xemacpsif->txHead = head;
+    } while( pdFALSE );
+
+    if( iReleaseAfterSend != pdFALSE )
+    {
+        vReleaseNetworkBufferAndDescriptor( pxBuffer );
+        pxBuffer = NULL;
+    }
+
+    /* Data Synchronization Barrier */
+    dsb();
+
+    if( iHasSent != pdFALSE )
+    {
+        /* Make STARTTX high */
+        uint32_t ulValue = XEmacPs_ReadReg( ulBaseAddress, XEMACPS_NWCTRL_OFFSET );
+        /* Start transmit */
+        xemacpsif->txBusy = pdTRUE;
+        XEmacPs_WriteReg( ulBaseAddress, XEMACPS_NWCTRL_OFFSET, ( ulValue | XEMACPS_NWCTRL_STARTTX_MASK ) );
+        /* Read back the register to make sure the data is flushed. */
+        ( void ) XEmacPs_ReadReg( ulBaseAddress, XEMACPS_NWCTRL_OFFSET );
+    }
+
+    dsb();
+
+    return 0;
 }
 
-void emacps_recv_handler(void *arg)
+void emacps_recv_handler( void * arg )
 {
-	xemacpsif_s *xemacpsif;
-	BaseType_t xHigherPriorityTaskWoken = pdFALSE;
+    xemacpsif_s * xemacpsif;
+    BaseType_t xHigherPriorityTaskWoken = pdFALSE;
 
-	xemacpsif = (xemacpsif_s *)(arg);
-	xemacpsif->isr_events |= EMAC_IF_RX_EVENT;
+    xemacpsif = ( xemacpsif_s * ) ( arg );
+    xemacpsif->isr_events |= EMAC_IF_RX_EVENT;
 
-	/* The driver has already cleared the FRAMERX, BUFFNA and error bits
-	in the XEMACPS_RXSR register,
-	But it forgets to do a read-back. Do so now. */
-	( void ) XEmacPs_ReadReg(xemacpsif->emacps.Config.BaseAddress, XEMACPS_RXSR_OFFSET);
+    /* The driver has already cleared the FRAMERX, BUFFNA and error bits
+     * in the XEMACPS_RXSR register,
+     * But it forgets to do a read-back. Do so now. */
+    ( void ) XEmacPs_ReadReg( xemacpsif->emacps.Config.BaseAddress, XEMACPS_RXSR_OFFSET );
 
-	if( xEMACTaskHandle != NULL )
-	{
-		vTaskNotifyGiveFromISR( xEMACTaskHandle, &xHigherPriorityTaskWoken );
-	}
+    if( xEMACTaskHandle != NULL )
+    {
+        vTaskNotifyGiveFromISR( xEMACTaskHandle, &xHigherPriorityTaskWoken );
+    }
 
-	portYIELD_FROM_ISR( xHigherPriorityTaskWoken );
+    portYIELD_FROM_ISR( xHigherPriorityTaskWoken );
 }
 
-static void prvPassEthMessages( NetworkBufferDescriptor_t *pxDescriptor )
+static void prvPassEthMessages( NetworkBufferDescriptor_t * pxDescriptor )
 {
-IPStackEvent_t xRxEvent;
+    IPStackEvent_t xRxEvent;
 
-	xRxEvent.eEventType = eNetworkRxEvent;
-	xRxEvent.pvData = ( void * ) pxDescriptor;
+    xRxEvent.eEventType = eNetworkRxEvent;
+    xRxEvent.pvData = ( void * ) pxDescriptor;
 
-	if( xSendEventStructToIPTask( &xRxEvent, ( TickType_t ) 1000 ) != pdPASS )
-	{
-		/* The buffer could not be sent to the stack so	must be released again.
-		This is a deferred handler taskr, not a real interrupt, so it is ok to
-		use the task level function here. */
-		#if( ipconfigUSE_LINKED_RX_MESSAGES != 0 )
-		{
-			do
-			{
-				NetworkBufferDescriptor_t *pxNext = pxDescriptor->pxNextBuffer;
-				vReleaseNetworkBufferAndDescriptor( pxDescriptor );
-				pxDescriptor = pxNext;
-			} while( pxDescriptor != NULL );
-		}
-		#else
-		{
-			vReleaseNetworkBufferAndDescriptor( pxDescriptor );
-		}
-		#endif	/* ipconfigUSE_LINKED_RX_MESSAGES */
-		iptraceETHERNET_RX_EVENT_LOST();
-		FreeRTOS_printf( ( "prvPassEthMessages: Can not queue return packet!\n" ) );
-	}
+    if( xSendEventStructToIPTask( &xRxEvent, ( TickType_t ) 1000 ) != pdPASS )
+    {
+        /* The buffer could not be sent to the stack so	must be released again.
+         * This is a deferred handler taskr, not a real interrupt, so it is ok to
+         * use the task level function here. */
+        #if ( ipconfigUSE_LINKED_RX_MESSAGES != 0 )
+            {
+                do
+                {
+                    NetworkBufferDescriptor_t * pxNext = pxDescriptor->pxNextBuffer;
+                    vReleaseNetworkBufferAndDescriptor( pxDescriptor );
+                    pxDescriptor = pxNext;
+                } while( pxDescriptor != NULL );
+            }
+        #else
+            {
+                vReleaseNetworkBufferAndDescriptor( pxDescriptor );
+            }
+        #endif /* ipconfigUSE_LINKED_RX_MESSAGES */
+        iptraceETHERNET_RX_EVENT_LOST();
+        FreeRTOS_printf( ( "prvPassEthMessages: Can not queue return packet!\n" ) );
+    }
 }
 
-int emacps_check_rx( xemacpsif_s *xemacpsif )
+int emacps_check_rx( xemacpsif_s * xemacpsif )
 {
-NetworkBufferDescriptor_t *pxBuffer, *pxNewBuffer;
-int rx_bytes;
-volatile int msgCount = 0;
-int head = xemacpsif->rxHead;
-#if( ipconfigUSE_LINKED_RX_MESSAGES != 0 )
-	NetworkBufferDescriptor_t *pxFirstDescriptor = NULL;
-	NetworkBufferDescriptor_t *pxLastDescriptor = NULL;
-#endif	/* ipconfigUSE_LINKED_RX_MESSAGES */
+    NetworkBufferDescriptor_t * pxBuffer, * pxNewBuffer;
+    int rx_bytes;
+    volatile int msgCount = 0;
+    int head = xemacpsif->rxHead;
 
-	/* There seems to be an issue (SI# 692601), see comments below. */
-	resetrx_on_no_rxdata(xemacpsif);
+    #if ( ipconfigUSE_LINKED_RX_MESSAGES != 0 )
+        NetworkBufferDescriptor_t * pxFirstDescriptor = NULL;
+        NetworkBufferDescriptor_t * pxLastDescriptor = NULL;
+    #endif /* ipconfigUSE_LINKED_RX_MESSAGES */
 
-	/* This FreeRTOS+TCP driver shall be compiled with the option
-	"ipconfigUSE_LINKED_RX_MESSAGES" enabled.  It allows the driver to send a
-	chain of RX messages within one message to the IP-task.	*/
-	for( ;; )
-	{
-		if( ( ( xemacpsif->rxSegments[ head ].address & XEMACPS_RXBUF_NEW_MASK ) == 0 ) ||
-			( pxDMA_rx_buffers[ head ] == NULL ) )
-		{
-			break;
-		}
+    /* There seems to be an issue (SI# 692601), see comments below. */
+    resetrx_on_no_rxdata( xemacpsif );
 
-		pxNewBuffer = pxGetNetworkBufferWithDescriptor( dmaRX_TX_BUFFER_SIZE, ( TickType_t ) 0 );
-		if( pxNewBuffer == NULL )
-		{
-			/* A packet has been received, but there is no replacement for this Network Buffer.
-			The packet will be dropped, and it Network Buffer will stay in place. */
-			FreeRTOS_printf( ("emacps_check_rx: unable to allocate a Network Buffer\n" ) );
-			pxNewBuffer = ( NetworkBufferDescriptor_t * )pxDMA_rx_buffers[ head ];
-		}
-		else
-		{
-			pxBuffer = ( NetworkBufferDescriptor_t * )pxDMA_rx_buffers[ head ];
+    /* This FreeRTOS+TCP driver shall be compiled with the option
+     * "ipconfigUSE_LINKED_RX_MESSAGES" enabled.  It allows the driver to send a
+     * chain of RX messages within one message to the IP-task.	*/
+    for( ; ; )
+    {
+        if( ( ( xemacpsif->rxSegments[ head ].address & XEMACPS_RXBUF_NEW_MASK ) == 0 ) ||
+            ( pxDMA_rx_buffers[ head ] == NULL ) )
+        {
+            break;
+        }
 
-			/* Just avoiding to use or refer to the same buffer again */
-			pxDMA_rx_buffers[ head ] = pxNewBuffer;
+        pxNewBuffer = pxGetNetworkBufferWithDescriptor( dmaRX_TX_BUFFER_SIZE, ( TickType_t ) 0 );
 
-			/*
-			 * Adjust the buffer size to the actual number of bytes received.
-			 */
-			rx_bytes = xemacpsif->rxSegments[ head ].flags & XEMACPS_RXBUF_LEN_MASK;
+        if( pxNewBuffer == NULL )
+        {
+            /* A packet has been received, but there is no replacement for this Network Buffer.
+             * The packet will be dropped, and it Network Buffer will stay in place. */
+            FreeRTOS_printf( ( "emacps_check_rx: unable to allocate a Network Buffer\n" ) );
+            pxNewBuffer = ( NetworkBufferDescriptor_t * ) pxDMA_rx_buffers[ head ];
+        }
+        else
+        {
+            pxBuffer = ( NetworkBufferDescriptor_t * ) pxDMA_rx_buffers[ head ];
 
-			pxBuffer->xDataLength = rx_bytes;
+            /* Just avoiding to use or refer to the same buffer again */
+            pxDMA_rx_buffers[ head ] = pxNewBuffer;
 
-			if( ucIsCachedMemory( pxBuffer->pucEthernetBuffer ) != 0 )
-			{
-				Xil_DCacheInvalidateRange( ( ( uint32_t )pxBuffer->pucEthernetBuffer ) - ipconfigPACKET_FILLER_SIZE, (unsigned)rx_bytes );
-			}
+            /*
+             * Adjust the buffer size to the actual number of bytes received.
+             */
+            rx_bytes = xemacpsif->rxSegments[ head ].flags & XEMACPS_RXBUF_LEN_MASK;
 
-			/* store it in the receive queue, where it'll be processed by a
-			different handler. */
-			iptraceNETWORK_INTERFACE_RECEIVE();
-			#if( ipconfigUSE_LINKED_RX_MESSAGES != 0 )
-			{
-				pxBuffer->pxNextBuffer = NULL;
+            pxBuffer->xDataLength = rx_bytes;
 
-				if( pxFirstDescriptor == NULL )
-				{
-					// Becomes the first message
-					pxFirstDescriptor = pxBuffer;
-				}
-				else if( pxLastDescriptor != NULL )
-				{
-					// Add to the tail
-					pxLastDescriptor->pxNextBuffer = pxBuffer;
-				}
+            if( ucIsCachedMemory( pxBuffer->pucEthernetBuffer ) != 0 )
+            {
+                Xil_DCacheInvalidateRange( ( ( uint32_t ) pxBuffer->pucEthernetBuffer ) - ipconfigPACKET_FILLER_SIZE, ( unsigned ) rx_bytes );
+            }
 
-				pxLastDescriptor = pxBuffer;
-			}
-			#else
-			{
-				prvPassEthMessages( pxBuffer );
-			}
-			#endif	/* ipconfigUSE_LINKED_RX_MESSAGES */
+            /* store it in the receive queue, where it'll be processed by a
+             * different handler. */
+            iptraceNETWORK_INTERFACE_RECEIVE();
+            #if ( ipconfigUSE_LINKED_RX_MESSAGES != 0 )
+                {
+                    pxBuffer->pxNextBuffer = NULL;
 
-			msgCount++;
-		}
-		{
-			if( ucIsCachedMemory( pxNewBuffer->pucEthernetBuffer ) != 0 )
-			{
-				Xil_DCacheInvalidateRange( ( ( uint32_t ) pxNewBuffer->pucEthernetBuffer ) - ipconfigPACKET_FILLER_SIZE, ( uint32_t ) dmaRX_TX_BUFFER_SIZE );
-			}
-			{
-				uint32_t addr = ( ( uint32_t )pxNewBuffer->pucEthernetBuffer ) & XEMACPS_RXBUF_ADD_MASK;
-				if( head == ( ipconfigNIC_N_RX_DESC - 1 ) )
-				{
-					addr |= XEMACPS_RXBUF_WRAP_MASK;
-				}
-				/* Clearing 'XEMACPS_RXBUF_NEW_MASK'       0x00000001 *< Used bit.. */
-				xemacpsif->rxSegments[ head ].flags = 0;
-				xemacpsif->rxSegments[ head ].address = addr;
-				/* Make sure that the value has reached the peripheral by reading it back. */
-				( void ) xemacpsif->rxSegments[ head ].address;
-			}
-		}
+                    if( pxFirstDescriptor == NULL )
+                    {
+                        /* Becomes the first message */
+                        pxFirstDescriptor = pxBuffer;
+                    }
+                    else if( pxLastDescriptor != NULL )
+                    {
+                        /* Add to the tail */
+                        pxLastDescriptor->pxNextBuffer = pxBuffer;
+                    }
 
-		if( ++head == ipconfigNIC_N_RX_DESC )
-		{
-			head = 0;
-		}
-		xemacpsif->rxHead = head;
-	}
+                    pxLastDescriptor = pxBuffer;
+                }
+            #else /* if ( ipconfigUSE_LINKED_RX_MESSAGES != 0 ) */
+                {
+                    prvPassEthMessages( pxBuffer );
+                }
+            #endif /* ipconfigUSE_LINKED_RX_MESSAGES */
 
-	#if( ipconfigUSE_LINKED_RX_MESSAGES != 0 )
-	{
-		if( pxFirstDescriptor != NULL )
-		{
-			prvPassEthMessages( pxFirstDescriptor );
-		}
-	}
-	#endif	/* ipconfigUSE_LINKED_RX_MESSAGES */
+            msgCount++;
+        }
 
-	return msgCount;
+        {
+            if( ucIsCachedMemory( pxNewBuffer->pucEthernetBuffer ) != 0 )
+            {
+                Xil_DCacheInvalidateRange( ( ( uint32_t ) pxNewBuffer->pucEthernetBuffer ) - ipconfigPACKET_FILLER_SIZE, ( uint32_t ) dmaRX_TX_BUFFER_SIZE );
+            }
+
+            {
+                uint32_t addr = ( ( uint32_t ) pxNewBuffer->pucEthernetBuffer ) & XEMACPS_RXBUF_ADD_MASK;
+
+                if( head == ( ipconfigNIC_N_RX_DESC - 1 ) )
+                {
+                    addr |= XEMACPS_RXBUF_WRAP_MASK;
+                }
+
+                /* Clearing 'XEMACPS_RXBUF_NEW_MASK'       0x00000001 *< Used bit.. */
+                xemacpsif->rxSegments[ head ].flags = 0;
+                xemacpsif->rxSegments[ head ].address = addr;
+                /* Make sure that the value has reached the peripheral by reading it back. */
+                ( void ) xemacpsif->rxSegments[ head ].address;
+            }
+        }
+
+        if( ++head == ipconfigNIC_N_RX_DESC )
+        {
+            head = 0;
+        }
+
+        xemacpsif->rxHead = head;
+    }
+
+    #if ( ipconfigUSE_LINKED_RX_MESSAGES != 0 )
+        {
+            if( pxFirstDescriptor != NULL )
+            {
+                prvPassEthMessages( pxFirstDescriptor );
+            }
+        }
+    #endif /* ipconfigUSE_LINKED_RX_MESSAGES */
+
+    return msgCount;
 }
 
-void clean_dma_txdescs(xemacpsif_s *xemacpsif)
+void clean_dma_txdescs( xemacpsif_s * xemacpsif )
 {
-int index;
-unsigned char *ucTxBuffer;
+    int index;
+    unsigned char * ucTxBuffer;
 
-	/* Clear all TX descriptors and assign uncached memory to each descriptor.
-	"tx_space" points to the first available TX buffer. */
-	ucTxBuffer = xemacpsif->tx_space;
+    /* Clear all TX descriptors and assign uncached memory to each descriptor.
+     * "tx_space" points to the first available TX buffer. */
+    ucTxBuffer = xemacpsif->tx_space;
 
-	for( index = 0; index < ipconfigNIC_N_TX_DESC; index++ )
-	{
-		xemacpsif->txSegments[ index ].address = ( uint32_t )ucTxBuffer;
-		xemacpsif->txSegments[ index ].flags = XEMACPS_TXBUF_USED_MASK;
-		pxDMA_tx_buffers[ index ] = ( unsigned char * )NULL;
-		ucTxBuffer += xemacpsif->uTxUnitSize;
-	}
-	xemacpsif->txSegments[ ipconfigNIC_N_TX_DESC - 1 ].flags =
-		XEMACPS_TXBUF_USED_MASK | XEMACPS_TXBUF_WRAP_MASK;
+    for( index = 0; index < ipconfigNIC_N_TX_DESC; index++ )
+    {
+        xemacpsif->txSegments[ index ].address = ( uint32_t ) ucTxBuffer;
+        xemacpsif->txSegments[ index ].flags = XEMACPS_TXBUF_USED_MASK;
+        pxDMA_tx_buffers[ index ] = ( unsigned char * ) NULL;
+        ucTxBuffer += xemacpsif->uTxUnitSize;
+    }
+
+    xemacpsif->txSegments[ ipconfigNIC_N_TX_DESC - 1 ].flags =
+        XEMACPS_TXBUF_USED_MASK | XEMACPS_TXBUF_WRAP_MASK;
 }
 
-XStatus init_dma(xemacpsif_s *xemacpsif)
+XStatus init_dma( xemacpsif_s * xemacpsif )
 {
-	NetworkBufferDescriptor_t *pxBuffer;
+    NetworkBufferDescriptor_t * pxBuffer;
 
-	int iIndex;
-	UBaseType_t xRxSize;
-	UBaseType_t xTxSize;
-	struct xtopology_t *xtopologyp = &xXTopology;
+    int iIndex;
+    UBaseType_t xRxSize;
+    UBaseType_t xTxSize;
+    struct xtopology_t * xtopologyp = &xXTopology;
 
-	xRxSize = ipconfigNIC_N_RX_DESC * sizeof( xemacpsif->rxSegments[ 0 ] );
+    xRxSize = ipconfigNIC_N_RX_DESC * sizeof( xemacpsif->rxSegments[ 0 ] );
 
-	xTxSize = ipconfigNIC_N_TX_DESC * sizeof( xemacpsif->txSegments[ 0 ] );
+    xTxSize = ipconfigNIC_N_TX_DESC * sizeof( xemacpsif->txSegments[ 0 ] );
 
-	xemacpsif->uTxUnitSize = dmaRX_TX_BUFFER_SIZE;
-	/*
-	 * We allocate 65536 bytes for RX BDs which can accommodate a
-	 * maximum of 8192 BDs which is much more than any application
-	 * will ever need.
-	 */
-	xemacpsif->rxSegments = ( struct xBD_TYPE * )( pucGetUncachedMemory ( xRxSize )  );
-	xemacpsif->txSegments = ( struct xBD_TYPE * )( pucGetUncachedMemory ( xTxSize ) );
-	xemacpsif->tx_space   = ( unsigned char *   )( pucGetUncachedMemory ( ipconfigNIC_N_TX_DESC * xemacpsif->uTxUnitSize ) );
+    xemacpsif->uTxUnitSize = dmaRX_TX_BUFFER_SIZE;
 
-	/* These variables will be used in XEmacPs_Start (see src/xemacps.c). */
-	xemacpsif->emacps.RxBdRing.BaseBdAddr = ( uint32_t ) xemacpsif->rxSegments;
-	xemacpsif->emacps.TxBdRing.BaseBdAddr = ( uint32_t ) xemacpsif->txSegments;
+    /*
+     * We allocate 65536 bytes for RX BDs which can accommodate a
+     * maximum of 8192 BDs which is much more than any application
+     * will ever need.
+     */
+    xemacpsif->rxSegments = ( struct xBD_TYPE * ) ( pucGetUncachedMemory( xRxSize ) );
+    xemacpsif->txSegments = ( struct xBD_TYPE * ) ( pucGetUncachedMemory( xTxSize ) );
+    xemacpsif->tx_space = ( unsigned char * ) ( pucGetUncachedMemory( ipconfigNIC_N_TX_DESC * xemacpsif->uTxUnitSize ) );
 
-	if( xTXDescriptorSemaphore == NULL )
-	{
-		xTXDescriptorSemaphore = xSemaphoreCreateCounting( ( UBaseType_t ) ipconfigNIC_N_TX_DESC, ( UBaseType_t ) ipconfigNIC_N_TX_DESC );
-		configASSERT( xTXDescriptorSemaphore );
-	}
-	/*
-	 * Allocate RX descriptors, 1 RxBD at a time.
-	 */
-	for( iIndex = 0; iIndex < ipconfigNIC_N_RX_DESC; iIndex++ )
-	{
-		pxBuffer = pxDMA_rx_buffers[ iIndex ];
-		if( pxBuffer == NULL )
-		{
-			pxBuffer = pxGetNetworkBufferWithDescriptor( dmaRX_TX_BUFFER_SIZE, ( TickType_t ) 0 );
-			if( pxBuffer == NULL )
-			{
-				FreeRTOS_printf( ("Unable to allocate a network buffer in recv_handler\n" ) );
-				return -1;
-			}
-		}
+    /* These variables will be used in XEmacPs_Start (see src/xemacps.c). */
+    xemacpsif->emacps.RxBdRing.BaseBdAddr = ( uint32_t ) xemacpsif->rxSegments;
+    xemacpsif->emacps.TxBdRing.BaseBdAddr = ( uint32_t ) xemacpsif->txSegments;
 
-		xemacpsif->rxSegments[ iIndex ].flags = 0;
-		xemacpsif->rxSegments[ iIndex ].address = ( ( uint32_t )pxBuffer->pucEthernetBuffer ) & XEMACPS_RXBUF_ADD_MASK;
+    if( xTXDescriptorSemaphore == NULL )
+    {
+        xTXDescriptorSemaphore = xSemaphoreCreateCounting( ( UBaseType_t ) ipconfigNIC_N_TX_DESC, ( UBaseType_t ) ipconfigNIC_N_TX_DESC );
+        configASSERT( xTXDescriptorSemaphore );
+    }
 
-		pxDMA_rx_buffers[ iIndex ] = pxBuffer;
-		/* Make sure this memory is not in cache for now. */
-		if( ucIsCachedMemory( pxBuffer->pucEthernetBuffer ) != 0 )
-		{
-			Xil_DCacheInvalidateRange( ( ( uint32_t )pxBuffer->pucEthernetBuffer ) - ipconfigPACKET_FILLER_SIZE,
-				(unsigned)dmaRX_TX_BUFFER_SIZE );
-		}
-	}
+    /*
+     * Allocate RX descriptors, 1 RxBD at a time.
+     */
+    for( iIndex = 0; iIndex < ipconfigNIC_N_RX_DESC; iIndex++ )
+    {
+        pxBuffer = pxDMA_rx_buffers[ iIndex ];
 
-	xemacpsif->rxSegments[ ipconfigNIC_N_RX_DESC - 1 ].address |= XEMACPS_RXBUF_WRAP_MASK;
+        if( pxBuffer == NULL )
+        {
+            pxBuffer = pxGetNetworkBufferWithDescriptor( dmaRX_TX_BUFFER_SIZE, ( TickType_t ) 0 );
 
-	memset( xemacpsif->tx_space, '\0', ipconfigNIC_N_TX_DESC * xemacpsif->uTxUnitSize );
+            if( pxBuffer == NULL )
+            {
+                FreeRTOS_printf( ( "Unable to allocate a network buffer in recv_handler\n" ) );
+                return -1;
+            }
+        }
 
-	clean_dma_txdescs( xemacpsif );
+        xemacpsif->rxSegments[ iIndex ].flags = 0;
+        xemacpsif->rxSegments[ iIndex ].address = ( ( uint32_t ) pxBuffer->pucEthernetBuffer ) & XEMACPS_RXBUF_ADD_MASK;
 
-	{
-		uint32_t value;
-		value = XEmacPs_ReadReg( xemacpsif->emacps.Config.BaseAddress, XEMACPS_DMACR_OFFSET );
+        pxDMA_rx_buffers[ iIndex ] = pxBuffer;
 
-		// 1xxxx: Attempt to use INCR16 AHB bursts
-		value = ( value & ~( XEMACPS_DMACR_BLENGTH_MASK ) ) | XEMACPS_DMACR_INCR16_AHB_BURST;
-#if( ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM != 0 )
-		value |= XEMACPS_DMACR_TCPCKSUM_MASK;
-#else
-#warning Are you sure the EMAC should not calculate outgoing checksums?
-		value &= ~XEMACPS_DMACR_TCPCKSUM_MASK;
-#endif
-		XEmacPs_WriteReg( xemacpsif->emacps.Config.BaseAddress, XEMACPS_DMACR_OFFSET, value );
-	}
-	{
-		uint32_t value;
-		value = XEmacPs_ReadReg( xemacpsif->emacps.Config.BaseAddress, XEMACPS_NWCFG_OFFSET );
+        /* Make sure this memory is not in cache for now. */
+        if( ucIsCachedMemory( pxBuffer->pucEthernetBuffer ) != 0 )
+        {
+            Xil_DCacheInvalidateRange( ( ( uint32_t ) pxBuffer->pucEthernetBuffer ) - ipconfigPACKET_FILLER_SIZE,
+                                       ( unsigned ) dmaRX_TX_BUFFER_SIZE );
+        }
+    }
 
-		/* Network buffers are 32-bit aligned + 2 bytes (because ipconfigPACKET_FILLER_SIZE = 2 ).
-		Now tell the EMAC that received messages should be stored at "address + 2". */
-		value = ( value & ~XEMACPS_NWCFG_RXOFFS_MASK ) | 0x8000;
+    xemacpsif->rxSegments[ ipconfigNIC_N_RX_DESC - 1 ].address |= XEMACPS_RXBUF_WRAP_MASK;
 
-#if( ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM != 0 )
-		value |= XEMACPS_NWCFG_RXCHKSUMEN_MASK;
-#else
-#warning Are you sure the EMAC should not calculate incoming checksums?
-		value &= ~XEMACPS_NWCFG_RXCHKSUMEN_MASK;
-#endif
-		XEmacPs_WriteReg( xemacpsif->emacps.Config.BaseAddress, XEMACPS_NWCFG_OFFSET, value );
-	}
+    memset( xemacpsif->tx_space, '\0', ipconfigNIC_N_TX_DESC * xemacpsif->uTxUnitSize );
 
-	/*
-	 * Connect the device driver handler that will be called when an
-	 * interrupt for the device occurs, the handler defined above performs
-	 * the specific interrupt processing for the device.
-	 */
-	XScuGic_RegisterHandler(INTC_BASE_ADDR, xtopologyp->scugic_emac_intr,
-		(Xil_ExceptionHandler)XEmacPs_IntrHandler,
-		(void *)&xemacpsif->emacps);
-	/*
-	 * Enable the interrupt for emacps.
-	 */
-	EmacEnableIntr( );
+    clean_dma_txdescs( xemacpsif );
 
-	return 0;
+    {
+        uint32_t value;
+        value = XEmacPs_ReadReg( xemacpsif->emacps.Config.BaseAddress, XEMACPS_DMACR_OFFSET );
+
+        /* 1xxxx: Attempt to use INCR16 AHB bursts */
+        value = ( value & ~( XEMACPS_DMACR_BLENGTH_MASK ) ) | XEMACPS_DMACR_INCR16_AHB_BURST;
+        #if ( ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM != 0 )
+            value |= XEMACPS_DMACR_TCPCKSUM_MASK;
+        #else
+        #warning Are you sure the EMAC should not calculate outgoing checksums?
+            value &= ~XEMACPS_DMACR_TCPCKSUM_MASK;
+        #endif
+        XEmacPs_WriteReg( xemacpsif->emacps.Config.BaseAddress, XEMACPS_DMACR_OFFSET, value );
+    }
+    {
+        uint32_t value;
+        value = XEmacPs_ReadReg( xemacpsif->emacps.Config.BaseAddress, XEMACPS_NWCFG_OFFSET );
+
+        /* Network buffers are 32-bit aligned + 2 bytes (because ipconfigPACKET_FILLER_SIZE = 2 ).
+         * Now tell the EMAC that received messages should be stored at "address + 2". */
+        value = ( value & ~XEMACPS_NWCFG_RXOFFS_MASK ) | 0x8000;
+
+        #if ( ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM != 0 )
+            value |= XEMACPS_NWCFG_RXCHKSUMEN_MASK;
+        #else
+        #warning Are you sure the EMAC should not calculate incoming checksums?
+            value &= ~XEMACPS_NWCFG_RXCHKSUMEN_MASK;
+        #endif
+        XEmacPs_WriteReg( xemacpsif->emacps.Config.BaseAddress, XEMACPS_NWCFG_OFFSET, value );
+    }
+
+    /*
+     * Connect the device driver handler that will be called when an
+     * interrupt for the device occurs, the handler defined above performs
+     * the specific interrupt processing for the device.
+     */
+    XScuGic_RegisterHandler( INTC_BASE_ADDR, xtopologyp->scugic_emac_intr,
+                             ( Xil_ExceptionHandler ) XEmacPs_IntrHandler,
+                             ( void * ) &xemacpsif->emacps );
+
+    /*
+     * Enable the interrupt for emacps.
+     */
+    EmacEnableIntr();
+
+    return 0;
 }
 
 /*
@@ -606,33 +634,34 @@ XStatus init_dma(xemacpsif_s *xemacpsif)
  *
  */
 
-void resetrx_on_no_rxdata(xemacpsif_s *xemacpsif)
+void resetrx_on_no_rxdata( xemacpsif_s * xemacpsif )
 {
-	unsigned long regctrl;
-	unsigned long tempcntr;
+    unsigned long regctrl;
+    unsigned long tempcntr;
 
-	tempcntr = XEmacPs_ReadReg( xemacpsif->emacps.Config.BaseAddress, XEMACPS_RXCNT_OFFSET );
-	if ( ( tempcntr == 0 ) && ( xemacpsif->last_rx_frms_cntr == 0 ) )
-	{
-		regctrl = XEmacPs_ReadReg(xemacpsif->emacps.Config.BaseAddress,
-				XEMACPS_NWCTRL_OFFSET);
-		regctrl &= (~XEMACPS_NWCTRL_RXEN_MASK);
-		XEmacPs_WriteReg(xemacpsif->emacps.Config.BaseAddress,
-				XEMACPS_NWCTRL_OFFSET, regctrl);
-		regctrl = XEmacPs_ReadReg(xemacpsif->emacps.Config.BaseAddress, XEMACPS_NWCTRL_OFFSET);
-		regctrl |= (XEMACPS_NWCTRL_RXEN_MASK);
-		XEmacPs_WriteReg(xemacpsif->emacps.Config.BaseAddress, XEMACPS_NWCTRL_OFFSET, regctrl);
-	}
-	xemacpsif->last_rx_frms_cntr = tempcntr;
+    tempcntr = XEmacPs_ReadReg( xemacpsif->emacps.Config.BaseAddress, XEMACPS_RXCNT_OFFSET );
+
+    if( ( tempcntr == 0 ) && ( xemacpsif->last_rx_frms_cntr == 0 ) )
+    {
+        regctrl = XEmacPs_ReadReg( xemacpsif->emacps.Config.BaseAddress,
+                                   XEMACPS_NWCTRL_OFFSET );
+        regctrl &= ( ~XEMACPS_NWCTRL_RXEN_MASK );
+        XEmacPs_WriteReg( xemacpsif->emacps.Config.BaseAddress,
+                          XEMACPS_NWCTRL_OFFSET, regctrl );
+        regctrl = XEmacPs_ReadReg( xemacpsif->emacps.Config.BaseAddress, XEMACPS_NWCTRL_OFFSET );
+        regctrl |= ( XEMACPS_NWCTRL_RXEN_MASK );
+        XEmacPs_WriteReg( xemacpsif->emacps.Config.BaseAddress, XEMACPS_NWCTRL_OFFSET, regctrl );
+    }
+
+    xemacpsif->last_rx_frms_cntr = tempcntr;
 }
 
-void EmacDisableIntr(void)
+void EmacDisableIntr( void )
 {
-	XScuGic_DisableIntr(INTC_DIST_BASE_ADDR, xXTopology.scugic_emac_intr);
+    XScuGic_DisableIntr( INTC_DIST_BASE_ADDR, xXTopology.scugic_emac_intr );
 }
 
-void EmacEnableIntr(void)
+void EmacEnableIntr( void )
 {
-	XScuGic_EnableIntr(INTC_DIST_BASE_ADDR, xXTopology.scugic_emac_intr);
+    XScuGic_EnableIntr( INTC_DIST_BASE_ADDR, xXTopology.scugic_emac_intr );
 }
-

--- a/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/portable/NetworkInterface/Zynq/x_emacpsif_hw.c
+++ b/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/portable/NetworkInterface/Zynq/x_emacpsif_hw.c
@@ -42,196 +42,217 @@ extern TaskHandle_t xEMACTaskHandle;
  *** to run it on a PEEP board
  ***/
 
-void setup_isr( xemacpsif_s *xemacpsif )
+void setup_isr( xemacpsif_s * xemacpsif )
 {
-	/*
-	 * Setup callbacks
-	 */
-	XEmacPs_SetHandler(&xemacpsif->emacps, XEMACPS_HANDLER_DMASEND,
-		(void *) emacps_send_handler,
-		(void *) xemacpsif);
+    /*
+     * Setup callbacks
+     */
+    XEmacPs_SetHandler( &xemacpsif->emacps, XEMACPS_HANDLER_DMASEND,
+                        ( void * ) emacps_send_handler,
+                        ( void * ) xemacpsif );
 
-	XEmacPs_SetHandler(&xemacpsif->emacps, XEMACPS_HANDLER_DMARECV,
-		(void *) emacps_recv_handler,
-		(void *) xemacpsif);
+    XEmacPs_SetHandler( &xemacpsif->emacps, XEMACPS_HANDLER_DMARECV,
+                        ( void * ) emacps_recv_handler,
+                        ( void * ) xemacpsif );
 
-	XEmacPs_SetHandler(&xemacpsif->emacps, XEMACPS_HANDLER_ERROR,
-		(void *) emacps_error_handler,
-		(void *) xemacpsif);
+    XEmacPs_SetHandler( &xemacpsif->emacps, XEMACPS_HANDLER_ERROR,
+                        ( void * ) emacps_error_handler,
+                        ( void * ) xemacpsif );
 }
 
-void start_emacps (xemacpsif_s *xemacps)
+void start_emacps( xemacpsif_s * xemacps )
 {
-	/* start the temac */
-	XEmacPs_Start(&xemacps->emacps);
+    /* start the temac */
+    XEmacPs_Start( &xemacps->emacps );
 }
 
 extern struct xtopology_t xXTopology;
 
 volatile int error_msg_count = 0;
-volatile const char *last_err_msg = "";
+volatile const char * last_err_msg = "";
 
-struct xERROR_MSG {
-	void *arg;
-	u8 Direction;
-	u32 ErrorWord;
+struct xERROR_MSG
+{
+    void * arg;
+    u8 Direction;
+    u32 ErrorWord;
 };
 
 static struct xERROR_MSG xErrorList[ 8 ];
 static BaseType_t xErrorHead, xErrorTail;
 
-void emacps_error_handler(void *arg, u8 Direction, u32 ErrorWord)
+void emacps_error_handler( void * arg,
+                           u8 Direction,
+                           u32 ErrorWord )
 {
-	BaseType_t xHigherPriorityTaskWoken = pdFALSE;
-	xemacpsif_s *xemacpsif;
-	BaseType_t xNextHead = xErrorHead;
+    BaseType_t xHigherPriorityTaskWoken = pdFALSE;
+    xemacpsif_s * xemacpsif;
+    BaseType_t xNextHead = xErrorHead;
 
-	xemacpsif = (xemacpsif_s *)(arg);
+    xemacpsif = ( xemacpsif_s * ) ( arg );
 
-	if( ( Direction != XEMACPS_SEND ) || (ErrorWord != XEMACPS_TXSR_USEDREAD_MASK ) )
-	{
-		if( ++xNextHead == ( sizeof( xErrorList ) / sizeof( xErrorList[ 0 ] ) ) )
-			xNextHead = 0;
-		if( xNextHead != xErrorTail )
-		{
+    if( ( Direction != XEMACPS_SEND ) || ( ErrorWord != XEMACPS_TXSR_USEDREAD_MASK ) )
+    {
+        if( ++xNextHead == ( sizeof( xErrorList ) / sizeof( xErrorList[ 0 ] ) ) )
+        {
+            xNextHead = 0;
+        }
 
-			xErrorList[ xErrorHead ].arg = arg;
-			xErrorList[ xErrorHead ].Direction = Direction;
-			xErrorList[ xErrorHead ].ErrorWord = ErrorWord;
+        if( xNextHead != xErrorTail )
+        {
+            xErrorList[ xErrorHead ].arg = arg;
+            xErrorList[ xErrorHead ].Direction = Direction;
+            xErrorList[ xErrorHead ].ErrorWord = ErrorWord;
 
-			xErrorHead = xNextHead;
+            xErrorHead = xNextHead;
 
-			xemacpsif = (xemacpsif_s *)(arg);
-			xemacpsif->isr_events |= EMAC_IF_ERR_EVENT;
-		}
+            xemacpsif = ( xemacpsif_s * ) ( arg );
+            xemacpsif->isr_events |= EMAC_IF_ERR_EVENT;
+        }
 
-		if( xEMACTaskHandle != NULL )
-		{
-			vTaskNotifyGiveFromISR( xEMACTaskHandle, &xHigherPriorityTaskWoken );
-		}
+        if( xEMACTaskHandle != NULL )
+        {
+            vTaskNotifyGiveFromISR( xEMACTaskHandle, &xHigherPriorityTaskWoken );
+        }
+    }
 
-	}
-
-	portYIELD_FROM_ISR( xHigherPriorityTaskWoken );
+    portYIELD_FROM_ISR( xHigherPriorityTaskWoken );
 }
 
-static void emacps_handle_error(void *arg, u8 Direction, u32 ErrorWord);
+static void emacps_handle_error( void * arg,
+                                 u8 Direction,
+                                 u32 ErrorWord );
 
-int emacps_check_errors( xemacpsif_s *xemacps )
+int emacps_check_errors( xemacpsif_s * xemacps )
 {
-int xResult;
+    int xResult;
 
-	( void ) xemacps;
+    ( void ) xemacps;
 
-	if( xErrorHead == xErrorTail )
-	{
-		xResult = 0;
-	}
-	else
-	{
-		xResult = 1;
-		emacps_handle_error(
-			xErrorList[ xErrorTail ].arg,
-			xErrorList[ xErrorTail ].Direction,
-			xErrorList[ xErrorTail ].ErrorWord );
-	}
+    if( xErrorHead == xErrorTail )
+    {
+        xResult = 0;
+    }
+    else
+    {
+        xResult = 1;
+        emacps_handle_error(
+            xErrorList[ xErrorTail ].arg,
+            xErrorList[ xErrorTail ].Direction,
+            xErrorList[ xErrorTail ].ErrorWord );
+    }
 
-	return xResult;
+    return xResult;
 }
 
-static void emacps_handle_error(void *arg, u8 Direction, u32 ErrorWord)
+static void emacps_handle_error( void * arg,
+                                 u8 Direction,
+                                 u32 ErrorWord )
 {
-	xemacpsif_s   *xemacpsif;
-	struct xtopology_t *xtopologyp;
-	XEmacPs *xemacps;
+    xemacpsif_s * xemacpsif;
+    struct xtopology_t * xtopologyp;
+    XEmacPs * xemacps;
 
-	xemacpsif = (xemacpsif_s *)(arg);
+    xemacpsif = ( xemacpsif_s * ) ( arg );
 
-	xtopologyp = &xXTopology;
+    xtopologyp = &xXTopology;
 
-	xemacps = &xemacpsif->emacps;
+    xemacps = &xemacpsif->emacps;
 
-	/* Do not appear to be used. */
-	( void ) xemacps;
-	( void ) xtopologyp;
+    /* Do not appear to be used. */
+    ( void ) xemacps;
+    ( void ) xtopologyp;
 
-	last_err_msg = NULL;
+    last_err_msg = NULL;
 
-	if( ErrorWord != 0 )
-	{
-		switch (Direction) {
-		case XEMACPS_RECV:
-			if( ( ErrorWord & XEMACPS_RXSR_HRESPNOK_MASK ) != 0 )
-			{
-				last_err_msg = "Receive DMA error";
-				xNetworkInterfaceInitialise( );
-			}
-			if( ( ErrorWord & XEMACPS_RXSR_RXOVR_MASK ) != 0 )
-			{
-				last_err_msg = "Receive over run";
-				emacps_recv_handler(arg);
-			}
-			if( ( ErrorWord & XEMACPS_RXSR_BUFFNA_MASK ) != 0 )
-			{
-				last_err_msg = "Receive buffer not available";
-				emacps_recv_handler(arg);
-			}
-			break;
-		case XEMACPS_SEND:
-			if( ( ErrorWord & XEMACPS_TXSR_HRESPNOK_MASK ) != 0 )
-			{
-				last_err_msg = "Transmit DMA error";
-				xNetworkInterfaceInitialise( );
-			}
-			if( ( ErrorWord & XEMACPS_TXSR_URUN_MASK ) != 0 )
-			{
-				last_err_msg = "Transmit under run";
-				HandleTxErrors( xemacpsif );
-			}
-			if( ( ErrorWord & XEMACPS_TXSR_BUFEXH_MASK ) != 0 )
-			{
-				last_err_msg = "Transmit buffer exhausted";
-				HandleTxErrors( xemacpsif );
-			}
-			if( ( ErrorWord & XEMACPS_TXSR_RXOVR_MASK ) != 0 )
-			{
-				last_err_msg = "Transmit retry excessed limits";
-				HandleTxErrors( xemacpsif );
-			}
-			if( ( ErrorWord & XEMACPS_TXSR_FRAMERX_MASK ) != 0 )
-			{
-				last_err_msg = "Transmit collision";
-				emacps_check_tx( xemacpsif );
-			}
-			break;
-		}
-	}
-	// Break on this statement and inspect error_msg if you like
-	if( last_err_msg != NULL )
-	{
-		error_msg_count++;
-		FreeRTOS_printf( ( "emacps_handle_error: %s\n", last_err_msg ) );
-	}
+    if( ErrorWord != 0 )
+    {
+        switch( Direction )
+        {
+            case XEMACPS_RECV:
+
+                if( ( ErrorWord & XEMACPS_RXSR_HRESPNOK_MASK ) != 0 )
+                {
+                    last_err_msg = "Receive DMA error";
+                    xNetworkInterfaceInitialise();
+                }
+
+                if( ( ErrorWord & XEMACPS_RXSR_RXOVR_MASK ) != 0 )
+                {
+                    last_err_msg = "Receive over run";
+                    emacps_recv_handler( arg );
+                }
+
+                if( ( ErrorWord & XEMACPS_RXSR_BUFFNA_MASK ) != 0 )
+                {
+                    last_err_msg = "Receive buffer not available";
+                    emacps_recv_handler( arg );
+                }
+
+                break;
+
+            case XEMACPS_SEND:
+
+                if( ( ErrorWord & XEMACPS_TXSR_HRESPNOK_MASK ) != 0 )
+                {
+                    last_err_msg = "Transmit DMA error";
+                    xNetworkInterfaceInitialise();
+                }
+
+                if( ( ErrorWord & XEMACPS_TXSR_URUN_MASK ) != 0 )
+                {
+                    last_err_msg = "Transmit under run";
+                    HandleTxErrors( xemacpsif );
+                }
+
+                if( ( ErrorWord & XEMACPS_TXSR_BUFEXH_MASK ) != 0 )
+                {
+                    last_err_msg = "Transmit buffer exhausted";
+                    HandleTxErrors( xemacpsif );
+                }
+
+                if( ( ErrorWord & XEMACPS_TXSR_RXOVR_MASK ) != 0 )
+                {
+                    last_err_msg = "Transmit retry excessed limits";
+                    HandleTxErrors( xemacpsif );
+                }
+
+                if( ( ErrorWord & XEMACPS_TXSR_FRAMERX_MASK ) != 0 )
+                {
+                    last_err_msg = "Transmit collision";
+                    emacps_check_tx( xemacpsif );
+                }
+
+                break;
+        }
+    }
+
+    /* Break on this statement and inspect error_msg if you like */
+    if( last_err_msg != NULL )
+    {
+        error_msg_count++;
+        FreeRTOS_printf( ( "emacps_handle_error: %s\n", last_err_msg ) );
+    }
 }
 
-void HandleTxErrors(xemacpsif_s *xemacpsif)
+void HandleTxErrors( xemacpsif_s * xemacpsif )
 {
-	u32 netctrlreg;
+    u32 netctrlreg;
 
-	//taskENTER_CRITICAL()
-	{
-		netctrlreg = XEmacPs_ReadReg(xemacpsif->emacps.Config.BaseAddress,
-													XEMACPS_NWCTRL_OFFSET);
-		netctrlreg = netctrlreg & (~XEMACPS_NWCTRL_TXEN_MASK);
-		XEmacPs_WriteReg(xemacpsif->emacps.Config.BaseAddress,
-										XEMACPS_NWCTRL_OFFSET, netctrlreg);
+    /*taskENTER_CRITICAL() */
+    {
+        netctrlreg = XEmacPs_ReadReg( xemacpsif->emacps.Config.BaseAddress,
+                                      XEMACPS_NWCTRL_OFFSET );
+        netctrlreg = netctrlreg & ( ~XEMACPS_NWCTRL_TXEN_MASK );
+        XEmacPs_WriteReg( xemacpsif->emacps.Config.BaseAddress,
+                          XEMACPS_NWCTRL_OFFSET, netctrlreg );
 
-		clean_dma_txdescs( xemacpsif );
-		netctrlreg = XEmacPs_ReadReg(xemacpsif->emacps.Config.BaseAddress,
-														XEMACPS_NWCTRL_OFFSET);
-		netctrlreg = netctrlreg | (XEMACPS_NWCTRL_TXEN_MASK);
-		XEmacPs_WriteReg(xemacpsif->emacps.Config.BaseAddress,
-											XEMACPS_NWCTRL_OFFSET, netctrlreg);
-	}
-	//taskEXIT_CRITICAL( );
+        clean_dma_txdescs( xemacpsif );
+        netctrlreg = XEmacPs_ReadReg( xemacpsif->emacps.Config.BaseAddress,
+                                      XEMACPS_NWCTRL_OFFSET );
+        netctrlreg = netctrlreg | ( XEMACPS_NWCTRL_TXEN_MASK );
+        XEmacPs_WriteReg( xemacpsif->emacps.Config.BaseAddress,
+                          XEMACPS_NWCTRL_OFFSET, netctrlreg );
+    }
+    /*taskEXIT_CRITICAL( ); */
 }

--- a/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/portable/NetworkInterface/Zynq/x_emacpsif_hw.h
+++ b/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/portable/NetworkInterface/Zynq/x_emacpsif_hw.h
@@ -17,23 +17,23 @@
  */
 
 #ifndef __XEMACPSIF_HW_H_
-#define __XEMACPSIF_HW_H_
+    #define __XEMACPSIF_HW_H_
 
-#include "Zynq/x_emacpsif.h"
-//#include "lwip/netif.h"
+    #include "Zynq/x_emacpsif.h"
+/*#include "lwip/netif.h" */
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+    #ifdef __cplusplus
+        extern "C" {
+    #endif
 
-XEmacPs_Config * lookup_config(unsigned mac_base);
+    XEmacPs_Config * lookup_config( unsigned mac_base );
 
-//void init_emacps(xemacpsif_s *xemacpsif, struct netif *netif);
+/*void init_emacps(xemacpsif_s *xemacpsif, struct netif *netif); */
 
-int emacps_check_errors( xemacpsif_s *xemacps );
+    int emacps_check_errors( xemacpsif_s * xemacps );
 
-#ifdef __cplusplus
-}
-#endif
+    #ifdef __cplusplus
+        }
+    #endif
 
-#endif
+#endif /* ifndef __XEMACPSIF_HW_H_ */

--- a/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/portable/NetworkInterface/Zynq/x_emacpsif_physpeed.c
+++ b/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/portable/NetworkInterface/Zynq/x_emacpsif_physpeed.c
@@ -77,510 +77,590 @@ int phy_detected = 0;
  ***/
 
 /* Advertisement control register. */
-#define ADVERTISE_10HALF		0x0020  /* Try for 10mbps half-duplex  */
-#define ADVERTISE_10FULL		0x0040  /* Try for 10mbps full-duplex  */
-#define ADVERTISE_100HALF		0x0080  /* Try for 100mbps half-duplex */
-#define ADVERTISE_100FULL		0x0100  /* Try for 100mbps full-duplex */
+#define ADVERTISE_10HALF     0x0020     /* Try for 10mbps half-duplex  */
+#define ADVERTISE_10FULL     0x0040     /* Try for 10mbps full-duplex  */
+#define ADVERTISE_100HALF    0x0080     /* Try for 100mbps half-duplex */
+#define ADVERTISE_100FULL    0x0100     /* Try for 100mbps full-duplex */
 
-#define ADVERTISE_100_AND_10	(ADVERTISE_10FULL | ADVERTISE_100FULL | \
-								ADVERTISE_10HALF | ADVERTISE_100HALF)
-#define ADVERTISE_100			(ADVERTISE_100FULL | ADVERTISE_100HALF)
-#define ADVERTISE_10			(ADVERTISE_10FULL | ADVERTISE_10HALF)
+#define ADVERTISE_100_AND_10                 \
+    ( ADVERTISE_10FULL | ADVERTISE_100FULL | \
+      ADVERTISE_10HALF | ADVERTISE_100HALF )
+#define ADVERTISE_100        ( ADVERTISE_100FULL | ADVERTISE_100HALF )
+#define ADVERTISE_10         ( ADVERTISE_10FULL | ADVERTISE_10HALF )
 
-#define ADVERTISE_1000			0x0300
-
-
-//#define PHY_REG_00_BMCR            0x00 // Basic mode control register
-//#define PHY_REG_01_BMSR            0x01 // Basic mode status register
-//#define PHY_REG_02_PHYSID1         0x02 // PHYS ID 1
-//#define PHY_REG_03_PHYSID2         0x03 // PHYS ID 2
-//#define PHY_REG_04_ADVERTISE       0x04 // Advertisement control reg
-
-#define IEEE_CONTROL_REG_OFFSET				0
-#define IEEE_STATUS_REG_OFFSET				1
-#define IEEE_PHYSID1_OFFSET					2
-#define IEEE_PHYSID2_OFFSET					3
-#define IEEE_AUTONEGO_ADVERTISE_REG			4
-#define IEEE_PARTNER_ABILITIES_1_REG_OFFSET	5
-#define IEEE_1000_ADVERTISE_REG_OFFSET		9
-#define IEEE_PARTNER_ABILITIES_3_REG_OFFSET	10
-#define IEEE_COPPER_SPECIFIC_CONTROL_REG	16
-#define IEEE_SPECIFIC_STATUS_REG			17
-#define IEEE_COPPER_SPECIFIC_STATUS_REG_2	19
-#define IEEE_CONTROL_REG_MAC				21
-#define IEEE_PAGE_ADDRESS_REGISTER			22
+#define ADVERTISE_1000       0x0300
 
 
-#define IEEE_CTRL_1GBPS_LINKSPEED_MASK		0x2040
-#define IEEE_CTRL_LINKSPEED_MASK			0x0040
-#define IEEE_CTRL_LINKSPEED_1000M			0x0040
-#define IEEE_CTRL_LINKSPEED_100M			0x2000
-#define IEEE_CTRL_LINKSPEED_10M				0x0000
-#define IEEE_CTRL_RESET_MASK				0x8000
-#define IEEE_CTRL_AUTONEGOTIATE_ENABLE		0x1000
+/*#define PHY_REG_00_BMCR            0x00 // Basic mode control register */
+/*#define PHY_REG_01_BMSR            0x01 // Basic mode status register */
+/*#define PHY_REG_02_PHYSID1         0x02 // PHYS ID 1 */
+/*#define PHY_REG_03_PHYSID2         0x03 // PHYS ID 2 */
+/*#define PHY_REG_04_ADVERTISE       0x04 // Advertisement control reg */
+
+#define IEEE_CONTROL_REG_OFFSET                0
+#define IEEE_STATUS_REG_OFFSET                 1
+#define IEEE_PHYSID1_OFFSET                    2
+#define IEEE_PHYSID2_OFFSET                    3
+#define IEEE_AUTONEGO_ADVERTISE_REG            4
+#define IEEE_PARTNER_ABILITIES_1_REG_OFFSET    5
+#define IEEE_1000_ADVERTISE_REG_OFFSET         9
+#define IEEE_PARTNER_ABILITIES_3_REG_OFFSET    10
+#define IEEE_COPPER_SPECIFIC_CONTROL_REG       16
+#define IEEE_SPECIFIC_STATUS_REG               17
+#define IEEE_COPPER_SPECIFIC_STATUS_REG_2      19
+#define IEEE_CONTROL_REG_MAC                   21
+#define IEEE_PAGE_ADDRESS_REGISTER             22
+
+
+#define IEEE_CTRL_1GBPS_LINKSPEED_MASK         0x2040
+#define IEEE_CTRL_LINKSPEED_MASK               0x0040
+#define IEEE_CTRL_LINKSPEED_1000M              0x0040
+#define IEEE_CTRL_LINKSPEED_100M               0x2000
+#define IEEE_CTRL_LINKSPEED_10M                0x0000
+#define IEEE_CTRL_RESET_MASK                   0x8000
+#define IEEE_CTRL_AUTONEGOTIATE_ENABLE         0x1000
 #if XPAR_GIGE_PCS_PMA_CORE_PRESENT == 1
-#define IEEE_CTRL_RESET                         0x9140
-#define IEEE_CTRL_ISOLATE_DISABLE               0xFBFF
+    #define IEEE_CTRL_RESET                    0x9140
+    #define IEEE_CTRL_ISOLATE_DISABLE          0xFBFF
 #endif
-#define IEEE_STAT_AUTONEGOTIATE_CAPABLE		0x0008
-#define IEEE_STAT_AUTONEGOTIATE_COMPLETE	0x0020
-#define IEEE_STAT_AUTONEGOTIATE_RESTART		0x0200
-#define IEEE_STAT_1GBPS_EXTENSIONS			0x0100
-#define IEEE_AN1_ABILITY_MASK				0x1FE0
-#define IEEE_AN3_ABILITY_MASK_1GBPS			0x0C00
-#define IEEE_AN1_ABILITY_MASK_100MBPS		0x0380
-#define IEEE_AN1_ABILITY_MASK_10MBPS		0x0060
-#define IEEE_RGMII_TXRX_CLOCK_DELAYED_MASK	0x0030
+#define IEEE_STAT_AUTONEGOTIATE_CAPABLE        0x0008
+#define IEEE_STAT_AUTONEGOTIATE_COMPLETE       0x0020
+#define IEEE_STAT_AUTONEGOTIATE_RESTART        0x0200
+#define IEEE_STAT_1GBPS_EXTENSIONS             0x0100
+#define IEEE_AN1_ABILITY_MASK                  0x1FE0
+#define IEEE_AN3_ABILITY_MASK_1GBPS            0x0C00
+#define IEEE_AN1_ABILITY_MASK_100MBPS          0x0380
+#define IEEE_AN1_ABILITY_MASK_10MBPS           0x0060
+#define IEEE_RGMII_TXRX_CLOCK_DELAYED_MASK     0x0030
 
-#define IEEE_ASYMMETRIC_PAUSE_MASK			0x0800
-#define IEEE_PAUSE_MASK						0x0400
-#define IEEE_AUTONEG_ERROR_MASK				0x8000
+#define IEEE_ASYMMETRIC_PAUSE_MASK             0x0800
+#define IEEE_PAUSE_MASK                        0x0400
+#define IEEE_AUTONEG_ERROR_MASK                0x8000
 
-#define XEMACPS_GMII2RGMII_SPEED1000_FD		0x140
-#define XEMACPS_GMII2RGMII_SPEED100_FD		0x2100
-#define XEMACPS_GMII2RGMII_SPEED10_FD		0x100
-#define XEMACPS_GMII2RGMII_REG_NUM			0x10
+#define XEMACPS_GMII2RGMII_SPEED1000_FD        0x140
+#define XEMACPS_GMII2RGMII_SPEED100_FD         0x2100
+#define XEMACPS_GMII2RGMII_SPEED10_FD          0x100
+#define XEMACPS_GMII2RGMII_REG_NUM             0x10
 
 /* Frequency setting */
-#define SLCR_LOCK_ADDR			(XPS_SYS_CTRL_BASEADDR + 0x4)
-#define SLCR_UNLOCK_ADDR		(XPS_SYS_CTRL_BASEADDR + 0x8)
-#define SLCR_GEM0_CLK_CTRL_ADDR	(XPS_SYS_CTRL_BASEADDR + 0x140)
-#define SLCR_GEM1_CLK_CTRL_ADDR	(XPS_SYS_CTRL_BASEADDR + 0x144)
+#define SLCR_LOCK_ADDR                         ( XPS_SYS_CTRL_BASEADDR + 0x4 )
+#define SLCR_UNLOCK_ADDR                       ( XPS_SYS_CTRL_BASEADDR + 0x8 )
+#define SLCR_GEM0_CLK_CTRL_ADDR                ( XPS_SYS_CTRL_BASEADDR + 0x140 )
+#define SLCR_GEM1_CLK_CTRL_ADDR                ( XPS_SYS_CTRL_BASEADDR + 0x144 )
 #ifdef PEEP
-#define SLCR_GEM_10M_CLK_CTRL_VALUE		0x00103031
-#define SLCR_GEM_100M_CLK_CTRL_VALUE	0x00103001
-#define SLCR_GEM_1G_CLK_CTRL_VALUE		0x00103011
+    #define SLCR_GEM_10M_CLK_CTRL_VALUE        0x00103031
+    #define SLCR_GEM_100M_CLK_CTRL_VALUE       0x00103001
+    #define SLCR_GEM_1G_CLK_CTRL_VALUE         0x00103011
 #endif
-#define SLCR_LOCK_KEY_VALUE 			0x767B
-#define SLCR_UNLOCK_KEY_VALUE			0xDF0D
-#define SLCR_ADDR_GEM_RST_CTRL			(XPS_SYS_CTRL_BASEADDR + 0x214)
-#define EMACPS_SLCR_DIV_MASK			0xFC0FC0FF
+#define SLCR_LOCK_KEY_VALUE                    0x767B
+#define SLCR_UNLOCK_KEY_VALUE                  0xDF0D
+#define SLCR_ADDR_GEM_RST_CTRL                 ( XPS_SYS_CTRL_BASEADDR + 0x214 )
+#define EMACPS_SLCR_DIV_MASK                   0xFC0FC0FF
 
-#define EMAC0_BASE_ADDRESS				0xE000B000
-#define EMAC1_BASE_ADDRESS				0xE000C000
+#define EMAC0_BASE_ADDRESS                     0xE000B000
+#define EMAC1_BASE_ADDRESS                     0xE000C000
 
-#define PHY_ADDRESS_COUNT				32
+#define PHY_ADDRESS_COUNT                      32
 
-#define MINIMUM_SLEEP_TIME				2
+#define MINIMUM_SLEEP_TIME                     2
 
 
-static int detect_phy(XEmacPs *xemacpsp)
+static int detect_phy( XEmacPs * xemacpsp )
 {
-	u16 id_lower, id_upper;
-	u32 phy_addr, id;
+    u16 id_lower, id_upper;
+    u32 phy_addr, id;
 
-	for (phy_addr = 0; phy_addr < PHY_ADDRESS_COUNT; phy_addr++) {
-		XEmacPs_PhyRead(xemacpsp, phy_addr, IEEE_PHYSID1_OFFSET, &id_lower);
+    for( phy_addr = 0; phy_addr < PHY_ADDRESS_COUNT; phy_addr++ )
+    {
+        XEmacPs_PhyRead( xemacpsp, phy_addr, IEEE_PHYSID1_OFFSET, &id_lower );
 
-		if ((id_lower != ( u16 )0xFFFFu) && (id_lower != ( u16 )0x0u)) {
+        if( ( id_lower != ( u16 ) 0xFFFFu ) && ( id_lower != ( u16 ) 0x0u ) )
+        {
+            XEmacPs_PhyRead( xemacpsp, phy_addr, IEEE_PHYSID2_OFFSET, &id_upper );
+            id = ( ( ( uint32_t ) id_upper ) << 16 ) | ( id_lower & 0xFFF0 );
+            FreeRTOS_printf( ( "XEmacPs detect_phy: %04lX at address %d.\n", id, phy_addr ) );
+            phy_detected = phy_addr;
+            return phy_addr;
+        }
+    }
 
-			XEmacPs_PhyRead(xemacpsp, phy_addr, IEEE_PHYSID2_OFFSET, &id_upper);
-			id = ( ( ( uint32_t ) id_upper ) << 16 ) | ( id_lower & 0xFFF0 );
-			FreeRTOS_printf( ("XEmacPs detect_phy: %04lX at address %d.\n", id, phy_addr ) );
-			phy_detected = phy_addr;
-			return phy_addr;
-		}
-	}
+    FreeRTOS_printf( ( "XEmacPs detect_phy: No PHY detected.  Assuming a PHY at address 0\n" ) );
 
-	FreeRTOS_printf( ("XEmacPs detect_phy: No PHY detected.  Assuming a PHY at address 0\n" ) );
-
-        /* default to zero */
-	return 0;
+    /* default to zero */
+    return 0;
 }
 
 #ifdef PEEP
-unsigned get_IEEE_phy_speed(XEmacPs *xemacpsp)
-{
+    unsigned get_IEEE_phy_speed( XEmacPs * xemacpsp )
+    {
+        u16 control;
+        u16 status;
+        u16 partner_capabilities;
+        u16 partner_capabilities_1000;
+        u16 phylinkspeed;
+        u32 phy_addr = detect_phy( xemacpsp );
 
-	u16 control;
-	u16 status;
-	u16 partner_capabilities;
-	u16 partner_capabilities_1000;
-	u16 phylinkspeed;
-	u32 phy_addr = detect_phy(xemacpsp);
+        XEmacPs_PhyWrite( xemacpsp, phy_addr, IEEE_1000_ADVERTISE_REG_OFFSET,
+                          ADVERTISE_1000 );
+        /* Advertise PHY speed of 100 and 10 Mbps */
+        XEmacPs_PhyWrite( xemacpsp, phy_addr, IEEE_AUTONEGO_ADVERTISE_REG,
+                          ADVERTISE_100_AND_10 );
 
-	XEmacPs_PhyWrite(xemacpsp, phy_addr, IEEE_1000_ADVERTISE_REG_OFFSET,
-															ADVERTISE_1000);
-	/* Advertise PHY speed of 100 and 10 Mbps */
-	XEmacPs_PhyWrite(xemacpsp, phy_addr, IEEE_AUTONEGO_ADVERTISE_REG,
-													ADVERTISE_100_AND_10);
+        XEmacPs_PhyRead( xemacpsp, phy_addr, IEEE_CONTROL_REG_OFFSET,
+                         &control );
+        control |= ( IEEE_CTRL_AUTONEGOTIATE_ENABLE |
+                     IEEE_STAT_AUTONEGOTIATE_RESTART );
 
-	XEmacPs_PhyRead(xemacpsp, phy_addr, IEEE_CONTROL_REG_OFFSET,
-																&control);
-	control |= (IEEE_CTRL_AUTONEGOTIATE_ENABLE |
-					IEEE_STAT_AUTONEGOTIATE_RESTART);
+        XEmacPs_PhyWrite( xemacpsp, phy_addr, IEEE_CONTROL_REG_OFFSET, control );
 
-	XEmacPs_PhyWrite(xemacpsp, phy_addr, IEEE_CONTROL_REG_OFFSET, control);
+        /* Read PHY control and status registers is successful. */
+        XEmacPs_PhyRead( xemacpsp, phy_addr, IEEE_CONTROL_REG_OFFSET, &control );
+        XEmacPs_PhyRead( xemacpsp, phy_addr, IEEE_STATUS_REG_OFFSET, &status );
 
-	/* Read PHY control and status registers is successful. */
-	XEmacPs_PhyRead(xemacpsp, phy_addr, IEEE_CONTROL_REG_OFFSET, &control);
-	XEmacPs_PhyRead(xemacpsp, phy_addr, IEEE_STATUS_REG_OFFSET, &status);
+        if( ( control & IEEE_CTRL_AUTONEGOTIATE_ENABLE ) && ( status &
+                                                              IEEE_STAT_AUTONEGOTIATE_CAPABLE ) )
+        {
+            while( !( status & IEEE_STAT_AUTONEGOTIATE_COMPLETE ) )
+            {
+                XEmacPs_PhyRead( xemacpsp, phy_addr, IEEE_STATUS_REG_OFFSET,
+                                 &status );
+            }
 
-	if ((control & IEEE_CTRL_AUTONEGOTIATE_ENABLE) && (status &
-					IEEE_STAT_AUTONEGOTIATE_CAPABLE)) {
+            XEmacPs_PhyRead( xemacpsp, phy_addr, IEEE_PARTNER_ABILITIES_1_REG_OFFSET,
+                             &partner_capabilities );
 
-		while ( !(status & IEEE_STAT_AUTONEGOTIATE_COMPLETE) ) {
-			XEmacPs_PhyRead(xemacpsp, phy_addr, IEEE_STATUS_REG_OFFSET,
-																&status);
-		}
+            if( status & IEEE_STAT_1GBPS_EXTENSIONS )
+            {
+                XEmacPs_PhyRead( xemacpsp, phy_addr, IEEE_PARTNER_ABILITIES_3_REG_OFFSET,
+                                 &partner_capabilities_1000 );
 
-		XEmacPs_PhyRead(xemacpsp, phy_addr, IEEE_PARTNER_ABILITIES_1_REG_OFFSET,
-															&partner_capabilities);
+                if( partner_capabilities_1000 & IEEE_AN3_ABILITY_MASK_1GBPS )
+                {
+                    return 1000;
+                }
+            }
 
-		if (status & IEEE_STAT_1GBPS_EXTENSIONS) {
-			XEmacPs_PhyRead(xemacpsp, phy_addr, IEEE_PARTNER_ABILITIES_3_REG_OFFSET,
-														&partner_capabilities_1000);
-			if (partner_capabilities_1000 & IEEE_AN3_ABILITY_MASK_1GBPS)
-				return 1000;
-		}
+            if( partner_capabilities & IEEE_AN1_ABILITY_MASK_100MBPS )
+            {
+                return 100;
+            }
 
-		if (partner_capabilities & IEEE_AN1_ABILITY_MASK_100MBPS)
-			return 100;
-		if (partner_capabilities & IEEE_AN1_ABILITY_MASK_10MBPS)
-			return 10;
+            if( partner_capabilities & IEEE_AN1_ABILITY_MASK_10MBPS )
+            {
+                return 10;
+            }
 
-		FreeRTOS_printf( ( "%s: unknown PHY link speed, setting TEMAC speed to be 10 Mbps\n",
-				__FUNCTION__ ) );
-		return 10;
+            FreeRTOS_printf( ( "%s: unknown PHY link speed, setting TEMAC speed to be 10 Mbps\n",
+                               __FUNCTION__ ) );
+            return 10;
+        }
+        else
+        {
+            /* Update TEMAC speed accordingly */
+            if( status & IEEE_STAT_1GBPS_EXTENSIONS )
+            {
+                /* Get commanded link speed */
+                phylinkspeed = control & IEEE_CTRL_1GBPS_LINKSPEED_MASK;
 
-	} else {
+                switch( phylinkspeed )
+                {
+                    case ( IEEE_CTRL_LINKSPEED_1000M ):
+                        return 1000;
 
-		/* Update TEMAC speed accordingly */
-		if (status & IEEE_STAT_1GBPS_EXTENSIONS) {
-			/* Get commanded link speed */
-			phylinkspeed = control & IEEE_CTRL_1GBPS_LINKSPEED_MASK;
+                    case ( IEEE_CTRL_LINKSPEED_100M ):
+                        return 100;
 
-			switch (phylinkspeed) {
-				case (IEEE_CTRL_LINKSPEED_1000M):
-					return 1000;
-				case (IEEE_CTRL_LINKSPEED_100M):
-					return 100;
-				case (IEEE_CTRL_LINKSPEED_10M):
-					return 10;
-				default:
-					FreeRTOS_printf( ( "%s: unknown PHY link speed (%d), setting TEMAC speed to be 10 Mbps\n",
-							__FUNCTION__, phylinkspeed ) );
-					return 10;
-			}
+                    case ( IEEE_CTRL_LINKSPEED_10M ):
+                        return 10;
 
-		} else {
-
-			return (control & IEEE_CTRL_LINKSPEED_MASK) ? 100 : 10;
-
-		}
-	}
-}
+                    default:
+                        FreeRTOS_printf( ( "%s: unknown PHY link speed (%d), setting TEMAC speed to be 10 Mbps\n",
+                                           __FUNCTION__, phylinkspeed ) );
+                        return 10;
+                }
+            }
+            else
+            {
+                return ( control & IEEE_CTRL_LINKSPEED_MASK ) ? 100 : 10;
+            }
+        }
+    }
 
 #else /* Zynq */
-unsigned get_IEEE_phy_speed(XEmacPs *xemacpsp)
+    unsigned get_IEEE_phy_speed( XEmacPs * xemacpsp )
+    {
+        u16 temp;
+        u16 control;
+        u16 status;
+        u16 partner_capabilities;
+
+        #if XPAR_GIGE_PCS_PMA_CORE_PRESENT == 1
+            u32 phy_addr = XPAR_PCSPMA_SGMII_PHYADDR;
+        #else
+            u32 phy_addr = detect_phy( xemacpsp );
+        #endif
+        FreeRTOS_printf( ( "Start PHY autonegotiation \n" ) );
+
+        #if XPAR_GIGE_PCS_PMA_CORE_PRESENT == 1
+        #else
+            XEmacPs_PhyWrite( xemacpsp, phy_addr, IEEE_PAGE_ADDRESS_REGISTER, 2 );
+            XEmacPs_PhyRead( xemacpsp, phy_addr, IEEE_CONTROL_REG_MAC, &control );
+            control |= IEEE_RGMII_TXRX_CLOCK_DELAYED_MASK;
+            XEmacPs_PhyWrite( xemacpsp, phy_addr, IEEE_CONTROL_REG_MAC, control );
+
+            XEmacPs_PhyWrite( xemacpsp, phy_addr, IEEE_PAGE_ADDRESS_REGISTER, 0 );
+
+            XEmacPs_PhyRead( xemacpsp, phy_addr, IEEE_AUTONEGO_ADVERTISE_REG, &control );
+            control |= IEEE_ASYMMETRIC_PAUSE_MASK;
+            control |= IEEE_PAUSE_MASK;
+            control |= ADVERTISE_100;
+            control |= ADVERTISE_10;
+            XEmacPs_PhyWrite( xemacpsp, phy_addr, IEEE_AUTONEGO_ADVERTISE_REG, control );
+
+            XEmacPs_PhyRead( xemacpsp, phy_addr, IEEE_1000_ADVERTISE_REG_OFFSET,
+                             &control );
+            control |= ADVERTISE_1000;
+            XEmacPs_PhyWrite( xemacpsp, phy_addr, IEEE_1000_ADVERTISE_REG_OFFSET,
+                              control );
+
+            XEmacPs_PhyWrite( xemacpsp, phy_addr, IEEE_PAGE_ADDRESS_REGISTER, 0 );
+            XEmacPs_PhyRead( xemacpsp, phy_addr, IEEE_COPPER_SPECIFIC_CONTROL_REG,
+                             &control );
+            control |= ( 7 << 12 ); /* max number of gigabit attempts */
+            control |= ( 1 << 11 ); /* enable downshift */
+            XEmacPs_PhyWrite( xemacpsp, phy_addr, IEEE_COPPER_SPECIFIC_CONTROL_REG,
+                              control );
+        #endif /* if XPAR_GIGE_PCS_PMA_CORE_PRESENT == 1 */
+        XEmacPs_PhyRead( xemacpsp, phy_addr, IEEE_CONTROL_REG_OFFSET, &control );
+        control |= IEEE_CTRL_AUTONEGOTIATE_ENABLE;
+        control |= IEEE_STAT_AUTONEGOTIATE_RESTART;
+        #if XPAR_GIGE_PCS_PMA_CORE_PRESENT == 1
+            control &= IEEE_CTRL_ISOLATE_DISABLE;
+        #endif
+
+        XEmacPs_PhyWrite( xemacpsp, phy_addr, IEEE_CONTROL_REG_OFFSET, control );
+
+
+        #if XPAR_GIGE_PCS_PMA_CORE_PRESENT == 1
+        #else
+            XEmacPs_PhyRead( xemacpsp, phy_addr, IEEE_CONTROL_REG_OFFSET, &control );
+            control |= IEEE_CTRL_RESET_MASK;
+            XEmacPs_PhyWrite( xemacpsp, phy_addr, IEEE_CONTROL_REG_OFFSET, control );
+
+            while( 1 )
+            {
+                XEmacPs_PhyRead( xemacpsp, phy_addr, IEEE_CONTROL_REG_OFFSET, &control );
+
+                if( control & IEEE_CTRL_RESET_MASK )
+                {
+                    continue;
+                }
+                else
+                {
+                    break;
+                }
+            }
+        #endif /* if XPAR_GIGE_PCS_PMA_CORE_PRESENT == 1 */
+        FreeRTOS_printf( ( "Waiting for PHY to complete autonegotiation.\n" ) );
+
+        XEmacPs_PhyRead( xemacpsp, phy_addr, IEEE_STATUS_REG_OFFSET, &status );
+
+        while( !( status & IEEE_STAT_AUTONEGOTIATE_COMPLETE ) )
+        {
+            vTaskDelay( MINIMUM_SLEEP_TIME );
+            #if XPAR_GIGE_PCS_PMA_CORE_PRESENT == 1
+            #else
+                XEmacPs_PhyRead( xemacpsp, phy_addr, IEEE_COPPER_SPECIFIC_STATUS_REG_2,
+                                 &temp );
+
+                if( temp & IEEE_AUTONEG_ERROR_MASK )
+                {
+                    FreeRTOS_printf( ( "Auto negotiation error \n" ) );
+                }
+            #endif
+            XEmacPs_PhyRead( xemacpsp, phy_addr, IEEE_STATUS_REG_OFFSET,
+                             &status );
+        }
+
+        FreeRTOS_printf( ( "autonegotiation complete \n" ) );
+
+        #if XPAR_GIGE_PCS_PMA_CORE_PRESENT == 1
+        #else
+            XEmacPs_PhyRead( xemacpsp, phy_addr, IEEE_SPECIFIC_STATUS_REG, &partner_capabilities );
+        #endif
+
+        #if XPAR_GIGE_PCS_PMA_CORE_PRESENT == 1
+            FreeRTOS_printf( ( "Waiting for Link to be up; Polling for SGMII core Reg \n" ) );
+            XEmacPs_PhyRead( xemacpsp, phy_addr, 5, &temp );
+
+            while( !( temp & 0x8000 ) )
+            {
+                XEmacPs_PhyRead( xemacpsp, phy_addr, 5, &temp );
+            }
+
+            if( ( temp & 0x0C00 ) == 0x0800 )
+            {
+                XEmacPs_PhyRead( xemacpsp, phy_addr, 0, &temp );
+                return 1000;
+            }
+            else if( ( temp & 0x0C00 ) == 0x0400 )
+            {
+                XEmacPs_PhyRead( xemacpsp, phy_addr, 0, &temp );
+                return 100;
+            }
+            else if( ( temp & 0x0C00 ) == 0x0000 )
+            {
+                XEmacPs_PhyRead( xemacpsp, phy_addr, 0, &temp );
+                return 10;
+            }
+            else
+            {
+                FreeRTOS_printf( ( "get_IEEE_phy_speed(): Invalid speed bit value, Deafulting to Speed = 10 Mbps\n" ) );
+                XEmacPs_PhyRead( xemacpsp, phy_addr, 0, &temp );
+                XEmacPs_PhyWrite( xemacpsp, phy_addr, 0, 0x0100 );
+                return 10;
+            }
+        #else /* if XPAR_GIGE_PCS_PMA_CORE_PRESENT == 1 */
+            if( ( ( partner_capabilities >> 14 ) & 3 ) == 2 ) /* 1000Mbps */
+            {
+                return 1000;
+            }
+            else if( ( ( partner_capabilities >> 14 ) & 3 ) == 1 ) /* 100Mbps */
+            {
+                return 100;
+            }
+            else /* 10Mbps */
+            {
+                return 10;
+            }
+        #endif /* if XPAR_GIGE_PCS_PMA_CORE_PRESENT == 1 */
+    }
+#endif /* ifdef PEEP */
+
+unsigned configure_IEEE_phy_speed( XEmacPs * xemacpsp,
+                                   unsigned speed )
 {
-	u16 temp;
-	u16 control;
-	u16 status;
-	u16 partner_capabilities;
-#if XPAR_GIGE_PCS_PMA_CORE_PRESENT == 1
-	u32 phy_addr = XPAR_PCSPMA_SGMII_PHYADDR;
-#else
-	u32 phy_addr = detect_phy(xemacpsp);
-#endif
-	FreeRTOS_printf( ( "Start PHY autonegotiation \n" ) );
+    u16 control;
+    u32 phy_addr = detect_phy( xemacpsp );
 
-#if XPAR_GIGE_PCS_PMA_CORE_PRESENT == 1
-#else
-	XEmacPs_PhyWrite(xemacpsp,phy_addr, IEEE_PAGE_ADDRESS_REGISTER, 2);
-	XEmacPs_PhyRead(xemacpsp, phy_addr, IEEE_CONTROL_REG_MAC, &control);
-	control |= IEEE_RGMII_TXRX_CLOCK_DELAYED_MASK;
-	XEmacPs_PhyWrite(xemacpsp, phy_addr, IEEE_CONTROL_REG_MAC, control);
+    XEmacPs_PhyWrite( xemacpsp, phy_addr, IEEE_PAGE_ADDRESS_REGISTER, 2 );
+    XEmacPs_PhyRead( xemacpsp, phy_addr, IEEE_CONTROL_REG_MAC, &control );
+    control |= IEEE_RGMII_TXRX_CLOCK_DELAYED_MASK;
+    XEmacPs_PhyWrite( xemacpsp, phy_addr, IEEE_CONTROL_REG_MAC, control );
 
-	XEmacPs_PhyWrite(xemacpsp, phy_addr, IEEE_PAGE_ADDRESS_REGISTER, 0);
+    XEmacPs_PhyWrite( xemacpsp, phy_addr, IEEE_PAGE_ADDRESS_REGISTER, 0 );
 
-	XEmacPs_PhyRead(xemacpsp, phy_addr, IEEE_AUTONEGO_ADVERTISE_REG, &control);
-	control |= IEEE_ASYMMETRIC_PAUSE_MASK;
-	control |= IEEE_PAUSE_MASK;
-	control |= ADVERTISE_100;
-	control |= ADVERTISE_10;
-	XEmacPs_PhyWrite(xemacpsp, phy_addr, IEEE_AUTONEGO_ADVERTISE_REG, control);
+    XEmacPs_PhyRead( xemacpsp, phy_addr, IEEE_AUTONEGO_ADVERTISE_REG, &control );
+    control |= IEEE_ASYMMETRIC_PAUSE_MASK;
+    control |= IEEE_PAUSE_MASK;
+    XEmacPs_PhyWrite( xemacpsp, phy_addr, IEEE_AUTONEGO_ADVERTISE_REG, control );
 
-	XEmacPs_PhyRead(xemacpsp, phy_addr, IEEE_1000_ADVERTISE_REG_OFFSET,
-																	&control);
-	control |= ADVERTISE_1000;
-	XEmacPs_PhyWrite(xemacpsp, phy_addr, IEEE_1000_ADVERTISE_REG_OFFSET,
-																	control);
+    XEmacPs_PhyRead( xemacpsp, phy_addr, IEEE_CONTROL_REG_OFFSET, &control );
+    control &= ~IEEE_CTRL_LINKSPEED_1000M;
+    control &= ~IEEE_CTRL_LINKSPEED_100M;
+    control &= ~IEEE_CTRL_LINKSPEED_10M;
 
-	XEmacPs_PhyWrite(xemacpsp, phy_addr, IEEE_PAGE_ADDRESS_REGISTER, 0);
-	XEmacPs_PhyRead(xemacpsp, phy_addr, IEEE_COPPER_SPECIFIC_CONTROL_REG,
-																&control);
-	control |= (7 << 12);	/* max number of gigabit attempts */
-	control |= (1 << 11);	/* enable downshift */
-	XEmacPs_PhyWrite(xemacpsp, phy_addr, IEEE_COPPER_SPECIFIC_CONTROL_REG,
-																control);
-#endif
-	XEmacPs_PhyRead(xemacpsp, phy_addr, IEEE_CONTROL_REG_OFFSET, &control);
-	control |= IEEE_CTRL_AUTONEGOTIATE_ENABLE;
-	control |= IEEE_STAT_AUTONEGOTIATE_RESTART;
-#if XPAR_GIGE_PCS_PMA_CORE_PRESENT == 1
-    control &= IEEE_CTRL_ISOLATE_DISABLE;
-#endif
+    if( speed == 1000 )
+    {
+        control |= IEEE_CTRL_LINKSPEED_1000M;
+    }
 
-	XEmacPs_PhyWrite(xemacpsp, phy_addr, IEEE_CONTROL_REG_OFFSET, control);
+    else if( speed == 100 )
+    {
+        control |= IEEE_CTRL_LINKSPEED_100M;
+        /* Dont advertise PHY speed of 1000 Mbps */
+        XEmacPs_PhyWrite( xemacpsp, phy_addr, IEEE_1000_ADVERTISE_REG_OFFSET, 0 );
+        /* Dont advertise PHY speed of 10 Mbps */
+        XEmacPs_PhyWrite( xemacpsp, phy_addr, IEEE_AUTONEGO_ADVERTISE_REG,
+                          ADVERTISE_100 );
+    }
 
+    else if( speed == 10 )
+    {
+        control |= IEEE_CTRL_LINKSPEED_10M;
+        /* Dont advertise PHY speed of 1000 Mbps */
+        XEmacPs_PhyWrite( xemacpsp, phy_addr, IEEE_1000_ADVERTISE_REG_OFFSET,
+                          0 );
+        /* Dont advertise PHY speed of 100 Mbps */
+        XEmacPs_PhyWrite( xemacpsp, phy_addr, IEEE_AUTONEGO_ADVERTISE_REG,
+                          ADVERTISE_10 );
+    }
 
-#if XPAR_GIGE_PCS_PMA_CORE_PRESENT == 1
-#else
-	XEmacPs_PhyRead(xemacpsp, phy_addr, IEEE_CONTROL_REG_OFFSET, &control);
-	control |= IEEE_CTRL_RESET_MASK;
-	XEmacPs_PhyWrite(xemacpsp, phy_addr, IEEE_CONTROL_REG_OFFSET, control);
+    XEmacPs_PhyWrite( xemacpsp, phy_addr, IEEE_CONTROL_REG_OFFSET,
+                      control | IEEE_CTRL_RESET_MASK );
+    {
+        volatile int wait;
 
-	while (1) {
-		XEmacPs_PhyRead(xemacpsp, phy_addr, IEEE_CONTROL_REG_OFFSET, &control);
-		if (control & IEEE_CTRL_RESET_MASK)
-			continue;
-		else
-			break;
-	}
-#endif
-	FreeRTOS_printf( ( "Waiting for PHY to complete autonegotiation.\n" ) );
-
-	XEmacPs_PhyRead(xemacpsp, phy_addr, IEEE_STATUS_REG_OFFSET, &status);
-	while ( !(status & IEEE_STAT_AUTONEGOTIATE_COMPLETE) ) {
-		vTaskDelay( MINIMUM_SLEEP_TIME );
-#if XPAR_GIGE_PCS_PMA_CORE_PRESENT == 1
-#else
-		XEmacPs_PhyRead(xemacpsp, phy_addr, IEEE_COPPER_SPECIFIC_STATUS_REG_2,
-																	&temp);
-		if (temp & IEEE_AUTONEG_ERROR_MASK) {
-			FreeRTOS_printf( ( "Auto negotiation error \n" ) );
-		}
-#endif
-		XEmacPs_PhyRead(xemacpsp, phy_addr, IEEE_STATUS_REG_OFFSET,
-																&status);
-		}
-
-	FreeRTOS_printf( ( "autonegotiation complete \n" ) );
-
-#if XPAR_GIGE_PCS_PMA_CORE_PRESENT == 1
-#else
-	XEmacPs_PhyRead(xemacpsp, phy_addr, IEEE_SPECIFIC_STATUS_REG, &partner_capabilities);
-#endif
-
-#if XPAR_GIGE_PCS_PMA_CORE_PRESENT == 1
-	FreeRTOS_printf( ( "Waiting for Link to be up; Polling for SGMII core Reg \n" ) );
-	XEmacPs_PhyRead(xemacpsp, phy_addr, 5, &temp);
-	while(!(temp & 0x8000)) {
-		XEmacPs_PhyRead(xemacpsp, phy_addr, 5, &temp);
-	}
-	if((temp & 0x0C00) == 0x0800) {
-		XEmacPs_PhyRead(xemacpsp, phy_addr, 0, &temp);
-		return 1000;
-	}
-	else if((temp & 0x0C00) == 0x0400) {
-		XEmacPs_PhyRead(xemacpsp, phy_addr, 0, &temp);
-		return 100;
-	}
-	else if((temp & 0x0C00) == 0x0000) {
-		XEmacPs_PhyRead(xemacpsp, phy_addr, 0, &temp);
-		return 10;
-	} else {
-		FreeRTOS_printf( ( "get_IEEE_phy_speed(): Invalid speed bit value, Deafulting to Speed = 10 Mbps\n" ) );
-		XEmacPs_PhyRead(xemacpsp, phy_addr, 0, &temp);
-		XEmacPs_PhyWrite(xemacpsp, phy_addr, 0, 0x0100);
-		return 10;
-	}
-#else
-	if ( ((partner_capabilities >> 14) & 3) == 2)/* 1000Mbps */
-		return 1000;
-	else if ( ((partner_capabilities >> 14) & 3) == 1)/* 100Mbps */
-		return 100;
-	else					/* 10Mbps */
-		return 10;
-#endif
+        for( wait = 0; wait < 100000; wait++ )
+        {
+        }
+    }
+    return 0;
 }
-#endif
 
-unsigned configure_IEEE_phy_speed(XEmacPs *xemacpsp, unsigned speed)
+static void SetUpSLCRDivisors( int mac_baseaddr,
+                               int speed )
 {
-	u16 control;
-	u32 phy_addr = detect_phy(xemacpsp);
+    volatile u32 slcrBaseAddress;
 
-	XEmacPs_PhyWrite(xemacpsp,phy_addr, IEEE_PAGE_ADDRESS_REGISTER, 2);
-	XEmacPs_PhyRead(xemacpsp, phy_addr, IEEE_CONTROL_REG_MAC, &control);
-	control |= IEEE_RGMII_TXRX_CLOCK_DELAYED_MASK;
-	XEmacPs_PhyWrite(xemacpsp, phy_addr, IEEE_CONTROL_REG_MAC, control);
+    #ifndef PEEP
+        u32 SlcrDiv0;
+        u32 SlcrDiv1 = 0;
+        u32 SlcrTxClkCntrl;
+    #endif
 
-	XEmacPs_PhyWrite(xemacpsp, phy_addr, IEEE_PAGE_ADDRESS_REGISTER, 0);
+    *( volatile unsigned int * ) ( SLCR_UNLOCK_ADDR ) = SLCR_UNLOCK_KEY_VALUE;
 
-	XEmacPs_PhyRead(xemacpsp, phy_addr, IEEE_AUTONEGO_ADVERTISE_REG, &control);
-	control |= IEEE_ASYMMETRIC_PAUSE_MASK;
-	control |= IEEE_PAUSE_MASK;
-	XEmacPs_PhyWrite(xemacpsp, phy_addr, IEEE_AUTONEGO_ADVERTISE_REG, control);
+    if( ( unsigned long ) mac_baseaddr == EMAC0_BASE_ADDRESS )
+    {
+        slcrBaseAddress = SLCR_GEM0_CLK_CTRL_ADDR;
+    }
+    else
+    {
+        slcrBaseAddress = SLCR_GEM1_CLK_CTRL_ADDR;
+    }
 
-	XEmacPs_PhyRead(xemacpsp, phy_addr, IEEE_CONTROL_REG_OFFSET, &control);
-	control &= ~IEEE_CTRL_LINKSPEED_1000M;
-	control &= ~IEEE_CTRL_LINKSPEED_100M;
-	control &= ~IEEE_CTRL_LINKSPEED_10M;
+    #ifdef PEEP
+        if( speed == 1000 )
+        {
+            *( volatile unsigned int * ) ( slcrBaseAddress ) =
+                SLCR_GEM_1G_CLK_CTRL_VALUE;
+        }
+        else if( speed == 100 )
+        {
+            *( volatile unsigned int * ) ( slcrBaseAddress ) =
+                SLCR_GEM_100M_CLK_CTRL_VALUE;
+        }
+        else
+        {
+            *( volatile unsigned int * ) ( slcrBaseAddress ) =
+                SLCR_GEM_10M_CLK_CTRL_VALUE;
+        }
+    #else /* ifdef PEEP */
+        if( speed == 1000 )
+        {
+            if( ( unsigned long ) mac_baseaddr == EMAC0_BASE_ADDRESS )
+            {
+                #ifdef XPAR_PS7_ETHERNET_0_ENET_SLCR_1000MBPS_DIV0
+                    SlcrDiv0 = XPAR_PS7_ETHERNET_0_ENET_SLCR_1000MBPS_DIV0;
+                    SlcrDiv1 = XPAR_PS7_ETHERNET_0_ENET_SLCR_1000MBPS_DIV1;
+                #endif
+            }
+            else
+            {
+                #ifdef XPAR_PS7_ETHERNET_1_ENET_SLCR_1000MBPS_DIV0
+                    SlcrDiv0 = XPAR_PS7_ETHERNET_1_ENET_SLCR_1000MBPS_DIV0;
+                    SlcrDiv1 = XPAR_PS7_ETHERNET_1_ENET_SLCR_1000MBPS_DIV1;
+                #endif
+            }
+        }
+        else if( speed == 100 )
+        {
+            if( ( unsigned long ) mac_baseaddr == EMAC0_BASE_ADDRESS )
+            {
+                #ifdef XPAR_PS7_ETHERNET_0_ENET_SLCR_100MBPS_DIV0
+                    SlcrDiv0 = XPAR_PS7_ETHERNET_0_ENET_SLCR_100MBPS_DIV0;
+                    SlcrDiv1 = XPAR_PS7_ETHERNET_0_ENET_SLCR_100MBPS_DIV1;
+                #endif
+            }
+            else
+            {
+                #ifdef XPAR_PS7_ETHERNET_1_ENET_SLCR_100MBPS_DIV0
+                    SlcrDiv0 = XPAR_PS7_ETHERNET_1_ENET_SLCR_100MBPS_DIV0;
+                    SlcrDiv1 = XPAR_PS7_ETHERNET_1_ENET_SLCR_100MBPS_DIV1;
+                #endif
+            }
+        }
+        else
+        {
+            if( ( unsigned long ) mac_baseaddr == EMAC0_BASE_ADDRESS )
+            {
+                #ifdef XPAR_PS7_ETHERNET_0_ENET_SLCR_10MBPS_DIV0
+                    SlcrDiv0 = XPAR_PS7_ETHERNET_0_ENET_SLCR_10MBPS_DIV0;
+                    SlcrDiv1 = XPAR_PS7_ETHERNET_0_ENET_SLCR_10MBPS_DIV1;
+                #endif
+            }
+            else
+            {
+                #ifdef XPAR_PS7_ETHERNET_1_ENET_SLCR_10MBPS_DIV0
+                    SlcrDiv0 = XPAR_PS7_ETHERNET_1_ENET_SLCR_10MBPS_DIV0;
+                    SlcrDiv1 = XPAR_PS7_ETHERNET_1_ENET_SLCR_10MBPS_DIV1;
+                #endif
+            }
+        }
 
-	if (speed == 1000) {
-		control |= IEEE_CTRL_LINKSPEED_1000M;
-	}
-
-	else if (speed == 100) {
-		control |= IEEE_CTRL_LINKSPEED_100M;
-		/* Dont advertise PHY speed of 1000 Mbps */
-		XEmacPs_PhyWrite(xemacpsp, phy_addr, IEEE_1000_ADVERTISE_REG_OFFSET, 0);
-		/* Dont advertise PHY speed of 10 Mbps */
-		XEmacPs_PhyWrite(xemacpsp, phy_addr, IEEE_AUTONEGO_ADVERTISE_REG,
-																ADVERTISE_100);
-	}
-
-	else if (speed == 10) {
-		control |= IEEE_CTRL_LINKSPEED_10M;
-		/* Dont advertise PHY speed of 1000 Mbps */
-		XEmacPs_PhyWrite(xemacpsp, phy_addr, IEEE_1000_ADVERTISE_REG_OFFSET,
-																			0);
-		/* Dont advertise PHY speed of 100 Mbps */
-		XEmacPs_PhyWrite(xemacpsp, phy_addr, IEEE_AUTONEGO_ADVERTISE_REG,
-																ADVERTISE_10);
-	}
-
-	XEmacPs_PhyWrite(xemacpsp, phy_addr, IEEE_CONTROL_REG_OFFSET,
-											control | IEEE_CTRL_RESET_MASK);
-	{
-		volatile int wait;
-		for (wait=0; wait < 100000; wait++);
-	}
-	return 0;
-}
-
-static void SetUpSLCRDivisors(int mac_baseaddr, int speed)
-{
-	volatile u32 slcrBaseAddress;
-#ifndef PEEP
-	u32 SlcrDiv0;
-	u32 SlcrDiv1=0;
-	u32 SlcrTxClkCntrl;
-#endif
-
-	*(volatile unsigned int *)(SLCR_UNLOCK_ADDR) = SLCR_UNLOCK_KEY_VALUE;
-
-	if ((unsigned long)mac_baseaddr == EMAC0_BASE_ADDRESS) {
-		slcrBaseAddress = SLCR_GEM0_CLK_CTRL_ADDR;
-	} else {
-		slcrBaseAddress = SLCR_GEM1_CLK_CTRL_ADDR;
-	}
-#ifdef PEEP
-	if (speed == 1000) {
-		*(volatile unsigned int *)(slcrBaseAddress) =
-											SLCR_GEM_1G_CLK_CTRL_VALUE;
-	} else if (speed == 100) {
-		*(volatile unsigned int *)(slcrBaseAddress) =
-											SLCR_GEM_100M_CLK_CTRL_VALUE;
-	} else {
-		*(volatile unsigned int *)(slcrBaseAddress) =
-											SLCR_GEM_10M_CLK_CTRL_VALUE;
-	}
-#else
-	if (speed == 1000) {
-		if ((unsigned long)mac_baseaddr == EMAC0_BASE_ADDRESS) {
-#ifdef XPAR_PS7_ETHERNET_0_ENET_SLCR_1000MBPS_DIV0
-			SlcrDiv0 = XPAR_PS7_ETHERNET_0_ENET_SLCR_1000MBPS_DIV0;
-			SlcrDiv1 = XPAR_PS7_ETHERNET_0_ENET_SLCR_1000MBPS_DIV1;
-#endif
-		} else {
-#ifdef XPAR_PS7_ETHERNET_1_ENET_SLCR_1000MBPS_DIV0
-			SlcrDiv0 = XPAR_PS7_ETHERNET_1_ENET_SLCR_1000MBPS_DIV0;
-			SlcrDiv1 = XPAR_PS7_ETHERNET_1_ENET_SLCR_1000MBPS_DIV1;
-#endif
-		}
-	} else if (speed == 100) {
-		if ((unsigned long)mac_baseaddr == EMAC0_BASE_ADDRESS) {
-#ifdef XPAR_PS7_ETHERNET_0_ENET_SLCR_100MBPS_DIV0
-			SlcrDiv0 = XPAR_PS7_ETHERNET_0_ENET_SLCR_100MBPS_DIV0;
-			SlcrDiv1 = XPAR_PS7_ETHERNET_0_ENET_SLCR_100MBPS_DIV1;
-#endif
-		} else {
-#ifdef XPAR_PS7_ETHERNET_1_ENET_SLCR_100MBPS_DIV0
-			SlcrDiv0 = XPAR_PS7_ETHERNET_1_ENET_SLCR_100MBPS_DIV0;
-			SlcrDiv1 = XPAR_PS7_ETHERNET_1_ENET_SLCR_100MBPS_DIV1;
-#endif
-		}
-	} else {
-		if ((unsigned long)mac_baseaddr == EMAC0_BASE_ADDRESS) {
-#ifdef XPAR_PS7_ETHERNET_0_ENET_SLCR_10MBPS_DIV0
-			SlcrDiv0 = XPAR_PS7_ETHERNET_0_ENET_SLCR_10MBPS_DIV0;
-			SlcrDiv1 = XPAR_PS7_ETHERNET_0_ENET_SLCR_10MBPS_DIV1;
-#endif
-		} else {
-#ifdef XPAR_PS7_ETHERNET_1_ENET_SLCR_10MBPS_DIV0
-			SlcrDiv0 = XPAR_PS7_ETHERNET_1_ENET_SLCR_10MBPS_DIV0;
-			SlcrDiv1 = XPAR_PS7_ETHERNET_1_ENET_SLCR_10MBPS_DIV1;
-#endif
-		}
-	}
-	SlcrTxClkCntrl = *(volatile unsigned int *)(slcrBaseAddress);
-	SlcrTxClkCntrl &= EMACPS_SLCR_DIV_MASK;
-	SlcrTxClkCntrl |= (SlcrDiv1 << 20);
-	SlcrTxClkCntrl |= (SlcrDiv0 << 8);
-	*(volatile unsigned int *)(slcrBaseAddress) = SlcrTxClkCntrl;
-#endif
-	*(volatile unsigned int *)(SLCR_LOCK_ADDR) = SLCR_LOCK_KEY_VALUE;
-	return;
+        SlcrTxClkCntrl = *( volatile unsigned int * ) ( slcrBaseAddress );
+        SlcrTxClkCntrl &= EMACPS_SLCR_DIV_MASK;
+        SlcrTxClkCntrl |= ( SlcrDiv1 << 20 );
+        SlcrTxClkCntrl |= ( SlcrDiv0 << 8 );
+        *( volatile unsigned int * ) ( slcrBaseAddress ) = SlcrTxClkCntrl;
+    #endif /* ifdef PEEP */
+    *( volatile unsigned int * ) ( SLCR_LOCK_ADDR ) = SLCR_LOCK_KEY_VALUE;
+    return;
 }
 
 
 unsigned link_speed;
-unsigned Phy_Setup (XEmacPs *xemacpsp)
+unsigned Phy_Setup( XEmacPs * xemacpsp )
 {
-	unsigned long conv_present = 0;
-	unsigned long convspeeddupsetting = 0;
-	unsigned long convphyaddr = 0;
+    unsigned long conv_present = 0;
+    unsigned long convspeeddupsetting = 0;
+    unsigned long convphyaddr = 0;
 
-#ifdef XPAR_GMII2RGMIICON_0N_ETH0_ADDR
-	convphyaddr = XPAR_GMII2RGMIICON_0N_ETH0_ADDR;
-	conv_present = 1;
-#else
-#ifdef XPAR_GMII2RGMIICON_0N_ETH1_ADDR
-	convphyaddr = XPAR_GMII2RGMIICON_0N_ETH1_ADDR;
-	conv_present = 1;
-#endif
-#endif
+    #ifdef XPAR_GMII2RGMIICON_0N_ETH0_ADDR
+        convphyaddr = XPAR_GMII2RGMIICON_0N_ETH0_ADDR;
+        conv_present = 1;
+    #else
+        #ifdef XPAR_GMII2RGMIICON_0N_ETH1_ADDR
+            convphyaddr = XPAR_GMII2RGMIICON_0N_ETH1_ADDR;
+            conv_present = 1;
+        #endif
+    #endif
 
-#ifdef  ipconfigNIC_LINKSPEED_AUTODETECT
-	link_speed = get_IEEE_phy_speed(xemacpsp);
-	if (link_speed == 1000) {
-		SetUpSLCRDivisors(xemacpsp->Config.BaseAddress,1000);
-		convspeeddupsetting = XEMACPS_GMII2RGMII_SPEED1000_FD;
-	} else if (link_speed == 100) {
-		SetUpSLCRDivisors(xemacpsp->Config.BaseAddress,100);
-		convspeeddupsetting = XEMACPS_GMII2RGMII_SPEED100_FD;
-	} else {
-		SetUpSLCRDivisors(xemacpsp->Config.BaseAddress,10);
-		convspeeddupsetting = XEMACPS_GMII2RGMII_SPEED10_FD;
-	}
-#elif	defined(ipconfigNIC_LINKSPEED1000)
-	SetUpSLCRDivisors(xemacpsp->Config.BaseAddress,1000);
-	link_speed = 1000;
-	configure_IEEE_phy_speed(xemacpsp, link_speed);
-	convspeeddupsetting = XEMACPS_GMII2RGMII_SPEED1000_FD;
-	vTaskDelay( MINIMUM_SLEEP_TIME );
-#elif	defined(ipconfigNIC_LINKSPEED100)
-	SetUpSLCRDivisors(xemacpsp->Config.BaseAddress,100);
-	link_speed = 100;
-	configure_IEEE_phy_speed(xemacpsp, link_speed);
-	convspeeddupsetting = XEMACPS_GMII2RGMII_SPEED100_FD;
-	vTaskDelay( MINIMUM_SLEEP_TIME );
-#elif	defined(ipconfigNIC_LINKSPEED10)
-	SetUpSLCRDivisors(xemacpsp->Config.BaseAddress,10);
-	link_speed = 10;
-	configure_IEEE_phy_speed(xemacpsp, link_speed);
-	convspeeddupsetting = XEMACPS_GMII2RGMII_SPEED10_FD;
-	vTaskDelay( MINIMUM_SLEEP_TIME );
-#endif
-	if (conv_present) {
-		XEmacPs_PhyWrite(xemacpsp, convphyaddr,
-		XEMACPS_GMII2RGMII_REG_NUM, convspeeddupsetting);
-	}
+    #ifdef  ipconfigNIC_LINKSPEED_AUTODETECT
+        link_speed = get_IEEE_phy_speed( xemacpsp );
 
-	FreeRTOS_printf( ( "link speed: %d\n", link_speed ) );
-	return link_speed;
+        if( link_speed == 1000 )
+        {
+            SetUpSLCRDivisors( xemacpsp->Config.BaseAddress, 1000 );
+            convspeeddupsetting = XEMACPS_GMII2RGMII_SPEED1000_FD;
+        }
+        else if( link_speed == 100 )
+        {
+            SetUpSLCRDivisors( xemacpsp->Config.BaseAddress, 100 );
+            convspeeddupsetting = XEMACPS_GMII2RGMII_SPEED100_FD;
+        }
+        else
+        {
+            SetUpSLCRDivisors( xemacpsp->Config.BaseAddress, 10 );
+            convspeeddupsetting = XEMACPS_GMII2RGMII_SPEED10_FD;
+        }
+    #elif   defined( ipconfigNIC_LINKSPEED1000 )
+        SetUpSLCRDivisors( xemacpsp->Config.BaseAddress, 1000 );
+        link_speed = 1000;
+        configure_IEEE_phy_speed( xemacpsp, link_speed );
+        convspeeddupsetting = XEMACPS_GMII2RGMII_SPEED1000_FD;
+        vTaskDelay( MINIMUM_SLEEP_TIME );
+    #elif   defined( ipconfigNIC_LINKSPEED100 )
+        SetUpSLCRDivisors( xemacpsp->Config.BaseAddress, 100 );
+        link_speed = 100;
+        configure_IEEE_phy_speed( xemacpsp, link_speed );
+        convspeeddupsetting = XEMACPS_GMII2RGMII_SPEED100_FD;
+        vTaskDelay( MINIMUM_SLEEP_TIME );
+    #elif   defined( ipconfigNIC_LINKSPEED10 )
+        SetUpSLCRDivisors( xemacpsp->Config.BaseAddress, 10 );
+        link_speed = 10;
+        configure_IEEE_phy_speed( xemacpsp, link_speed );
+        convspeeddupsetting = XEMACPS_GMII2RGMII_SPEED10_FD;
+        vTaskDelay( MINIMUM_SLEEP_TIME );
+    #endif /* ifdef  ipconfigNIC_LINKSPEED_AUTODETECT */
+
+    if( conv_present )
+    {
+        XEmacPs_PhyWrite( xemacpsp, convphyaddr,
+                          XEMACPS_GMII2RGMII_REG_NUM, convspeeddupsetting );
+    }
+
+    FreeRTOS_printf( ( "link speed: %d\n", link_speed ) );
+    return link_speed;
 }
-

--- a/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/portable/NetworkInterface/Zynq/x_topology.h
+++ b/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/portable/NetworkInterface/Zynq/x_topology.h
@@ -17,30 +17,34 @@
  */
 
 #ifndef __XTOPOLOGY_H_
-#define __XTOPOLOGY_H_
+    #define __XTOPOLOGY_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+    #ifdef __cplusplus
+        extern "C" {
+    #endif
 
-enum xemac_types { xemac_type_unknown = -1, xemac_type_xps_emaclite, xemac_type_xps_ll_temac, xemac_type_axi_ethernet, xemac_type_emacps };
+    enum xemac_types
+    {
+        xemac_type_unknown = -1, xemac_type_xps_emaclite, xemac_type_xps_ll_temac, xemac_type_axi_ethernet, xemac_type_emacps
+    };
 
-struct xtopology_t {
-	unsigned emac_baseaddr;
-	enum xemac_types emac_type;
-	unsigned intc_baseaddr;
-	unsigned intc_emac_intr;	/* valid only for xemac_type_xps_emaclite */
-	unsigned scugic_baseaddr; /* valid only for Zynq */
-	unsigned scugic_emac_intr; /* valid only for GEM */
-};
+    struct xtopology_t
+    {
+        unsigned emac_baseaddr;
+        enum xemac_types emac_type;
+        unsigned intc_baseaddr;
+        unsigned intc_emac_intr;   /* valid only for xemac_type_xps_emaclite */
+        unsigned scugic_baseaddr;  /* valid only for Zynq */
+        unsigned scugic_emac_intr; /* valid only for GEM */
+    };
 
-extern int x_topology_n_emacs;
-extern struct xtopology_t x_topology[];
+    extern int x_topology_n_emacs;
+    extern struct xtopology_t x_topology[];
 
-int x_topology_find_index(unsigned base);
+    int x_topology_find_index( unsigned base );
 
-#ifdef __cplusplus
-}
-#endif
+    #ifdef __cplusplus
+        }
+    #endif
 
-#endif
+#endif /* ifndef __XTOPOLOGY_H_ */

--- a/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/portable/NetworkInterface/board_family/NetworkInterface.c
+++ b/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/portable/NetworkInterface/board_family/NetworkInterface.c
@@ -1,27 +1,27 @@
 /*
-FreeRTOS+TCP V2.2.1
-Copyright (C) 2018 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of
-this software and associated documentation files (the "Software"), to deal in
-the Software without restriction, including without limitation the rights to
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
-the Software, and to permit persons to whom the Software is furnished to do so,
-subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
-COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
-IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
- http://aws.amazon.com/freertos
- http://www.FreeRTOS.org
-*/
+ * FreeRTOS+TCP V2.2.1
+ * Copyright (C) 2018 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
 
 /* FreeRTOS includes. */
 #include "FreeRTOS.h"
@@ -31,33 +31,34 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "FreeRTOS_IP.h"
 
 /* If ipconfigETHERNET_DRIVER_FILTERS_FRAME_TYPES is set to 1, then the Ethernet
-driver will filter incoming packets and only pass the stack those packets it
-considers need processing. */
-#if( ipconfigETHERNET_DRIVER_FILTERS_FRAME_TYPES == 0 )
-#define ipCONSIDER_FRAME_FOR_PROCESSING( pucEthernetBuffer ) eProcessBuffer
+ * driver will filter incoming packets and only pass the stack those packets it
+ * considers need processing. */
+#if ( ipconfigETHERNET_DRIVER_FILTERS_FRAME_TYPES == 0 )
+    #define ipCONSIDER_FRAME_FOR_PROCESSING( pucEthernetBuffer )    eProcessBuffer
 #else
-#define ipCONSIDER_FRAME_FOR_PROCESSING( pucEthernetBuffer ) eConsiderFrameForProcessing( ( pucEthernetBuffer ) )
+    #define ipCONSIDER_FRAME_FOR_PROCESSING( pucEthernetBuffer )    eConsiderFrameForProcessing( ( pucEthernetBuffer ) )
 #endif
 
 BaseType_t xNetworkInterfaceInitialise( void )
 {
-	/* FIX ME. */
-	return pdFALSE;
+    /* FIX ME. */
+    return pdFALSE;
 }
 
-BaseType_t xNetworkInterfaceOutput( NetworkBufferDescriptor_t * const pxNetworkBuffer, BaseType_t xReleaseAfterSend )
+BaseType_t xNetworkInterfaceOutput( NetworkBufferDescriptor_t * const pxNetworkBuffer,
+                                    BaseType_t xReleaseAfterSend )
 {
-	/* FIX ME. */
-	return pdFALSE;
+    /* FIX ME. */
+    return pdFALSE;
 }
 
 void vNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
 {
-	/* FIX ME. */
+    /* FIX ME. */
 }
 
 BaseType_t xGetPhyLinkStatus( void )
 {
-	/* FIX ME. */
-	return pdFALSE;
+    /* FIX ME. */
+    return pdFALSE;
 }

--- a/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/portable/NetworkInterface/include/phyHandling.h
+++ b/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/portable/NetworkInterface/include/phyHandling.h
@@ -4,115 +4,125 @@
  * a Media-Independent Interface (MII), or a Reduced Media-Independent Interface (RMII).
  * The EMAC can poll for PHY ports on 32 different addresses. Each of the PHY ports
  * shall be treated independently.
- * 
+ *
  */
 
 #ifndef PHYHANDLING_H
 
-#define PHYHANDLING_H
+    #define PHYHANDLING_H
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+    #ifdef __cplusplus
+        extern "C" {
+    #endif
 
 
-#ifndef ipconfigPHY_MAX_PORTS
-	/* There can be at most 32 PHY ports, but in most cases there are 4 or less. */
-	#define	ipconfigPHY_MAX_PORTS	4
-#endif
+    #ifndef ipconfigPHY_MAX_PORTS
+        /* There can be at most 32 PHY ports, but in most cases there are 4 or less. */
+        #define ipconfigPHY_MAX_PORTS    4
+    #endif
 
 /* A generic user-provided function that reads from the PHY-port at 'xAddress'( 0-based ). A 16-bit value shall be stored in
-  '*pulValue'. xRegister is the register number ( 0 .. 31 ). In fact all PHY registers are 16-bit.
-  Return non-zero in case the action failed. */
-typedef BaseType_t ( *xApplicationPhyReadHook_t )( BaseType_t xAddress, BaseType_t xRegister, uint32_t *pulValue );
+ * '*pulValue'. xRegister is the register number ( 0 .. 31 ). In fact all PHY registers are 16-bit.
+ * Return non-zero in case the action failed. */
+    typedef BaseType_t ( * xApplicationPhyReadHook_t )( BaseType_t xAddress,
+                                                        BaseType_t xRegister,
+                                                        uint32_t * pulValue );
 
 /* A generic user-provided function that writes 'ulValue' to the
-   PHY-port at 'xAddress' ( 0-based ). xRegister is the register number ( 0 .. 31 ).
-   Return non-zero in case the action failed. */
-typedef BaseType_t ( *xApplicationPhyWriteHook_t )( BaseType_t xAddress, BaseType_t xRegister, uint32_t ulValue );
+ * PHY-port at 'xAddress' ( 0-based ). xRegister is the register number ( 0 .. 31 ).
+ * Return non-zero in case the action failed. */
+    typedef BaseType_t ( * xApplicationPhyWriteHook_t )( BaseType_t xAddress,
+                                                         BaseType_t xRegister,
+                                                         uint32_t ulValue );
 
-typedef struct xPhyProperties
-{
-	uint8_t ucSpeed;
-	uint8_t ucMDI_X;		/* MDI-X : Medium Dependent Interface - Crossover */
-	uint8_t ucDuplex;
-	uint8_t ucSpare;
-} PhyProperties_t;
+    typedef struct xPhyProperties
+    {
+        uint8_t ucSpeed;
+        uint8_t ucMDI_X; /* MDI-X : Medium Dependent Interface - Crossover */
+        uint8_t ucDuplex;
+        uint8_t ucSpare;
+    } PhyProperties_t;
 
-typedef struct xEthernetPhy
-{
-	xApplicationPhyReadHook_t fnPhyRead;
-	xApplicationPhyWriteHook_t fnPhyWrite;
-	uint32_t ulPhyIDs[ ipconfigPHY_MAX_PORTS ];
-	uint8_t ucPhyIndexes[ ipconfigPHY_MAX_PORTS ];
-	TimeOut_t xLinkStatusTimer;
-	TickType_t xLinkStatusRemaining;
-	BaseType_t xPortCount;
-	uint32_t ulBCRValue;
-	uint32_t ulACRValue;
-	uint32_t ulLinkStatusMask;
-	PhyProperties_t xPhyPreferences;
-	PhyProperties_t xPhyProperties;
-} EthernetPhy_t;
+    typedef struct xEthernetPhy
+    {
+        xApplicationPhyReadHook_t fnPhyRead;
+        xApplicationPhyWriteHook_t fnPhyWrite;
+        uint32_t ulPhyIDs[ ipconfigPHY_MAX_PORTS ];
+        uint8_t ucPhyIndexes[ ipconfigPHY_MAX_PORTS ];
+        TimeOut_t xLinkStatusTimer;
+        TickType_t xLinkStatusRemaining;
+        BaseType_t xPortCount;
+        uint32_t ulBCRValue;
+        uint32_t ulACRValue;
+        uint32_t ulLinkStatusMask;
+        PhyProperties_t xPhyPreferences;
+        PhyProperties_t xPhyProperties;
+    } EthernetPhy_t;
 
 /* Some defines used internally here to indicate preferences about speed, MDIX
-(wired direct or crossed), and duplex (half or full). */
+ * (wired direct or crossed), and duplex (half or full). */
 
 /* Values for PhyProperties_t::ucSpeed : */
-#define	PHY_SPEED_10		1
-#define	PHY_SPEED_100		2
-#define	PHY_SPEED_AUTO		3
+    #define PHY_SPEED_10           1
+    #define PHY_SPEED_100          2
+    #define PHY_SPEED_AUTO         3
 
 /* Values for PhyProperties_t::ucMDI_X : */
-#define	PHY_MDIX_DIRECT		1
-#define	PHY_MDIX_CROSSED	2
-#define	PHY_MDIX_AUTO		3
+    #define PHY_MDIX_DIRECT        1
+    #define PHY_MDIX_CROSSED       2
+    #define PHY_MDIX_AUTO          3
 
 /* Values for PhyProperties_t::ucDuplex : */
-#define	PHY_DUPLEX_HALF		1
-#define	PHY_DUPLEX_FULL		2
-#define	PHY_DUPLEX_AUTO		3
+    #define PHY_DUPLEX_HALF        1
+    #define PHY_DUPLEX_FULL        2
+    #define PHY_DUPLEX_AUTO        3
 
 /* ID's of supported PHY's : */
-#define PHY_ID_LAN8742A		0x0007c130
-#define PHY_ID_LAN8720		0x0007c0f0
+    #define PHY_ID_LAN8742A        0x0007c130
+    #define PHY_ID_LAN8720         0x0007c0f0
 
-#define PHY_ID_KSZ8041		0x000010A1
-#define PHY_ID_KSZ8051		0x000010A1
-#define PHY_ID_KSZ8081		0x000010A1
+    #define PHY_ID_KSZ8041         0x000010A1
+    #define PHY_ID_KSZ8051         0x000010A1
+    #define PHY_ID_KSZ8081         0x000010A1
 
-#define PHY_ID_KSZ8863		0x00221430
-#define PHY_ID_KSZ8081MNXIA 0x00221560
+    #define PHY_ID_KSZ8863         0x00221430
+    #define PHY_ID_KSZ8081MNXIA    0x00221560
 
-#define PHY_ID_DP83848I		0x20005C90
+    #define PHY_ID_DP83848I        0x20005C90
 
 
 /* Initialise the struct and assign a PHY-read and -write function. */
-void vPhyInitialise( EthernetPhy_t *pxPhyObject, xApplicationPhyReadHook_t fnPhyRead, xApplicationPhyWriteHook_t fnPhyWrite );
+    void vPhyInitialise( EthernetPhy_t * pxPhyObject,
+                         xApplicationPhyReadHook_t fnPhyRead,
+                         xApplicationPhyWriteHook_t fnPhyWrite );
 
 /* Discover all PHY's connected by polling 32 indexes ( zero-based ) */
-BaseType_t xPhyDiscover( EthernetPhy_t *pxPhyObject );
+    BaseType_t xPhyDiscover( EthernetPhy_t * pxPhyObject );
 
 /* Send a reset command to the connected PHY ports and send configuration. */
-BaseType_t xPhyConfigure( EthernetPhy_t *pxPhyObject, const PhyProperties_t *pxPhyProperties );
+    BaseType_t xPhyConfigure( EthernetPhy_t * pxPhyObject,
+                              const PhyProperties_t * pxPhyProperties );
 
 /* Give a command to start auto negotiation on a set of PHY port's. */
-BaseType_t xPhyStartAutoNegotiation( EthernetPhy_t *pxPhyObject, uint32_t ulPhyMask );
+    BaseType_t xPhyStartAutoNegotiation( EthernetPhy_t * pxPhyObject,
+                                         uint32_t ulPhyMask );
 
 /* Do not use auto negotiation but use predefined values from 'pxPhyObject->xPhyPreferences'. */
-BaseType_t xPhyFixedValue( EthernetPhy_t *pxPhyObject, uint32_t ulPhyMask );
+    BaseType_t xPhyFixedValue( EthernetPhy_t * pxPhyObject,
+                               uint32_t ulPhyMask );
 
 /* Check the current Link Status.
-'xHadReception' : make this true if a packet has been received since the
-last call to this function. */
-BaseType_t xPhyCheckLinkStatus( EthernetPhy_t *pxPhyObject, BaseType_t xHadReception );
+ * 'xHadReception' : make this true if a packet has been received since the
+ * last call to this function. */
+    BaseType_t xPhyCheckLinkStatus( EthernetPhy_t * pxPhyObject,
+                                    BaseType_t xHadReception );
 
 /* Get the bitmask of a given 'EthernetPhy_t'. */
-#define xPhyGetMask( pxPhyObject ) \
-	( ( ( ( uint32_t ) 1u ) << ( pxPhyObject )->xPortCount ) - 1u )
+    #define xPhyGetMask( pxPhyObject ) \
+    ( ( ( ( uint32_t ) 1u ) << ( pxPhyObject )->xPortCount ) - 1u )
 
-#ifdef __cplusplus
-} /* extern "C" */
-#endif
+    #ifdef __cplusplus
+        } /* extern "C" */
+    #endif
 
-#endif
+#endif /* ifndef PHYHANDLING_H */

--- a/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/portable/NetworkInterface/ksz8851snl/NetworkInterface.c
+++ b/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/portable/NetworkInterface/ksz8851snl/NetworkInterface.c
@@ -1,27 +1,27 @@
 /*
-FreeRTOS+TCP V2.2.1
-Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of
-this software and associated documentation files (the "Software"), to deal in
-the Software without restriction, including without limitation the rights to
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
-the Software, and to permit persons to whom the Software is furnished to do so,
-subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
-COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
-IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
- http://aws.amazon.com/freertos
- http://www.FreeRTOS.org
-*/
+ * FreeRTOS+TCP V2.2.1
+ * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
 
 /* Standard includes. */
 #include <stdint.h>
@@ -54,237 +54,239 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include <spi/spi.h>
 
 /*
-	Sending a packet:
+ *  Sending a packet:
+ *
+ *      1) Called by UP-task, add buffer to the TX-list:
+ *          xNetworkInterfaceOutput()
+ *              tx_buffers[ us_tx_head ] = pxNetworkBuffer;
+ *              tx_busy[ us_tx_head ] = pdTRUE;
+ *              us_tx_head++;
+ *
+ *      2) Called by EMAC-Task: start SPI transfer
+ *          ksz8851snl_update()
+ *          if( ul_spi_pdc_status == SPI_PDC_IDLE )
+ *          {
+ *              if( ( tx_busy[ us_tx_tail ] != pdFALSE ) &&
+ *                  ( us_pending_frame == 0 ) &&
+ *                  ( ul_had_intn_interrupt == 0 ) )
+ *              {
+ *                  // disable all interrupts.
+ *                  ksz8851_reg_write( REG_INT_MASK, 0 );
+ *                  Bring KSZ8851SNL_CSN_GPIO low
+ *                  ksz8851_fifo_write( pxNetworkBuffer->pucEthernetBuffer, xLength, xLength );
+ *                  ul_spi_pdc_status = SPI_PDC_TX_START;
+ *                  tx_cur_buffer = pxNetworkBuffer;
+ *              }
+ *          }
+ *      3) Wait for SPI RXBUFF interrupt
+ *          SPI_Handler()
+ *              if( ul_spi_pdc_status == SPI_PDC_TX_START )
+ *              {
+ *                  if( SPI_Status & SPI_SR_RXBUFF )
+ *                  {
+ *                      ul_spi_pdc_status = SPI_PDC_TX_COMPLETE;
+ *                  }
+ *              }
+ *
+ *      4) Called by EMAC-Task: finish SPI transfer
+ *          ksz8851snl_update()
+ *              if( ul_spi_pdc_status == SPI_PDC_TX_COMPLETE )
+ *              {
+ *                  ul_spi_pdc_status = SPI_PDC_IDLE;
+ *                  Bring KSZ8851SNL_CSN_GPIO high
+ *                  // TX step12: disable TXQ write access.
+ *                  ksz8851_reg_clrbits( REG_RXQ_CMD, RXQ_START );
+ *                  // TX step12.1: enqueue frame in TXQ.
+ *                  ksz8851_reg_setbits( REG_TXQ_CMD, TXQ_ENQUEUE );
+ *
+ *                  // RX step13: enable INT_RX flag.
+ *                  ksz8851_reg_write( REG_INT_MASK, INT_RX );
+ *
+ *                  // Buffer sent, free the corresponding buffer and mark descriptor as owned by software.
+ *                  vReleaseNetworkBufferAndDescriptor( pxNetworkBuffer );
+ *
+ *                  tx_buffers[ us_tx_tail ] = NULL;
+ *                  tx_busy[ us_tx_tail ] = pdFALSE;
+ *                  us_tx_tail++
+ *              }
+ *
+ *  Receiving a packet:
+ *
+ *      1) Wait for a INTN interrupt
+ *          INTN_Handler()
+ *              ul_had_intn_interrupt = 1
+ *              vTaskNotifyGiveFromISR();	// Wake up the EMAC task
+ *
+ *      2) Called by EMAC-Task: check for new fragments and start SPI transfer
+ *          ksz8851snl_update()
+ *              if( ul_spi_pdc_status == SPI_PDC_IDLE )
+ *              {
+ *                  if( ( ul_had_intn_interrupt != 0 ) || ( us_pending_frame > 0 ) )
+ *                  {
+ *                      if( us_pending_frame == 0 )
+ *                      {
+ *                          us_pending_frame = ksz8851_reg_read(REG_RX_FRAME_CNT_THRES) >> 8;
+ *                          if( us_pending_frame == 0 )
+ *                          {
+ *                              break;
+ *                          }
+ *                      }
+ *                      // RX step2: disable all interrupts.
+ *                      ksz8851_reg_write( REG_INT_MASK, 0 );
+ *                      Check if there is a valid packet: REG_RX_FHR_STATUS
+ *                      Read the length of the next fragment: REG_RX_FHR_BYTE_CNT
+ *                      ul_spi_pdc_status = SPI_PDC_RX_START;
+ *                      gpio_set_pin_low(KSZ8851SNL_CSN_GPIO);
+ *                      // Start SPI data transfer
+ *                      ksz8851_fifo_read( pxNetworkBuffer->pucEthernetBuffer, xReadLength );
+ *                  }
+ *              }
+ *
+ *      3) Wait for SPI RXBUFF interrupt
+ *          SPI_Handler()
+ *          if( ul_spi_pdc_status == SPI_PDC_RX_START:
+ *          {
+ *              if( ( ulCurrentSPIStatus & SPI_SR_RXBUFF ) != 0 )
+ *              {
+ *                  // Transfer complete, disable SPI RXBUFF interrupt.
+ *                  spi_disable_interrupt( KSZ8851SNL_SPI, SPI_IDR_RXBUFF );
+ *
+ *                  ul_spi_pdc_status = SPI_PDC_RX_COMPLETE;
+ *              }
+ *          }
+ *      }
+ *
+ *      4) Finish SPI transfer
+ *          ksz8851snl_update()
+ *              if( ul_spi_pdc_status == SPI_PDC_RX_COMPLETE )
+ *              {
+ *                  ul_spi_pdc_status = SPI_PDC_IDLE;
+ *                  Bring KSZ8851SNL_CSN_GPIO high
+ *                  // RX step21: end RXQ read access.
+ *                  ksz8851_reg_clrbits(REG_RXQ_CMD, RXQ_START);
+ *                  // RX step22-23: update frame count to be read.
+ *                  us_pending_frame--
+ *                  // RX step24: enable INT_RX flag if transfer complete.
+ *                  if( us_pending_frame == 0 )
+ *                  {
+ *                      // Allow more RX interrupts.
+ *                      ksz8851_reg_write( REG_INT_MASK, INT_RX );
+ *                  }
+ *
+ *                  // Mark descriptor ready to be read.
+ *                  rx_ready[ rxHead ] = pdTRUE;
+ *                  rxHead++
+ *              }
+ */
 
-		1) Called by UP-task, add buffer to the TX-list:
-			xNetworkInterfaceOutput()
-				tx_buffers[ us_tx_head ] = pxNetworkBuffer;
-				tx_busy[ us_tx_head ] = pdTRUE;
-				us_tx_head++;
+#define PHY_REG_00_BMCR         0x00    /* Basic mode control register */
+#define PHY_REG_01_BMSR         0x01    /* Basic mode status register */
+#define PHY_REG_02_PHYSID1      0x02    /* PHYS ID 1 */
+#define PHY_REG_03_PHYSID2      0x03    /* PHYS ID 2 */
+#define PHY_REG_04_ADVERTISE    0x04    /* Advertisement control reg */
+#define PHY_REG_05_LPA          0x05    /* Link partner ability reg */
+#define PHY_REG_06_ANER         0x06    /*	6	RW		Auto-Negotiation Expansion Register */
+#define PHY_REG_07_ANNPTR       0x07    /*	7	RW		Auto-Negotiation Next Page TX */
+#define PHY_REG_08_RESERVED0    0x08    /* 0x08..0x0Fh	8-15	RW		RESERVED */
 
-		2) Called by EMAC-Task: start SPI transfer
-			ksz8851snl_update()
-			if( ul_spi_pdc_status == SPI_PDC_IDLE )
-			{
-				if( ( tx_busy[ us_tx_tail ] != pdFALSE ) &&
-					( us_pending_frame == 0 ) &&
-					( ul_had_intn_interrupt == 0 ) )
-				{
-					// disable all interrupts.
-					ksz8851_reg_write( REG_INT_MASK, 0 );
-					Bring KSZ8851SNL_CSN_GPIO low
-					ksz8851_fifo_write( pxNetworkBuffer->pucEthernetBuffer, xLength, xLength );
-					ul_spi_pdc_status = SPI_PDC_TX_START;
-					tx_cur_buffer = pxNetworkBuffer;
-				}
-			}
-		3) Wait for SPI RXBUFF interrupt
-			SPI_Handler()
-				if( ul_spi_pdc_status == SPI_PDC_TX_START )
-				{
-					if( SPI_Status & SPI_SR_RXBUFF )
-					{
-						ul_spi_pdc_status = SPI_PDC_TX_COMPLETE;
-					}
-				}
+#define BMSR_LINK_STATUS        0x0004  /*!< Link status */
 
-		4) Called by EMAC-Task: finish SPI transfer
-			ksz8851snl_update()
-				if( ul_spi_pdc_status == SPI_PDC_TX_COMPLETE )
-				{
-					ul_spi_pdc_status = SPI_PDC_IDLE;
-					Bring KSZ8851SNL_CSN_GPIO high
-					// TX step12: disable TXQ write access.
-					ksz8851_reg_clrbits( REG_RXQ_CMD, RXQ_START );
-					// TX step12.1: enqueue frame in TXQ.
-					ksz8851_reg_setbits( REG_TXQ_CMD, TXQ_ENQUEUE );
+#ifndef PHY_LS_HIGH_CHECK_TIME_MS
 
-					// RX step13: enable INT_RX flag.
-					ksz8851_reg_write( REG_INT_MASK, INT_RX );
-
-					// Buffer sent, free the corresponding buffer and mark descriptor as owned by software.
-					vReleaseNetworkBufferAndDescriptor( pxNetworkBuffer );
-
-					tx_buffers[ us_tx_tail ] = NULL;
-					tx_busy[ us_tx_tail ] = pdFALSE;
-					us_tx_tail++
-				}
-
-	Receiving a packet:
-
-		1) Wait for a INTN interrupt
-			INTN_Handler()
-				ul_had_intn_interrupt = 1
-				vTaskNotifyGiveFromISR();	// Wake up the EMAC task
-
-		2) Called by EMAC-Task: check for new fragments and start SPI transfer
-			ksz8851snl_update()
-				if( ul_spi_pdc_status == SPI_PDC_IDLE )
-				{
-					if( ( ul_had_intn_interrupt != 0 ) || ( us_pending_frame > 0 ) )
-					{
-						if( us_pending_frame == 0 )
-						{
-							us_pending_frame = ksz8851_reg_read(REG_RX_FRAME_CNT_THRES) >> 8;
-							if( us_pending_frame == 0 )
-							{
-								break;
-							}
-						}
-						// RX step2: disable all interrupts.
-						ksz8851_reg_write( REG_INT_MASK, 0 );
-						Check if there is a valid packet: REG_RX_FHR_STATUS
-						Read the length of the next fragment: REG_RX_FHR_BYTE_CNT
-						ul_spi_pdc_status = SPI_PDC_RX_START;
-						gpio_set_pin_low(KSZ8851SNL_CSN_GPIO);
-						// Start SPI data transfer
-						ksz8851_fifo_read( pxNetworkBuffer->pucEthernetBuffer, xReadLength );
-					}
-				}
-
-		3) Wait for SPI RXBUFF interrupt
-			SPI_Handler()
-			if( ul_spi_pdc_status == SPI_PDC_RX_START:
-			{
-				if( ( ulCurrentSPIStatus & SPI_SR_RXBUFF ) != 0 )
-				{
-					// Transfer complete, disable SPI RXBUFF interrupt.
-					spi_disable_interrupt( KSZ8851SNL_SPI, SPI_IDR_RXBUFF );
-
-					ul_spi_pdc_status = SPI_PDC_RX_COMPLETE;
-				}
-			}
-		}
-
-		4) Finish SPI transfer
-			ksz8851snl_update()
-				if( ul_spi_pdc_status == SPI_PDC_RX_COMPLETE )
-				{
-					ul_spi_pdc_status = SPI_PDC_IDLE;
-					Bring KSZ8851SNL_CSN_GPIO high
-					// RX step21: end RXQ read access.
-					ksz8851_reg_clrbits(REG_RXQ_CMD, RXQ_START);
-					// RX step22-23: update frame count to be read.
-					us_pending_frame--
-					// RX step24: enable INT_RX flag if transfer complete.
-					if( us_pending_frame == 0 )
-					{
-						// Allow more RX interrupts.
-						ksz8851_reg_write( REG_INT_MASK, INT_RX );
-					}
-
-					// Mark descriptor ready to be read.
-					rx_ready[ rxHead ] = pdTRUE;
-					rxHead++
-				}
-*/
-
-#define PHY_REG_00_BMCR            0x00 // Basic mode control register
-#define PHY_REG_01_BMSR            0x01 // Basic mode status register
-#define PHY_REG_02_PHYSID1         0x02 // PHYS ID 1
-#define PHY_REG_03_PHYSID2         0x03 // PHYS ID 2
-#define PHY_REG_04_ADVERTISE       0x04 // Advertisement control reg
-#define PHY_REG_05_LPA             0x05 // Link partner ability reg
-#define	PHY_REG_06_ANER            0x06 //	6	RW		Auto-Negotiation Expansion Register
-#define	PHY_REG_07_ANNPTR          0x07 //	7	RW		Auto-Negotiation Next Page TX
-#define	PHY_REG_08_RESERVED0       0x08 // 0x08..0x0Fh	8-15	RW		RESERVED
-
-#define BMSR_LINK_STATUS            0x0004  //!< Link status
-
-#ifndef	PHY_LS_HIGH_CHECK_TIME_MS
-	/* Check if the LinkSStatus in the PHY is still high after 15 seconds of not
-	receiving packets. */
-	#define PHY_LS_HIGH_CHECK_TIME_MS	15000
+    /* Check if the LinkSStatus in the PHY is still high after 15 seconds of not
+     * receiving packets. */
+    #define PHY_LS_HIGH_CHECK_TIME_MS    15000
 #endif
 
-#ifndef	PHY_LS_LOW_CHECK_TIME_MS
-	/* Check if the LinkSStatus in the PHY is still low every second. */
-	#define PHY_LS_LOW_CHECK_TIME_MS	1000
+#ifndef PHY_LS_LOW_CHECK_TIME_MS
+    /* Check if the LinkSStatus in the PHY is still low every second. */
+    #define PHY_LS_LOW_CHECK_TIME_MS    1000
 #endif
 
 /* Interrupt events to process.  Currently only the Rx event is processed
-although code for other events is included to allow for possible future
-expansion. */
-#define EMAC_IF_RX_EVENT				1UL
-#define EMAC_IF_TX_EVENT				2UL
-#define EMAC_IF_ERR_EVENT				4UL
-#define EMAC_IF_ALL_EVENT				( EMAC_IF_RX_EVENT | EMAC_IF_TX_EVENT | EMAC_IF_ERR_EVENT )
+ * although code for other events is included to allow for possible future
+ * expansion. */
+#define EMAC_IF_RX_EVENT          1UL
+#define EMAC_IF_TX_EVENT          2UL
+#define EMAC_IF_ERR_EVENT         4UL
+#define EMAC_IF_ALL_EVENT         ( EMAC_IF_RX_EVENT | EMAC_IF_TX_EVENT | EMAC_IF_ERR_EVENT )
 
-#define ETHERNET_CONF_PHY_ADDR	BOARD_GMAC_PHY_ADDR
+#define ETHERNET_CONF_PHY_ADDR    BOARD_GMAC_PHY_ADDR
 
 #ifdef ipconfigHAS_TX_CRC_OFFLOADING
-	#undef ipconfigHAS_TX_CRC_OFFLOADING
+    #undef ipconfigHAS_TX_CRC_OFFLOADING
 #endif
 /* Override this define because the KSZ8851 is programmed to set all outgoing CRC's */
-#define	ipconfigHAS_TX_CRC_OFFLOADING	1
+#define ipconfigHAS_TX_CRC_OFFLOADING    1
 
-#ifndef	EMAC_MAX_BLOCK_TIME_MS
-	#define	EMAC_MAX_BLOCK_TIME_MS	100ul
+#ifndef EMAC_MAX_BLOCK_TIME_MS
+    #define EMAC_MAX_BLOCK_TIME_MS       100ul
 #endif
 
 /* Default the size of the stack used by the EMAC deferred handler task to 4x
-the size of the stack used by the idle task - but allow this to be overridden in
-FreeRTOSConfig.h as configMINIMAL_STACK_SIZE is a user definable constant. */
+ *  the size of the stack used by the idle task - but allow this to be overridden in
+ *  FreeRTOSConfig.h as configMINIMAL_STACK_SIZE is a user definable constant. */
 #ifndef configEMAC_TASK_STACK_SIZE
-	#define configEMAC_TASK_STACK_SIZE ( 6 * configMINIMAL_STACK_SIZE )
+    #define configEMAC_TASK_STACK_SIZE    ( 6 * configMINIMAL_STACK_SIZE )
 #endif
 
-#define SPI_PDC_IDLE			0
-#define SPI_PDC_RX_START		1
-#define SPI_PDC_TX_ERROR		2
-#define SPI_PDC_RX_COMPLETE		3
-#define SPI_PDC_TX_START		4
-#define SPI_PDC_RX_ERROR		5
-#define SPI_PDC_TX_COMPLETE		6
+#define SPI_PDC_IDLE                      0
+#define SPI_PDC_RX_START                  1
+#define SPI_PDC_TX_ERROR                  2
+#define SPI_PDC_RX_COMPLETE               3
+#define SPI_PDC_TX_START                  4
+#define SPI_PDC_RX_ERROR                  5
+#define SPI_PDC_TX_COMPLETE               6
 
 /**
  * ksz8851snl driver structure.
  */
-typedef struct {
-	/** Set to 1 when owner is software (ready to read), 0 for Micrel. */
-	uint32_t rx_ready[MICREL_RX_BUFFERS];
-	/** Set to 1 when owner is Micrel, 0 for software. */
-	uint32_t tx_busy[MICREL_TX_BUFFERS];
-	/** RX NetworkBufferDescriptor_t pointer list */
-	NetworkBufferDescriptor_t *rx_buffers[MICREL_RX_BUFFERS];
-	/** TX NetworkBufferDescriptor_t pointer list */
-	NetworkBufferDescriptor_t *tx_buffers[MICREL_TX_BUFFERS];
-	NetworkBufferDescriptor_t *tx_cur_buffer;
+typedef struct
+{
+    /** Set to 1 when owner is software (ready to read), 0 for Micrel. */
+    uint32_t rx_ready[ MICREL_RX_BUFFERS ];
+    /** Set to 1 when owner is Micrel, 0 for software. */
+    uint32_t tx_busy[ MICREL_TX_BUFFERS ];
+    /** RX NetworkBufferDescriptor_t pointer list */
+    NetworkBufferDescriptor_t * rx_buffers[ MICREL_RX_BUFFERS ];
+    /** TX NetworkBufferDescriptor_t pointer list */
+    NetworkBufferDescriptor_t * tx_buffers[ MICREL_TX_BUFFERS ];
+    NetworkBufferDescriptor_t * tx_cur_buffer;
 
-	/** Circular buffer head pointer for packet received. */
-	uint32_t us_rx_head;
-	/** Circular buffer tail pointer for packet to be read. */
-	uint32_t us_rx_tail;
-	/** Circular buffer head pointer by upper layer (buffer to be sent). */
-	uint32_t us_tx_head;
-	/** Circular buffer tail pointer incremented by handlers (buffer sent). */
-	uint32_t us_tx_tail;
+    /** Circular buffer head pointer for packet received. */
+    uint32_t us_rx_head;
+    /** Circular buffer tail pointer for packet to be read. */
+    uint32_t us_rx_tail;
+    /** Circular buffer head pointer by upper layer (buffer to be sent). */
+    uint32_t us_tx_head;
+    /** Circular buffer tail pointer incremented by handlers (buffer sent). */
+    uint32_t us_tx_tail;
 
-	uint32_t ul_total_tx;
-	uint32_t ul_total_rx;
-	uint32_t tx_space;
+    uint32_t ul_total_tx;
+    uint32_t ul_total_rx;
+    uint32_t tx_space;
 
-	/** Still experimental: hash table to allow certain multicast addresses. */
-	uint16_t pusHashTable[ 4 ];
+    /** Still experimental: hash table to allow certain multicast addresses. */
+    uint16_t pusHashTable[ 4 ];
 
-	/* ul_spi_pdc_status has "SPI_PDC_xxx" values. */
-	volatile uint32_t ul_spi_pdc_status;
+    /* ul_spi_pdc_status has "SPI_PDC_xxx" values. */
+    volatile uint32_t ul_spi_pdc_status;
 
-	/* ul_had_intn_interrupt becomes true within the INTN interrupt. */
-	volatile uint32_t ul_had_intn_interrupt;
+    /* ul_had_intn_interrupt becomes true within the INTN interrupt. */
+    volatile uint32_t ul_had_intn_interrupt;
 
-	uint16_t us_pending_frame;
+    uint16_t us_pending_frame;
 } xKSZ8851_Device_t;
 
 /* SPI PDC register base.
-Declared in ASF\sam\components\ksz8851snl\ksz8851snl.c */
-extern Pdc *g_p_spi_pdc;
+ * Declared in ASF\sam\components\ksz8851snl\ksz8851snl.c */
+extern Pdc * g_p_spi_pdc;
 
 /* Temporary buffer for PDC reception.
-declared in ASF\sam\components\ksz8851snl\ksz8851snl.c */
-extern uint8_t tmpbuf[1536];
+ * declared in ASF\sam\components\ksz8851snl\ksz8851snl.c */
+extern uint8_t tmpbuf[ 1536 ];
 
-COMPILER_ALIGNED(8)
+COMPILER_ALIGNED( 8 )
 static xKSZ8851_Device_t xMicrelDevice;
 
 static TaskHandle_t xTransmitHandle;
@@ -299,7 +301,7 @@ static BaseType_t xGMACWaitLS( TickType_t xMaxTime );
 /*
  * A deferred interrupt handler task that processes GMAC interrupts.
  */
-static void prvEMACHandlerTask( void *pvParameters );
+static void prvEMACHandlerTask( void * pvParameters );
 
 /*
  * Try to obtain an Rx packet from the hardware.
@@ -310,13 +312,13 @@ static inline unsigned long ulReadMDIO( unsigned uAddress );
 
 static void ksz8851snl_low_level_init( void );
 
-static NetworkBufferDescriptor_t *ksz8851snl_low_level_input( void );
+static NetworkBufferDescriptor_t * ksz8851snl_low_level_input( void );
 
 /*-----------------------------------------------------------*/
 
 /* Bit map of outstanding ETH interrupt events for processing.  Currently only
-the Rx interrupt is handled, although code is included for other events to
-enable future expansion. */
+ * the Rx interrupt is handled, although code is included for other events to
+ * enable future expansion. */
 static volatile uint32_t ulISREvents;
 
 /* A copy of PHY register 1: 'PHY_REG_01_BMSR' */
@@ -330,8 +332,8 @@ static void ksz8851snl_rx_init( void );
 static void ksz8851snl_tx_init( void );
 
 /* Holds the handle of the task used as a deferred interrupt processor.  The
-handle is used so direct notifications can be sent to the task for all EMAC/DMA
-related interrupts. */
+ * handle is used so direct notifications can be sent to the task for all EMAC/DMA
+ * related interrupts. */
 TaskHandle_t xEMACTaskHandle = NULL;
 
 
@@ -339,279 +341,296 @@ TaskHandle_t xEMACTaskHandle = NULL;
 
 BaseType_t xNetworkInterfaceInitialise( void )
 {
-const TickType_t x5_Seconds = 5000UL;
+    const TickType_t x5_Seconds = 5000UL;
 
-	if( xEMACTaskHandle == NULL )
-	{
-		ksz8851snl_low_level_init();
+    if( xEMACTaskHandle == NULL )
+    {
+        ksz8851snl_low_level_init();
 
-		/* Wait at most 5 seconds for a Link Status in the PHY. */
-		xGMACWaitLS( pdMS_TO_TICKS( x5_Seconds ) );
+        /* Wait at most 5 seconds for a Link Status in the PHY. */
+        xGMACWaitLS( pdMS_TO_TICKS( x5_Seconds ) );
 
-		/* The handler task is created at the highest possible priority to
-		ensure the interrupt handler can return directly to it. */
-		xTaskCreate( prvEMACHandlerTask, "KSZ8851", configEMAC_TASK_STACK_SIZE, NULL, configMAX_PRIORITIES - 1, &xEMACTaskHandle );
-		configASSERT( xEMACTaskHandle != NULL );
-	}
+        /* The handler task is created at the highest possible priority to
+         * ensure the interrupt handler can return directly to it. */
+        xTaskCreate( prvEMACHandlerTask, "KSZ8851", configEMAC_TASK_STACK_SIZE, NULL, configMAX_PRIORITIES - 1, &xEMACTaskHandle );
+        configASSERT( xEMACTaskHandle != NULL );
+    }
 
-	/* When returning non-zero, the stack will become active and
-    start DHCP (in configured) */
-	ulPHYLinkStatus = ulReadMDIO( PHY_REG_01_BMSR );
+    /* When returning non-zero, the stack will become active and
+     * start DHCP (in configured) */
+    ulPHYLinkStatus = ulReadMDIO( PHY_REG_01_BMSR );
 
-	return ( ulPHYLinkStatus & BMSR_LINK_STATUS ) != 0;
+    return ( ulPHYLinkStatus & BMSR_LINK_STATUS ) != 0;
 }
 /*-----------------------------------------------------------*/
 
 BaseType_t xGetPhyLinkStatus( void )
 {
-BaseType_t xResult;
+    BaseType_t xResult;
 
-	/* This function returns true if the Link Status in the PHY is high. */
-	if( ( ulPHYLinkStatus & BMSR_LINK_STATUS ) != 0 )
-	{
-		xResult = pdTRUE;
-	}
-	else
-	{
-		xResult = pdFALSE;
-	}
+    /* This function returns true if the Link Status in the PHY is high. */
+    if( ( ulPHYLinkStatus & BMSR_LINK_STATUS ) != 0 )
+    {
+        xResult = pdTRUE;
+    }
+    else
+    {
+        xResult = pdFALSE;
+    }
 
-	return xResult;
+    return xResult;
 }
 /*-----------------------------------------------------------*/
 
-BaseType_t xNetworkInterfaceOutput( NetworkBufferDescriptor_t * const pxNetworkBuffer, BaseType_t bReleaseAfterSend )
+BaseType_t xNetworkInterfaceOutput( NetworkBufferDescriptor_t * const pxNetworkBuffer,
+                                    BaseType_t bReleaseAfterSend )
 {
-BaseType_t xResult = pdFALSE;
-int txHead = xMicrelDevice.us_tx_head;
+    BaseType_t xResult = pdFALSE;
+    int txHead = xMicrelDevice.us_tx_head;
 
-	/* Make sure the next descriptor is free. */
-	if( xMicrelDevice.tx_busy[ txHead ] != pdFALSE )
-	{
-		/* All TX buffers busy. */
-	}
-	else if( ( ulPHYLinkStatus & BMSR_LINK_STATUS ) == 0 )
-	{
-		/* Output: LS low. */
-	}
-	else
-	{
-		/* Pass the packet. */
-		xMicrelDevice.tx_buffers[ txHead ] = pxNetworkBuffer;
-		/* The descriptor is now owned by Micrel. */
-		xMicrelDevice.tx_busy[ txHead ] = pdTRUE;
+    /* Make sure the next descriptor is free. */
+    if( xMicrelDevice.tx_busy[ txHead ] != pdFALSE )
+    {
+        /* All TX buffers busy. */
+    }
+    else if( ( ulPHYLinkStatus & BMSR_LINK_STATUS ) == 0 )
+    {
+        /* Output: LS low. */
+    }
+    else
+    {
+        /* Pass the packet. */
+        xMicrelDevice.tx_buffers[ txHead ] = pxNetworkBuffer;
+        /* The descriptor is now owned by Micrel. */
+        xMicrelDevice.tx_busy[ txHead ] = pdTRUE;
 
-		/* Move the head pointer. */
-		if( ++txHead == MICREL_TX_BUFFERS )
-		{
-			txHead = 0;
-		}
-		xMicrelDevice.us_tx_head = txHead;
-		if( xEMACTaskHandle != NULL )
-		{
-			xTaskNotifyGive( xEMACTaskHandle );
-		}
+        /* Move the head pointer. */
+        if( ++txHead == MICREL_TX_BUFFERS )
+        {
+            txHead = 0;
+        }
 
-	#if( ipconfigZERO_COPY_TX_DRIVER != 1 )
-		#warning Please ipconfigZERO_COPY_TX_DRIVER as 1
-	#endif
-		configASSERT( bReleaseAfterSend != pdFALSE );
-		xResult = pdTRUE;
-	}
-	if( ( xResult == pdFALSE ) && ( bReleaseAfterSend  != pdFALSE ) )
-	{
-		vReleaseNetworkBufferAndDescriptor( pxNetworkBuffer );
-	}
-	return xResult;
+        xMicrelDevice.us_tx_head = txHead;
+
+        if( xEMACTaskHandle != NULL )
+        {
+            xTaskNotifyGive( xEMACTaskHandle );
+        }
+
+        #if ( ipconfigZERO_COPY_TX_DRIVER != 1 )
+        #warning Please ipconfigZERO_COPY_TX_DRIVER as 1
+        #endif
+        configASSERT( bReleaseAfterSend != pdFALSE );
+        xResult = pdTRUE;
+    }
+
+    if( ( xResult == pdFALSE ) && ( bReleaseAfterSend != pdFALSE ) )
+    {
+        vReleaseNetworkBufferAndDescriptor( pxNetworkBuffer );
+    }
+
+    return xResult;
 }
 /*-----------------------------------------------------------*/
 
 /* This Micrel has numbered it's PHY registers in a different way.
-Translate the register index. */
+ * Translate the register index. */
 static int ks8851_phy_reg( int reg )
 {
-	switch (reg) {
-	case PHY_REG_00_BMCR:
-		return REG_PHY_CNTL;	// P1MBCR;
-	case PHY_REG_01_BMSR:
-		return REG_PHY_STATUS;
-	case PHY_REG_02_PHYSID1:
-		return REG_PHY_ID_LOW;
-	case PHY_REG_03_PHYSID2:
-		return REG_PHY_ID_HIGH;
-	case PHY_REG_04_ADVERTISE:
-		return REG_PHY_AUTO_NEGOTIATION;
-	case PHY_REG_05_LPA:
-		return REG_PHY_REMOTE_CAPABILITY;
-	}
+    switch( reg )
+    {
+        case PHY_REG_00_BMCR:
+            return REG_PHY_CNTL; /* P1MBCR; */
 
-	return 0x0;
+        case PHY_REG_01_BMSR:
+            return REG_PHY_STATUS;
+
+        case PHY_REG_02_PHYSID1:
+            return REG_PHY_ID_LOW;
+
+        case PHY_REG_03_PHYSID2:
+            return REG_PHY_ID_HIGH;
+
+        case PHY_REG_04_ADVERTISE:
+            return REG_PHY_AUTO_NEGOTIATION;
+
+        case PHY_REG_05_LPA:
+            return REG_PHY_REMOTE_CAPABILITY;
+    }
+
+    return 0x0;
 }
 /*-----------------------------------------------------------*/
 
 static inline unsigned long ulReadMDIO( unsigned uAddress )
 {
-uint16_t usPHYStatus;
-int ks8851_reg = ks8851_phy_reg( uAddress );
+    uint16_t usPHYStatus;
+    int ks8851_reg = ks8851_phy_reg( uAddress );
 
-	if( ks8851_reg != 0 )
-	{
-		usPHYStatus = ksz8851_reg_read( ks8851_reg );
-	}
-	else
-	{
-		/* Other addresses not yet implemented. */
-		usPHYStatus = 0;
-	}
-	return usPHYStatus;
+    if( ks8851_reg != 0 )
+    {
+        usPHYStatus = ksz8851_reg_read( ks8851_reg );
+    }
+    else
+    {
+        /* Other addresses not yet implemented. */
+        usPHYStatus = 0;
+    }
+
+    return usPHYStatus;
 }
 /*-----------------------------------------------------------*/
 
 static BaseType_t xGMACWaitLS( TickType_t xMaxTime )
 {
-TickType_t xStartTime = xTaskGetTickCount();
-TickType_t xEndTime;
-BaseType_t xReturn;
-const TickType_t xShortTime = pdMS_TO_TICKS( 100UL );
-const uint32_t ulHz_Per_MHz = 1000000UL;
+    TickType_t xStartTime = xTaskGetTickCount();
+    TickType_t xEndTime;
+    BaseType_t xReturn;
+    const TickType_t xShortTime = pdMS_TO_TICKS( 100UL );
+    const uint32_t ulHz_Per_MHz = 1000000UL;
 
-	for( ;; )
-	{
-		xEndTime = xTaskGetTickCount();
+    for( ; ; )
+    {
+        xEndTime = xTaskGetTickCount();
 
-		if( ( xEndTime - xStartTime ) > xMaxTime )
-		{
-			/* Wated more than xMaxTime, return. */
-			xReturn = pdFALSE;
-			break;
-		}
+        if( ( xEndTime - xStartTime ) > xMaxTime )
+        {
+            /* Wated more than xMaxTime, return. */
+            xReturn = pdFALSE;
+            break;
+        }
 
-		/* Check the link status again. */
-		ulPHYLinkStatus = ulReadMDIO( PHY_REG_01_BMSR );
+        /* Check the link status again. */
+        ulPHYLinkStatus = ulReadMDIO( PHY_REG_01_BMSR );
 
-		if( ( ulPHYLinkStatus & BMSR_LINK_STATUS ) != 0 )
-		{
-			/* Link is up - return. */
-			xReturn = pdTRUE;
-			break;
-		}
+        if( ( ulPHYLinkStatus & BMSR_LINK_STATUS ) != 0 )
+        {
+            /* Link is up - return. */
+            xReturn = pdTRUE;
+            break;
+        }
 
-		/* Link is down - wait in the Blocked state for a short while (to allow
-		other tasks to execute) before checking again. */
-		vTaskDelay( xShortTime );
-	}
+        /* Link is down - wait in the Blocked state for a short while (to allow
+         * other tasks to execute) before checking again. */
+        vTaskDelay( xShortTime );
+    }
 
-	FreeRTOS_printf( ( "xGMACWaitLS: %ld freq %lu Mz\n",
-		xReturn,
-		sysclk_get_cpu_hz() / ulHz_Per_MHz ) );
+    FreeRTOS_printf( ( "xGMACWaitLS: %ld freq %lu Mz\n",
+                       xReturn,
+                       sysclk_get_cpu_hz() / ulHz_Per_MHz ) );
 
-	return xReturn;
+    return xReturn;
 }
 /*-----------------------------------------------------------*/
 
-static void vPioSetPinHigh(uint32_t ul_pin)
+static void vPioSetPinHigh( uint32_t ul_pin )
 {
-	Pio *p_pio = (Pio *)((uint32_t)PIOA + (PIO_DELTA * (ul_pin >> 5)));
-	// Value to be driven on the I/O line: 1.
-	p_pio->PIO_SODR = 1 << (ul_pin & 0x1F);
+    Pio * p_pio = ( Pio * ) ( ( uint32_t ) PIOA + ( PIO_DELTA * ( ul_pin >> 5 ) ) );
+
+    /* Value to be driven on the I/O line: 1. */
+    p_pio->PIO_SODR = 1 << ( ul_pin & 0x1F );
 }
 
 /**
  * \brief Handler for SPI interrupt.
  */
-void SPI_Handler(void)
+void SPI_Handler( void )
 {
-BaseType_t xDoWakeup = pdFALSE;
-BaseType_t xKSZTaskWoken = pdFALSE;
-uint32_t ulCurrentSPIStatus;
-uint32_t ulEnabledSPIStatus;
+    BaseType_t xDoWakeup = pdFALSE;
+    BaseType_t xKSZTaskWoken = pdFALSE;
+    uint32_t ulCurrentSPIStatus;
+    uint32_t ulEnabledSPIStatus;
 
-	ulCurrentSPIStatus = spi_read_status( KSZ8851SNL_SPI );
-	ulEnabledSPIStatus = spi_read_interrupt_mask( KSZ8851SNL_SPI );
-	ulCurrentSPIStatus &= ulEnabledSPIStatus;
-	spi_disable_interrupt( KSZ8851SNL_SPI, ulCurrentSPIStatus );
+    ulCurrentSPIStatus = spi_read_status( KSZ8851SNL_SPI );
+    ulEnabledSPIStatus = spi_read_interrupt_mask( KSZ8851SNL_SPI );
+    ulCurrentSPIStatus &= ulEnabledSPIStatus;
+    spi_disable_interrupt( KSZ8851SNL_SPI, ulCurrentSPIStatus );
 
+    switch( xMicrelDevice.ul_spi_pdc_status )
+    {
+        case SPI_PDC_RX_START:
 
-	switch( xMicrelDevice.ul_spi_pdc_status )
-	{
-		case SPI_PDC_RX_START:
-		{
-			if( ( ulCurrentSPIStatus & SPI_SR_OVRES ) != 0 )
-			{
-				pdc_disable_transfer(g_p_spi_pdc, PERIPH_PTCR_RXTDIS | PERIPH_PTCR_TXTDIS);
-				xMicrelDevice.ul_spi_pdc_status = SPI_PDC_RX_ERROR;
-				xDoWakeup = pdTRUE;
-			}
-			else
-			{
-				if( ( ulCurrentSPIStatus & SPI_SR_RXBUFF ) != 0 )
-				{
-					xMicrelDevice.ul_spi_pdc_status = SPI_PDC_RX_COMPLETE;
-					xDoWakeup = pdTRUE;
-				}
-			}
-		}
-		break;
+            if( ( ulCurrentSPIStatus & SPI_SR_OVRES ) != 0 )
+            {
+                pdc_disable_transfer( g_p_spi_pdc, PERIPH_PTCR_RXTDIS | PERIPH_PTCR_TXTDIS );
+                xMicrelDevice.ul_spi_pdc_status = SPI_PDC_RX_ERROR;
+                xDoWakeup = pdTRUE;
+            }
+            else
+            {
+                if( ( ulCurrentSPIStatus & SPI_SR_RXBUFF ) != 0 )
+                {
+                    xMicrelDevice.ul_spi_pdc_status = SPI_PDC_RX_COMPLETE;
+                    xDoWakeup = pdTRUE;
+                }
+            }
 
-		case SPI_PDC_TX_START:
-		{
-			/* Middle of TX. */
-			if( ( ulCurrentSPIStatus & SPI_SR_OVRES ) != 0 )
-			{
-				pdc_disable_transfer(g_p_spi_pdc, PERIPH_PTCR_RXTDIS | PERIPH_PTCR_TXTDIS);
-				xMicrelDevice.ul_spi_pdc_status = SPI_PDC_TX_ERROR;
-				xDoWakeup = pdTRUE;
-			}
-			else
-			{
-				if( ( ulCurrentSPIStatus & SPI_SR_ENDRX ) != 0 )
-				{
-					/* Enable RX complete interrupt. */
-					spi_enable_interrupt( KSZ8851SNL_SPI, SPI_IER_RXBUFF );
-				}
-				/* End of TX. */
-				if( ( ulCurrentSPIStatus & SPI_END_OF_TX ) != 0 )
-				{
-					xMicrelDevice.ul_spi_pdc_status = SPI_PDC_TX_COMPLETE;
-					xDoWakeup = pdTRUE;
-				}
-			}
-		}
-		break;
-	}	/* switch( xMicrelDevice.ul_spi_pdc_status ) */
+            break;
 
-	if( xDoWakeup != pdFALSE )
-	{
-		if( xEMACTaskHandle != NULL )
-		{
-			vTaskNotifyGiveFromISR( xEMACTaskHandle, ( BaseType_t * ) &xKSZTaskWoken );
-		}
-	}
-	else
-	{
-	}
-	portEND_SWITCHING_ISR( xKSZTaskWoken );
+        case SPI_PDC_TX_START:
+
+            /* Middle of TX. */
+            if( ( ulCurrentSPIStatus & SPI_SR_OVRES ) != 0 )
+            {
+                pdc_disable_transfer( g_p_spi_pdc, PERIPH_PTCR_RXTDIS | PERIPH_PTCR_TXTDIS );
+                xMicrelDevice.ul_spi_pdc_status = SPI_PDC_TX_ERROR;
+                xDoWakeup = pdTRUE;
+            }
+            else
+            {
+                if( ( ulCurrentSPIStatus & SPI_SR_ENDRX ) != 0 )
+                {
+                    /* Enable RX complete interrupt. */
+                    spi_enable_interrupt( KSZ8851SNL_SPI, SPI_IER_RXBUFF );
+                }
+
+                /* End of TX. */
+                if( ( ulCurrentSPIStatus & SPI_END_OF_TX ) != 0 )
+                {
+                    xMicrelDevice.ul_spi_pdc_status = SPI_PDC_TX_COMPLETE;
+                    xDoWakeup = pdTRUE;
+                }
+            }
+
+            break;
+    } /* switch( xMicrelDevice.ul_spi_pdc_status ) */
+
+    if( xDoWakeup != pdFALSE )
+    {
+        if( xEMACTaskHandle != NULL )
+        {
+            vTaskNotifyGiveFromISR( xEMACTaskHandle, ( BaseType_t * ) &xKSZTaskWoken );
+        }
+    }
+    else
+    {
+    }
+
+    portEND_SWITCHING_ISR( xKSZTaskWoken );
 }
 /*-----------------------------------------------------------*/
 
-static void INTN_Handler(uint32_t id, uint32_t mask)
+static void INTN_Handler( uint32_t id,
+                          uint32_t mask )
 {
-BaseType_t xKSZTaskWoken = pdFALSE;
+    BaseType_t xKSZTaskWoken = pdFALSE;
 
-	if( ( id == INTN_ID ) &&
-		( mask == INTN_PIN_MSK ) )
-	{
-		/* Clear the PIO interrupt flags. */
-		pio_get_interrupt_status( INTN_PIO );
+    if( ( id == INTN_ID ) &&
+        ( mask == INTN_PIN_MSK ) )
+    {
+        /* Clear the PIO interrupt flags. */
+        pio_get_interrupt_status( INTN_PIO );
 
-		/* Set the INTN flag. */
-		xMicrelDevice.ul_had_intn_interrupt++;
-		if( xEMACTaskHandle != NULL )
-		{
-			vTaskNotifyGiveFromISR( xEMACTaskHandle, &( xKSZTaskWoken ) );
-		}
-	}
-	portEND_SWITCHING_ISR( xKSZTaskWoken );
+        /* Set the INTN flag. */
+        xMicrelDevice.ul_had_intn_interrupt++;
+
+        if( xEMACTaskHandle != NULL )
+        {
+            vTaskNotifyGiveFromISR( xEMACTaskHandle, &( xKSZTaskWoken ) );
+        }
+    }
+
+    portEND_SWITCHING_ISR( xKSZTaskWoken );
 }
 /*-----------------------------------------------------------*/
 
@@ -622,34 +641,37 @@ BaseType_t xKSZTaskWoken = pdFALSE;
  */
 static void ksz8851snl_rx_populate_queue( void )
 {
-	uint32_t ul_index = 0;
-	NetworkBufferDescriptor_t *pxNetworkBuffer;
+    uint32_t ul_index = 0;
+    NetworkBufferDescriptor_t * pxNetworkBuffer;
 
-	/* Set up the RX descriptors */
-	for (ul_index = 0; ul_index < MICREL_RX_BUFFERS; ul_index++) {
-		if( xMicrelDevice.rx_buffers[ ul_index ] == NULL )
-		{
-			/* Allocate a new NetworkBufferDescriptor_t with the maximum size. */
-			pxNetworkBuffer = pxGetNetworkBufferWithDescriptor( ipconfigNETWORK_MTU + 36, 100 );
-			if( pxNetworkBuffer == NULL )
-			{
-				FreeRTOS_printf( ( "ksz8851snl_rx_populate_queue: NetworkBufferDescriptor_t allocation failure\n" ) );
-				configASSERT( 1 == 2 );
-			}
+    /* Set up the RX descriptors */
+    for( ul_index = 0; ul_index < MICREL_RX_BUFFERS; ul_index++ )
+    {
+        if( xMicrelDevice.rx_buffers[ ul_index ] == NULL )
+        {
+            /* Allocate a new NetworkBufferDescriptor_t with the maximum size. */
+            pxNetworkBuffer = pxGetNetworkBufferWithDescriptor( ipconfigNETWORK_MTU + 36, 100 );
 
-			/* Make sure lwIP is well configured so one NetworkBufferDescriptor_t can contain the maximum packet size. */
-			//LWIP_ASSERT("ksz8851snl_rx_populate_queue: NetworkBufferDescriptor_t size too small!", pbuf_clen(pxNetworkBuffer) <= 1);
+            if( pxNetworkBuffer == NULL )
+            {
+                FreeRTOS_printf( ( "ksz8851snl_rx_populate_queue: NetworkBufferDescriptor_t allocation failure\n" ) );
+                configASSERT( 1 == 2 );
+            }
 
-			/* Save NetworkBufferDescriptor_t pointer to be sent to lwIP upper layer. */
-			xMicrelDevice.rx_buffers[ ul_index ] = pxNetworkBuffer;
-			/* Pass it to Micrel for reception. */
-			xMicrelDevice.rx_ready[ ul_index ] = pdFALSE;
-		}
-	}
+            /* Make sure lwIP is well configured so one NetworkBufferDescriptor_t can contain the maximum packet size. */
+            /*LWIP_ASSERT("ksz8851snl_rx_populate_queue: NetworkBufferDescriptor_t size too small!", pbuf_clen(pxNetworkBuffer) <= 1); */
+
+            /* Save NetworkBufferDescriptor_t pointer to be sent to lwIP upper layer. */
+            xMicrelDevice.rx_buffers[ ul_index ] = pxNetworkBuffer;
+            /* Pass it to Micrel for reception. */
+            xMicrelDevice.rx_ready[ ul_index ] = pdFALSE;
+        }
+    }
 }
 
 unsigned tx_space, wait_tx_space, tx_status, fhr_status;
 unsigned rx_debug = 0;
+
 /**
  * \brief Update Micrel state machine and perform required actions.
  *
@@ -657,340 +679,365 @@ unsigned rx_debug = 0;
  */
 static void ksz8851snl_update()
 {
-	uint16_t txmir = 0;
+    uint16_t txmir = 0;
 
 /* Check for free PDC. */
-	switch( xMicrelDevice.ul_spi_pdc_status )
-	{
-	case SPI_PDC_TX_ERROR:
-		{
-		uint32_t ulValue;
-	//		/* TX step11: end TX transfer. */
-			gpio_set_pin_high( KSZ8851SNL_CSN_GPIO );
+    switch( xMicrelDevice.ul_spi_pdc_status )
+    {
+        case SPI_PDC_TX_ERROR:
+           {
+               uint32_t ulValue;
+               /*		/ * TX step11: end TX transfer. * / */
+               gpio_set_pin_high( KSZ8851SNL_CSN_GPIO );
 
-			vTaskDelay( 2 ); gpio_set_pin_low( KSZ8851SNL_CSN_GPIO );
-			vTaskDelay( 1 ); gpio_set_pin_high( KSZ8851SNL_CSN_GPIO );
-			vTaskDelay( 1 );
+               vTaskDelay( 2 );
+               gpio_set_pin_low( KSZ8851SNL_CSN_GPIO );
+               vTaskDelay( 1 );
+               gpio_set_pin_high( KSZ8851SNL_CSN_GPIO );
+               vTaskDelay( 1 );
 
-			/* Disable asynchronous transfer mode. */
-			xMicrelDevice.ul_spi_pdc_status = SPI_PDC_IDLE;
+               /* Disable asynchronous transfer mode. */
+               xMicrelDevice.ul_spi_pdc_status = SPI_PDC_IDLE;
 
-			/* TX step12: disable TXQ write access. */
-			ksz8851_reg_clrbits( REG_RXQ_CMD, RXQ_START );
+               /* TX step12: disable TXQ write access. */
+               ksz8851_reg_clrbits( REG_RXQ_CMD, RXQ_START );
 
-			ulValue = ksz8851snl_reset_tx();
+               ulValue = ksz8851snl_reset_tx();
 
-			xMicrelDevice.tx_space = ksz8851_reg_read( REG_TX_MEM_INFO ) & TX_MEM_AVAILABLE_MASK;
+               xMicrelDevice.tx_space = ksz8851_reg_read( REG_TX_MEM_INFO ) & TX_MEM_AVAILABLE_MASK;
 
-			FreeRTOS_printf( ("SPI_PDC_TX_ERROR %02X\n", ulValue ) );
-		}
-		break;
+               FreeRTOS_printf( ( "SPI_PDC_TX_ERROR %02X\n", ulValue ) );
+           }
+           break;
 
-	case SPI_PDC_RX_ERROR:
-		{
-		uint32_t ulValue;
-			/* TX step11: end TX transfer. */
-			gpio_set_pin_high( KSZ8851SNL_CSN_GPIO );
+        case SPI_PDC_RX_ERROR:
+           {
+               uint32_t ulValue;
+               /* TX step11: end TX transfer. */
+               gpio_set_pin_high( KSZ8851SNL_CSN_GPIO );
 
-			vTaskDelay( 2 ); gpio_set_pin_low( KSZ8851SNL_CSN_GPIO );
-			vTaskDelay( 1 ); gpio_set_pin_high( KSZ8851SNL_CSN_GPIO );
-			vTaskDelay( 1 );
+               vTaskDelay( 2 );
+               gpio_set_pin_low( KSZ8851SNL_CSN_GPIO );
+               vTaskDelay( 1 );
+               gpio_set_pin_high( KSZ8851SNL_CSN_GPIO );
+               vTaskDelay( 1 );
 
-			/* Disable asynchronous transfer mode. */
-			xMicrelDevice.ul_spi_pdc_status = SPI_PDC_IDLE;
+               /* Disable asynchronous transfer mode. */
+               xMicrelDevice.ul_spi_pdc_status = SPI_PDC_IDLE;
 
-			/* TX step12: disable TXQ write access. */
-			ksz8851_reg_clrbits( REG_RXQ_CMD, RXQ_START );
+               /* TX step12: disable TXQ write access. */
+               ksz8851_reg_clrbits( REG_RXQ_CMD, RXQ_START );
 
-			//ulValue = ksz8851snl_reset_rx();
-			ulValue = ksz8851snl_reinit();
+               /*ulValue = ksz8851snl_reset_rx(); */
+               ulValue = ksz8851snl_reinit();
 
-			xGMACWaitLS( pdMS_TO_TICKS( 5000UL ) );
+               xGMACWaitLS( pdMS_TO_TICKS( 5000UL ) );
 
-			FreeRTOS_printf( ("SPI_PDC_RX_ERROR %02X\n", ulValue ) );
-		}
-		break;
-	}
-	switch( xMicrelDevice.ul_spi_pdc_status )
-	{
-		case SPI_PDC_IDLE:
-		{
-		int txTail = xMicrelDevice.us_tx_tail;
+               FreeRTOS_printf( ( "SPI_PDC_RX_ERROR %02X\n", ulValue ) );
+           }
+           break;
+    }
 
-			/*
-			 * ========================== Handle RX ==========================
-			 */
-			if( ( xMicrelDevice.ul_had_intn_interrupt != 0 ) || ( xMicrelDevice.us_pending_frame > 0 ) )
-			{
-			int rxHead = xMicrelDevice.us_rx_head;
-			NetworkBufferDescriptor_t *pxNetworkBuffer;
-#warning try
-				xMicrelDevice.ul_had_intn_interrupt = 0;
+    switch( xMicrelDevice.ul_spi_pdc_status )
+    {
+        case SPI_PDC_IDLE:
+           {
+               int txTail = xMicrelDevice.us_tx_tail;
 
-				if( xMicrelDevice.us_pending_frame == 0 )
-				{
-				uint16_t int_status;
-					/* RX step1: read interrupt status for INT_RX flag. */
-					int_status = ksz8851_reg_read( REG_INT_STATUS );
+               /*
+                * ========================== Handle RX ==========================
+                */
+               if( ( xMicrelDevice.ul_had_intn_interrupt != 0 ) || ( xMicrelDevice.us_pending_frame > 0 ) )
+               {
+                   int rxHead = xMicrelDevice.us_rx_head;
+                   NetworkBufferDescriptor_t * pxNetworkBuffer;
+                   #warning try
+                   xMicrelDevice.ul_had_intn_interrupt = 0;
+
+                   if( xMicrelDevice.us_pending_frame == 0 )
+                   {
+                       uint16_t int_status;
+                       /* RX step1: read interrupt status for INT_RX flag. */
+                       int_status = ksz8851_reg_read( REG_INT_STATUS );
 
 
-					/* RX step2: disable all interrupts. */
-					ksz8851_reg_write( REG_INT_MASK, 0 );
+                       /* RX step2: disable all interrupts. */
+                       ksz8851_reg_write( REG_INT_MASK, 0 );
 
-					/* RX step3: clear INT_RX flag. */
-					ksz8851_reg_setbits( REG_INT_STATUS, INT_RX );
+                       /* RX step3: clear INT_RX flag. */
+                       ksz8851_reg_setbits( REG_INT_STATUS, INT_RX );
 
-					/* RX step4-5: check for received frames. */
-					xMicrelDevice.us_pending_frame = ksz8851_reg_read(REG_RX_FRAME_CNT_THRES) >> 8;
-					if( xMicrelDevice.us_pending_frame == 0 )
-					{
-						/* RX step24: enable INT_RX flag. */
-						ksz8851_reg_write(REG_INT_MASK, INT_RX);
-						return;
-					}
-				}
-#warning try
-				xMicrelDevice.ul_had_intn_interrupt = 0;
+                       /* RX step4-5: check for received frames. */
+                       xMicrelDevice.us_pending_frame = ksz8851_reg_read( REG_RX_FRAME_CNT_THRES ) >> 8;
 
-				/* Now xMicrelDevice.us_pending_frame != 0 */
+                       if( xMicrelDevice.us_pending_frame == 0 )
+                       {
+                           /* RX step24: enable INT_RX flag. */
+                           ksz8851_reg_write( REG_INT_MASK, INT_RX );
+                           return;
+                       }
+                   }
 
-				/* Don't break Micrel state machine, wait for a free descriptor first! */
-				if( xMicrelDevice.rx_ready[ rxHead ] != pdFALSE )
-				{
-					FreeRTOS_printf( ( "ksz8851snl_update: out of free descriptor! [tail=%u head=%u]\n",
-							xMicrelDevice.us_rx_tail, rxHead ) );
-					return;
-				}
-				pxNetworkBuffer = xMicrelDevice.rx_buffers[ rxHead ];
+                   #warning try
+                   xMicrelDevice.ul_had_intn_interrupt = 0;
 
-				if( pxNetworkBuffer == NULL )
-				{
-					ksz8851snl_rx_populate_queue();
-					FreeRTOS_printf( ( "ksz8851snl_update: no buffer set [head=%u]\n", rxHead ) );
-					return;
-				}
+                   /* Now xMicrelDevice.us_pending_frame != 0 */
 
-				/* RX step6: get RX packet status. */
-				fhr_status = ksz8851_reg_read( REG_RX_FHR_STATUS );
-				if( ( ( fhr_status & RX_VALID ) == 0 ) || ( ( fhr_status & RX_ERRORS ) != 0 ) )
-				{
-					ksz8851_reg_setbits(REG_RXQ_CMD, RXQ_CMD_FREE_PACKET);
-					FreeRTOS_printf( ( "ksz8851snl_update: RX packet error!\n" ) );
+                   /* Don't break Micrel state machine, wait for a free descriptor first! */
+                   if( xMicrelDevice.rx_ready[ rxHead ] != pdFALSE )
+                   {
+                       FreeRTOS_printf( ( "ksz8851snl_update: out of free descriptor! [tail=%u head=%u]\n",
+                                          xMicrelDevice.us_rx_tail, rxHead ) );
+                       return;
+                   }
 
-					/* RX step4-5: check for received frames. */
-					xMicrelDevice.us_pending_frame = ksz8851_reg_read(REG_RX_FRAME_CNT_THRES) >> 8;
-					if( xMicrelDevice.us_pending_frame == 0 )
-					{
-						/* RX step24: enable INT_RX flag. */
-						ksz8851_reg_write(REG_INT_MASK, INT_RX);
-					}
-					ulISREvents |= EMAC_IF_ERR_EVENT;
-				}
-				else
-				{
-				size_t xLength;
-					/* RX step7: read frame length. */
-					xLength = ksz8851_reg_read(REG_RX_FHR_BYTE_CNT) & RX_BYTE_CNT_MASK;
+                   pxNetworkBuffer = xMicrelDevice.rx_buffers[ rxHead ];
 
-					/* RX step8: Drop packet if len is invalid or no descriptor available. */
-					if( xLength == 0 )
-					{
-						ksz8851_reg_setbits( REG_RXQ_CMD, RXQ_CMD_FREE_PACKET );
-						FreeRTOS_printf( ( "ksz8851snl_update: RX bad len!\n" ) );
-						ulISREvents |= EMAC_IF_ERR_EVENT;
-					}
-					else
-					{
-					size_t xReadLength = xLength;
+                   if( pxNetworkBuffer == NULL )
+                   {
+                       ksz8851snl_rx_populate_queue();
+                       FreeRTOS_printf( ( "ksz8851snl_update: no buffer set [head=%u]\n", rxHead ) );
+                       return;
+                   }
 
-						xMicrelDevice.ul_total_rx++;
-						/* RX step9: reset RX frame pointer. */
-						ksz8851_reg_clrbits(REG_RX_ADDR_PTR, ADDR_PTR_MASK);
+                   /* RX step6: get RX packet status. */
+                   fhr_status = ksz8851_reg_read( REG_RX_FHR_STATUS );
 
-						/* RX step10: start RXQ read access. */
-						ksz8851_reg_setbits(REG_RXQ_CMD, RXQ_START);
-						/* RX step11-17: start asynchronous FIFO read operation. */
-						xMicrelDevice.ul_spi_pdc_status = SPI_PDC_RX_START;
-						gpio_set_pin_low( KSZ8851SNL_CSN_GPIO );
-						if( ( xReadLength & ( sizeof( size_t ) - 1 ) ) != 0 )
-						{
-							xReadLength = ( xReadLength | ( sizeof( size_t ) - 1 ) ) + 1;
-						}
+                   if( ( ( fhr_status & RX_VALID ) == 0 ) || ( ( fhr_status & RX_ERRORS ) != 0 ) )
+                   {
+                       ksz8851_reg_setbits( REG_RXQ_CMD, RXQ_CMD_FREE_PACKET );
+                       FreeRTOS_printf( ( "ksz8851snl_update: RX packet error!\n" ) );
 
-						/* Pass the buffer minus 2 bytes, see ksz8851snl.c: RXQ_TWOBYTE_OFFSET. */
-						ksz8851_fifo_read( pxNetworkBuffer->pucEthernetBuffer - 2, xReadLength );
-						/* Remove CRC and update buffer length. */
-						xLength -= 4;
-						pxNetworkBuffer->xDataLength = xLength;
-						/* Wait for SPI interrupt to set status 'SPI_PDC_RX_COMPLETE'. */
-					}
-				}
-				break;
-			} /* ul_had_intn_interrupt || us_pending_frame */
-			/*
-			 * ========================== Handle TX ==========================
-			 */
+                       /* RX step4-5: check for received frames. */
+                       xMicrelDevice.us_pending_frame = ksz8851_reg_read( REG_RX_FRAME_CNT_THRES ) >> 8;
 
-			/* Fetch next packet to be sent. */
-			if( ( xMicrelDevice.tx_busy[ txTail ] != pdFALSE ) &&
-				( xMicrelDevice.us_pending_frame == 0 ) &&
-				( xMicrelDevice.ul_had_intn_interrupt == 0 ) )
-			{
-			NetworkBufferDescriptor_t *pxNetworkBuffer = xMicrelDevice.tx_buffers[ txTail ];
-			size_t xLength = pxNetworkBuffer->xDataLength;
-			int iIndex = xLength;
+                       if( xMicrelDevice.us_pending_frame == 0 )
+                       {
+                           /* RX step24: enable INT_RX flag. */
+                           ksz8851_reg_write( REG_INT_MASK, INT_RX );
+                       }
 
-				xLength = 4 * ( ( xLength + 3 ) / 4 );
-				while( iIndex < ( int ) xLength )
-				{
-					pxNetworkBuffer->pucEthernetBuffer[ iIndex ] = '\0';
-					iIndex++;
-				}
-				pxNetworkBuffer->xDataLength = xLength;
+                       ulISREvents |= EMAC_IF_ERR_EVENT;
+                   }
+                   else
+                   {
+                       size_t xLength;
+                       /* RX step7: read frame length. */
+                       xLength = ksz8851_reg_read( REG_RX_FHR_BYTE_CNT ) & RX_BYTE_CNT_MASK;
 
-				/* TX step1: check if TXQ memory size is available for transmit. */
-				txmir = ksz8851_reg_read( REG_TX_MEM_INFO );
-				txmir = txmir & TX_MEM_AVAILABLE_MASK;
+                       /* RX step8: Drop packet if len is invalid or no descriptor available. */
+                       if( xLength == 0 )
+                       {
+                           ksz8851_reg_setbits( REG_RXQ_CMD, RXQ_CMD_FREE_PACKET );
+                           FreeRTOS_printf( ( "ksz8851snl_update: RX bad len!\n" ) );
+                           ulISREvents |= EMAC_IF_ERR_EVENT;
+                       }
+                       else
+                       {
+                           size_t xReadLength = xLength;
 
-				if( txmir < ( xLength + 8 ) )
-				{
-					if( wait_tx_space == pdFALSE )
-					{
-						tx_status = ksz8851_reg_read( REG_TX_STATUS );
-						fhr_status = ksz8851_reg_read( REG_RX_FHR_STATUS );
-						wait_tx_space = pdTRUE;
-					}
-					//return;
-					rx_debug = 1;
-					tx_space = txmir;
-				}
-				else
-				{
-					tx_space = txmir;
+                           xMicrelDevice.ul_total_rx++;
+                           /* RX step9: reset RX frame pointer. */
+                           ksz8851_reg_clrbits( REG_RX_ADDR_PTR, ADDR_PTR_MASK );
 
-					/* TX step2: disable all interrupts. */
-					ksz8851_reg_write( REG_INT_MASK, 0 );
+                           /* RX step10: start RXQ read access. */
+                           ksz8851_reg_setbits( REG_RXQ_CMD, RXQ_START );
+                           /* RX step11-17: start asynchronous FIFO read operation. */
+                           xMicrelDevice.ul_spi_pdc_status = SPI_PDC_RX_START;
+                           gpio_set_pin_low( KSZ8851SNL_CSN_GPIO );
 
-					xMicrelDevice.tx_space -= xLength;
+                           if( ( xReadLength & ( sizeof( size_t ) - 1 ) ) != 0 )
+                           {
+                               xReadLength = ( xReadLength | ( sizeof( size_t ) - 1 ) ) + 1;
+                           }
 
-					/* TX step3: enable TXQ write access. */
-					ksz8851_reg_setbits( REG_RXQ_CMD, RXQ_START );
-					/* TX step4-8: perform FIFO write operation. */
-					xMicrelDevice.ul_spi_pdc_status = SPI_PDC_TX_START;
-					xMicrelDevice.tx_cur_buffer = pxNetworkBuffer;
-					/* Bring SPI SS low. */
-					gpio_set_pin_low( KSZ8851SNL_CSN_GPIO );
-					xMicrelDevice.ul_total_tx++;
+                           /* Pass the buffer minus 2 bytes, see ksz8851snl.c: RXQ_TWOBYTE_OFFSET. */
+                           ksz8851_fifo_read( pxNetworkBuffer->pucEthernetBuffer - 2, xReadLength );
+                           /* Remove CRC and update buffer length. */
+                           xLength -= 4;
+                           pxNetworkBuffer->xDataLength = xLength;
+                           /* Wait for SPI interrupt to set status 'SPI_PDC_RX_COMPLETE'. */
+                       }
+                   }
 
-					ksz8851_fifo_write( pxNetworkBuffer->pucEthernetBuffer, xLength, xLength );
-				}
-			}
-		}
-		break;	/* SPI_PDC_IDLE */
+                   break;
+               } /* ul_had_intn_interrupt || us_pending_frame */
 
-	case SPI_PDC_RX_COMPLETE:
-		{
-		int rxHead = xMicrelDevice.us_rx_head;
-			/* RX step18-19: pad with dummy data to keep dword alignment. */
-			/* Packet lengths will be rounded up to a multiple of "sizeof size_t". */
-//			xLength = xMicrelDevice.rx_buffers[ rxHead ]->xDataLength & 3;
-//			if( xLength != 0 )
-//			{
-//				ksz8851_fifo_dummy( 4 - xLength );
-//			}
+               /*
+                * ========================== Handle TX ==========================
+                */
 
-			/* RX step20: end RX transfer. */
-			gpio_set_pin_high( KSZ8851SNL_CSN_GPIO );
+               /* Fetch next packet to be sent. */
+               if( ( xMicrelDevice.tx_busy[ txTail ] != pdFALSE ) &&
+                   ( xMicrelDevice.us_pending_frame == 0 ) &&
+                   ( xMicrelDevice.ul_had_intn_interrupt == 0 ) )
+               {
+                   NetworkBufferDescriptor_t * pxNetworkBuffer = xMicrelDevice.tx_buffers[ txTail ];
+                   size_t xLength = pxNetworkBuffer->xDataLength;
+                   int iIndex = xLength;
 
-			/* Disable asynchronous transfer mode. */
-			xMicrelDevice.ul_spi_pdc_status = SPI_PDC_IDLE;
+                   xLength = 4 * ( ( xLength + 3 ) / 4 );
 
-			/* RX step21: end RXQ read access. */
-			ksz8851_reg_clrbits(REG_RXQ_CMD, RXQ_START);
+                   while( iIndex < ( int ) xLength )
+                   {
+                       pxNetworkBuffer->pucEthernetBuffer[ iIndex ] = '\0';
+                       iIndex++;
+                   }
 
-			/* RX step22-23: update frame count to be read. */
-			xMicrelDevice.us_pending_frame -= 1;
+                   pxNetworkBuffer->xDataLength = xLength;
 
-			/* RX step24: enable INT_RX flag if transfer complete. */
-			if( xMicrelDevice.us_pending_frame == 0 )
-			{
-				ksz8851_reg_write(REG_INT_MASK, INT_RX);
-			}
+                   /* TX step1: check if TXQ memory size is available for transmit. */
+                   txmir = ksz8851_reg_read( REG_TX_MEM_INFO );
+                   txmir = txmir & TX_MEM_AVAILABLE_MASK;
 
-			/* Mark descriptor ready to be read. */
-			xMicrelDevice.rx_ready[ rxHead ] = pdTRUE;
-			if( ++rxHead == MICREL_RX_BUFFERS )
-			{
-				rxHead = 0;
-			}
-			xMicrelDevice.us_rx_head = rxHead;
-			if( rx_debug != 0 )
-			{
-			uint32_t txmir;
-				rx_debug = 0;
-				txmir = ksz8851_reg_read( REG_TX_MEM_INFO );
-				txmir = txmir & TX_MEM_AVAILABLE_MASK;
-			}
-			/* Tell prvEMACHandlerTask that RX packets are available. */
-			ulISREvents |= EMAC_IF_RX_EVENT;
-		}	/* case SPI_PDC_RX_COMPLETE */
-		break;
+                   if( txmir < ( xLength + 8 ) )
+                   {
+                       if( wait_tx_space == pdFALSE )
+                       {
+                           tx_status = ksz8851_reg_read( REG_TX_STATUS );
+                           fhr_status = ksz8851_reg_read( REG_RX_FHR_STATUS );
+                           wait_tx_space = pdTRUE;
+                       }
 
-	case SPI_PDC_TX_COMPLETE:
-		{
-		int txTail = xMicrelDevice.us_tx_tail;
-		NetworkBufferDescriptor_t *pxNetworkBuffer = xMicrelDevice.tx_buffers[ txTail ];
+                       /*return; */
+                       rx_debug = 1;
+                       tx_space = txmir;
+                   }
+                   else
+                   {
+                       tx_space = txmir;
 
-		size_t xLength;
-			/* TX step9-10: pad with dummy data to keep dword alignment. */
-			/* Not necessary: length is already a multiple of 4. */
-			xLength = pxNetworkBuffer->xDataLength & 3;
-			if( xLength != 0 )
-			{
-//				ksz8851_fifo_dummy( 4 - xLength );
-			}
+                       /* TX step2: disable all interrupts. */
+                       ksz8851_reg_write( REG_INT_MASK, 0 );
 
-//			/* TX step11: end TX transfer. */
-			gpio_set_pin_high( KSZ8851SNL_CSN_GPIO );
+                       xMicrelDevice.tx_space -= xLength;
 
-			/* Disable asynchronous transfer mode. */
-			xMicrelDevice.ul_spi_pdc_status = SPI_PDC_IDLE;
+                       /* TX step3: enable TXQ write access. */
+                       ksz8851_reg_setbits( REG_RXQ_CMD, RXQ_START );
+                       /* TX step4-8: perform FIFO write operation. */
+                       xMicrelDevice.ul_spi_pdc_status = SPI_PDC_TX_START;
+                       xMicrelDevice.tx_cur_buffer = pxNetworkBuffer;
+                       /* Bring SPI SS low. */
+                       gpio_set_pin_low( KSZ8851SNL_CSN_GPIO );
+                       xMicrelDevice.ul_total_tx++;
 
-			/* TX step12: disable TXQ write access. */
-			ksz8851_reg_clrbits( REG_RXQ_CMD, RXQ_START );
+                       ksz8851_fifo_write( pxNetworkBuffer->pucEthernetBuffer, xLength, xLength );
+                   }
+               }
+           }
+           break; /* SPI_PDC_IDLE */
 
-			xMicrelDevice.tx_space = ksz8851_reg_read( REG_TX_MEM_INFO ) & TX_MEM_AVAILABLE_MASK;
+        case SPI_PDC_RX_COMPLETE:
+           {
+               int rxHead = xMicrelDevice.us_rx_head;
+               /* RX step18-19: pad with dummy data to keep dword alignment. */
+               /* Packet lengths will be rounded up to a multiple of "sizeof size_t". */
+/*			xLength = xMicrelDevice.rx_buffers[ rxHead ]->xDataLength & 3; */
+/*			if( xLength != 0 ) */
+/*			{ */
+/*				ksz8851_fifo_dummy( 4 - xLength ); */
+/*			} */
 
-			/* TX step12.1: enqueue frame in TXQ. */
-			ksz8851_reg_setbits( REG_TXQ_CMD, TXQ_ENQUEUE );
+               /* RX step20: end RX transfer. */
+               gpio_set_pin_high( KSZ8851SNL_CSN_GPIO );
 
-			/* RX step13: enable INT_RX flag. */
-//			ksz8851_reg_write( REG_INT_MASK, INT_RX );
-			/* Buffer sent, free the corresponding buffer and mark descriptor as owned by software. */
-			vReleaseNetworkBufferAndDescriptor( pxNetworkBuffer );
+               /* Disable asynchronous transfer mode. */
+               xMicrelDevice.ul_spi_pdc_status = SPI_PDC_IDLE;
 
-			xMicrelDevice.tx_buffers[ txTail ] = NULL;
-			xMicrelDevice.tx_busy[ txTail ] = pdFALSE;
-			if( ++txTail == MICREL_TX_BUFFERS )
-			{
-				txTail = 0;
-			}
+               /* RX step21: end RXQ read access. */
+               ksz8851_reg_clrbits( REG_RXQ_CMD, RXQ_START );
 
-			xMicrelDevice.us_tx_tail = txTail;
-			/* Experiment. */
-			//xMicrelDevice.ul_had_intn_interrupt = 1;
-			if( xTransmitHandle != NULL )
-			{
-				xTaskNotifyGive( xTransmitHandle );
-			}
-#warning moved downward
-			/* RX step13: enable INT_RX flag. */
-			ksz8851_reg_write( REG_INT_MASK, INT_RX );
-			/* Prevent the EMAC task from sleeping a single time. */
-			ulISREvents |= EMAC_IF_TX_EVENT;
-		}	/* case SPI_PDC_TX_COMPLETE */
-		break;
-	}	/* switch( xMicrelDevice.ul_spi_pdc_status ) */
+               /* RX step22-23: update frame count to be read. */
+               xMicrelDevice.us_pending_frame -= 1;
+
+               /* RX step24: enable INT_RX flag if transfer complete. */
+               if( xMicrelDevice.us_pending_frame == 0 )
+               {
+                   ksz8851_reg_write( REG_INT_MASK, INT_RX );
+               }
+
+               /* Mark descriptor ready to be read. */
+               xMicrelDevice.rx_ready[ rxHead ] = pdTRUE;
+
+               if( ++rxHead == MICREL_RX_BUFFERS )
+               {
+                   rxHead = 0;
+               }
+
+               xMicrelDevice.us_rx_head = rxHead;
+
+               if( rx_debug != 0 )
+               {
+                   uint32_t txmir;
+                   rx_debug = 0;
+                   txmir = ksz8851_reg_read( REG_TX_MEM_INFO );
+                   txmir = txmir & TX_MEM_AVAILABLE_MASK;
+               }
+
+               /* Tell prvEMACHandlerTask that RX packets are available. */
+               ulISREvents |= EMAC_IF_RX_EVENT;
+           } /* case SPI_PDC_RX_COMPLETE */
+           break;
+
+        case SPI_PDC_TX_COMPLETE:
+           {
+               int txTail = xMicrelDevice.us_tx_tail;
+               NetworkBufferDescriptor_t * pxNetworkBuffer = xMicrelDevice.tx_buffers[ txTail ];
+
+               size_t xLength;
+               /* TX step9-10: pad with dummy data to keep dword alignment. */
+               /* Not necessary: length is already a multiple of 4. */
+               xLength = pxNetworkBuffer->xDataLength & 3;
+
+               if( xLength != 0 )
+               {
+/*				ksz8851_fifo_dummy( 4 - xLength ); */
+               }
+
+/*			/ * TX step11: end TX transfer. * / */
+               gpio_set_pin_high( KSZ8851SNL_CSN_GPIO );
+
+               /* Disable asynchronous transfer mode. */
+               xMicrelDevice.ul_spi_pdc_status = SPI_PDC_IDLE;
+
+               /* TX step12: disable TXQ write access. */
+               ksz8851_reg_clrbits( REG_RXQ_CMD, RXQ_START );
+
+               xMicrelDevice.tx_space = ksz8851_reg_read( REG_TX_MEM_INFO ) & TX_MEM_AVAILABLE_MASK;
+
+               /* TX step12.1: enqueue frame in TXQ. */
+               ksz8851_reg_setbits( REG_TXQ_CMD, TXQ_ENQUEUE );
+
+               /* RX step13: enable INT_RX flag. */
+/*			ksz8851_reg_write( REG_INT_MASK, INT_RX ); */
+               /* Buffer sent, free the corresponding buffer and mark descriptor as owned by software. */
+               vReleaseNetworkBufferAndDescriptor( pxNetworkBuffer );
+
+               xMicrelDevice.tx_buffers[ txTail ] = NULL;
+               xMicrelDevice.tx_busy[ txTail ] = pdFALSE;
+
+               if( ++txTail == MICREL_TX_BUFFERS )
+               {
+                   txTail = 0;
+               }
+
+               xMicrelDevice.us_tx_tail = txTail;
+
+               /* Experiment. */
+               /*xMicrelDevice.ul_had_intn_interrupt = 1; */
+               if( xTransmitHandle != NULL )
+               {
+                   xTaskNotifyGive( xTransmitHandle );
+               }
+
+               #warning moved downward
+               /* RX step13: enable INT_RX flag. */
+               ksz8851_reg_write( REG_INT_MASK, INT_RX );
+               /* Prevent the EMAC task from sleeping a single time. */
+               ulISREvents |= EMAC_IF_TX_EVENT;
+           } /* case SPI_PDC_TX_COMPLETE */
+           break;
+    }        /* switch( xMicrelDevice.ul_spi_pdc_status ) */
 }
 
 /**
@@ -1001,20 +1048,21 @@ static void ksz8851snl_update()
  */
 static void ksz8851snl_rx_init()
 {
-	uint32_t ul_index = 0;
+    uint32_t ul_index = 0;
 
-	/* Init pointer index. */
-	xMicrelDevice.us_rx_head = 0;
-	xMicrelDevice.us_rx_tail = 0;
+    /* Init pointer index. */
+    xMicrelDevice.us_rx_head = 0;
+    xMicrelDevice.us_rx_tail = 0;
 
-	/* Set up the RX descriptors. */
-	for (ul_index = 0; ul_index < MICREL_RX_BUFFERS; ul_index++) {
-		xMicrelDevice.rx_buffers[ul_index] = NULL;
-		xMicrelDevice.rx_ready[ul_index] = pdFALSE;
-	}
+    /* Set up the RX descriptors. */
+    for( ul_index = 0; ul_index < MICREL_RX_BUFFERS; ul_index++ )
+    {
+        xMicrelDevice.rx_buffers[ ul_index ] = NULL;
+        xMicrelDevice.rx_ready[ ul_index ] = pdFALSE;
+    }
 
-	/* Build RX buffer and descriptors. */
-	ksz8851snl_rx_populate_queue();
+    /* Build RX buffer and descriptors. */
+    ksz8851snl_rx_populate_queue();
 }
 
 /**
@@ -1025,18 +1073,19 @@ static void ksz8851snl_rx_init()
  */
 static void ksz8851snl_tx_init()
 {
-	uint32_t ul_index = 0;
+    uint32_t ul_index = 0;
 
-	/* Init TX index pointer. */
-	xMicrelDevice.us_tx_head = 0;
-	xMicrelDevice.us_tx_tail = 0;
+    /* Init TX index pointer. */
+    xMicrelDevice.us_tx_head = 0;
+    xMicrelDevice.us_tx_tail = 0;
 
-	/* Set up the TX descriptors */
-	for( ul_index = 0; ul_index < MICREL_TX_BUFFERS; ul_index++ )
-	{
-		xMicrelDevice.tx_busy[ul_index] = pdFALSE;
-	}
-	xMicrelDevice.tx_space = 6144;
+    /* Set up the TX descriptors */
+    for( ul_index = 0; ul_index < MICREL_TX_BUFFERS; ul_index++ )
+    {
+        xMicrelDevice.tx_busy[ ul_index ] = pdFALSE;
+    }
+
+    xMicrelDevice.tx_space = 6144;
 }
 
 /**
@@ -1048,27 +1097,28 @@ static void ksz8851snl_tx_init()
  */
 static void ksz8851snl_low_level_init( void )
 {
-	ksz8851snl_rx_init();
-	ksz8851snl_tx_init();
+    ksz8851snl_rx_init();
+    ksz8851snl_tx_init();
 
-	/* Enable NVIC interrupts. */
-	NVIC_SetPriority(SPI_IRQn, INT_PRIORITY_SPI);
-	NVIC_EnableIRQ(SPI_IRQn);
+    /* Enable NVIC interrupts. */
+    NVIC_SetPriority( SPI_IRQn, INT_PRIORITY_SPI );
+    NVIC_EnableIRQ( SPI_IRQn );
 
-	/* Initialize SPI link. */
-	if( ksz8851snl_init() < 0 )
-	{
-		FreeRTOS_printf( ( "ksz8851snl_low_level_init: failed to initialize the Micrel driver!\n" ) );
-		configASSERT( ipFALSE_BOOL );
-	}
-	memset( xMicrelDevice.pusHashTable, 255, sizeof( xMicrelDevice.pusHashTable ) );
-	ksz8851_reg_write( REG_MAC_HASH_0, FreeRTOS_htons( xMicrelDevice.pusHashTable[ 0 ] ) );
-	ksz8851_reg_write( REG_MAC_HASH_2, FreeRTOS_htons( xMicrelDevice.pusHashTable[ 1 ] ) );
-	ksz8851_reg_write( REG_MAC_HASH_4, FreeRTOS_htons( xMicrelDevice.pusHashTable[ 2 ] ) );
-	ksz8851_reg_write( REG_MAC_HASH_6, FreeRTOS_htons( xMicrelDevice.pusHashTable[ 3 ] ) );
+    /* Initialize SPI link. */
+    if( ksz8851snl_init() < 0 )
+    {
+        FreeRTOS_printf( ( "ksz8851snl_low_level_init: failed to initialize the Micrel driver!\n" ) );
+        configASSERT( ipFALSE_BOOL );
+    }
 
-	/* Initialize interrupt line INTN. */
-	configure_intn( INTN_Handler );
+    memset( xMicrelDevice.pusHashTable, 255, sizeof( xMicrelDevice.pusHashTable ) );
+    ksz8851_reg_write( REG_MAC_HASH_0, FreeRTOS_htons( xMicrelDevice.pusHashTable[ 0 ] ) );
+    ksz8851_reg_write( REG_MAC_HASH_2, FreeRTOS_htons( xMicrelDevice.pusHashTable[ 1 ] ) );
+    ksz8851_reg_write( REG_MAC_HASH_4, FreeRTOS_htons( xMicrelDevice.pusHashTable[ 2 ] ) );
+    ksz8851_reg_write( REG_MAC_HASH_6, FreeRTOS_htons( xMicrelDevice.pusHashTable[ 3 ] ) );
+
+    /* Initialize interrupt line INTN. */
+    configure_intn( INTN_Handler );
 }
 
 /**
@@ -1079,194 +1129,202 @@ static void ksz8851snl_low_level_init( void )
  * \return a pbuf filled with the received packet (including MAC header).
  * 0 on memory error.
  */
-static NetworkBufferDescriptor_t *ksz8851snl_low_level_input( void )
+static NetworkBufferDescriptor_t * ksz8851snl_low_level_input( void )
 {
-NetworkBufferDescriptor_t *pxNetworkBuffer = NULL;
-int rxTail = xMicrelDevice.us_rx_tail;
+    NetworkBufferDescriptor_t * pxNetworkBuffer = NULL;
+    int rxTail = xMicrelDevice.us_rx_tail;
 
-	/* Check that descriptor is owned by software (ie packet received). */
-	if( xMicrelDevice.rx_ready[ rxTail ] != pdFALSE )
-	{
+    /* Check that descriptor is owned by software (ie packet received). */
+    if( xMicrelDevice.rx_ready[ rxTail ] != pdFALSE )
+    {
+        /* Fetch pre-allocated buffer */
+        pxNetworkBuffer = xMicrelDevice.rx_buffers[ rxTail ];
 
-		/* Fetch pre-allocated buffer */
-		pxNetworkBuffer = xMicrelDevice.rx_buffers[ rxTail ];
+        /* Remove this pbuf from its descriptor. */
+        xMicrelDevice.rx_buffers[ rxTail ] = NULL;
 
-		/* Remove this pbuf from its descriptor. */
-		xMicrelDevice.rx_buffers[ rxTail ] = NULL;
+        /* Clears rx_ready and sets rx_buffers. */
+        ksz8851snl_rx_populate_queue();
 
-		/* Clears rx_ready and sets rx_buffers. */
-		ksz8851snl_rx_populate_queue();
+        if( ++rxTail == MICREL_RX_BUFFERS )
+        {
+            rxTail = 0;
+        }
 
-		if( ++rxTail == MICREL_RX_BUFFERS )
-		{
-			rxTail = 0;
-		}
-		xMicrelDevice.us_rx_tail = rxTail;
-	}
+        xMicrelDevice.us_rx_tail = rxTail;
+    }
 
-	return pxNetworkBuffer;
+    return pxNetworkBuffer;
 }
 /*-----------------------------------------------------------*/
 
 static uint32_t prvEMACRxPoll( void )
 {
-NetworkBufferDescriptor_t *pxNetworkBuffer;
-IPStackEvent_t xRxEvent = { eNetworkRxEvent, NULL };
-uint32_t ulReturnValue = 0;
+    NetworkBufferDescriptor_t * pxNetworkBuffer;
+    IPStackEvent_t xRxEvent = { eNetworkRxEvent, NULL };
+    uint32_t ulReturnValue = 0;
 
-	for( ;; )
-	{
-	/* Only for logging. */
-	int rxTail = xMicrelDevice.us_rx_tail;
-	EthernetHeader_t *pxEthernetHeader;
+    for( ; ; )
+    {
+        /* Only for logging. */
+        int rxTail = xMicrelDevice.us_rx_tail;
+        EthernetHeader_t * pxEthernetHeader;
 
-	pxNetworkBuffer = ksz8851snl_low_level_input();
-	
-		if( pxNetworkBuffer == NULL )
-		{
-			break;
-		}
-		pxEthernetHeader = ( EthernetHeader_t * ) ( pxNetworkBuffer->pucEthernetBuffer );
+        pxNetworkBuffer = ksz8851snl_low_level_input();
 
-		if( ( pxEthernetHeader->usFrameType != ipIPv4_FRAME_TYPE ) &&
-			( pxEthernetHeader->usFrameType != ipARP_FRAME_TYPE	) )
-		{
-			FreeRTOS_printf( ( "Frame type %02X received\n", pxEthernetHeader->usFrameType ) );
-		}
-		ulReturnValue++;
+        if( pxNetworkBuffer == NULL )
+        {
+            break;
+        }
 
-		xRxEvent.pvData = ( void * )pxNetworkBuffer;
-		/* Send the descriptor to the IP task for processing. */
-		if( xSendEventStructToIPTask( &xRxEvent, 100UL ) != pdTRUE )
-		{
-			vReleaseNetworkBufferAndDescriptor( pxNetworkBuffer );
-			iptraceETHERNET_RX_EVENT_LOST();
-			FreeRTOS_printf( ( "prvEMACRxPoll: Can not queue return packet!\n" ) );
-		}
-	}
+        pxEthernetHeader = ( EthernetHeader_t * ) ( pxNetworkBuffer->pucEthernetBuffer );
 
-	return ulReturnValue;
+        if( ( pxEthernetHeader->usFrameType != ipIPv4_FRAME_TYPE ) &&
+            ( pxEthernetHeader->usFrameType != ipARP_FRAME_TYPE ) )
+        {
+            FreeRTOS_printf( ( "Frame type %02X received\n", pxEthernetHeader->usFrameType ) );
+        }
+
+        ulReturnValue++;
+
+        xRxEvent.pvData = ( void * ) pxNetworkBuffer;
+
+        /* Send the descriptor to the IP task for processing. */
+        if( xSendEventStructToIPTask( &xRxEvent, 100UL ) != pdTRUE )
+        {
+            vReleaseNetworkBufferAndDescriptor( pxNetworkBuffer );
+            iptraceETHERNET_RX_EVENT_LOST();
+            FreeRTOS_printf( ( "prvEMACRxPoll: Can not queue return packet!\n" ) );
+        }
+    }
+
+    return ulReturnValue;
 }
 /*-----------------------------------------------------------*/
 
-static void prvEMACHandlerTask( void *pvParameters )
+static void prvEMACHandlerTask( void * pvParameters )
 {
-TimeOut_t xPhyTime;
-TickType_t xPhyRemTime;
-TickType_t xLoggingTime;
-UBaseType_t uxLastMinBufferCount = 0;
-UBaseType_t uxCurrentCount;
-BaseType_t xResult = 0;
-uint32_t xStatus;
-const TickType_t ulMaxBlockTime = pdMS_TO_TICKS( EMAC_MAX_BLOCK_TIME_MS );
-#if( ipconfigCHECK_IP_QUEUE_SPACE != 0 )
-	UBaseType_t uxLastMinQueueSpace = 0;
-#endif
+    TimeOut_t xPhyTime;
+    TickType_t xPhyRemTime;
+    TickType_t xLoggingTime;
+    UBaseType_t uxLastMinBufferCount = 0;
+    UBaseType_t uxCurrentCount;
+    BaseType_t xResult = 0;
+    uint32_t xStatus;
+    const TickType_t ulMaxBlockTime = pdMS_TO_TICKS( EMAC_MAX_BLOCK_TIME_MS );
 
-	/* Remove compiler warnings about unused parameters. */
-	( void ) pvParameters;
+    #if ( ipconfigCHECK_IP_QUEUE_SPACE != 0 )
+        UBaseType_t uxLastMinQueueSpace = 0;
+    #endif
 
-	configASSERT( xEMACTaskHandle != NULL );
+    /* Remove compiler warnings about unused parameters. */
+    ( void ) pvParameters;
 
-	vTaskSetTimeOutState( &xPhyTime );
-	xPhyRemTime = pdMS_TO_TICKS( PHY_LS_LOW_CHECK_TIME_MS );
-	xLoggingTime = xTaskGetTickCount();
+    configASSERT( xEMACTaskHandle != NULL );
 
-	for( ;; )
-	{
-		uxCurrentCount = uxGetMinimumFreeNetworkBuffers();
-		if( uxLastMinBufferCount != uxCurrentCount )
-		{
-			/* The logging produced below may be helpful
-			while tuning +TCP: see how many buffers are in use. */
-			uxLastMinBufferCount = uxCurrentCount;
-			FreeRTOS_printf( ( "Network buffers: %lu lowest %lu\n",
-				uxGetNumberOfFreeNetworkBuffers(), uxCurrentCount ) );
-		}
+    vTaskSetTimeOutState( &xPhyTime );
+    xPhyRemTime = pdMS_TO_TICKS( PHY_LS_LOW_CHECK_TIME_MS );
+    xLoggingTime = xTaskGetTickCount();
 
-		#if( ipconfigCHECK_IP_QUEUE_SPACE != 0 )
-		{
-			uxCurrentCount = uxGetMinimumIPQueueSpace();
-			if( uxLastMinQueueSpace != uxCurrentCount )
-			{
-				/* The logging produced below may be helpful
-				while tuning +TCP: see how many buffers are in use. */
-				uxLastMinQueueSpace = uxCurrentCount;
-				FreeRTOS_printf( ( "Queue space: lowest %lu\n", uxCurrentCount ) );
-			}
-		}
-		#endif /* ipconfigCHECK_IP_QUEUE_SPACE */
+    for( ; ; )
+    {
+        uxCurrentCount = uxGetMinimumFreeNetworkBuffers();
 
-		/* Run the state-machine of the ksz8851 driver. */
-		ksz8851snl_update();
+        if( uxLastMinBufferCount != uxCurrentCount )
+        {
+            /* The logging produced below may be helpful
+             * while tuning +TCP: see how many buffers are in use. */
+            uxLastMinBufferCount = uxCurrentCount;
+            FreeRTOS_printf( ( "Network buffers: %lu lowest %lu\n",
+                               uxGetNumberOfFreeNetworkBuffers(), uxCurrentCount ) );
+        }
 
-		if( ( ulISREvents & EMAC_IF_ALL_EVENT ) == 0 )
-		{
-			/* No events to process now, wait for the next. */
-			ulTaskNotifyTake( pdTRUE, ulMaxBlockTime );
-		}
+        #if ( ipconfigCHECK_IP_QUEUE_SPACE != 0 )
+            {
+                uxCurrentCount = uxGetMinimumIPQueueSpace();
 
-		if( ( xTaskGetTickCount() - xLoggingTime ) > 10000 )
-		{
-			xLoggingTime += 10000;
-			FreeRTOS_printf( ( "Now Tx/Rx %7d /%7d\n",
-				xMicrelDevice.ul_total_tx, xMicrelDevice.ul_total_rx ) );
-		}
+                if( uxLastMinQueueSpace != uxCurrentCount )
+                {
+                    /* The logging produced below may be helpful
+                     * while tuning +TCP: see how many buffers are in use. */
+                    uxLastMinQueueSpace = uxCurrentCount;
+                    FreeRTOS_printf( ( "Queue space: lowest %lu\n", uxCurrentCount ) );
+                }
+            }
+        #endif /* ipconfigCHECK_IP_QUEUE_SPACE */
 
-		if( ( ulISREvents & EMAC_IF_RX_EVENT ) != 0 )
-		{
-			ulISREvents &= ~EMAC_IF_RX_EVENT;
+        /* Run the state-machine of the ksz8851 driver. */
+        ksz8851snl_update();
 
-			/* Wait for the EMAC interrupt to indicate that another packet has been
-			received. */
-			xResult = prvEMACRxPoll();
-		}
+        if( ( ulISREvents & EMAC_IF_ALL_EVENT ) == 0 )
+        {
+            /* No events to process now, wait for the next. */
+            ulTaskNotifyTake( pdTRUE, ulMaxBlockTime );
+        }
 
-		if( ( ulISREvents & EMAC_IF_TX_EVENT ) != 0 )
-		{
-			/* Future extension: code to release TX buffers if zero-copy is used. */
-			ulISREvents &= ~EMAC_IF_TX_EVENT;
-		}
+        if( ( xTaskGetTickCount() - xLoggingTime ) > 10000 )
+        {
+            xLoggingTime += 10000;
+            FreeRTOS_printf( ( "Now Tx/Rx %7d /%7d\n",
+                               xMicrelDevice.ul_total_tx, xMicrelDevice.ul_total_rx ) );
+        }
 
-		if( ( ulISREvents & EMAC_IF_ERR_EVENT ) != 0 )
-		{
-			/* Future extension: logging about errors that occurred. */
-			ulISREvents &= ~EMAC_IF_ERR_EVENT;
-		}
+        if( ( ulISREvents & EMAC_IF_RX_EVENT ) != 0 )
+        {
+            ulISREvents &= ~EMAC_IF_RX_EVENT;
 
-		if( xResult > 0 )
-		{
-			/* As long as packets are being received, assume that
-			the Link Status is high. */
-			ulPHYLinkStatus |= BMSR_LINK_STATUS;
-			/* A packet was received. No need to check for the PHY status now,
-			but set a timer to check it later on. */
-			vTaskSetTimeOutState( &xPhyTime );
-			xPhyRemTime = pdMS_TO_TICKS( PHY_LS_HIGH_CHECK_TIME_MS );
-			xResult = 0;
-		}
-		else if( ( xTaskCheckForTimeOut( &xPhyTime, &xPhyRemTime ) != pdFALSE ) &&
-			( xMicrelDevice.ul_spi_pdc_status == SPI_PDC_IDLE ) )
-		{
-			/* Check the link status again. */
-			xStatus = ulReadMDIO( PHY_REG_01_BMSR );
+            /* Wait for the EMAC interrupt to indicate that another packet has been
+             * received. */
+            xResult = prvEMACRxPoll();
+        }
 
-			if( ( ulPHYLinkStatus & BMSR_LINK_STATUS ) != ( xStatus & BMSR_LINK_STATUS ) )
-			{
-				ulPHYLinkStatus = xStatus;
-				FreeRTOS_printf( ( "prvEMACHandlerTask: PHY LS now %d\n", ( ulPHYLinkStatus & BMSR_LINK_STATUS ) != 0 ) );
-			}
+        if( ( ulISREvents & EMAC_IF_TX_EVENT ) != 0 )
+        {
+            /* Future extension: code to release TX buffers if zero-copy is used. */
+            ulISREvents &= ~EMAC_IF_TX_EVENT;
+        }
 
-			vTaskSetTimeOutState( &xPhyTime );
-			if( ( ulPHYLinkStatus & BMSR_LINK_STATUS ) != 0 )
-			{
-				xPhyRemTime = pdMS_TO_TICKS( PHY_LS_HIGH_CHECK_TIME_MS );
-			}
-			else
-			{
-				xPhyRemTime = pdMS_TO_TICKS( PHY_LS_LOW_CHECK_TIME_MS );
-			}
-		}
-	}
+        if( ( ulISREvents & EMAC_IF_ERR_EVENT ) != 0 )
+        {
+            /* Future extension: logging about errors that occurred. */
+            ulISREvents &= ~EMAC_IF_ERR_EVENT;
+        }
+
+        if( xResult > 0 )
+        {
+            /* As long as packets are being received, assume that
+             * the Link Status is high. */
+            ulPHYLinkStatus |= BMSR_LINK_STATUS;
+
+            /* A packet was received. No need to check for the PHY status now,
+             * but set a timer to check it later on. */
+            vTaskSetTimeOutState( &xPhyTime );
+            xPhyRemTime = pdMS_TO_TICKS( PHY_LS_HIGH_CHECK_TIME_MS );
+            xResult = 0;
+        }
+        else if( ( xTaskCheckForTimeOut( &xPhyTime, &xPhyRemTime ) != pdFALSE ) &&
+                 ( xMicrelDevice.ul_spi_pdc_status == SPI_PDC_IDLE ) )
+        {
+            /* Check the link status again. */
+            xStatus = ulReadMDIO( PHY_REG_01_BMSR );
+
+            if( ( ulPHYLinkStatus & BMSR_LINK_STATUS ) != ( xStatus & BMSR_LINK_STATUS ) )
+            {
+                ulPHYLinkStatus = xStatus;
+                FreeRTOS_printf( ( "prvEMACHandlerTask: PHY LS now %d\n", ( ulPHYLinkStatus & BMSR_LINK_STATUS ) != 0 ) );
+            }
+
+            vTaskSetTimeOutState( &xPhyTime );
+
+            if( ( ulPHYLinkStatus & BMSR_LINK_STATUS ) != 0 )
+            {
+                xPhyRemTime = pdMS_TO_TICKS( PHY_LS_HIGH_CHECK_TIME_MS );
+            }
+            else
+            {
+                xPhyRemTime = pdMS_TO_TICKS( PHY_LS_LOW_CHECK_TIME_MS );
+            }
+        }
+    }
 }
 /*-----------------------------------------------------------*/

--- a/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/portable/NetworkInterface/ksz8851snl/ksz8851snl.c
+++ b/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/portable/NetworkInterface/ksz8851snl/ksz8851snl.c
@@ -59,25 +59,29 @@
 #include "conf_eth.h"
 
 /* Clock polarity. */
-#define SPI_CLK_POLARITY 0
+#define SPI_CLK_POLARITY    0
 
 /* Clock phase. */
-#define SPI_CLK_PHASE 1
+#define SPI_CLK_PHASE       1
 
 /* SPI PDC register base. */
-Pdc *g_p_spi_pdc = 0;
+Pdc * g_p_spi_pdc = 0;
 
-int lUDPLoggingPrintf( const char *pcFormatString, ... );
+int lUDPLoggingPrintf( const char * pcFormatString,
+                       ... );
 
 /* Temporary buffer for PDC reception. */
-uint8_t tmpbuf[1536] __attribute__ ((aligned (16)));
+uint8_t tmpbuf[ 1536 ] __attribute__( ( aligned( 16 ) ) );
 
-union {
-	uint64_t ul[2];
-	uint8_t uc[16];
-} cmdBuf, respBuf;
+union
+{
+    uint64_t ul[ 2 ];
+    uint8_t uc[ 16 ];
+}
+cmdBuf, respBuf;
 
-void dbg_add_line( const char *pcFormat, ... );
+void dbg_add_line( const char * pcFormat,
+                   ... );
 
 static void spi_clear_ovres( void );
 
@@ -87,13 +91,14 @@ static void spi_clear_ovres( void );
  * \param reg the register address to modify.
  * \param bits_to_set bitmask to apply.
  */
-void ksz8851_reg_setbits(uint16_t reg, uint16_t bits_to_set)
+void ksz8851_reg_setbits( uint16_t reg,
+                          uint16_t bits_to_set )
 {
-   uint16_t	temp;
+    uint16_t temp;
 
-   temp = ksz8851_reg_read(reg);
-   temp |= bits_to_set;
-   ksz8851_reg_write(reg, temp);
+    temp = ksz8851_reg_read( reg );
+    temp |= bits_to_set;
+    ksz8851_reg_write( reg, temp );
 }
 
 /**
@@ -102,39 +107,40 @@ void ksz8851_reg_setbits(uint16_t reg, uint16_t bits_to_set)
  * \param reg the register address to modify.
  * \param bits_to_set bitmask to apply.
  */
-void ksz8851_reg_clrbits(uint16_t reg, uint16_t bits_to_clr)
+void ksz8851_reg_clrbits( uint16_t reg,
+                          uint16_t bits_to_clr )
 {
-   uint16_t	temp;
+    uint16_t temp;
 
-   temp = ksz8851_reg_read(reg);
-   temp &= ~(uint32_t) bits_to_clr;
-   ksz8851_reg_write(reg, temp);
+    temp = ksz8851_reg_read( reg );
+    temp &= ~( uint32_t ) bits_to_clr;
+    ksz8851_reg_write( reg, temp );
 }
 
 /**
  * \brief Configure the INTN interrupt.
  */
-void configure_intn(void (*p_handler) (uint32_t, uint32_t))
+void configure_intn( void ( * p_handler )( uint32_t, uint32_t ) )
 {
-//	gpio_configure_pin(KSZ8851SNL_INTN_GPIO, PIO_INPUT);
-//	pio_set_input(PIOA, PIO_PA11_IDX, PIO_PULLUP);
+/*	gpio_configure_pin(KSZ8851SNL_INTN_GPIO, PIO_INPUT); */
+/*	pio_set_input(PIOA, PIO_PA11_IDX, PIO_PULLUP); */
 
-	/* Configure PIO clock. */
-	pmc_enable_periph_clk(INTN_ID);
+    /* Configure PIO clock. */
+    pmc_enable_periph_clk( INTN_ID );
 
-	/* Adjust PIO debounce filter parameters, uses 10 Hz filter. */
-	pio_set_debounce_filter(INTN_PIO, INTN_PIN_MSK, 10);
+    /* Adjust PIO debounce filter parameters, uses 10 Hz filter. */
+    pio_set_debounce_filter( INTN_PIO, INTN_PIN_MSK, 10 );
 
-	/* Initialize PIO interrupt handlers, see PIO definition in board.h. */
-	pio_handler_set(INTN_PIO, INTN_ID, INTN_PIN_MSK,
-		INTN_ATTR, p_handler);
+    /* Initialize PIO interrupt handlers, see PIO definition in board.h. */
+    pio_handler_set( INTN_PIO, INTN_ID, INTN_PIN_MSK,
+                     INTN_ATTR, p_handler );
 
-	/* Enable NVIC interrupts. */
-	NVIC_SetPriority(INTN_IRQn, INT_PRIORITY_PIO);
-	NVIC_EnableIRQ((IRQn_Type)INTN_ID);
+    /* Enable NVIC interrupts. */
+    NVIC_SetPriority( INTN_IRQn, INT_PRIORITY_PIO );
+    NVIC_EnableIRQ( ( IRQn_Type ) INTN_ID );
 
-	/* Enable PIO interrupts. */
-	pio_enable_interrupt(INTN_PIO, INTN_PIN_MSK);
+    /* Enable PIO interrupts. */
+    pio_enable_interrupt( INTN_PIO, INTN_PIN_MSK );
 }
 
 /**
@@ -144,70 +150,78 @@ void configure_intn(void (*p_handler) (uint32_t, uint32_t))
  *
  * \return the register value.
  */
-uint16_t ksz8851_reg_read(uint16_t reg)
+uint16_t ksz8851_reg_read( uint16_t reg )
 {
-pdc_packet_t g_pdc_spi_tx_packet;
-pdc_packet_t g_pdc_spi_rx_packet;
-uint16_t cmd = 0;
-uint16_t res = 0;
-int iTryCount = 3;
+    pdc_packet_t g_pdc_spi_tx_packet;
+    pdc_packet_t g_pdc_spi_rx_packet;
+    uint16_t cmd = 0;
+    uint16_t res = 0;
+    int iTryCount = 3;
 
-	while( iTryCount-- > 0 )
-	{
-	uint32_t ulStatus;
+    while( iTryCount-- > 0 )
+    {
+        uint32_t ulStatus;
 
-		spi_clear_ovres();
-		/* Move register address to cmd bits 9-2, make 32-bit address. */
-		cmd = (reg << 2) & REG_ADDR_MASK;
+        spi_clear_ovres();
+        /* Move register address to cmd bits 9-2, make 32-bit address. */
+        cmd = ( reg << 2 ) & REG_ADDR_MASK;
 
-		/* Last 2 bits still under "don't care bits" handled with byte enable. */
-		/* Select byte enable for command. */
-		if (reg & 2) {
-			/* Odd word address writes bytes 2 and 3 */
-			cmd |= (0xc << 10);
-		} else {
-			/* Even word address write bytes 0 and 1 */
-			cmd |= (0x3 << 10);
-		}
+        /* Last 2 bits still under "don't care bits" handled with byte enable. */
+        /* Select byte enable for command. */
+        if( reg & 2 )
+        {
+            /* Odd word address writes bytes 2 and 3 */
+            cmd |= ( 0xc << 10 );
+        }
+        else
+        {
+            /* Even word address write bytes 0 and 1 */
+            cmd |= ( 0x3 << 10 );
+        }
 
-		/* Add command read code. */
-		cmd |= CMD_READ;
-		cmdBuf.uc[0] = cmd >> 8;
-		cmdBuf.uc[1] = cmd & 0xff;
-		cmdBuf.uc[2] = CONFIG_SPI_MASTER_DUMMY;
-		cmdBuf.uc[3] = CONFIG_SPI_MASTER_DUMMY;
+        /* Add command read code. */
+        cmd |= CMD_READ;
+        cmdBuf.uc[ 0 ] = cmd >> 8;
+        cmdBuf.uc[ 1 ] = cmd & 0xff;
+        cmdBuf.uc[ 2 ] = CONFIG_SPI_MASTER_DUMMY;
+        cmdBuf.uc[ 3 ] = CONFIG_SPI_MASTER_DUMMY;
 
-		/* Prepare PDC transfer. */
-		g_pdc_spi_tx_packet.ul_addr = (uint32_t) cmdBuf.uc;
-		g_pdc_spi_tx_packet.ul_size = 4;
-		g_pdc_spi_rx_packet.ul_addr = (uint32_t) tmpbuf;
-		g_pdc_spi_rx_packet.ul_size = 4;
-		pdc_disable_transfer(g_p_spi_pdc, PERIPH_PTCR_RXTDIS | PERIPH_PTCR_TXTDIS);
-		pdc_tx_init(g_p_spi_pdc, &g_pdc_spi_tx_packet, NULL);
-		pdc_rx_init(g_p_spi_pdc, &g_pdc_spi_rx_packet, NULL);
-	gpio_set_pin_low(KSZ8851SNL_CSN_GPIO);
+        /* Prepare PDC transfer. */
+        g_pdc_spi_tx_packet.ul_addr = ( uint32_t ) cmdBuf.uc;
+        g_pdc_spi_tx_packet.ul_size = 4;
+        g_pdc_spi_rx_packet.ul_addr = ( uint32_t ) tmpbuf;
+        g_pdc_spi_rx_packet.ul_size = 4;
+        pdc_disable_transfer( g_p_spi_pdc, PERIPH_PTCR_RXTDIS | PERIPH_PTCR_TXTDIS );
+        pdc_tx_init( g_p_spi_pdc, &g_pdc_spi_tx_packet, NULL );
+        pdc_rx_init( g_p_spi_pdc, &g_pdc_spi_rx_packet, NULL );
+        gpio_set_pin_low( KSZ8851SNL_CSN_GPIO );
 
-	spi_disable_interrupt( KSZ8851SNL_SPI, ~0ul );
-		pdc_enable_transfer(g_p_spi_pdc, PERIPH_PTCR_RXTEN | PERIPH_PTCR_TXTEN);
-		for( ;; )
-		{
-			ulStatus = spi_read_status( KSZ8851SNL_SPI );
-			if( ( ulStatus & ( SPI_SR_OVRES | SPI_SR_ENDRX ) ) != 0 )
-			{
-				break;
-			}
-		}
-		gpio_set_pin_high( KSZ8851SNL_CSN_GPIO );
-		if( ( ulStatus & SPI_SR_OVRES ) == 0 )
-		{
-			break;
-		}
-		pdc_disable_transfer(g_p_spi_pdc, PERIPH_PTCR_RXTDIS | PERIPH_PTCR_TXTDIS);
-		lUDPLoggingPrintf( "ksz8851_reg_read: SPI_SR_OVRES\n" );
-	}
+        spi_disable_interrupt( KSZ8851SNL_SPI, ~0ul );
+        pdc_enable_transfer( g_p_spi_pdc, PERIPH_PTCR_RXTEN | PERIPH_PTCR_TXTEN );
 
-	res = (tmpbuf[3] << 8) | tmpbuf[2];
-	return res;
+        for( ; ; )
+        {
+            ulStatus = spi_read_status( KSZ8851SNL_SPI );
+
+            if( ( ulStatus & ( SPI_SR_OVRES | SPI_SR_ENDRX ) ) != 0 )
+            {
+                break;
+            }
+        }
+
+        gpio_set_pin_high( KSZ8851SNL_CSN_GPIO );
+
+        if( ( ulStatus & SPI_SR_OVRES ) == 0 )
+        {
+            break;
+        }
+
+        pdc_disable_transfer( g_p_spi_pdc, PERIPH_PTCR_RXTDIS | PERIPH_PTCR_TXTDIS );
+        lUDPLoggingPrintf( "ksz8851_reg_read: SPI_SR_OVRES\n" );
+    }
+
+    res = ( tmpbuf[ 3 ] << 8 ) | tmpbuf[ 2 ];
+    return res;
 }
 
 /**
@@ -216,76 +230,86 @@ int iTryCount = 3;
  * \param reg the register address to modify.
  * \param wrdata the new register value.
  */
-void ksz8851_reg_write(uint16_t reg, uint16_t wrdata)
+void ksz8851_reg_write( uint16_t reg,
+                        uint16_t wrdata )
 {
-pdc_packet_t g_pdc_spi_tx_packet;
-pdc_packet_t g_pdc_spi_rx_packet;
-uint16_t cmd = 0;
-int iTryCount = 3;
+    pdc_packet_t g_pdc_spi_tx_packet;
+    pdc_packet_t g_pdc_spi_rx_packet;
+    uint16_t cmd = 0;
+    int iTryCount = 3;
 
-	while( iTryCount-- > 0 )
-	{
-	uint32_t ulStatus;
+    while( iTryCount-- > 0 )
+    {
+        uint32_t ulStatus;
 
 
-		spi_clear_ovres();
-		/* Move register address to cmd bits 9-2, make 32-bit address. */
-		cmd = (reg << 2) & REG_ADDR_MASK;
+        spi_clear_ovres();
+        /* Move register address to cmd bits 9-2, make 32-bit address. */
+        cmd = ( reg << 2 ) & REG_ADDR_MASK;
 
-		/* Last 2 bits still under "don't care bits" handled with byte enable. */
-		/* Select byte enable for command. */
-		if (reg & 2) {
-			/* Odd word address writes bytes 2 and 3 */
-			cmd |= (0xc << 10);
-		} else {
-			/* Even word address write bytes 0 and 1 */
-			cmd |= (0x3 << 10);
-		}
+        /* Last 2 bits still under "don't care bits" handled with byte enable. */
+        /* Select byte enable for command. */
+        if( reg & 2 )
+        {
+            /* Odd word address writes bytes 2 and 3 */
+            cmd |= ( 0xc << 10 );
+        }
+        else
+        {
+            /* Even word address write bytes 0 and 1 */
+            cmd |= ( 0x3 << 10 );
+        }
 
-		/* Add command write code. */
-		cmd |= CMD_WRITE;
-		cmdBuf.uc[0] = cmd >> 8;
-		cmdBuf.uc[1] = cmd & 0xff;
-		cmdBuf.uc[2] = wrdata & 0xff;
-		cmdBuf.uc[3] = wrdata >> 8;
+        /* Add command write code. */
+        cmd |= CMD_WRITE;
+        cmdBuf.uc[ 0 ] = cmd >> 8;
+        cmdBuf.uc[ 1 ] = cmd & 0xff;
+        cmdBuf.uc[ 2 ] = wrdata & 0xff;
+        cmdBuf.uc[ 3 ] = wrdata >> 8;
 
-		/* Prepare PDC transfer. */
-		g_pdc_spi_tx_packet.ul_addr = (uint32_t) cmdBuf.uc;
-		g_pdc_spi_tx_packet.ul_size = 4;
-		g_pdc_spi_rx_packet.ul_addr = (uint32_t) tmpbuf;
-		g_pdc_spi_rx_packet.ul_size = 4;
-		pdc_disable_transfer(g_p_spi_pdc, PERIPH_PTCR_RXTDIS | PERIPH_PTCR_TXTDIS);
-		pdc_tx_init(g_p_spi_pdc, &g_pdc_spi_tx_packet, NULL);
-		pdc_rx_init(g_p_spi_pdc, &g_pdc_spi_rx_packet, NULL);
-		gpio_set_pin_low(KSZ8851SNL_CSN_GPIO);
+        /* Prepare PDC transfer. */
+        g_pdc_spi_tx_packet.ul_addr = ( uint32_t ) cmdBuf.uc;
+        g_pdc_spi_tx_packet.ul_size = 4;
+        g_pdc_spi_rx_packet.ul_addr = ( uint32_t ) tmpbuf;
+        g_pdc_spi_rx_packet.ul_size = 4;
+        pdc_disable_transfer( g_p_spi_pdc, PERIPH_PTCR_RXTDIS | PERIPH_PTCR_TXTDIS );
+        pdc_tx_init( g_p_spi_pdc, &g_pdc_spi_tx_packet, NULL );
+        pdc_rx_init( g_p_spi_pdc, &g_pdc_spi_rx_packet, NULL );
+        gpio_set_pin_low( KSZ8851SNL_CSN_GPIO );
 
-		spi_disable_interrupt( KSZ8851SNL_SPI, ~0ul );
+        spi_disable_interrupt( KSZ8851SNL_SPI, ~0ul );
 
-		pdc_enable_transfer(g_p_spi_pdc, PERIPH_PTCR_RXTEN | PERIPH_PTCR_TXTEN);
-		for( ;; )
-		{
-			ulStatus = spi_read_status( KSZ8851SNL_SPI );
-			if( ( ulStatus & ( SPI_SR_OVRES | SPI_SR_ENDRX ) ) != 0 )
-			{
-				break;
-			}
-		}
-		gpio_set_pin_high( KSZ8851SNL_CSN_GPIO );
-		if( ( ulStatus & SPI_SR_OVRES ) == 0 )
-		{
-			break;
-		}
-		pdc_disable_transfer(g_p_spi_pdc, PERIPH_PTCR_RXTDIS | PERIPH_PTCR_TXTDIS);
-		lUDPLoggingPrintf( "ksz8851_reg_write: SPI_SR_OVRES\n" );
-	}
+        pdc_enable_transfer( g_p_spi_pdc, PERIPH_PTCR_RXTEN | PERIPH_PTCR_TXTEN );
+
+        for( ; ; )
+        {
+            ulStatus = spi_read_status( KSZ8851SNL_SPI );
+
+            if( ( ulStatus & ( SPI_SR_OVRES | SPI_SR_ENDRX ) ) != 0 )
+            {
+                break;
+            }
+        }
+
+        gpio_set_pin_high( KSZ8851SNL_CSN_GPIO );
+
+        if( ( ulStatus & SPI_SR_OVRES ) == 0 )
+        {
+            break;
+        }
+
+        pdc_disable_transfer( g_p_spi_pdc, PERIPH_PTCR_RXTDIS | PERIPH_PTCR_TXTDIS );
+        lUDPLoggingPrintf( "ksz8851_reg_write: SPI_SR_OVRES\n" );
+    }
 }
 
 static void spi_clear_ovres( void )
 {
-volatile uint32_t rc;
-	rc = KSZ8851SNL_SPI->SPI_RDR;
+    volatile uint32_t rc;
 
-	spi_read_status( KSZ8851SNL_SPI );
+    rc = KSZ8851SNL_SPI->SPI_RDR;
+
+    spi_read_status( KSZ8851SNL_SPI );
 }
 
 /**
@@ -294,34 +318,35 @@ volatile uint32_t rc;
  * \param buf the buffer to store the data from the fifo buffer.
  * \param len the amount of data to read.
  */
-void ksz8851_fifo_read(uint8_t *buf, uint32_t len)
+void ksz8851_fifo_read( uint8_t * buf,
+                        uint32_t len )
 {
-	pdc_packet_t g_pdc_spi_tx_packet;
-	pdc_packet_t g_pdc_spi_rx_packet;
-	pdc_packet_t g_pdc_spi_tx_npacket;
-	pdc_packet_t g_pdc_spi_rx_npacket;
+    pdc_packet_t g_pdc_spi_tx_packet;
+    pdc_packet_t g_pdc_spi_rx_packet;
+    pdc_packet_t g_pdc_spi_tx_npacket;
+    pdc_packet_t g_pdc_spi_rx_npacket;
 
-	memset( cmdBuf.uc, '\0', sizeof cmdBuf );
-	cmdBuf.uc[0] = FIFO_READ;
-	spi_clear_ovres();
+    memset( cmdBuf.uc, '\0', sizeof cmdBuf );
+    cmdBuf.uc[ 0 ] = FIFO_READ;
+    spi_clear_ovres();
 
-	/* Prepare PDC transfer. */
-	g_pdc_spi_tx_packet.ul_addr = (uint32_t) cmdBuf.uc;
-	g_pdc_spi_tx_packet.ul_size = 9;
-	g_pdc_spi_rx_packet.ul_addr = (uint32_t) respBuf.uc;
-	g_pdc_spi_rx_packet.ul_size = 9;
+    /* Prepare PDC transfer. */
+    g_pdc_spi_tx_packet.ul_addr = ( uint32_t ) cmdBuf.uc;
+    g_pdc_spi_tx_packet.ul_size = 9;
+    g_pdc_spi_rx_packet.ul_addr = ( uint32_t ) respBuf.uc;
+    g_pdc_spi_rx_packet.ul_size = 9;
 
-	g_pdc_spi_tx_npacket.ul_addr = (uint32_t) buf;
-	g_pdc_spi_tx_npacket.ul_size = len;
-	g_pdc_spi_rx_npacket.ul_addr = (uint32_t) buf;
-	g_pdc_spi_rx_npacket.ul_size = len;
-	pdc_disable_transfer(g_p_spi_pdc, PERIPH_PTCR_RXTDIS | PERIPH_PTCR_TXTDIS);
-	pdc_tx_init(g_p_spi_pdc, &g_pdc_spi_tx_packet, &g_pdc_spi_tx_npacket);
-	pdc_rx_init(g_p_spi_pdc, &g_pdc_spi_rx_packet, &g_pdc_spi_rx_npacket);
+    g_pdc_spi_tx_npacket.ul_addr = ( uint32_t ) buf;
+    g_pdc_spi_tx_npacket.ul_size = len;
+    g_pdc_spi_rx_npacket.ul_addr = ( uint32_t ) buf;
+    g_pdc_spi_rx_npacket.ul_size = len;
+    pdc_disable_transfer( g_p_spi_pdc, PERIPH_PTCR_RXTDIS | PERIPH_PTCR_TXTDIS );
+    pdc_tx_init( g_p_spi_pdc, &g_pdc_spi_tx_packet, &g_pdc_spi_tx_npacket );
+    pdc_rx_init( g_p_spi_pdc, &g_pdc_spi_rx_packet, &g_pdc_spi_rx_npacket );
 
-spi_enable_interrupt(KSZ8851SNL_SPI, SPI_IER_RXBUFF | SPI_IER_OVRES);
+    spi_enable_interrupt( KSZ8851SNL_SPI, SPI_IER_RXBUFF | SPI_IER_OVRES );
 
-	pdc_enable_transfer(g_p_spi_pdc, PERIPH_PTCR_RXTEN | PERIPH_PTCR_TXTEN);
+    pdc_enable_transfer( g_p_spi_pdc, PERIPH_PTCR_RXTEN | PERIPH_PTCR_TXTEN );
 }
 
 /**
@@ -331,47 +356,49 @@ spi_enable_interrupt(KSZ8851SNL_SPI, SPI_IER_RXBUFF | SPI_IER_OVRES);
  * \param ulActualLength the total amount of data to write.
  * \param ulFIFOLength the size of the first pbuf to write from the pbuf chain.
  */
-void ksz8851_fifo_write(uint8_t *buf, uint32_t ulActualLength, uint32_t ulFIFOLength)
+void ksz8851_fifo_write( uint8_t * buf,
+                         uint32_t ulActualLength,
+                         uint32_t ulFIFOLength )
 {
-	static uint8_t frameID = 0;
+    static uint8_t frameID = 0;
 
-	pdc_packet_t g_pdc_spi_tx_packet;
-	pdc_packet_t g_pdc_spi_rx_packet;
-	pdc_packet_t g_pdc_spi_tx_npacket;
-	pdc_packet_t g_pdc_spi_rx_npacket;
+    pdc_packet_t g_pdc_spi_tx_packet;
+    pdc_packet_t g_pdc_spi_rx_packet;
+    pdc_packet_t g_pdc_spi_tx_npacket;
+    pdc_packet_t g_pdc_spi_rx_npacket;
 
-	/* Prepare control word and byte count. */
-	cmdBuf.uc[0] = FIFO_WRITE;
-	cmdBuf.uc[1] = frameID++ & 0x3f;
-	cmdBuf.uc[2] = 0;
-	cmdBuf.uc[3] = ulActualLength & 0xff;
-	cmdBuf.uc[4] = ulActualLength >> 8;
+    /* Prepare control word and byte count. */
+    cmdBuf.uc[ 0 ] = FIFO_WRITE;
+    cmdBuf.uc[ 1 ] = frameID++ & 0x3f;
+    cmdBuf.uc[ 2 ] = 0;
+    cmdBuf.uc[ 3 ] = ulActualLength & 0xff;
+    cmdBuf.uc[ 4 ] = ulActualLength >> 8;
 
-	spi_clear_ovres();
+    spi_clear_ovres();
 
-	/* Prepare PDC transfer. */
-	g_pdc_spi_tx_packet.ul_addr = (uint32_t) cmdBuf.uc;
-	g_pdc_spi_tx_packet.ul_size = 5;
+    /* Prepare PDC transfer. */
+    g_pdc_spi_tx_packet.ul_addr = ( uint32_t ) cmdBuf.uc;
+    g_pdc_spi_tx_packet.ul_size = 5;
 
-	g_pdc_spi_rx_packet.ul_addr = (uint32_t) respBuf.uc;
-	g_pdc_spi_rx_packet.ul_size = 5;
+    g_pdc_spi_rx_packet.ul_addr = ( uint32_t ) respBuf.uc;
+    g_pdc_spi_rx_packet.ul_size = 5;
 
-	g_pdc_spi_tx_npacket.ul_addr = (uint32_t) buf;
-	g_pdc_spi_tx_npacket.ul_size = ulFIFOLength;
+    g_pdc_spi_tx_npacket.ul_addr = ( uint32_t ) buf;
+    g_pdc_spi_tx_npacket.ul_size = ulFIFOLength;
 
-	g_pdc_spi_rx_npacket.ul_addr = (uint32_t) tmpbuf;
-	g_pdc_spi_rx_npacket.ul_size = ulFIFOLength;
+    g_pdc_spi_rx_npacket.ul_addr = ( uint32_t ) tmpbuf;
+    g_pdc_spi_rx_npacket.ul_size = ulFIFOLength;
 
-	pdc_disable_transfer(g_p_spi_pdc, PERIPH_PTCR_RXTDIS | PERIPH_PTCR_TXTDIS);
-	pdc_tx_init(g_p_spi_pdc, &g_pdc_spi_tx_packet, &g_pdc_spi_tx_npacket);
-	#if( TX_USES_RECV == 1 )
-		pdc_rx_init(g_p_spi_pdc, &g_pdc_spi_rx_packet, &g_pdc_spi_rx_npacket);
-		spi_enable_interrupt(KSZ8851SNL_SPI, SPI_IER_ENDRX | SPI_IER_OVRES);
-		pdc_enable_transfer(g_p_spi_pdc, PERIPH_PTCR_RXTEN | PERIPH_PTCR_TXTEN);
-	#else
-		spi_enable_interrupt(KSZ8851SNL_SPI, SPI_SR_TXBUFE | SPI_IER_OVRES);
-		pdc_enable_transfer(g_p_spi_pdc, PERIPH_PTCR_TXTEN);
-	#endif
+    pdc_disable_transfer( g_p_spi_pdc, PERIPH_PTCR_RXTDIS | PERIPH_PTCR_TXTDIS );
+    pdc_tx_init( g_p_spi_pdc, &g_pdc_spi_tx_packet, &g_pdc_spi_tx_npacket );
+    #if ( TX_USES_RECV == 1 )
+        pdc_rx_init( g_p_spi_pdc, &g_pdc_spi_rx_packet, &g_pdc_spi_rx_npacket );
+        spi_enable_interrupt( KSZ8851SNL_SPI, SPI_IER_ENDRX | SPI_IER_OVRES );
+        pdc_enable_transfer( g_p_spi_pdc, PERIPH_PTCR_RXTEN | PERIPH_PTCR_TXTEN );
+    #else
+        spi_enable_interrupt( KSZ8851SNL_SPI, SPI_SR_TXBUFE | SPI_IER_OVRES );
+        pdc_enable_transfer( g_p_spi_pdc, PERIPH_PTCR_TXTEN );
+    #endif
 }
 
 /**
@@ -379,232 +406,247 @@ void ksz8851_fifo_write(uint8_t *buf, uint32_t ulActualLength, uint32_t ulFIFOLe
  *
  * \param len the amount of dummy data to write.
  */
-void ksz8851_fifo_dummy(uint32_t len)
+void ksz8851_fifo_dummy( uint32_t len )
 {
-	pdc_packet_t g_pdc_spi_tx_packet;
-	pdc_packet_t g_pdc_spi_rx_packet;
+    pdc_packet_t g_pdc_spi_tx_packet;
+    pdc_packet_t g_pdc_spi_rx_packet;
 
-	/* Prepare PDC transfer. */
-	g_pdc_spi_tx_packet.ul_addr = (uint32_t) tmpbuf;
-	g_pdc_spi_tx_packet.ul_size = len;
-	g_pdc_spi_rx_packet.ul_addr = (uint32_t) tmpbuf;
-	g_pdc_spi_rx_packet.ul_size = len;
-	pdc_disable_transfer(g_p_spi_pdc, PERIPH_PTCR_RXTDIS | PERIPH_PTCR_TXTDIS);
-	pdc_tx_init(g_p_spi_pdc, &g_pdc_spi_tx_packet, NULL);
-	pdc_rx_init(g_p_spi_pdc, &g_pdc_spi_rx_packet, NULL);
-	pdc_enable_transfer(g_p_spi_pdc, PERIPH_PTCR_RXTEN | PERIPH_PTCR_TXTEN);
+    /* Prepare PDC transfer. */
+    g_pdc_spi_tx_packet.ul_addr = ( uint32_t ) tmpbuf;
+    g_pdc_spi_tx_packet.ul_size = len;
+    g_pdc_spi_rx_packet.ul_addr = ( uint32_t ) tmpbuf;
+    g_pdc_spi_rx_packet.ul_size = len;
+    pdc_disable_transfer( g_p_spi_pdc, PERIPH_PTCR_RXTDIS | PERIPH_PTCR_TXTDIS );
+    pdc_tx_init( g_p_spi_pdc, &g_pdc_spi_tx_packet, NULL );
+    pdc_rx_init( g_p_spi_pdc, &g_pdc_spi_rx_packet, NULL );
+    pdc_enable_transfer( g_p_spi_pdc, PERIPH_PTCR_RXTEN | PERIPH_PTCR_TXTEN );
 
-	while (!(spi_read_status(KSZ8851SNL_SPI) & SPI_SR_ENDRX))
-		;
+    while( !( spi_read_status( KSZ8851SNL_SPI ) & SPI_SR_ENDRX ) )
+    {
+    }
 }
 
-void ksz8851snl_set_registers(void)
+void ksz8851snl_set_registers( void )
 {
-	/* Init step2-4: write QMU MAC address (low, middle then high). */
-	ksz8851_reg_write(REG_MAC_ADDR_0, (ETHERNET_CONF_ETHADDR4 << 8) | ETHERNET_CONF_ETHADDR5);
-	ksz8851_reg_write(REG_MAC_ADDR_2, (ETHERNET_CONF_ETHADDR2 << 8) | ETHERNET_CONF_ETHADDR3);
-	ksz8851_reg_write(REG_MAC_ADDR_4, (ETHERNET_CONF_ETHADDR0 << 8) | ETHERNET_CONF_ETHADDR1);
+    /* Init step2-4: write QMU MAC address (low, middle then high). */
+    ksz8851_reg_write( REG_MAC_ADDR_0, ( ETHERNET_CONF_ETHADDR4 << 8 ) | ETHERNET_CONF_ETHADDR5 );
+    ksz8851_reg_write( REG_MAC_ADDR_2, ( ETHERNET_CONF_ETHADDR2 << 8 ) | ETHERNET_CONF_ETHADDR3 );
+    ksz8851_reg_write( REG_MAC_ADDR_4, ( ETHERNET_CONF_ETHADDR0 << 8 ) | ETHERNET_CONF_ETHADDR1 );
 
-	/* Init step5: enable QMU Transmit Frame Data Pointer Auto Increment. */
-	ksz8851_reg_write(REG_TX_ADDR_PTR, ADDR_PTR_AUTO_INC);
+    /* Init step5: enable QMU Transmit Frame Data Pointer Auto Increment. */
+    ksz8851_reg_write( REG_TX_ADDR_PTR, ADDR_PTR_AUTO_INC );
 
-	/* Init step6: configure QMU transmit control register. */
-	ksz8851_reg_write(REG_TX_CTRL,
-			TX_CTRL_ICMP_CHECKSUM |
-			TX_CTRL_UDP_CHECKSUM |
-			TX_CTRL_TCP_CHECKSUM |
-			TX_CTRL_IP_CHECKSUM |
-			TX_CTRL_FLOW_ENABLE |
-			TX_CTRL_PAD_ENABLE |
-			TX_CTRL_CRC_ENABLE
-		);
+    /* Init step6: configure QMU transmit control register. */
+    ksz8851_reg_write( REG_TX_CTRL,
+                       TX_CTRL_ICMP_CHECKSUM |
+                       TX_CTRL_UDP_CHECKSUM |
+                       TX_CTRL_TCP_CHECKSUM |
+                       TX_CTRL_IP_CHECKSUM |
+                       TX_CTRL_FLOW_ENABLE |
+                       TX_CTRL_PAD_ENABLE |
+                       TX_CTRL_CRC_ENABLE
+                       );
 
-	/* Init step7: enable QMU Receive Frame Data Pointer Auto Increment. */
-	ksz8851_reg_write(REG_RX_ADDR_PTR, ADDR_PTR_AUTO_INC);
+    /* Init step7: enable QMU Receive Frame Data Pointer Auto Increment. */
+    ksz8851_reg_write( REG_RX_ADDR_PTR, ADDR_PTR_AUTO_INC );
 
-	/* Init step8: configure QMU Receive Frame Threshold for one frame. */
-	ksz8851_reg_write(REG_RX_FRAME_CNT_THRES, 1);
+    /* Init step8: configure QMU Receive Frame Threshold for one frame. */
+    ksz8851_reg_write( REG_RX_FRAME_CNT_THRES, 1 );
 
-	/* Init step9: configure QMU receive control register1. */
-	ksz8851_reg_write(REG_RX_CTRL1,
-			RX_CTRL_UDP_CHECKSUM |
-			RX_CTRL_TCP_CHECKSUM |
-			RX_CTRL_IP_CHECKSUM |
-			RX_CTRL_MAC_FILTER |
-			RX_CTRL_FLOW_ENABLE |
-			RX_CTRL_BROADCAST |
-			RX_CTRL_ALL_MULTICAST|
-			RX_CTRL_UNICAST);
-//	ksz8851_reg_write(REG_RX_CTRL1,
-//			RX_CTRL_UDP_CHECKSUM |
-//			RX_CTRL_TCP_CHECKSUM |
-//			RX_CTRL_IP_CHECKSUM |
-//			RX_CTRL_FLOW_ENABLE |
-//			RX_CTRL_PROMISCUOUS);
+    /* Init step9: configure QMU receive control register1. */
+    ksz8851_reg_write( REG_RX_CTRL1,
+                       RX_CTRL_UDP_CHECKSUM |
+                       RX_CTRL_TCP_CHECKSUM |
+                       RX_CTRL_IP_CHECKSUM |
+                       RX_CTRL_MAC_FILTER |
+                       RX_CTRL_FLOW_ENABLE |
+                       RX_CTRL_BROADCAST |
+                       RX_CTRL_ALL_MULTICAST |
+                       RX_CTRL_UNICAST );
+/*	ksz8851_reg_write(REG_RX_CTRL1, */
+/*			RX_CTRL_UDP_CHECKSUM | */
+/*			RX_CTRL_TCP_CHECKSUM | */
+/*			RX_CTRL_IP_CHECKSUM | */
+/*			RX_CTRL_FLOW_ENABLE | */
+/*			RX_CTRL_PROMISCUOUS); */
 
-	ksz8851_reg_write(REG_RX_CTRL2,
-			RX_CTRL_IPV6_UDP_NOCHECKSUM |
-			RX_CTRL_UDP_LITE_CHECKSUM |
-			RX_CTRL_ICMP_CHECKSUM |
-			RX_CTRL_BURST_LEN_FRAME);
+    ksz8851_reg_write( REG_RX_CTRL2,
+                       RX_CTRL_IPV6_UDP_NOCHECKSUM |
+                       RX_CTRL_UDP_LITE_CHECKSUM |
+                       RX_CTRL_ICMP_CHECKSUM |
+                       RX_CTRL_BURST_LEN_FRAME );
 
 
-//#define   RXQ_TWOBYTE_OFFSET          (0x0200)    /* Enable adding 2-byte before frame header for IP aligned with DWORD */
-#warning Remember to try the above option to get a 2-byte offset
+/*#define   RXQ_TWOBYTE_OFFSET          (0x0200)    / * Enable adding 2-byte before frame header for IP aligned with DWORD * / */
+    #warning Remember to try the above option to get a 2-byte offset
 
-	/* Init step11: configure QMU receive queue: trigger INT and auto-dequeue frame. */
-	ksz8851_reg_write( REG_RXQ_CMD, RXQ_CMD_CNTL | RXQ_TWOBYTE_OFFSET );
+    /* Init step11: configure QMU receive queue: trigger INT and auto-dequeue frame. */
+    ksz8851_reg_write( REG_RXQ_CMD, RXQ_CMD_CNTL | RXQ_TWOBYTE_OFFSET );
 
-	/* Init step12: adjust SPI data output delay. */
-	ksz8851_reg_write(REG_BUS_CLOCK_CTRL, BUS_CLOCK_166 | BUS_CLOCK_DIVIDEDBY_1);
+    /* Init step12: adjust SPI data output delay. */
+    ksz8851_reg_write( REG_BUS_CLOCK_CTRL, BUS_CLOCK_166 | BUS_CLOCK_DIVIDEDBY_1 );
 
-	/* Init step13: restart auto-negotiation. */
-	ksz8851_reg_setbits(REG_PORT_CTRL, PORT_AUTO_NEG_RESTART);
+    /* Init step13: restart auto-negotiation. */
+    ksz8851_reg_setbits( REG_PORT_CTRL, PORT_AUTO_NEG_RESTART );
 
-	/* Init step13.1: force link in half duplex if auto-negotiation failed. */
-	if ((ksz8851_reg_read(REG_PORT_CTRL) & PORT_AUTO_NEG_RESTART) != PORT_AUTO_NEG_RESTART)
-	{
-		ksz8851_reg_clrbits(REG_PORT_CTRL, PORT_FORCE_FULL_DUPLEX);
-	}
+    /* Init step13.1: force link in half duplex if auto-negotiation failed. */
+    if( ( ksz8851_reg_read( REG_PORT_CTRL ) & PORT_AUTO_NEG_RESTART ) != PORT_AUTO_NEG_RESTART )
+    {
+        ksz8851_reg_clrbits( REG_PORT_CTRL, PORT_FORCE_FULL_DUPLEX );
+    }
 
-	/* Init step14: clear interrupt status. */
-	ksz8851_reg_write(REG_INT_STATUS, 0xFFFF);
+    /* Init step14: clear interrupt status. */
+    ksz8851_reg_write( REG_INT_STATUS, 0xFFFF );
 
-	/* Init step15: set interrupt mask. */
-	ksz8851_reg_write(REG_INT_MASK, INT_RX);
+    /* Init step15: set interrupt mask. */
+    ksz8851_reg_write( REG_INT_MASK, INT_RX );
 
-	/* Init step16: enable QMU Transmit. */
-	ksz8851_reg_setbits(REG_TX_CTRL, TX_CTRL_ENABLE);
+    /* Init step16: enable QMU Transmit. */
+    ksz8851_reg_setbits( REG_TX_CTRL, TX_CTRL_ENABLE );
 
-	/* Init step17: enable QMU Receive. */
-	ksz8851_reg_setbits(REG_RX_CTRL1, RX_CTRL_ENABLE);
+    /* Init step17: enable QMU Receive. */
+    ksz8851_reg_setbits( REG_RX_CTRL1, RX_CTRL_ENABLE );
 }
+
 /**
  * \brief KSZ8851SNL initialization function.
  *
  * \return 0 on success, 1 on communication error.
  */
-uint32_t ksz8851snl_init(void)
+uint32_t ksz8851snl_init( void )
 {
-uint32_t count = 10;
-uint16_t dev_id = 0;
-uint8_t id_ok = 0;
+    uint32_t count = 10;
+    uint16_t dev_id = 0;
+    uint8_t id_ok = 0;
 
-	/* Configure the SPI peripheral. */
-	spi_enable_clock(KSZ8851SNL_SPI);
-	spi_disable(KSZ8851SNL_SPI);
-	spi_reset(KSZ8851SNL_SPI);
-	spi_set_master_mode(KSZ8851SNL_SPI);
-	spi_disable_mode_fault_detect(KSZ8851SNL_SPI);
-	spi_set_peripheral_chip_select_value(KSZ8851SNL_SPI, ~(uint32_t)(1UL << KSZ8851SNL_CS_PIN));
-spi_set_fixed_peripheral_select(KSZ8851SNL_SPI);
-//spi_disable_peripheral_select_decode(KSZ8851SNL_SPI);
+    /* Configure the SPI peripheral. */
+    spi_enable_clock( KSZ8851SNL_SPI );
+    spi_disable( KSZ8851SNL_SPI );
+    spi_reset( KSZ8851SNL_SPI );
+    spi_set_master_mode( KSZ8851SNL_SPI );
+    spi_disable_mode_fault_detect( KSZ8851SNL_SPI );
+    spi_set_peripheral_chip_select_value( KSZ8851SNL_SPI, ~( uint32_t ) ( 1UL << KSZ8851SNL_CS_PIN ) );
+    spi_set_fixed_peripheral_select( KSZ8851SNL_SPI );
+/*spi_disable_peripheral_select_decode(KSZ8851SNL_SPI); */
 
-	spi_set_clock_polarity(KSZ8851SNL_SPI, KSZ8851SNL_CS_PIN, SPI_CLK_POLARITY);
-	spi_set_clock_phase(KSZ8851SNL_SPI, KSZ8851SNL_CS_PIN, SPI_CLK_PHASE);
-	spi_set_bits_per_transfer(KSZ8851SNL_SPI, KSZ8851SNL_CS_PIN,
-			SPI_CSR_BITS_8_BIT);
-	spi_set_baudrate_div(KSZ8851SNL_SPI, KSZ8851SNL_CS_PIN, (sysclk_get_cpu_hz() / KSZ8851SNL_CLOCK_SPEED));
-//	spi_set_transfer_delay(KSZ8851SNL_SPI, KSZ8851SNL_CS_PIN, CONFIG_SPI_MASTER_DELAY_BS,
-//			CONFIG_SPI_MASTER_DELAY_BCT);
+    spi_set_clock_polarity( KSZ8851SNL_SPI, KSZ8851SNL_CS_PIN, SPI_CLK_POLARITY );
+    spi_set_clock_phase( KSZ8851SNL_SPI, KSZ8851SNL_CS_PIN, SPI_CLK_PHASE );
+    spi_set_bits_per_transfer( KSZ8851SNL_SPI, KSZ8851SNL_CS_PIN,
+                               SPI_CSR_BITS_8_BIT );
+    spi_set_baudrate_div( KSZ8851SNL_SPI, KSZ8851SNL_CS_PIN, ( sysclk_get_cpu_hz() / KSZ8851SNL_CLOCK_SPEED ) );
+/*	spi_set_transfer_delay(KSZ8851SNL_SPI, KSZ8851SNL_CS_PIN, CONFIG_SPI_MASTER_DELAY_BS, */
+/*			CONFIG_SPI_MASTER_DELAY_BCT); */
 
 
-	spi_set_transfer_delay(KSZ8851SNL_SPI, KSZ8851SNL_CS_PIN, 0, 0);
+    spi_set_transfer_delay( KSZ8851SNL_SPI, KSZ8851SNL_CS_PIN, 0, 0 );
 
-	spi_enable(KSZ8851SNL_SPI);
+    spi_enable( KSZ8851SNL_SPI );
 
-	/* Get pointer to UART PDC register base. */
-	g_p_spi_pdc = spi_get_pdc_base(KSZ8851SNL_SPI);
-	pdc_enable_transfer(g_p_spi_pdc, PERIPH_PTCR_RXTEN | PERIPH_PTCR_TXTEN);
+    /* Get pointer to UART PDC register base. */
+    g_p_spi_pdc = spi_get_pdc_base( KSZ8851SNL_SPI );
+    pdc_enable_transfer( g_p_spi_pdc, PERIPH_PTCR_RXTEN | PERIPH_PTCR_TXTEN );
 
-	/* Control RSTN and CSN pin from the driver. */
-	gpio_configure_pin(KSZ8851SNL_CSN_GPIO, KSZ8851SNL_CSN_FLAGS);
-	gpio_set_pin_high(KSZ8851SNL_CSN_GPIO);
-	gpio_configure_pin(KSZ8851SNL_RSTN_GPIO, KSZ8851SNL_RSTN_FLAGS);
+    /* Control RSTN and CSN pin from the driver. */
+    gpio_configure_pin( KSZ8851SNL_CSN_GPIO, KSZ8851SNL_CSN_FLAGS );
+    gpio_set_pin_high( KSZ8851SNL_CSN_GPIO );
+    gpio_configure_pin( KSZ8851SNL_RSTN_GPIO, KSZ8851SNL_RSTN_FLAGS );
 
-	/* Reset the Micrel in a proper state. */
-	while( count-- )
-	{
-		/* Perform hardware reset with respect to the reset timing from the datasheet. */
-		gpio_set_pin_low(KSZ8851SNL_RSTN_GPIO);
-		vTaskDelay(2);
-		gpio_set_pin_high(KSZ8851SNL_RSTN_GPIO);
-		vTaskDelay(2);
+    /* Reset the Micrel in a proper state. */
+    while( count-- )
+    {
+        /* Perform hardware reset with respect to the reset timing from the datasheet. */
+        gpio_set_pin_low( KSZ8851SNL_RSTN_GPIO );
+        vTaskDelay( 2 );
+        gpio_set_pin_high( KSZ8851SNL_RSTN_GPIO );
+        vTaskDelay( 2 );
 
-		/* Init step1: read chip ID. */
-		dev_id = ksz8851_reg_read(REG_CHIP_ID);
-		if( ( dev_id & 0xFFF0 ) == CHIP_ID_8851_16 )
-		{
-			id_ok = 1;
-			break;
-		}
-	}
-	if( id_ok != 0 )
-	{
-		ksz8851snl_set_registers();
-	}
+        /* Init step1: read chip ID. */
+        dev_id = ksz8851_reg_read( REG_CHIP_ID );
 
-	return id_ok ? 1 : -1;
+        if( ( dev_id & 0xFFF0 ) == CHIP_ID_8851_16 )
+        {
+            id_ok = 1;
+            break;
+        }
+    }
+
+    if( id_ok != 0 )
+    {
+        ksz8851snl_set_registers();
+    }
+
+    return id_ok ? 1 : -1;
 }
 
-uint32_t ksz8851snl_reinit(void)
+uint32_t ksz8851snl_reinit( void )
 {
-uint32_t count = 10;
-uint16_t dev_id = 0;
-uint8_t id_ok = 0;
-	/* Reset the Micrel in a proper state. */
-	while( count-- )
-	{
-		/* Perform hardware reset with respect to the reset timing from the datasheet. */
-		gpio_set_pin_low(KSZ8851SNL_RSTN_GPIO);
-		vTaskDelay(2);
-		gpio_set_pin_high(KSZ8851SNL_RSTN_GPIO);
-		vTaskDelay(2);
+    uint32_t count = 10;
+    uint16_t dev_id = 0;
+    uint8_t id_ok = 0;
 
-		/* Init step1: read chip ID. */
-		dev_id = ksz8851_reg_read(REG_CHIP_ID);
-		if( ( dev_id & 0xFFF0 ) == CHIP_ID_8851_16 )
-		{
-			id_ok = 1;
-			break;
-		}
-	}
-	if( id_ok != 0 )
-	{
-		ksz8851snl_set_registers();
-	}
+    /* Reset the Micrel in a proper state. */
+    while( count-- )
+    {
+        /* Perform hardware reset with respect to the reset timing from the datasheet. */
+        gpio_set_pin_low( KSZ8851SNL_RSTN_GPIO );
+        vTaskDelay( 2 );
+        gpio_set_pin_high( KSZ8851SNL_RSTN_GPIO );
+        vTaskDelay( 2 );
 
-	return id_ok ? 1 : -1;
+        /* Init step1: read chip ID. */
+        dev_id = ksz8851_reg_read( REG_CHIP_ID );
+
+        if( ( dev_id & 0xFFF0 ) == CHIP_ID_8851_16 )
+        {
+            id_ok = 1;
+            break;
+        }
+    }
+
+    if( id_ok != 0 )
+    {
+        ksz8851snl_set_registers();
+    }
+
+    return id_ok ? 1 : -1;
 }
 
 uint32_t ksz8851snl_reset_rx( void )
 {
-uint16_t usValue;
+    uint16_t usValue;
 
-	usValue = ksz8851_reg_read(REG_RX_CTRL1);
+    usValue = ksz8851_reg_read( REG_RX_CTRL1 );
 
-	usValue &= ~( ( uint16_t ) RX_CTRL_ENABLE | RX_CTRL_FLUSH_QUEUE );
+    usValue &= ~( ( uint16_t ) RX_CTRL_ENABLE | RX_CTRL_FLUSH_QUEUE );
 
-	ksz8851_reg_write( REG_RX_CTRL1, usValue ); vTaskDelay( 2 );
-	ksz8851_reg_write( REG_RX_CTRL1, usValue | RX_CTRL_FLUSH_QUEUE ); vTaskDelay( 1 );
-	ksz8851_reg_write( REG_RX_CTRL1, usValue ); vTaskDelay( 1 );
-	ksz8851_reg_write( REG_RX_CTRL1, usValue | RX_CTRL_ENABLE ); vTaskDelay( 1 );
+    ksz8851_reg_write( REG_RX_CTRL1, usValue );
+    vTaskDelay( 2 );
+    ksz8851_reg_write( REG_RX_CTRL1, usValue | RX_CTRL_FLUSH_QUEUE );
+    vTaskDelay( 1 );
+    ksz8851_reg_write( REG_RX_CTRL1, usValue );
+    vTaskDelay( 1 );
+    ksz8851_reg_write( REG_RX_CTRL1, usValue | RX_CTRL_ENABLE );
+    vTaskDelay( 1 );
 
-	return ( uint32_t )usValue;
+    return ( uint32_t ) usValue;
 }
 
 uint32_t ksz8851snl_reset_tx( void )
 {
-uint16_t usValue;
+    uint16_t usValue;
 
-	usValue = ksz8851_reg_read( REG_TX_CTRL );
+    usValue = ksz8851_reg_read( REG_TX_CTRL );
 
-	usValue &= ~( ( uint16_t ) TX_CTRL_ENABLE | TX_CTRL_FLUSH_QUEUE );
+    usValue &= ~( ( uint16_t ) TX_CTRL_ENABLE | TX_CTRL_FLUSH_QUEUE );
 
-	ksz8851_reg_write( REG_TX_CTRL, usValue ); vTaskDelay( 2 );
-	ksz8851_reg_write( REG_TX_CTRL, usValue | TX_CTRL_FLUSH_QUEUE ); vTaskDelay( 1 );
-	ksz8851_reg_write( REG_TX_CTRL, usValue ); vTaskDelay( 1 );
-	ksz8851_reg_write( REG_TX_CTRL, usValue | TX_CTRL_ENABLE ); vTaskDelay( 1 );
+    ksz8851_reg_write( REG_TX_CTRL, usValue );
+    vTaskDelay( 2 );
+    ksz8851_reg_write( REG_TX_CTRL, usValue | TX_CTRL_FLUSH_QUEUE );
+    vTaskDelay( 1 );
+    ksz8851_reg_write( REG_TX_CTRL, usValue );
+    vTaskDelay( 1 );
+    ksz8851_reg_write( REG_TX_CTRL, usValue | TX_CTRL_ENABLE );
+    vTaskDelay( 1 );
 
-	return ( uint32_t )usValue;
+    return ( uint32_t ) usValue;
 }

--- a/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/portable/NetworkInterface/ksz8851snl/ksz8851snl.h
+++ b/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/portable/NetworkInterface/ksz8851snl/ksz8851snl.h
@@ -50,16 +50,22 @@
 
 #include "gpio.h"
 
-void configure_intn(void (*p_handler) (uint32_t, uint32_t));
-void ksz8851_reg_setbits(uint16_t reg, uint16_t bits_to_set);
-void ksz8851_reg_clrbits(uint16_t reg, uint16_t bits_to_clr);
-void ksz8851_fifo_read(uint8_t *buf, uint32_t len);
-void ksz8851_fifo_write(uint8_t *buf, uint32_t ulActualLength, uint32_t ulFIFOLength);
-void ksz8851_fifo_dummy(uint32_t len);
-void ksz8851_reg_write(uint16_t reg, uint16_t wrdata);
-uint16_t ksz8851_reg_read(uint16_t reg);
-uint32_t ksz8851snl_init(void);
-uint32_t ksz8851snl_reinit(void);
+void configure_intn( void ( * p_handler )( uint32_t, uint32_t ) );
+void ksz8851_reg_setbits( uint16_t reg,
+                          uint16_t bits_to_set );
+void ksz8851_reg_clrbits( uint16_t reg,
+                          uint16_t bits_to_clr );
+void ksz8851_fifo_read( uint8_t * buf,
+                        uint32_t len );
+void ksz8851_fifo_write( uint8_t * buf,
+                         uint32_t ulActualLength,
+                         uint32_t ulFIFOLength );
+void ksz8851_fifo_dummy( uint32_t len );
+void ksz8851_reg_write( uint16_t reg,
+                        uint16_t wrdata );
+uint16_t ksz8851_reg_read( uint16_t reg );
+uint32_t ksz8851snl_init( void );
+uint32_t ksz8851snl_reinit( void );
 
 uint32_t ksz8851snl_reset_rx( void );
 uint32_t ksz8851snl_reset_tx( void );

--- a/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/portable/NetworkInterface/ksz8851snl/ksz8851snl_reg.h
+++ b/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/portable/NetworkInterface/ksz8851snl/ksz8851snl_reg.h
@@ -48,115 +48,115 @@
 #ifndef KSZ8851SNL_REG_H_INCLUDED
 #define KSZ8851SNL_REG_H_INCLUDED
 
-#define REG_ADDR_MASK              (0x3F0)      /* Register address mask */
-#define OPCODE_MASK                (3 << 14)
-#define CMD_READ                   (0 << 14)
-#define CMD_WRITE                  (1 << 14)
-#define FIFO_READ                  (0x80)
-#define FIFO_WRITE                 (0xC0)
+#define REG_ADDR_MASK                 ( 0x3F0 ) /* Register address mask */
+#define OPCODE_MASK                   ( 3 << 14 )
+#define CMD_READ                      ( 0 << 14 )
+#define CMD_WRITE                     ( 1 << 14 )
+#define FIFO_READ                     ( 0x80 )
+#define FIFO_WRITE                    ( 0xC0 )
 
 /*
  * MAC Registers
  * (Offset 0x00 - 0x25)
  */
-#define REG_BUS_ERROR_STATUS       (0x06)       /* BESR */
-#define   BUS_ERROR_IBEC              (0x8000)
-#define   BUS_ERROR_IBECV_MASK        (0x7800)    /* Default IPSec clock at 166Mhz */
+#define REG_BUS_ERROR_STATUS          ( 0x06 )   /* BESR */
+#define   BUS_ERROR_IBEC              ( 0x8000 )
+#define   BUS_ERROR_IBECV_MASK        ( 0x7800 ) /* Default IPSec clock at 166Mhz */
 
-#define REG_CHIP_CFG_STATUS        (0x08)       /* CCFG */
-#define   LITTLE_ENDIAN_BUS_MODE      (0x0400)    /* Bus in little endian mode */
-#define   EEPROM_PRESENCE             (0x0200)    /* External EEPROM is used */
-#define   SPI_BUS_MODE                (0x0100)    /* In SPI bus mode */
-#define   DATA_BUS_8BIT               (0x0080)    /* In 8-bit bus mode operation */
-#define   DATA_BUS_16BIT              (0x0040)    /* In 16-bit bus mode operation */
-#define   DATA_BUS_32BIT              (0x0020)    /* In 32-bit bus mode operation */
-#define   MULTIPLEX_MODE              (0x0010)    /* Data and address bus are shared */
-#define   CHIP_PACKAGE_128PIN         (0x0008)    /* 128-pin package */
-#define   CHIP_PACKAGE_80PIN          (0x0004)    /* 80-pin package */
-#define   CHIP_PACKAGE_48PIN          (0x0002)    /* 48-pin package */
-#define   CHIP_PACKAGE_32PIN          (0x0001)    /* 32-pin package for SPI host interface only */
+#define REG_CHIP_CFG_STATUS           ( 0x08 )   /* CCFG */
+#define   LITTLE_ENDIAN_BUS_MODE      ( 0x0400 ) /* Bus in little endian mode */
+#define   EEPROM_PRESENCE             ( 0x0200 ) /* External EEPROM is used */
+#define   SPI_BUS_MODE                ( 0x0100 ) /* In SPI bus mode */
+#define   DATA_BUS_8BIT               ( 0x0080 ) /* In 8-bit bus mode operation */
+#define   DATA_BUS_16BIT              ( 0x0040 ) /* In 16-bit bus mode operation */
+#define   DATA_BUS_32BIT              ( 0x0020 ) /* In 32-bit bus mode operation */
+#define   MULTIPLEX_MODE              ( 0x0010 ) /* Data and address bus are shared */
+#define   CHIP_PACKAGE_128PIN         ( 0x0008 ) /* 128-pin package */
+#define   CHIP_PACKAGE_80PIN          ( 0x0004 ) /* 80-pin package */
+#define   CHIP_PACKAGE_48PIN          ( 0x0002 ) /* 48-pin package */
+#define   CHIP_PACKAGE_32PIN          ( 0x0001 ) /* 32-pin package for SPI host interface only */
 
-#define REG_MAC_ADDR_0             (0x10)       /* MARL */
-#define REG_MAC_ADDR_1             (0x11)       /* MARL */
-#define REG_MAC_ADDR_2             (0x12)       /* MARM */
-#define REG_MAC_ADDR_3             (0x13)       /* MARM */
-#define REG_MAC_ADDR_4             (0x14)       /* MARH */
-#define REG_MAC_ADDR_5             (0x15)       /* MARH */
+#define REG_MAC_ADDR_0                ( 0x10 )   /* MARL */
+#define REG_MAC_ADDR_1                ( 0x11 )   /* MARL */
+#define REG_MAC_ADDR_2                ( 0x12 )   /* MARM */
+#define REG_MAC_ADDR_3                ( 0x13 )   /* MARM */
+#define REG_MAC_ADDR_4                ( 0x14 )   /* MARH */
+#define REG_MAC_ADDR_5                ( 0x15 )   /* MARH */
 
-#define REG_BUS_CLOCK_CTRL         (0x20)       /* OBCR */
-#define   BUS_CLOCK_166               (0x0004)    /* 166 MHz on-chip bus clock (defaul is 125MHz) */
-#define   BUS_CLOCK_DIVIDEDBY_5       (0x0003)    /* Bus clock devided by 5 */
-#define   BUS_CLOCK_DIVIDEDBY_3       (0x0002)    /* Bus clock devided by 3 */
-#define   BUS_CLOCK_DIVIDEDBY_2       (0x0001)    /* Bus clock devided by 2 */
-#define   BUS_CLOCK_DIVIDEDBY_1       (0x0000)    /* Bus clock devided by 1 */
-#define   BUS_CLOCK_DIVIDED_MASK      (0x0003)    /* Bus clock devider mask */
+#define REG_BUS_CLOCK_CTRL            ( 0x20 )   /* OBCR */
+#define   BUS_CLOCK_166               ( 0x0004 ) /* 166 MHz on-chip bus clock (defaul is 125MHz) */
+#define   BUS_CLOCK_DIVIDEDBY_5       ( 0x0003 ) /* Bus clock devided by 5 */
+#define   BUS_CLOCK_DIVIDEDBY_3       ( 0x0002 ) /* Bus clock devided by 3 */
+#define   BUS_CLOCK_DIVIDEDBY_2       ( 0x0001 ) /* Bus clock devided by 2 */
+#define   BUS_CLOCK_DIVIDEDBY_1       ( 0x0000 ) /* Bus clock devided by 1 */
+#define   BUS_CLOCK_DIVIDED_MASK      ( 0x0003 ) /* Bus clock devider mask */
 
-#define   BUS_SPEED_166_MHZ           (0x0004)    /* Set bus speed to 166 MHz */
-#define   BUS_SPEED_125_MHZ           (0x0000)    /* Set bus speed to 125 MHz */
-#define   BUS_SPEED_83_MHZ            (0x0005)    /* Set bus speed to 83 MHz (166/2)*/
-#define   BUS_SPEED_62_5_MHZ          (0x0001)    /* Set bus speed to 62.5 MHz (125/2) */
-#define   BUS_SPEED_53_3_MHZ          (0x0006)    /* Set bus speed to 53.3 MHz (166/3) */
-#define   BUS_SPEED_41_7_MHZ          (0x0002)    /* Set bus speed to 41.67 MHz (125/3) */
-#define   BUS_SPEED_33_2_MHZ          (0x0007)    /* Set bus speed to 33.2 MHz (166/5) */
-#define   BUS_SPEED_25_MHZ            (0x0003)    /* Set bus speed to 25 MHz (125/5) */
+#define   BUS_SPEED_166_MHZ           ( 0x0004 ) /* Set bus speed to 166 MHz */
+#define   BUS_SPEED_125_MHZ           ( 0x0000 ) /* Set bus speed to 125 MHz */
+#define   BUS_SPEED_83_MHZ            ( 0x0005 ) /* Set bus speed to 83 MHz (166/2)*/
+#define   BUS_SPEED_62_5_MHZ          ( 0x0001 ) /* Set bus speed to 62.5 MHz (125/2) */
+#define   BUS_SPEED_53_3_MHZ          ( 0x0006 ) /* Set bus speed to 53.3 MHz (166/3) */
+#define   BUS_SPEED_41_7_MHZ          ( 0x0002 ) /* Set bus speed to 41.67 MHz (125/3) */
+#define   BUS_SPEED_33_2_MHZ          ( 0x0007 ) /* Set bus speed to 33.2 MHz (166/5) */
+#define   BUS_SPEED_25_MHZ            ( 0x0003 ) /* Set bus speed to 25 MHz (125/5) */
 
-#define REG_EEPROM_CTRL            (0x22)       /* EEPCR */
-#define   EEPROM_ACCESS_ENABLE        (0x0010)    /* Enable software to access EEPROM through bit 3 to bit 0 */
-#define   EEPROM_DATA_IN              (0x0008)    /* Data receive from EEPROM (EEDI pin) */
-#define   EEPROM_DATA_OUT             (0x0004)    /* Data transmit to EEPROM (EEDO pin) */
-#define   EEPROM_SERIAL_CLOCK         (0x0002)    /* Serial clock (EESK pin) */
-#define   EEPROM_CHIP_SELECT          (0x0001)    /* EEPROM chip select (EECS pin) */
+#define REG_EEPROM_CTRL               ( 0x22 )   /* EEPCR */
+#define   EEPROM_ACCESS_ENABLE        ( 0x0010 ) /* Enable software to access EEPROM through bit 3 to bit 0 */
+#define   EEPROM_DATA_IN              ( 0x0008 ) /* Data receive from EEPROM (EEDI pin) */
+#define   EEPROM_DATA_OUT             ( 0x0004 ) /* Data transmit to EEPROM (EEDO pin) */
+#define   EEPROM_SERIAL_CLOCK         ( 0x0002 ) /* Serial clock (EESK pin) */
+#define   EEPROM_CHIP_SELECT          ( 0x0001 ) /* EEPROM chip select (EECS pin) */
 
-#define REG_MEM_BIST_INFO          (0x24)       /* MBIR */
-#define   TX_MEM_TEST_FINISHED        (0x1000)    /* TX memeory BIST test finish */
-#define   TX_MEM_TEST_FAILED          (0x0800)    /* TX memory BIST test fail */
-#define   TX_MEM_TEST_FAILED_COUNT    (0x0700)    /* TX memory BIST test fail count */
-#define   RX_MEM_TEST_FINISHED        (0x0010)    /* RX memory BIST test finish */
-#define   RX_MEM_TEST_FAILED          (0x0008)    /* RX memory BIST test fail */
-#define   RX_MEM_TEST_FAILED_COUNT    (0x0003)    /* RX memory BIST test fail count */
+#define REG_MEM_BIST_INFO             ( 0x24 )   /* MBIR */
+#define   TX_MEM_TEST_FINISHED        ( 0x1000 ) /* TX memeory BIST test finish */
+#define   TX_MEM_TEST_FAILED          ( 0x0800 ) /* TX memory BIST test fail */
+#define   TX_MEM_TEST_FAILED_COUNT    ( 0x0700 ) /* TX memory BIST test fail count */
+#define   RX_MEM_TEST_FINISHED        ( 0x0010 ) /* RX memory BIST test finish */
+#define   RX_MEM_TEST_FAILED          ( 0x0008 ) /* RX memory BIST test fail */
+#define   RX_MEM_TEST_FAILED_COUNT    ( 0x0003 ) /* RX memory BIST test fail count */
 
-#define REG_RESET_CTRL             (0x26)       /* GRR */
-#define   QMU_SOFTWARE_RESET          (0x0002)    /* QMU soft reset (clear TxQ, RxQ) */
-#define   GLOBAL_SOFTWARE_RESET       (0x0001)    /* Global soft reset (PHY, MAC, QMU) */
+#define REG_RESET_CTRL                ( 0x26 )   /* GRR */
+#define   QMU_SOFTWARE_RESET          ( 0x0002 ) /* QMU soft reset (clear TxQ, RxQ) */
+#define   GLOBAL_SOFTWARE_RESET       ( 0x0001 ) /* Global soft reset (PHY, MAC, QMU) */
 
 /*
  * Wake On Lan Control Registers
  * (Offset 0x2A - 0x6B)
  */
-#define REG_WOL_CTRL               (0x2A)       /* WFCR */
-#define   WOL_MAGIC_ENABLE            (0x0080)    /* Enable the magic packet pattern detection */
-#define   WOL_FRAME3_ENABLE           (0x0008)    /* Enable the wake up frame 3 pattern detection */
-#define   WOL_FRAME2_ENABLE           (0x0004)    /* Enable the wake up frame 2 pattern detection */
-#define   WOL_FRAME1_ENABLE           (0x0002)    /* Enable the wake up frame 1 pattern detection */
-#define   WOL_FRAME0_ENABLE           (0x0001)    /* Enable the wake up frame 0 pattern detection */
+#define REG_WOL_CTRL                  ( 0x2A )   /* WFCR */
+#define   WOL_MAGIC_ENABLE            ( 0x0080 ) /* Enable the magic packet pattern detection */
+#define   WOL_FRAME3_ENABLE           ( 0x0008 ) /* Enable the wake up frame 3 pattern detection */
+#define   WOL_FRAME2_ENABLE           ( 0x0004 ) /* Enable the wake up frame 2 pattern detection */
+#define   WOL_FRAME1_ENABLE           ( 0x0002 ) /* Enable the wake up frame 1 pattern detection */
+#define   WOL_FRAME0_ENABLE           ( 0x0001 ) /* Enable the wake up frame 0 pattern detection */
 
-#define REG_WOL_FRAME0_CRC0        (0x30)       /* WF0CRC0 */
-#define REG_WOL_FRAME0_CRC1        (0x32)       /* WF0CRC1 */
-#define REG_WOL_FRAME0_BYTE_MASK0  (0x34)       /* WF0BM0 */
-#define REG_WOL_FRAME0_BYTE_MASK1  (0x36)       /* WF0BM1 */
-#define REG_WOL_FRAME0_BYTE_MASK2  (0x38)       /* WF0BM2 */
-#define REG_WOL_FRAME0_BYTE_MASK3  (0x3A)       /* WF0BM3 */
+#define REG_WOL_FRAME0_CRC0           ( 0x30 )   /* WF0CRC0 */
+#define REG_WOL_FRAME0_CRC1           ( 0x32 )   /* WF0CRC1 */
+#define REG_WOL_FRAME0_BYTE_MASK0     ( 0x34 )   /* WF0BM0 */
+#define REG_WOL_FRAME0_BYTE_MASK1     ( 0x36 )   /* WF0BM1 */
+#define REG_WOL_FRAME0_BYTE_MASK2     ( 0x38 )   /* WF0BM2 */
+#define REG_WOL_FRAME0_BYTE_MASK3     ( 0x3A )   /* WF0BM3 */
 
-#define REG_WOL_FRAME1_CRC0        (0x40)       /* WF1CRC0 */
-#define REG_WOL_FRAME1_CRC1        (0x42)       /* WF1CRC1 */
-#define REG_WOL_FRAME1_BYTE_MASK0  (0x44)       /* WF1BM0 */
-#define REG_WOL_FRAME1_BYTE_MASK1  (0x46)       /* WF1BM1 */
-#define REG_WOL_FRAME1_BYTE_MASK2  (0x48)       /* WF1BM2 */
-#define REG_WOL_FRAME1_BYTE_MASK3  (0x4A)       /* WF1BM3 */
+#define REG_WOL_FRAME1_CRC0           ( 0x40 )   /* WF1CRC0 */
+#define REG_WOL_FRAME1_CRC1           ( 0x42 )   /* WF1CRC1 */
+#define REG_WOL_FRAME1_BYTE_MASK0     ( 0x44 )   /* WF1BM0 */
+#define REG_WOL_FRAME1_BYTE_MASK1     ( 0x46 )   /* WF1BM1 */
+#define REG_WOL_FRAME1_BYTE_MASK2     ( 0x48 )   /* WF1BM2 */
+#define REG_WOL_FRAME1_BYTE_MASK3     ( 0x4A )   /* WF1BM3 */
 
-#define REG_WOL_FRAME2_CRC0        (0x50)       /* WF2CRC0 */
-#define REG_WOL_FRAME2_CRC1        (0x52)       /* WF2CRC1 */
-#define REG_WOL_FRAME2_BYTE_MASK0  (0x54)       /* WF2BM0 */
-#define REG_WOL_FRAME2_BYTE_MASK1  (0x56)       /* WF2BM1 */
-#define REG_WOL_FRAME2_BYTE_MASK2  (0x58)       /* WF2BM2 */
-#define REG_WOL_FRAME2_BYTE_MASK3  (0x5A)       /* WF2BM3 */
+#define REG_WOL_FRAME2_CRC0           ( 0x50 )   /* WF2CRC0 */
+#define REG_WOL_FRAME2_CRC1           ( 0x52 )   /* WF2CRC1 */
+#define REG_WOL_FRAME2_BYTE_MASK0     ( 0x54 )   /* WF2BM0 */
+#define REG_WOL_FRAME2_BYTE_MASK1     ( 0x56 )   /* WF2BM1 */
+#define REG_WOL_FRAME2_BYTE_MASK2     ( 0x58 )   /* WF2BM2 */
+#define REG_WOL_FRAME2_BYTE_MASK3     ( 0x5A )   /* WF2BM3 */
 
-#define REG_WOL_FRAME3_CRC0        (0x60)       /* WF3CRC0 */
-#define REG_WOL_FRAME3_CRC1        (0x62)       /* WF3CRC1 */
-#define REG_WOL_FRAME3_BYTE_MASK0  (0x64)       /* WF3BM0 */
-#define REG_WOL_FRAME3_BYTE_MASK1  (0x66)       /* WF3BM1 */
-#define REG_WOL_FRAME3_BYTE_MASK2  (0x68)       /* WF3BM2 */
-#define REG_WOL_FRAME3_BYTE_MASK3  (0x6A)       /* WF3BM3 */
+#define REG_WOL_FRAME3_CRC0           ( 0x60 )   /* WF3CRC0 */
+#define REG_WOL_FRAME3_CRC1           ( 0x62 )   /* WF3CRC1 */
+#define REG_WOL_FRAME3_BYTE_MASK0     ( 0x64 )   /* WF3BM0 */
+#define REG_WOL_FRAME3_BYTE_MASK1     ( 0x66 )   /* WF3BM1 */
+#define REG_WOL_FRAME3_BYTE_MASK2     ( 0x68 )   /* WF3BM2 */
+#define REG_WOL_FRAME3_BYTE_MASK3     ( 0x6A )   /* WF3BM3 */
 
 /*
  * Transmit/Receive Control Registers
@@ -164,310 +164,311 @@
  */
 
 /* Transmit Frame Header */
-#define REG_QDR_DUMMY              (0x00)       /* Dummy address to access QMU RxQ, TxQ */
-#define   TX_CTRL_INTERRUPT_ON        (0x8000)    /* Transmit Interrupt on Completion */
+#define REG_QDR_DUMMY                    ( 0x00 )   /* Dummy address to access QMU RxQ, TxQ */
+#define   TX_CTRL_INTERRUPT_ON           ( 0x8000 ) /* Transmit Interrupt on Completion */
 
-#define REG_TX_CTRL                (0x70)       /* TXCR */
-#define   TX_CTRL_ICMP_CHECKSUM       (0x0100)    /* Enable ICMP frame checksum generation */
-#define   TX_CTRL_UDP_CHECKSUM        (0x0080)    /* Enable UDP frame checksum generation */
-#define   TX_CTRL_TCP_CHECKSUM        (0x0040)    /* Enable TCP frame checksum generation */
-#define   TX_CTRL_IP_CHECKSUM         (0x0020)    /* Enable IP frame checksum generation */
-#define   TX_CTRL_FLUSH_QUEUE         (0x0010)    /* Clear transmit queue, reset tx frame pointer */
-#define   TX_CTRL_FLOW_ENABLE         (0x0008)    /* Enable transmit flow control */
-#define   TX_CTRL_PAD_ENABLE          (0x0004)    /* Eanble adding a padding to a packet shorter than 64 bytes */
-#define   TX_CTRL_CRC_ENABLE          (0x0002)    /* Enable adding a CRC to the end of transmit frame */
-#define   TX_CTRL_ENABLE              (0x0001)    /* Enable tranmsit */
+#define REG_TX_CTRL                      ( 0x70 )   /* TXCR */
+#define   TX_CTRL_ICMP_CHECKSUM          ( 0x0100 ) /* Enable ICMP frame checksum generation */
+#define   TX_CTRL_UDP_CHECKSUM           ( 0x0080 ) /* Enable UDP frame checksum generation */
+#define   TX_CTRL_TCP_CHECKSUM           ( 0x0040 ) /* Enable TCP frame checksum generation */
+#define   TX_CTRL_IP_CHECKSUM            ( 0x0020 ) /* Enable IP frame checksum generation */
+#define   TX_CTRL_FLUSH_QUEUE            ( 0x0010 ) /* Clear transmit queue, reset tx frame pointer */
+#define   TX_CTRL_FLOW_ENABLE            ( 0x0008 ) /* Enable transmit flow control */
+#define   TX_CTRL_PAD_ENABLE             ( 0x0004 ) /* Eanble adding a padding to a packet shorter than 64 bytes */
+#define   TX_CTRL_CRC_ENABLE             ( 0x0002 ) /* Enable adding a CRC to the end of transmit frame */
+#define   TX_CTRL_ENABLE                 ( 0x0001 ) /* Enable tranmsit */
 
-#define REG_TX_STATUS              (0x72)       /* TXSR */
-#define   TX_STAT_LATE_COL            (0x2000)    /* Tranmsit late collision occurs */
-#define   TX_STAT_MAX_COL             (0x1000)    /* Tranmsit maximum collision is reached */
-#define   TX_FRAME_ID_MASK            (0x003F)    /* Transmit frame ID mask */
-#define   TX_STAT_ERRORS             ( TX_STAT_MAX_COL | TX_STAT_LATE_COL )
+#define REG_TX_STATUS                    ( 0x72 )   /* TXSR */
+#define   TX_STAT_LATE_COL               ( 0x2000 ) /* Tranmsit late collision occurs */
+#define   TX_STAT_MAX_COL                ( 0x1000 ) /* Tranmsit maximum collision is reached */
+#define   TX_FRAME_ID_MASK               ( 0x003F ) /* Transmit frame ID mask */
+#define   TX_STAT_ERRORS                 ( TX_STAT_MAX_COL | TX_STAT_LATE_COL )
 
-#define REG_RX_CTRL1               (0x74)       /* RXCR1 */
-#define   RX_CTRL_FLUSH_QUEUE         (0x8000)    /* Clear receive queue, reset rx frame pointer */
-#define   RX_CTRL_UDP_CHECKSUM        (0x4000)    /* Enable UDP frame checksum verification */
-#define   RX_CTRL_TCP_CHECKSUM        (0x2000)    /* Enable TCP frame checksum verification */
-#define   RX_CTRL_IP_CHECKSUM         (0x1000)    /* Enable IP frame checksum verification */
-#define   RX_CTRL_MAC_FILTER          (0x0800)    /* Receive with address that pass MAC address filtering */
-#define   RX_CTRL_FLOW_ENABLE         (0x0400)    /* Enable receive flow control */
-#define   RX_CTRL_BAD_PACKET          (0x0200)    /* Eanble receive CRC error frames */
-#define   RX_CTRL_MULTICAST           (0x0100)    /* Receive multicast frames that pass the CRC hash filtering */
-#define   RX_CTRL_BROADCAST           (0x0080)    /* Receive all the broadcast frames */
-#define   RX_CTRL_ALL_MULTICAST       (0x0040)    /* Receive all the multicast frames (including broadcast frames) */
-#define   RX_CTRL_UNICAST             (0x0020)    /* Receive unicast frames that match the device MAC address */
-#define   RX_CTRL_PROMISCUOUS         (0x0010)    /* Receive all incoming frames, regardless of frame's DA */
-#define   RX_CTRL_STRIP_CRC           (0x0008)    /* Enable strip CRC on the received frames */
-#define   RX_CTRL_INVERSE_FILTER      (0x0002)    /* Receive with address check in inverse filtering mode */
-#define   RX_CTRL_ENABLE              (0x0001)    /* Enable receive */
+#define REG_RX_CTRL1                     ( 0x74 )   /* RXCR1 */
+#define   RX_CTRL_FLUSH_QUEUE            ( 0x8000 ) /* Clear receive queue, reset rx frame pointer */
+#define   RX_CTRL_UDP_CHECKSUM           ( 0x4000 ) /* Enable UDP frame checksum verification */
+#define   RX_CTRL_TCP_CHECKSUM           ( 0x2000 ) /* Enable TCP frame checksum verification */
+#define   RX_CTRL_IP_CHECKSUM            ( 0x1000 ) /* Enable IP frame checksum verification */
+#define   RX_CTRL_MAC_FILTER             ( 0x0800 ) /* Receive with address that pass MAC address filtering */
+#define   RX_CTRL_FLOW_ENABLE            ( 0x0400 ) /* Enable receive flow control */
+#define   RX_CTRL_BAD_PACKET             ( 0x0200 ) /* Eanble receive CRC error frames */
+#define   RX_CTRL_MULTICAST              ( 0x0100 ) /* Receive multicast frames that pass the CRC hash filtering */
+#define   RX_CTRL_BROADCAST              ( 0x0080 ) /* Receive all the broadcast frames */
+#define   RX_CTRL_ALL_MULTICAST          ( 0x0040 ) /* Receive all the multicast frames (including broadcast frames) */
+#define   RX_CTRL_UNICAST                ( 0x0020 ) /* Receive unicast frames that match the device MAC address */
+#define   RX_CTRL_PROMISCUOUS            ( 0x0010 ) /* Receive all incoming frames, regardless of frame's DA */
+#define   RX_CTRL_STRIP_CRC              ( 0x0008 ) /* Enable strip CRC on the received frames */
+#define   RX_CTRL_INVERSE_FILTER         ( 0x0002 ) /* Receive with address check in inverse filtering mode */
+#define   RX_CTRL_ENABLE                 ( 0x0001 ) /* Enable receive */
 
 /* Address filtering scheme mask */
-#define RX_CTRL_FILTER_MASK    ( RX_CTRL_INVERSE_FILTER | RX_CTRL_PROMISCUOUS | RX_CTRL_MULTICAST | RX_CTRL_MAC_FILTER )
+#define RX_CTRL_FILTER_MASK              ( RX_CTRL_INVERSE_FILTER | RX_CTRL_PROMISCUOUS | RX_CTRL_MULTICAST | RX_CTRL_MAC_FILTER )
 
-#define REG_RX_CTRL2               (0x76)       /* RXCR2 */
-#define   RX_CTRL_IPV6_UDP_NOCHECKSUM (0x0010)    /* No checksum generation and verification if IPv6 UDP is fragment */
-#define   RX_CTRL_IPV6_UDP_CHECKSUM   (0x0008)    /* Receive pass IPv6 UDP frame with UDP checksum is zero */
-#define   RX_CTRL_UDP_LITE_CHECKSUM   (0x0004)    /* Enable UDP Lite frame checksum generation and verification */
-#define   RX_CTRL_ICMP_CHECKSUM       (0x0002)    /* Enable ICMP frame checksum verification */
-#define   RX_CTRL_BLOCK_MAC           (0x0001)    /* Receive drop frame if the SA is same as device MAC address */
-#define   RX_CTRL_BURST_LEN_MASK      (0x00e0)    /* SRDBL SPI Receive Data Burst Length */
-#define   RX_CTRL_BURST_LEN_4         (0x0000)
-#define   RX_CTRL_BURST_LEN_8         (0x0020)
-#define   RX_CTRL_BURST_LEN_16        (0x0040)
-#define   RX_CTRL_BURST_LEN_32        (0x0060)
-#define   RX_CTRL_BURST_LEN_FRAME     (0x0080)
+#define REG_RX_CTRL2                     ( 0x76 )   /* RXCR2 */
+#define   RX_CTRL_IPV6_UDP_NOCHECKSUM    ( 0x0010 ) /* No checksum generation and verification if IPv6 UDP is fragment */
+#define   RX_CTRL_IPV6_UDP_CHECKSUM      ( 0x0008 ) /* Receive pass IPv6 UDP frame with UDP checksum is zero */
+#define   RX_CTRL_UDP_LITE_CHECKSUM      ( 0x0004 ) /* Enable UDP Lite frame checksum generation and verification */
+#define   RX_CTRL_ICMP_CHECKSUM          ( 0x0002 ) /* Enable ICMP frame checksum verification */
+#define   RX_CTRL_BLOCK_MAC              ( 0x0001 ) /* Receive drop frame if the SA is same as device MAC address */
+#define   RX_CTRL_BURST_LEN_MASK         ( 0x00e0 ) /* SRDBL SPI Receive Data Burst Length */
+#define   RX_CTRL_BURST_LEN_4            ( 0x0000 )
+#define   RX_CTRL_BURST_LEN_8            ( 0x0020 )
+#define   RX_CTRL_BURST_LEN_16           ( 0x0040 )
+#define   RX_CTRL_BURST_LEN_32           ( 0x0060 )
+#define   RX_CTRL_BURST_LEN_FRAME        ( 0x0080 )
 
-#define REG_TX_MEM_INFO            (0x78)       /* TXMIR */
-#define   TX_MEM_AVAILABLE_MASK       (0x1FFF)    /* The amount of memory available in TXQ */
+#define REG_TX_MEM_INFO                  ( 0x78 )   /* TXMIR */
+#define   TX_MEM_AVAILABLE_MASK          ( 0x1FFF ) /* The amount of memory available in TXQ */
 
-#define REG_RX_FHR_STATUS          (0x7C)       /* RXFHSR */
-#define   RX_VALID                    (0x8000)    /* Frame in the receive packet memory is valid */
-#define   RX_ICMP_ERROR               (0x2000)    /* ICMP checksum field doesn't match */
-#define   RX_IP_ERROR                 (0x1000)    /* IP checksum field doesn't match */
-#define   RX_TCP_ERROR                (0x0800)    /* TCP checksum field doesn't match */
-#define   RX_UDP_ERROR                (0x0400)    /* UDP checksum field doesn't match */
-#define   RX_BROADCAST                (0x0080)    /* Received frame is a broadcast frame */
-#define   RX_MULTICAST                (0x0040)    /* Received frame is a multicast frame */
-#define   RX_UNICAST                  (0x0020)    /* Received frame is a unicast frame */
-#define   RX_PHY_ERROR                (0x0010)    /* Received frame has runt error */
-#define   RX_FRAME_ETHER              (0x0008)    /* Received frame is an Ethernet-type frame */
-#define   RX_TOO_LONG                 (0x0004)    /* Received frame length exceeds max size 0f 2048 bytes */
-#define   RX_RUNT_ERROR               (0x0002)    /* Received frame was demaged by a collision */
-#define   RX_BAD_CRC                  (0x0001)    /* Received frame has a CRC error */
-#define   RX_ERRORS                   ( RX_BAD_CRC | RX_TOO_LONG | RX_RUNT_ERROR | RX_PHY_ERROR | \
-                                        RX_ICMP_ERROR | RX_IP_ERROR | RX_TCP_ERROR | RX_UDP_ERROR )
+#define REG_RX_FHR_STATUS                ( 0x7C )   /* RXFHSR */
+#define   RX_VALID                       ( 0x8000 ) /* Frame in the receive packet memory is valid */
+#define   RX_ICMP_ERROR                  ( 0x2000 ) /* ICMP checksum field doesn't match */
+#define   RX_IP_ERROR                    ( 0x1000 ) /* IP checksum field doesn't match */
+#define   RX_TCP_ERROR                   ( 0x0800 ) /* TCP checksum field doesn't match */
+#define   RX_UDP_ERROR                   ( 0x0400 ) /* UDP checksum field doesn't match */
+#define   RX_BROADCAST                   ( 0x0080 ) /* Received frame is a broadcast frame */
+#define   RX_MULTICAST                   ( 0x0040 ) /* Received frame is a multicast frame */
+#define   RX_UNICAST                     ( 0x0020 ) /* Received frame is a unicast frame */
+#define   RX_PHY_ERROR                   ( 0x0010 ) /* Received frame has runt error */
+#define   RX_FRAME_ETHER                 ( 0x0008 ) /* Received frame is an Ethernet-type frame */
+#define   RX_TOO_LONG                    ( 0x0004 ) /* Received frame length exceeds max size 0f 2048 bytes */
+#define   RX_RUNT_ERROR                  ( 0x0002 ) /* Received frame was demaged by a collision */
+#define   RX_BAD_CRC                     ( 0x0001 ) /* Received frame has a CRC error */
+#define   RX_ERRORS                                             \
+    ( RX_BAD_CRC | RX_TOO_LONG | RX_RUNT_ERROR | RX_PHY_ERROR | \
+      RX_ICMP_ERROR | RX_IP_ERROR | RX_TCP_ERROR | RX_UDP_ERROR )
 
-#define REG_RX_FHR_BYTE_CNT        (0x7E)       /* RXFHBCR */
-#define   RX_BYTE_CNT_MASK            (0x0FFF)    /* Received frame byte size mask */
+#define REG_RX_FHR_BYTE_CNT              ( 0x7E )   /* RXFHBCR */
+#define   RX_BYTE_CNT_MASK               ( 0x0FFF ) /* Received frame byte size mask */
 
-#define REG_TXQ_CMD                (0x80)       /* TXQCR */
-#define   TXQ_AUTO_ENQUEUE            (0x0004)    /* Enable enqueue tx frames from tx buffer automatically */
-#define   TXQ_MEM_AVAILABLE_INT       (0x0002)    /* Enable generate interrupt when tx memory is available */
-#define   TXQ_ENQUEUE                 (0x0001)    /* Enable enqueue tx frames one frame at a time */
+#define REG_TXQ_CMD                      ( 0x80 )   /* TXQCR */
+#define   TXQ_AUTO_ENQUEUE               ( 0x0004 ) /* Enable enqueue tx frames from tx buffer automatically */
+#define   TXQ_MEM_AVAILABLE_INT          ( 0x0002 ) /* Enable generate interrupt when tx memory is available */
+#define   TXQ_ENQUEUE                    ( 0x0001 ) /* Enable enqueue tx frames one frame at a time */
 
-#define REG_RXQ_CMD                (0x82)       /* RXQCR */
-#define   RXQ_STAT_TIME_INT           (0x1000)    /* RX interrupt is occured by timer duration */
-#define   RXQ_STAT_BYTE_CNT_INT       (0x0800)    /* RX interrupt is occured by byte count threshold */
-#define   RXQ_STAT_FRAME_CNT_INT      (0x0400)    /* RX interrupt is occured by frame count threshold */
-#define   RXQ_TWOBYTE_OFFSET          (0x0200)    /* Enable adding 2-byte before frame header for IP aligned with DWORD */
-#define   RXQ_TIME_INT                (0x0080)    /* Enable RX interrupt by timer duration */
-#define   RXQ_BYTE_CNT_INT            (0x0040)    /* Enable RX interrupt by byte count threshold */
-#define   RXQ_FRAME_CNT_INT           (0x0020)    /* Enable RX interrupt by frame count threshold */
-#define   RXQ_AUTO_DEQUEUE            (0x0010)    /* Enable release rx frames from rx buffer automatically */
-#define   RXQ_START                   (0x0008)    /* Start QMU transfer operation */
-#define   RXQ_CMD_FREE_PACKET         (0x0001)    /* Manual dequeue (release the current frame from RxQ) */
+#define REG_RXQ_CMD                      ( 0x82 )   /* RXQCR */
+#define   RXQ_STAT_TIME_INT              ( 0x1000 ) /* RX interrupt is occured by timer duration */
+#define   RXQ_STAT_BYTE_CNT_INT          ( 0x0800 ) /* RX interrupt is occured by byte count threshold */
+#define   RXQ_STAT_FRAME_CNT_INT         ( 0x0400 ) /* RX interrupt is occured by frame count threshold */
+#define   RXQ_TWOBYTE_OFFSET             ( 0x0200 ) /* Enable adding 2-byte before frame header for IP aligned with DWORD */
+#define   RXQ_TIME_INT                   ( 0x0080 ) /* Enable RX interrupt by timer duration */
+#define   RXQ_BYTE_CNT_INT               ( 0x0040 ) /* Enable RX interrupt by byte count threshold */
+#define   RXQ_FRAME_CNT_INT              ( 0x0020 ) /* Enable RX interrupt by frame count threshold */
+#define   RXQ_AUTO_DEQUEUE               ( 0x0010 ) /* Enable release rx frames from rx buffer automatically */
+#define   RXQ_START                      ( 0x0008 ) /* Start QMU transfer operation */
+#define   RXQ_CMD_FREE_PACKET            ( 0x0001 ) /* Manual dequeue (release the current frame from RxQ) */
 
-#define   RXQ_CMD_CNTL                (RXQ_FRAME_CNT_INT|RXQ_AUTO_DEQUEUE)
+#define   RXQ_CMD_CNTL                   ( RXQ_FRAME_CNT_INT | RXQ_AUTO_DEQUEUE )
 
-#define REG_TX_ADDR_PTR            (0x84)       /* TXFDPR */
-#define REG_RX_ADDR_PTR            (0x86)       /* RXFDPR */
-#define   ADDR_PTR_AUTO_INC           (0x4000)    /* Enable Frame data pointer increments automatically */
-#define   ADDR_PTR_MASK               (0x03ff)    /* Address pointer mask */
+#define REG_TX_ADDR_PTR                  ( 0x84 )   /* TXFDPR */
+#define REG_RX_ADDR_PTR                  ( 0x86 )   /* RXFDPR */
+#define   ADDR_PTR_AUTO_INC              ( 0x4000 ) /* Enable Frame data pointer increments automatically */
+#define   ADDR_PTR_MASK                  ( 0x03ff ) /* Address pointer mask */
 
-#define REG_RX_TIME_THRES          (0x8C)       /* RXDTTR */
-#define   RX_TIME_THRESHOLD_MASK      (0xFFFF)    /* Set receive timer duration threshold */
+#define REG_RX_TIME_THRES                ( 0x8C )   /* RXDTTR */
+#define   RX_TIME_THRESHOLD_MASK         ( 0xFFFF ) /* Set receive timer duration threshold */
 
-#define REG_RX_BYTE_CNT_THRES      (0x8E)       /* RXDBCTR */
-#define   RX_BYTE_THRESHOLD_MASK      (0xFFFF)    /* Set receive byte count threshold */
+#define REG_RX_BYTE_CNT_THRES            ( 0x8E )   /* RXDBCTR */
+#define   RX_BYTE_THRESHOLD_MASK         ( 0xFFFF ) /* Set receive byte count threshold */
 
-#define REG_INT_MASK               (0x90)       /* IER */
-#define   INT_PHY                     (0x8000)    /* Enable link change interrupt */
-#define   INT_TX                      (0x4000)    /* Enable transmit done interrupt */
-#define   INT_RX                      (0x2000)    /* Enable receive interrupt */
-#define   INT_RX_OVERRUN              (0x0800)    /* Enable receive overrun interrupt */
-#define   INT_TX_STOPPED              (0x0200)    /* Enable transmit process stopped interrupt */
-#define   INT_RX_STOPPED              (0x0100)    /* Enable receive process stopped interrupt */
-#define   INT_TX_SPACE                (0x0040)    /* Enable transmit space available interrupt */
-#define   INT_RX_WOL_FRAME            (0x0020)    /* Enable WOL on receive wake-up frame detect interrupt */
-#define   INT_RX_WOL_MAGIC            (0x0010)    /* Enable WOL on receive magic packet detect interrupt */
-#define   INT_RX_WOL_LINKUP           (0x0008)    /* Enable WOL on link up detect interrupt */
-#define   INT_RX_WOL_ENERGY           (0x0004)    /* Enable WOL on energy detect interrupt */
-#define   INT_RX_SPI_ERROR            (0x0002)    /* Enable receive SPI bus error interrupt */
-#define   INT_RX_WOL_DELAY_ENERGY     (0x0001)    /* Enable WOL on delay energy detect interrupt */
-#define   INT_MASK                    ( INT_RX | INT_TX | INT_PHY )
+#define REG_INT_MASK                     ( 0x90 )   /* IER */
+#define   INT_PHY                        ( 0x8000 ) /* Enable link change interrupt */
+#define   INT_TX                         ( 0x4000 ) /* Enable transmit done interrupt */
+#define   INT_RX                         ( 0x2000 ) /* Enable receive interrupt */
+#define   INT_RX_OVERRUN                 ( 0x0800 ) /* Enable receive overrun interrupt */
+#define   INT_TX_STOPPED                 ( 0x0200 ) /* Enable transmit process stopped interrupt */
+#define   INT_RX_STOPPED                 ( 0x0100 ) /* Enable receive process stopped interrupt */
+#define   INT_TX_SPACE                   ( 0x0040 ) /* Enable transmit space available interrupt */
+#define   INT_RX_WOL_FRAME               ( 0x0020 ) /* Enable WOL on receive wake-up frame detect interrupt */
+#define   INT_RX_WOL_MAGIC               ( 0x0010 ) /* Enable WOL on receive magic packet detect interrupt */
+#define   INT_RX_WOL_LINKUP              ( 0x0008 ) /* Enable WOL on link up detect interrupt */
+#define   INT_RX_WOL_ENERGY              ( 0x0004 ) /* Enable WOL on energy detect interrupt */
+#define   INT_RX_SPI_ERROR               ( 0x0002 ) /* Enable receive SPI bus error interrupt */
+#define   INT_RX_WOL_DELAY_ENERGY        ( 0x0001 ) /* Enable WOL on delay energy detect interrupt */
+#define   INT_MASK                       ( INT_RX | INT_TX | INT_PHY )
 
-#define REG_INT_STATUS             (0x92)       /* ISR */
+#define REG_INT_STATUS                   ( 0x92 )   /* ISR */
 
-#define REG_RX_FRAME_CNT_THRES     (0x9C)       /* RXFCTFC */
-#define   RX_FRAME_CNT_MASK           (0xFF00)    /* Received frame count mask */
-#define   RX_FRAME_THRESHOLD_MASK     (0x00FF)    /* Set receive frame count threshold mask */
+#define REG_RX_FRAME_CNT_THRES           ( 0x9C )   /* RXFCTFC */
+#define   RX_FRAME_CNT_MASK              ( 0xFF00 ) /* Received frame count mask */
+#define   RX_FRAME_THRESHOLD_MASK        ( 0x00FF ) /* Set receive frame count threshold mask */
 
-#define REG_TX_TOTAL_FRAME_SIZE    (0x9E)       /* TXNTFSR */
-#define   TX_TOTAL_FRAME_SIZE_MASK    (0xFFFF)    /* Set next total tx frame size mask */
+#define REG_TX_TOTAL_FRAME_SIZE          ( 0x9E )   /* TXNTFSR */
+#define   TX_TOTAL_FRAME_SIZE_MASK       ( 0xFFFF ) /* Set next total tx frame size mask */
 
 /*
  * MAC Address Hash Table Control Registers
  * (Offset 0xA0 - 0xA7)
  */
-#define REG_MAC_HASH_0             (0xA0)       /* MAHTR0 */
-#define REG_MAC_HASH_1             (0xA1)
+#define REG_MAC_HASH_0                   ( 0xA0 ) /* MAHTR0 */
+#define REG_MAC_HASH_1                   ( 0xA1 )
 
-#define REG_MAC_HASH_2             (0xA2)       /* MAHTR1 */
-#define REG_MAC_HASH_3             (0xA3)
+#define REG_MAC_HASH_2                   ( 0xA2 ) /* MAHTR1 */
+#define REG_MAC_HASH_3                   ( 0xA3 )
 
-#define REG_MAC_HASH_4             (0xA4)       /* MAHTR2 */
-#define REG_MAC_HASH_5             (0xA5)
+#define REG_MAC_HASH_4                   ( 0xA4 ) /* MAHTR2 */
+#define REG_MAC_HASH_5                   ( 0xA5 )
 
-#define REG_MAC_HASH_6             (0xA6)       /* MAHTR3 */
-#define REG_MAC_HASH_7             (0xA7)
+#define REG_MAC_HASH_6                   ( 0xA6 ) /* MAHTR3 */
+#define REG_MAC_HASH_7                   ( 0xA7 )
 
 /*
  * QMU Receive Queue Watermark Control Registers
  * (Offset 0xB0 - 0xB5)
  */
-#define REG_RX_LOW_WATERMARK       (0xB0)       /* FCLWR */
-#define   RX_LOW_WATERMARK_MASK       (0x0FFF)    /* Set QMU RxQ low watermark mask */
+#define REG_RX_LOW_WATERMARK             ( 0xB0 )   /* FCLWR */
+#define   RX_LOW_WATERMARK_MASK          ( 0x0FFF ) /* Set QMU RxQ low watermark mask */
 
-#define REG_RX_HIGH_WATERMARK      (0xB2)       /* FCHWR */
-#define   RX_HIGH_WATERMARK_MASK      (0x0FFF)    /* Set QMU RxQ high watermark mask */
+#define REG_RX_HIGH_WATERMARK            ( 0xB2 )   /* FCHWR */
+#define   RX_HIGH_WATERMARK_MASK         ( 0x0FFF ) /* Set QMU RxQ high watermark mask */
 
-#define REG_RX_OVERRUN_WATERMARK   (0xB4)       /* FCOWR */
-#define   RX_OVERRUN_WATERMARK_MASK   (0x0FFF)    /* Set QMU RxQ overrun watermark mask */
+#define REG_RX_OVERRUN_WATERMARK         ( 0xB4 )   /* FCOWR */
+#define   RX_OVERRUN_WATERMARK_MASK      ( 0x0FFF ) /* Set QMU RxQ overrun watermark mask */
 
 /*
  * Global Control Registers
  * (Offset 0xC0 - 0xD3)
  */
-#define REG_CHIP_ID                (0xC0)       /* CIDER */
-#define   CHIP_ID_MASK                (0xFFF0)     /* Family ID and chip ID mask */
-#define   REVISION_MASK               (0x000E)     /* Chip revision mask */
-#define   CHIP_ID_SHIFT               (4)
-#define   REVISION_SHIFT              (1)
-#define   CHIP_ID_8851_16             (0x8870)     /* KS8851-16/32MQL chip ID */
+#define REG_CHIP_ID                      ( 0xC0 )   /* CIDER */
+#define   CHIP_ID_MASK                   ( 0xFFF0 ) /* Family ID and chip ID mask */
+#define   REVISION_MASK                  ( 0x000E ) /* Chip revision mask */
+#define   CHIP_ID_SHIFT                  ( 4 )
+#define   REVISION_SHIFT                 ( 1 )
+#define   CHIP_ID_8851_16                ( 0x8870 ) /* KS8851-16/32MQL chip ID */
 
-#define REG_LED_CTRL               (0xC6)       /* CGCR */
-#define   LED_CTRL_SEL1               (0x8000)     /* Select LED3/LED2/LED1/LED0 indication */
-#define   LED_CTRL_SEL0               (0x0200)     /* Select LED3/LED2/LED1/LED0 indication */
+#define REG_LED_CTRL                     ( 0xC6 )   /* CGCR */
+#define   LED_CTRL_SEL1                  ( 0x8000 ) /* Select LED3/LED2/LED1/LED0 indication */
+#define   LED_CTRL_SEL0                  ( 0x0200 ) /* Select LED3/LED2/LED1/LED0 indication */
 
-#define REG_IND_IACR               (0xC8)       /* IACR */
-#define   TABLE_READ                  (0x1000)     /* Indirect read */
-#define   TABLE_MIB                   (0x0C00)     /* Select MIB counter table */
-#define   TABLE_ENTRY_MASK            (0x001F)     /* Set table entry to access */
+#define REG_IND_IACR                     ( 0xC8 )   /* IACR */
+#define   TABLE_READ                     ( 0x1000 ) /* Indirect read */
+#define   TABLE_MIB                      ( 0x0C00 ) /* Select MIB counter table */
+#define   TABLE_ENTRY_MASK               ( 0x001F ) /* Set table entry to access */
 
-#define REG_IND_DATA_LOW           (0xD0)       /* IADLR */
-#define REG_IND_DATA_HIGH          (0xD2)       /* IADHR */
+#define REG_IND_DATA_LOW                 ( 0xD0 )   /* IADLR */
+#define REG_IND_DATA_HIGH                ( 0xD2 )   /* IADHR */
 
 /*
  * Power Management Control Registers
  * (Offset 0xD4 - 0xD7)
  */
-#define REG_POWER_CNTL             (0xD4)       /* PMECR */
-#define   PME_DELAY_ENABLE            (0x4000)    /* Enable the PME output pin assertion delay */
-#define   PME_ACTIVE_HIGHT            (0x1000)    /* PME output pin is active high */
-#define   PME_FROM_WKFRAME            (0x0800)    /* PME asserted when wake-up frame is detected */
-#define   PME_FROM_MAGIC              (0x0400)    /* PME asserted when magic packet is detected */
-#define   PME_FROM_LINKUP             (0x0200)    /* PME asserted when link up is detected */
-#define   PME_FROM_ENERGY             (0x0100)    /* PME asserted when energy is detected */
-#define   PME_EVENT_MASK              (0x0F00)    /* PME asserted event mask */
-#define   WAKEUP_AUTO_ENABLE          (0x0080)    /* Enable auto wake-up in energy mode */
-#define   WAKEUP_NORMAL_AUTO_ENABLE   (0x0040)    /* Enable auto goto normal mode from energy detecion mode */
-#define   WAKEUP_FROM_WKFRAME         (0x0020)    /* Wake-up from wake-up frame event detected */
-#define   WAKEUP_FROM_MAGIC           (0x0010)    /* Wake-up from magic packet event detected */
-#define   WAKEUP_FROM_LINKUP          (0x0008)    /* Wake-up from link up event detected */
-#define   WAKEUP_FROM_ENERGY          (0x0004)    /* Wake-up from energy event detected */
-#define   WAKEUP_EVENT_MASK           (0x003C)    /* Wake-up event mask */
-#define   POWER_STATE_D1              (0x0003)    /* Power saving mode */
-#define   POWER_STATE_D3              (0x0002)    /* Power down mode */
-#define   POWER_STATE_D2              (0x0001)    /* Power detection mode */
-#define   POWER_STATE_D0              (0x0000)    /* Normal operation mode (default) */
-#define   POWER_STATE_MASK            (0x0003)    /* Power management mode mask */
+#define REG_POWER_CNTL                   ( 0xD4 )   /* PMECR */
+#define   PME_DELAY_ENABLE               ( 0x4000 ) /* Enable the PME output pin assertion delay */
+#define   PME_ACTIVE_HIGHT               ( 0x1000 ) /* PME output pin is active high */
+#define   PME_FROM_WKFRAME               ( 0x0800 ) /* PME asserted when wake-up frame is detected */
+#define   PME_FROM_MAGIC                 ( 0x0400 ) /* PME asserted when magic packet is detected */
+#define   PME_FROM_LINKUP                ( 0x0200 ) /* PME asserted when link up is detected */
+#define   PME_FROM_ENERGY                ( 0x0100 ) /* PME asserted when energy is detected */
+#define   PME_EVENT_MASK                 ( 0x0F00 ) /* PME asserted event mask */
+#define   WAKEUP_AUTO_ENABLE             ( 0x0080 ) /* Enable auto wake-up in energy mode */
+#define   WAKEUP_NORMAL_AUTO_ENABLE      ( 0x0040 ) /* Enable auto goto normal mode from energy detecion mode */
+#define   WAKEUP_FROM_WKFRAME            ( 0x0020 ) /* Wake-up from wake-up frame event detected */
+#define   WAKEUP_FROM_MAGIC              ( 0x0010 ) /* Wake-up from magic packet event detected */
+#define   WAKEUP_FROM_LINKUP             ( 0x0008 ) /* Wake-up from link up event detected */
+#define   WAKEUP_FROM_ENERGY             ( 0x0004 ) /* Wake-up from energy event detected */
+#define   WAKEUP_EVENT_MASK              ( 0x003C ) /* Wake-up event mask */
+#define   POWER_STATE_D1                 ( 0x0003 ) /* Power saving mode */
+#define   POWER_STATE_D3                 ( 0x0002 ) /* Power down mode */
+#define   POWER_STATE_D2                 ( 0x0001 ) /* Power detection mode */
+#define   POWER_STATE_D0                 ( 0x0000 ) /* Normal operation mode (default) */
+#define   POWER_STATE_MASK               ( 0x0003 ) /* Power management mode mask */
 
-#define REG_WAKEUP_TIME            (0xD6)       /* GSWUTR */
-#define   WAKEUP_TIME                 (0xFF00)    /* Min time (sec) wake-uo after detected energy */
-#define   GOSLEEP_TIME                (0x00FF)    /* Min time (sec) before goto sleep when in energy mode */
+#define REG_WAKEUP_TIME                  ( 0xD6 )   /* GSWUTR */
+#define   WAKEUP_TIME                    ( 0xFF00 ) /* Min time (sec) wake-uo after detected energy */
+#define   GOSLEEP_TIME                   ( 0x00FF ) /* Min time (sec) before goto sleep when in energy mode */
 
 /*
  * PHY Control Registers
  * (Offset 0xD8 - 0xF9)
  */
-#define REG_PHY_RESET              (0xD8)       /* PHYRR */
-#define   PHY_RESET                   (0x0001)    /* Reset PHY */
+#define REG_PHY_RESET                    ( 0xD8 )   /* PHYRR */
+#define   PHY_RESET                      ( 0x0001 ) /* Reset PHY */
 
-#define REG_PHY_CNTL               (0xE4)       /* P1MBCR */
-#define   PHY_SPEED_100MBIT           (0x2000)     /* Force PHY 100Mbps */
-#define   PHY_AUTO_NEG_ENABLE         (0x1000)     /* Enable PHY auto-negotiation */
-#define   PHY_POWER_DOWN              (0x0800)     /* Set PHY power-down */
-#define   PHY_AUTO_NEG_RESTART        (0x0200)     /* Restart PHY auto-negotiation */
-#define   PHY_FULL_DUPLEX             (0x0100)     /* Force PHY in full duplex mode */
-#define   PHY_HP_MDIX                 (0x0020)     /* Set PHY in HP auto MDI-X mode */
-#define   PHY_FORCE_MDIX              (0x0010)     /* Force MDI-X */
-#define   PHY_AUTO_MDIX_DISABLE       (0x0008)     /* Disable auto MDI-X */
-#define   PHY_TRANSMIT_DISABLE        (0x0002)     /* Disable PHY transmit */
-#define   PHY_LED_DISABLE             (0x0001)     /* Disable PHY LED */
+#define REG_PHY_CNTL                     ( 0xE4 )   /* P1MBCR */
+#define   PHY_SPEED_100MBIT              ( 0x2000 ) /* Force PHY 100Mbps */
+#define   PHY_AUTO_NEG_ENABLE            ( 0x1000 ) /* Enable PHY auto-negotiation */
+#define   PHY_POWER_DOWN                 ( 0x0800 ) /* Set PHY power-down */
+#define   PHY_AUTO_NEG_RESTART           ( 0x0200 ) /* Restart PHY auto-negotiation */
+#define   PHY_FULL_DUPLEX                ( 0x0100 ) /* Force PHY in full duplex mode */
+#define   PHY_HP_MDIX                    ( 0x0020 ) /* Set PHY in HP auto MDI-X mode */
+#define   PHY_FORCE_MDIX                 ( 0x0010 ) /* Force MDI-X */
+#define   PHY_AUTO_MDIX_DISABLE          ( 0x0008 ) /* Disable auto MDI-X */
+#define   PHY_TRANSMIT_DISABLE           ( 0x0002 ) /* Disable PHY transmit */
+#define   PHY_LED_DISABLE                ( 0x0001 ) /* Disable PHY LED */
 
-#define REG_PHY_STATUS             (0xE6)       /* P1MBSR */
-#define   PHY_100BT4_CAPABLE          (0x8000)     /* 100 BASE-T4 capable */
-#define   PHY_100BTX_FD_CAPABLE       (0x4000)     /* 100BASE-TX full duplex capable */
-#define   PHY_100BTX_CAPABLE          (0x2000)     /* 100BASE-TX half duplex capable */
-#define   PHY_10BT_FD_CAPABLE         (0x1000)     /* 10BASE-TX full duplex capable */
-#define   PHY_10BT_CAPABLE            (0x0800)     /* 10BASE-TX half duplex capable */
-#define   PHY_AUTO_NEG_ACKNOWLEDGE    (0x0020)     /* Auto-negotiation complete */
-#define   PHY_AUTO_NEG_CAPABLE        (0x0008)     /* Auto-negotiation capable */
-#define   PHY_LINK_UP                 (0x0004)     /* PHY link is up */
-#define   PHY_EXTENDED_CAPABILITY     (0x0001)     /* PHY extended register capable */
+#define REG_PHY_STATUS                   ( 0xE6 )   /* P1MBSR */
+#define   PHY_100BT4_CAPABLE             ( 0x8000 ) /* 100 BASE-T4 capable */
+#define   PHY_100BTX_FD_CAPABLE          ( 0x4000 ) /* 100BASE-TX full duplex capable */
+#define   PHY_100BTX_CAPABLE             ( 0x2000 ) /* 100BASE-TX half duplex capable */
+#define   PHY_10BT_FD_CAPABLE            ( 0x1000 ) /* 10BASE-TX full duplex capable */
+#define   PHY_10BT_CAPABLE               ( 0x0800 ) /* 10BASE-TX half duplex capable */
+#define   PHY_AUTO_NEG_ACKNOWLEDGE       ( 0x0020 ) /* Auto-negotiation complete */
+#define   PHY_AUTO_NEG_CAPABLE           ( 0x0008 ) /* Auto-negotiation capable */
+#define   PHY_LINK_UP                    ( 0x0004 ) /* PHY link is up */
+#define   PHY_EXTENDED_CAPABILITY        ( 0x0001 ) /* PHY extended register capable */
 
-#define REG_PHY_ID_LOW             (0xE8)       /* PHY1ILR */
-#define REG_PHY_ID_HIGH            (0xEA)       /* PHY1IHR */
+#define REG_PHY_ID_LOW                   ( 0xE8 )   /* PHY1ILR */
+#define REG_PHY_ID_HIGH                  ( 0xEA )   /* PHY1IHR */
 
-#define REG_PHY_AUTO_NEGOTIATION   (0xEC)       /* P1ANAR */
-#define   PHY_AUTO_NEG_SYM_PAUSE      (0x0400)     /* Advertise pause capability */
-#define   PHY_AUTO_NEG_100BTX_FD      (0x0100)     /* Advertise 100 full-duplex capability */
-#define   PHY_AUTO_NEG_100BTX         (0x0080)     /* Advertise 100 half-duplex capability */
-#define   PHY_AUTO_NEG_10BT_FD        (0x0040)     /* Advertise 10 full-duplex capability */
-#define   PHY_AUTO_NEG_10BT           (0x0020)     /* Advertise 10 half-duplex capability */
-#define   PHY_AUTO_NEG_SELECTOR       (0x001F)     /* Selector field mask */
-#define   PHY_AUTO_NEG_802_3          (0x0001)     /* 802.3 */
+#define REG_PHY_AUTO_NEGOTIATION         ( 0xEC )   /* P1ANAR */
+#define   PHY_AUTO_NEG_SYM_PAUSE         ( 0x0400 ) /* Advertise pause capability */
+#define   PHY_AUTO_NEG_100BTX_FD         ( 0x0100 ) /* Advertise 100 full-duplex capability */
+#define   PHY_AUTO_NEG_100BTX            ( 0x0080 ) /* Advertise 100 half-duplex capability */
+#define   PHY_AUTO_NEG_10BT_FD           ( 0x0040 ) /* Advertise 10 full-duplex capability */
+#define   PHY_AUTO_NEG_10BT              ( 0x0020 ) /* Advertise 10 half-duplex capability */
+#define   PHY_AUTO_NEG_SELECTOR          ( 0x001F ) /* Selector field mask */
+#define   PHY_AUTO_NEG_802_3             ( 0x0001 ) /* 802.3 */
 
-#define REG_PHY_REMOTE_CAPABILITY  (0xEE)       /* P1ANLPR */
-#define   PHY_REMOTE_SYM_PAUSE        (0x0400)     /* Link partner pause capability */
-#define   PHY_REMOTE_100BTX_FD        (0x0100)     /* Link partner 100 full-duplex capability */
-#define   PHY_REMOTE_100BTX           (0x0080)     /* Link partner 100 half-duplex capability */
-#define   PHY_REMOTE_10BT_FD          (0x0040)     /* Link partner 10 full-duplex capability */
-#define   PHY_REMOTE_10BT             (0x0020)     /* Link partner 10 half-duplex capability */
+#define REG_PHY_REMOTE_CAPABILITY        ( 0xEE )   /* P1ANLPR */
+#define   PHY_REMOTE_SYM_PAUSE           ( 0x0400 ) /* Link partner pause capability */
+#define   PHY_REMOTE_100BTX_FD           ( 0x0100 ) /* Link partner 100 full-duplex capability */
+#define   PHY_REMOTE_100BTX              ( 0x0080 ) /* Link partner 100 half-duplex capability */
+#define   PHY_REMOTE_10BT_FD             ( 0x0040 ) /* Link partner 10 full-duplex capability */
+#define   PHY_REMOTE_10BT                ( 0x0020 ) /* Link partner 10 half-duplex capability */
 
-#define REG_PORT_LINK_MD           (0xF4)       /* P1SCLMD */
-#define   PORT_CABLE_10M_SHORT        (0x8000)     /* Cable length is less than 10m short */
-#define   PORT_CABLE_STAT_FAILED      (0x6000)     /* Cable diagnostic test fail */
-#define   PORT_CABLE_STAT_SHORT       (0x4000)     /* Short condition detected in the cable */
-#define   PORT_CABLE_STAT_OPEN        (0x2000)     /* Open condition detected in the cable */
-#define   PORT_CABLE_STAT_NORMAL      (0x0000)     /* Normal condition */
-#define   PORT_CABLE_DIAG_RESULT      (0x6000)     /* Cable diagnostic test result mask */
-#define   PORT_START_CABLE_DIAG       (0x1000)     /* Enable cable diagnostic test */
-#define   PORT_FORCE_LINK             (0x0800)     /* Enable force link pass */
-#define   PORT_POWER_SAVING           (0x0400)     /* Disable power saving */
-#define   PORT_REMOTE_LOOPBACK        (0x0200)     /* Enable remote loopback at PHY */
-#define   PORT_CABLE_FAULT_COUNTER    (0x01FF)     /* Cable length distance to the fault */
+#define REG_PORT_LINK_MD                 ( 0xF4 )   /* P1SCLMD */
+#define   PORT_CABLE_10M_SHORT           ( 0x8000 ) /* Cable length is less than 10m short */
+#define   PORT_CABLE_STAT_FAILED         ( 0x6000 ) /* Cable diagnostic test fail */
+#define   PORT_CABLE_STAT_SHORT          ( 0x4000 ) /* Short condition detected in the cable */
+#define   PORT_CABLE_STAT_OPEN           ( 0x2000 ) /* Open condition detected in the cable */
+#define   PORT_CABLE_STAT_NORMAL         ( 0x0000 ) /* Normal condition */
+#define   PORT_CABLE_DIAG_RESULT         ( 0x6000 ) /* Cable diagnostic test result mask */
+#define   PORT_START_CABLE_DIAG          ( 0x1000 ) /* Enable cable diagnostic test */
+#define   PORT_FORCE_LINK                ( 0x0800 ) /* Enable force link pass */
+#define   PORT_POWER_SAVING              ( 0x0400 ) /* Disable power saving */
+#define   PORT_REMOTE_LOOPBACK           ( 0x0200 ) /* Enable remote loopback at PHY */
+#define   PORT_CABLE_FAULT_COUNTER       ( 0x01FF ) /* Cable length distance to the fault */
 
-#define REG_PORT_CTRL              (0xF6)       /* P1CR */
-#define   PORT_LED_OFF                (0x8000)     /* Turn off all the port LEDs (LED3/LED2/LED1/LED0) */
-#define   PORT_TX_DISABLE             (0x4000)     /* Disable port transmit */
-#define   PORT_AUTO_NEG_RESTART       (0x2000)     /* Restart auto-negotiation */
-#define   PORT_POWER_DOWN             (0x0800)     /* Set port power-down */
-#define   PORT_AUTO_MDIX_DISABLE      (0x0400)     /* Disable auto MDI-X */
-#define   PORT_FORCE_MDIX             (0x0200)     /* Force MDI-X */
-#define   PORT_AUTO_NEG_ENABLE        (0x0080)     /* Enable auto-negotiation */
-#define   PORT_FORCE_100_MBIT         (0x0040)     /* Force PHY 100Mbps */
-#define   PORT_FORCE_FULL_DUPLEX      (0x0020)     /* Force PHY in full duplex mode */
-#define   PORT_AUTO_NEG_SYM_PAUSE     (0x0010)     /* Advertise pause capability */
-#define   PORT_AUTO_NEG_100BTX_FD     (0x0008)     /* Advertise 100 full-duplex capability */
-#define   PORT_AUTO_NEG_100BTX        (0x0004)     /* Advertise 100 half-duplex capability */
-#define   PORT_AUTO_NEG_10BT_FD       (0x0002)     /* Advertise 10 full-duplex capability */
-#define   PORT_AUTO_NEG_10BT          (0x0001)     /* Advertise 10 half-duplex capability */
+#define REG_PORT_CTRL                    ( 0xF6 )   /* P1CR */
+#define   PORT_LED_OFF                   ( 0x8000 ) /* Turn off all the port LEDs (LED3/LED2/LED1/LED0) */
+#define   PORT_TX_DISABLE                ( 0x4000 ) /* Disable port transmit */
+#define   PORT_AUTO_NEG_RESTART          ( 0x2000 ) /* Restart auto-negotiation */
+#define   PORT_POWER_DOWN                ( 0x0800 ) /* Set port power-down */
+#define   PORT_AUTO_MDIX_DISABLE         ( 0x0400 ) /* Disable auto MDI-X */
+#define   PORT_FORCE_MDIX                ( 0x0200 ) /* Force MDI-X */
+#define   PORT_AUTO_NEG_ENABLE           ( 0x0080 ) /* Enable auto-negotiation */
+#define   PORT_FORCE_100_MBIT            ( 0x0040 ) /* Force PHY 100Mbps */
+#define   PORT_FORCE_FULL_DUPLEX         ( 0x0020 ) /* Force PHY in full duplex mode */
+#define   PORT_AUTO_NEG_SYM_PAUSE        ( 0x0010 ) /* Advertise pause capability */
+#define   PORT_AUTO_NEG_100BTX_FD        ( 0x0008 ) /* Advertise 100 full-duplex capability */
+#define   PORT_AUTO_NEG_100BTX           ( 0x0004 ) /* Advertise 100 half-duplex capability */
+#define   PORT_AUTO_NEG_10BT_FD          ( 0x0002 ) /* Advertise 10 full-duplex capability */
+#define   PORT_AUTO_NEG_10BT             ( 0x0001 ) /* Advertise 10 half-duplex capability */
 
-#define REG_PORT_STATUS            (0xF8)       /* P1SR */
-#define   PORT_HP_MDIX                (0x8000)     /* Set PHY in HP auto MDI-X mode */
-#define   PORT_REVERSED_POLARITY      (0x2000)     /* Polarity is reversed */
-#define   PORT_RX_FLOW_CTRL           (0x1000)     /* Reeive flow control feature is active */
-#define   PORT_TX_FLOW_CTRL           (0x0800)     /* Transmit flow control feature is active */
-#define   PORT_STAT_SPEED_100MBIT     (0x0400)     /* Link is 100Mbps */
-#define   PORT_STAT_FULL_DUPLEX       (0x0200)     /* Link is full duplex mode */
-#define   PORT_MDIX_STATUS            (0x0080)     /* Is MDI */
-#define   PORT_AUTO_NEG_COMPLETE      (0x0040)     /* Auto-negotiation complete */
-#define   PORT_STATUS_LINK_GOOD       (0x0020)     /* PHY link is up */
-#define   PORT_REMOTE_SYM_PAUSE       (0x0010)     /* Link partner pause capability */
-#define   PORT_REMOTE_100BTX_FD       (0x0008)     /* Link partner 100 full-duplex capability */
-#define   PORT_REMOTE_100BTX          (0x0004)     /* Link partner 100 half-duplex capability */
-#define   PORT_REMOTE_10BT_FD         (0x0002)     /* Link partner 10 full-duplex capability */
-#define   PORT_REMOTE_10BT            (0x0001)     /* Link partner 10 half-duplex capability */
+#define REG_PORT_STATUS                  ( 0xF8 )   /* P1SR */
+#define   PORT_HP_MDIX                   ( 0x8000 ) /* Set PHY in HP auto MDI-X mode */
+#define   PORT_REVERSED_POLARITY         ( 0x2000 ) /* Polarity is reversed */
+#define   PORT_RX_FLOW_CTRL              ( 0x1000 ) /* Reeive flow control feature is active */
+#define   PORT_TX_FLOW_CTRL              ( 0x0800 ) /* Transmit flow control feature is active */
+#define   PORT_STAT_SPEED_100MBIT        ( 0x0400 ) /* Link is 100Mbps */
+#define   PORT_STAT_FULL_DUPLEX          ( 0x0200 ) /* Link is full duplex mode */
+#define   PORT_MDIX_STATUS               ( 0x0080 ) /* Is MDI */
+#define   PORT_AUTO_NEG_COMPLETE         ( 0x0040 ) /* Auto-negotiation complete */
+#define   PORT_STATUS_LINK_GOOD          ( 0x0020 ) /* PHY link is up */
+#define   PORT_REMOTE_SYM_PAUSE          ( 0x0010 ) /* Link partner pause capability */
+#define   PORT_REMOTE_100BTX_FD          ( 0x0008 ) /* Link partner 100 full-duplex capability */
+#define   PORT_REMOTE_100BTX             ( 0x0004 ) /* Link partner 100 half-duplex capability */
+#define   PORT_REMOTE_10BT_FD            ( 0x0002 ) /* Link partner 10 full-duplex capability */
+#define   PORT_REMOTE_10BT               ( 0x0001 ) /* Link partner 10 half-duplex capability */
 
 #endif /* KSZ8851SNL_REG_H_INCLUDED */

--- a/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/portable/NetworkInterface/linux/NetworkInterface.c
+++ b/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/portable/NetworkInterface/linux/NetworkInterface.c
@@ -1,27 +1,27 @@
 /*
-FreeRTOS+TCP V2.0.11
-Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of
-this software and associated documentation files (the "Software"), to deal in
-the Software without restriction, including without limitation the rights to
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
-the Software, and to permit persons to whom the Software is furnished to do so,
-subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
-COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
-IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
- http://aws.amazon.com/freertos
- http://www.FreeRTOS.org
-*/
+ * FreeRTOS+TCP V2.0.11
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
 
 /* ========================= FreeRTOS includes ============================== */
 #include "FreeRTOS.h"
@@ -53,42 +53,42 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 /* ======================== Macro Definitions =============================== */
 #if ( ipconfigETHERNET_DRIVER_FILTERS_FRAME_TYPES == 0 )
-	#define ipCONSIDER_FRAME_FOR_PROCESSING( pucEthernetBuffer )    eProcessBuffer
+    #define ipCONSIDER_FRAME_FOR_PROCESSING( pucEthernetBuffer )    eProcessBuffer
 #else
-	#define ipCONSIDER_FRAME_FOR_PROCESSING( pucEthernetBuffer ) \
-	eConsiderFrameForProcessing( ( pucEthernetBuffer ) )
+    #define ipCONSIDER_FRAME_FOR_PROCESSING( pucEthernetBuffer ) \
+    eConsiderFrameForProcessing( ( pucEthernetBuffer ) )
 #endif
 
 /* ============================== Definitions =============================== */
-#define xSEND_BUFFER_SIZE	 32768
-#define xRECV_BUFFER_SIZE	 32768
-#define MAX_CAPTURE_LEN		 65535
-#define IP_SIZE				 100
+#define xSEND_BUFFER_SIZE    32768
+#define xRECV_BUFFER_SIZE    32768
+#define MAX_CAPTURE_LEN      65535
+#define IP_SIZE              100
 
 /* ================== Static Function Prototypes ============================ */
 static int prvConfigureCaptureBehaviour( void );
 static int prvCreateThreadSafeBuffers( void );
-static void * prvLinuxPcapSendThread( void *pvParam );
-static void * prvLinuxPcapRecvThread( void *pvParam );
-static void prvInterruptSimulatorTask( void *pvParameters );
-static void prvPrintAvailableNetworkInterfaces( pcap_if_t *  pxAllNetworkInterfaces );
+static void * prvLinuxPcapSendThread( void * pvParam );
+static void * prvLinuxPcapRecvThread( void * pvParam );
+static void prvInterruptSimulatorTask( void * pvParameters );
+static void prvPrintAvailableNetworkInterfaces( pcap_if_t * pxAllNetworkInterfaces );
 static pcap_if_t * prvGetAvailableNetworkInterfaces( void );
-static const char * prvRemoveSpaces( char *pcBuffer,
-									 int aBuflen,
-									 const char *pcMessage );
-static int prvOpenSelectedNetworkInterface( pcap_if_t *pxAllNetworkInterfaces );
+static const char * prvRemoveSpaces( char * pcBuffer,
+                                     int aBuflen,
+                                     const char * pcMessage );
+static int prvOpenSelectedNetworkInterface( pcap_if_t * pxAllNetworkInterfaces );
 static int prvCreateWorkerThreads( void );
 static int prvSetDeviceModes( void );
 static void print_hex( unsigned const char * const bin_data,
-					   size_t len );
+                       size_t len );
 
 /* ======================== Static Global Variables ========================= */
-static StreamBuffer_t *xSendBuffer = NULL;
-static StreamBuffer_t *xRecvBuffer = NULL;
+static StreamBuffer_t * xSendBuffer = NULL;
+static StreamBuffer_t * xRecvBuffer = NULL;
 extern uint8_t ucMACAddress[ 6 ];
 static char errbuf[ PCAP_ERRBUF_SIZE ];
-static pcap_t *pxOpenedInterfaceHandle = NULL;
-static struct event *pvSendEvent = NULL;
+static pcap_t * pxOpenedInterfaceHandle = NULL;
+static struct event * pvSendEvent = NULL;
 static uint32_t ulPCAPSendFailures = 0;
 static BaseType_t xConfigNetworkInterfaceToUse = configNETWORK_INTERFACE_TO_USE;
 static BaseType_t xInvalidInterfaceDetected = pdFALSE;
@@ -102,38 +102,38 @@ static BaseType_t xInvalidInterfaceDetected = pdFALSE;
  */
 BaseType_t xNetworkInterfaceInitialise( void )
 {
-BaseType_t ret = pdFAIL;
-pcap_if_t *pxAllNetworkInterfaces;
+    BaseType_t ret = pdFAIL;
+    pcap_if_t * pxAllNetworkInterfaces;
 
-	/* Query the computer the simulation is being executed on to find the
-	network interfaces it has installed. */
-	pxAllNetworkInterfaces = prvGetAvailableNetworkInterfaces();
+    /* Query the computer the simulation is being executed on to find the
+     * network interfaces it has installed. */
+    pxAllNetworkInterfaces = prvGetAvailableNetworkInterfaces();
 
-	if( pxAllNetworkInterfaces != NULL )
-	{
-		prvPrintAvailableNetworkInterfaces( pxAllNetworkInterfaces );
-		ret = prvOpenSelectedNetworkInterface( pxAllNetworkInterfaces );
+    if( pxAllNetworkInterfaces != NULL )
+    {
+        prvPrintAvailableNetworkInterfaces( pxAllNetworkInterfaces );
+        ret = prvOpenSelectedNetworkInterface( pxAllNetworkInterfaces );
 
-		if( ret == pdPASS )
-		{
-			ret = prvCreateThreadSafeBuffers();
+        if( ret == pdPASS )
+        {
+            ret = prvCreateThreadSafeBuffers();
 
-			if( ret == pdPASS )
-			{
-				ret = prvCreateWorkerThreads();
-			}
-		}
+            if( ret == pdPASS )
+            {
+                ret = prvCreateWorkerThreads();
+            }
+        }
 
-		/* The device list is no longer required. */
-		pcap_freealldevs( pxAllNetworkInterfaces );
-	}
+        /* The device list is no longer required. */
+        pcap_freealldevs( pxAllNetworkInterfaces );
+    }
 
-	if( ( pxOpenedInterfaceHandle != NULL ) && ( ret == pdPASS ) )
-	{
-		ret = pdPASS;
-	}
+    if( ( pxOpenedInterfaceHandle != NULL ) && ( ret == pdPASS ) )
+    {
+        ret = pdPASS;
+    }
 
-	return ret;
+    return ret;
 }
 
 /*!
@@ -142,52 +142,52 @@ pcap_if_t *pxAllNetworkInterfaces;
  * @return pdTRUE if successful else pdFALSE
  */
 BaseType_t xNetworkInterfaceOutput( NetworkBufferDescriptor_t * const pxNetworkBuffer,
-									BaseType_t bReleaseAfterSend )
+                                    BaseType_t bReleaseAfterSend )
 {
-size_t xSpace;
+    size_t xSpace;
 
-	iptraceNETWORK_INTERFACE_TRANSMIT();
-	configASSERT( xIsCallingFromIPTask() == pdTRUE );
+    iptraceNETWORK_INTERFACE_TRANSMIT();
+    configASSERT( xIsCallingFromIPTask() == pdTRUE );
 
-	/* Both the length of the data being sent and the actual data being sent
-	are placed in the thread safe buffer used to pass data between the FreeRTOS
-	tasks and the pthread that sends data via the pcap library.  Drop
-	the packet if there is insufficient space in the buffer to hold both. */
-	xSpace = uxStreamBufferGetSpace( xSendBuffer );
+    /* Both the length of the data being sent and the actual data being sent
+     *  are placed in the thread safe buffer used to pass data between the FreeRTOS
+     *  tasks and the pthread that sends data via the pcap library.  Drop
+     *  the packet if there is insufficient space in the buffer to hold both. */
+    xSpace = uxStreamBufferGetSpace( xSendBuffer );
 
-	if( ( pxNetworkBuffer->xDataLength <=
-		  ( ipconfigNETWORK_MTU + ipSIZE_OF_ETH_HEADER ) ) &&
-		( xSpace >= ( pxNetworkBuffer->xDataLength +
-					  sizeof( pxNetworkBuffer->xDataLength ) ) ) )
-	{
-		/* First write in the length of the data, then write in the data
-		itself. */
-		uxStreamBufferAdd( xSendBuffer,
-						   0,
-						   ( const uint8_t * ) &( pxNetworkBuffer->xDataLength ),
-						   sizeof( pxNetworkBuffer->xDataLength ) );
-		uxStreamBufferAdd( xSendBuffer,
-						   0,
-						   ( const uint8_t * ) pxNetworkBuffer->pucEthernetBuffer,
-						   pxNetworkBuffer->xDataLength );
-	}
-	else
-	{
-		FreeRTOS_printf( ( "xNetworkInterfaceOutput: send buffers full to store %lu\n",
-						   pxNetworkBuffer->xDataLength ) );
-	}
+    if( ( pxNetworkBuffer->xDataLength <=
+          ( ipconfigNETWORK_MTU + ipSIZE_OF_ETH_HEADER ) ) &&
+        ( xSpace >= ( pxNetworkBuffer->xDataLength +
+                      sizeof( pxNetworkBuffer->xDataLength ) ) ) )
+    {
+        /* First write in the length of the data, then write in the data
+         * itself. */
+        uxStreamBufferAdd( xSendBuffer,
+                           0,
+                           ( const uint8_t * ) &( pxNetworkBuffer->xDataLength ),
+                           sizeof( pxNetworkBuffer->xDataLength ) );
+        uxStreamBufferAdd( xSendBuffer,
+                           0,
+                           ( const uint8_t * ) pxNetworkBuffer->pucEthernetBuffer,
+                           pxNetworkBuffer->xDataLength );
+    }
+    else
+    {
+        FreeRTOS_printf( ( "xNetworkInterfaceOutput: send buffers full to store %lu\n",
+                           pxNetworkBuffer->xDataLength ) );
+    }
 
-	/* Kick the Tx task in either case in case it doesn't know the buffer is
-	full. */
-	event_signal( pvSendEvent );
+    /* Kick the Tx task in either case in case it doesn't know the buffer is
+     * full. */
+    event_signal( pvSendEvent );
 
-	/* The buffer has been sent so can be released. */
-	if( bReleaseAfterSend != pdFALSE )
-	{
-		vReleaseNetworkBufferAndDescriptor( pxNetworkBuffer );
-	}
+    /* The buffer has been sent so can be released. */
+    if( bReleaseAfterSend != pdFALSE )
+    {
+        vReleaseNetworkBufferAndDescriptor( pxNetworkBuffer );
+    }
 
-	return pdPASS;
+    return pdPASS;
 }
 
 /* ====================== Static Function definitions ======================= */
@@ -198,111 +198,111 @@ size_t xSpace;
  */
 static int prvCreateThreadSafeBuffers( void )
 {
-int ret = pdFAIL;
+    int ret = pdFAIL;
 
-	/* The buffer used to pass data to be transmitted from a FreeRTOS task to
-	the linux thread that sends via the pcap library. */
-	do
-	{
-		if( xSendBuffer == NULL )
-		{
-			xSendBuffer = ( StreamBuffer_t * ) malloc( sizeof( *xSendBuffer ) - sizeof( xSendBuffer->ucArray ) + xSEND_BUFFER_SIZE + 1 );
+    /* The buffer used to pass data to be transmitted from a FreeRTOS task to
+     * the linux thread that sends via the pcap library. */
+    do
+    {
+        if( xSendBuffer == NULL )
+        {
+            xSendBuffer = ( StreamBuffer_t * ) malloc( sizeof( *xSendBuffer ) - sizeof( xSendBuffer->ucArray ) + xSEND_BUFFER_SIZE + 1 );
 
-			if( xSendBuffer == NULL )
-			{
-				break;
-			}
+            if( xSendBuffer == NULL )
+            {
+                break;
+            }
 
-			configASSERT( xSendBuffer );
-			memset( xSendBuffer, '\0', sizeof( *xSendBuffer ) - sizeof( xSendBuffer->ucArray ) );
-			xSendBuffer->LENGTH = xSEND_BUFFER_SIZE + 1;
-		}
+            configASSERT( xSendBuffer );
+            memset( xSendBuffer, '\0', sizeof( *xSendBuffer ) - sizeof( xSendBuffer->ucArray ) );
+            xSendBuffer->LENGTH = xSEND_BUFFER_SIZE + 1;
+        }
 
-		/* The buffer used to pass received data from the pthread that receives
-		via the pcap library to the FreeRTOS task. */
-		if( xRecvBuffer == NULL )
-		{
-			xRecvBuffer = ( StreamBuffer_t * ) malloc( sizeof( *xRecvBuffer ) - sizeof( xRecvBuffer->ucArray ) + xRECV_BUFFER_SIZE + 1 );
+        /* The buffer used to pass received data from the pthread that receives
+         * via the pcap library to the FreeRTOS task. */
+        if( xRecvBuffer == NULL )
+        {
+            xRecvBuffer = ( StreamBuffer_t * ) malloc( sizeof( *xRecvBuffer ) - sizeof( xRecvBuffer->ucArray ) + xRECV_BUFFER_SIZE + 1 );
 
-			if( xRecvBuffer == NULL )
-			{
-				break;
-			}
+            if( xRecvBuffer == NULL )
+            {
+                break;
+            }
 
-			configASSERT( xRecvBuffer );
-			memset( xRecvBuffer, '\0', sizeof( *xRecvBuffer ) - sizeof( xRecvBuffer->ucArray ) );
-			xRecvBuffer->LENGTH = xRECV_BUFFER_SIZE + 1;
-		}
+            configASSERT( xRecvBuffer );
+            memset( xRecvBuffer, '\0', sizeof( *xRecvBuffer ) - sizeof( xRecvBuffer->ucArray ) );
+            xRecvBuffer->LENGTH = xRECV_BUFFER_SIZE + 1;
+        }
 
-		ret = pdPASS;
-	} while( 0 );
+        ret = pdPASS;
+    } while( 0 );
 
-	return ret;
+    return ret;
 }
 
 /*!
  * @brief  print network interfaces available on the system
  * @param[in]   pxAllNetworkInterfaces interface structure list to print
  */
-static void prvPrintAvailableNetworkInterfaces( pcap_if_t *  pxAllNetworkInterfaces )
+static void prvPrintAvailableNetworkInterfaces( pcap_if_t * pxAllNetworkInterfaces )
 {
-pcap_if_t *xInterface;
-int32_t lInterfaceNumber = 1;
-char cBuffer[ 512 ];
+    pcap_if_t * xInterface;
+    int32_t lInterfaceNumber = 1;
+    char cBuffer[ 512 ];
 
-	if( pxAllNetworkInterfaces != NULL )
-	{
-		/* Print out the list of network interfaces.  The first in the list
-		is interface '1', not interface '0'. */
-		for( xInterface = pxAllNetworkInterfaces;
-			 xInterface != NULL; xInterface = xInterface->next )
-		{
-			/* The descriptions of the devices can be full of spaces, clean them
-			a little.  printf() can only be used here because the network is not
-			up yet - so no other network tasks will be running. */
-			printf( "Interface %d - %s\n",
-					lInterfaceNumber,
-					prvRemoveSpaces( cBuffer, sizeof( cBuffer ), xInterface->name ) );
-			printf( "              (%s)\n",
-					prvRemoveSpaces( cBuffer,
-									 sizeof( cBuffer ),
-									 xInterface->description ? xInterface->description :
-									 "No description" ) );
-			printf( "\n" );
-			lInterfaceNumber++;
-		}
-	}
+    if( pxAllNetworkInterfaces != NULL )
+    {
+        /* Print out the list of network interfaces.  The first in the list
+         * is interface '1', not interface '0'. */
+        for( xInterface = pxAllNetworkInterfaces;
+             xInterface != NULL; xInterface = xInterface->next )
+        {
+            /* The descriptions of the devices can be full of spaces, clean them
+             * a little.  printf() can only be used here because the network is not
+             * up yet - so no other network tasks will be running. */
+            printf( "Interface %d - %s\n",
+                    lInterfaceNumber,
+                    prvRemoveSpaces( cBuffer, sizeof( cBuffer ), xInterface->name ) );
+            printf( "              (%s)\n",
+                    prvRemoveSpaces( cBuffer,
+                                     sizeof( cBuffer ),
+                                     xInterface->description ? xInterface->description :
+                                     "No description" ) );
+            printf( "\n" );
+            lInterfaceNumber++;
+        }
+    }
 
-	if( lInterfaceNumber == 1 )
-	{
-		/* The interface number was never incremented, so the above for() loop
-		did not execute meaning no interfaces were found. */
-		printf( " \nNo network interfaces were found.\n" );
-		pxAllNetworkInterfaces = NULL;
-	}
+    if( lInterfaceNumber == 1 )
+    {
+        /* The interface number was never incremented, so the above for() loop
+         * did not execute meaning no interfaces were found. */
+        printf( " \nNo network interfaces were found.\n" );
+        pxAllNetworkInterfaces = NULL;
+    }
 
-	printf( "\r\nThe interface that will be opened is set by " );
-	printf( "\"configNETWORK_INTERFACE_TO_USE\", which\r\nshould be defined in FreeRTOSConfig.h\r\n" );
+    printf( "\r\nThe interface that will be opened is set by " );
+    printf( "\"configNETWORK_INTERFACE_TO_USE\", which\r\nshould be defined in FreeRTOSConfig.h\r\n" );
 
-	if( ( xConfigNetworkInterfaceToUse < 1L ) || ( xConfigNetworkInterfaceToUse >= lInterfaceNumber ) )
-	{
-		printf( "\r\nERROR:  configNETWORK_INTERFACE_TO_USE is set to %ld, which is an invalid value.\r\n", xConfigNetworkInterfaceToUse );
-		printf( "Please set configNETWORK_INTERFACE_TO_USE to one of the interface numbers listed above,\r\n" );
-		printf( "then re-compile and re-start the application.  Only Ethernet (as opposed to WiFi)\r\n" );
-		printf( "interfaces are supported.\r\n\r\nHALTING\r\n\r\n\r\n" );
-		xInvalidInterfaceDetected = pdTRUE;
+    if( ( xConfigNetworkInterfaceToUse < 1L ) || ( xConfigNetworkInterfaceToUse >= lInterfaceNumber ) )
+    {
+        printf( "\r\nERROR:  configNETWORK_INTERFACE_TO_USE is set to %ld, which is an invalid value.\r\n", xConfigNetworkInterfaceToUse );
+        printf( "Please set configNETWORK_INTERFACE_TO_USE to one of the interface numbers listed above,\r\n" );
+        printf( "then re-compile and re-start the application.  Only Ethernet (as opposed to WiFi)\r\n" );
+        printf( "interfaces are supported.\r\n\r\nHALTING\r\n\r\n\r\n" );
+        xInvalidInterfaceDetected = pdTRUE;
 
-		if( pxAllNetworkInterfaces != NULL )
-		{
-			/* Free the device list, as no devices are going to be opened. */
-			pcap_freealldevs( pxAllNetworkInterfaces );
-			pxAllNetworkInterfaces = NULL;
-		}
-	}
-	else
-	{
-		printf( "Attempting to open interface number %ld.\n", xConfigNetworkInterfaceToUse );
-	}
+        if( pxAllNetworkInterfaces != NULL )
+        {
+            /* Free the device list, as no devices are going to be opened. */
+            pcap_freealldevs( pxAllNetworkInterfaces );
+            pxAllNetworkInterfaces = NULL;
+        }
+    }
+    else
+    {
+        printf( "Attempting to open interface number %ld.\n", xConfigNetworkInterfaceToUse );
+    }
 }
 
 /*!
@@ -311,26 +311,26 @@ char cBuffer[ 512 ];
  */
 static pcap_if_t * prvGetAvailableNetworkInterfaces( void )
 {
-pcap_if_t * pxAllNetworkInterfaces = NULL;
+    pcap_if_t * pxAllNetworkInterfaces = NULL;
 
-	if( xInvalidInterfaceDetected == pdFALSE )
-	{
-	int ret;
-		ret = pcap_findalldevs( &pxAllNetworkInterfaces, errbuf );
+    if( xInvalidInterfaceDetected == pdFALSE )
+    {
+        int ret;
+        ret = pcap_findalldevs( &pxAllNetworkInterfaces, errbuf );
 
-		if( ret == PCAP_ERROR )
-		{
-			FreeRTOS_printf( ( "Could not obtain a list of network interfaces\n%s\n",
-							   errbuf ) );
-			pxAllNetworkInterfaces = NULL;
-		}
-		else
-		{
-			printf( "\r\n\r\nThe following network interfaces are available:\r\n\r\n" );
-		}
-	}
+        if( ret == PCAP_ERROR )
+        {
+            FreeRTOS_printf( ( "Could not obtain a list of network interfaces\n%s\n",
+                               errbuf ) );
+            pxAllNetworkInterfaces = NULL;
+        }
+        else
+        {
+            printf( "\r\n\r\nThe following network interfaces are available:\r\n\r\n" );
+        }
+    }
 
-	return pxAllNetworkInterfaces;
+    return pxAllNetworkInterfaces;
 }
 
 /*!
@@ -339,58 +339,58 @@ pcap_if_t * pxAllNetworkInterfaces = NULL;
  */
 static int prvSetDeviceModes()
 {
-int ret = pdFAIL;
+    int ret = pdFAIL;
 
-	/*
-	  Open in promiscuous mode as the MAC and
-	  IP address is going to be "simulated", and
-	  not be the real MAC and IP address.  This allows
-	  traffic to the simulated IP address to be routed
-	  to uIP, and traffic to the real IP address to be
-	  routed to the Linux TCP/IP stack.
-	*/
-	FreeRTOS_debug_printf( ( "setting device modes of operation...\n" ) );
+    /*
+     * Open in promiscuous mode as the MAC and
+     * IP address is going to be "simulated", and
+     * not be the real MAC and IP address.  This allows
+     * traffic to the simulated IP address to be routed
+     * to uIP, and traffic to the real IP address to be
+     * routed to the Linux TCP/IP stack.
+     */
+    FreeRTOS_debug_printf( ( "setting device modes of operation...\n" ) );
 
-	do
-	{
-		ret = pcap_set_promisc( pxOpenedInterfaceHandle, 1 );
+    do
+    {
+        ret = pcap_set_promisc( pxOpenedInterfaceHandle, 1 );
 
-		if( ( ret != 0 ) && ( ret != PCAP_ERROR_ACTIVATED ) )
-		{
-			FreeRTOS_printf( ( "coult not activate promisuous mode\n" ) );
-			break;
-		}
+        if( ( ret != 0 ) && ( ret != PCAP_ERROR_ACTIVATED ) )
+        {
+            FreeRTOS_printf( ( "coult not activate promisuous mode\n" ) );
+            break;
+        }
 
-		ret = pcap_set_snaplen( pxOpenedInterfaceHandle,
-								ipTOTAL_ETHERNET_FRAME_SIZE );
+        ret = pcap_set_snaplen( pxOpenedInterfaceHandle,
+                                ipTOTAL_ETHERNET_FRAME_SIZE );
 
-		if( ( ret != 0 ) && ( ret != PCAP_ERROR_ACTIVATED ) )
-		{
-			FreeRTOS_printf( ( "coult not set snaplen\n" ) );
-			break;
-		}
+        if( ( ret != 0 ) && ( ret != PCAP_ERROR_ACTIVATED ) )
+        {
+            FreeRTOS_printf( ( "coult not set snaplen\n" ) );
+            break;
+        }
 
-		ret = pcap_set_timeout( pxOpenedInterfaceHandle, 200 );
+        ret = pcap_set_timeout( pxOpenedInterfaceHandle, 200 );
 
-		if( ( ret != 0 ) && ( ret != PCAP_ERROR_ACTIVATED ) )
-		{
-			FreeRTOS_printf( ( "coult not set timeout\n" ) );
-			break;
-		}
+        if( ( ret != 0 ) && ( ret != PCAP_ERROR_ACTIVATED ) )
+        {
+            FreeRTOS_printf( ( "coult not set timeout\n" ) );
+            break;
+        }
 
-		ret = pcap_set_buffer_size( pxOpenedInterfaceHandle,
-									ipTOTAL_ETHERNET_FRAME_SIZE * 1100 );
+        ret = pcap_set_buffer_size( pxOpenedInterfaceHandle,
+                                    ipTOTAL_ETHERNET_FRAME_SIZE * 1100 );
 
-		if( ( ret != 0 ) && ( ret != PCAP_ERROR_ACTIVATED ) )
-		{
-			FreeRTOS_printf( ( "coult not set buffer size\n" ) );
-			break;
-		}
+        if( ( ret != 0 ) && ( ret != PCAP_ERROR_ACTIVATED ) )
+        {
+            FreeRTOS_printf( ( "coult not set buffer size\n" ) );
+            break;
+        }
 
-		ret = pdPASS;
-	} while( 0 );
+        ret = pdPASS;
+    } while( 0 );
 
-	return ret;
+    return ret;
 }
 
 /*!
@@ -398,52 +398,52 @@ int ret = pdFAIL;
  * @param [in] pucName interface  name to pen
  * @returns pdPASS on success pdFAIL on failure
  */
-static int prvOpenInterface( const char *pucName )
+static int prvOpenInterface( const char * pucName )
 {
-static char pucInterfaceName[ 256 ];
-int ret = pdFAIL;
+    static char pucInterfaceName[ 256 ];
+    int ret = pdFAIL;
 
-	if( pucName != NULL )
-	{
-		( void ) strncpy( pucInterfaceName, pucName, sizeof( pucInterfaceName ) );
-		pucInterfaceName[ sizeof( pucInterfaceName ) - ( size_t ) 1 ] = '\0';
+    if( pucName != NULL )
+    {
+        ( void ) strncpy( pucInterfaceName, pucName, sizeof( pucInterfaceName ) );
+        pucInterfaceName[ sizeof( pucInterfaceName ) - ( size_t ) 1 ] = '\0';
 
-		FreeRTOS_debug_printf( ( "opening interface %s\n", pucInterfaceName ) );
+        FreeRTOS_debug_printf( ( "opening interface %s\n", pucInterfaceName ) );
 
-		pxOpenedInterfaceHandle = pcap_create( pucInterfaceName, errbuf );
+        pxOpenedInterfaceHandle = pcap_create( pucInterfaceName, errbuf );
 
-		if( pxOpenedInterfaceHandle != NULL )
-		{
-			ret = prvSetDeviceModes();
+        if( pxOpenedInterfaceHandle != NULL )
+        {
+            ret = prvSetDeviceModes();
 
-			if( ret == pdPASS )
-			{
-				if( pcap_activate( pxOpenedInterfaceHandle ) == 0 )
-				{
-					/* Configure the capture filter to allow blocking reads, and to filter
-					out packets that are not of interest to this demo. */
-					ret = prvConfigureCaptureBehaviour();
-				}
-				else
-				{
-					FreeRTOS_debug_printf( ( "pcap activate error %s\n",
-											 pcap_geterr( pxOpenedInterfaceHandle ) ) );
-					ret = pdFAIL;
-				}
-			}
-		}
-		else
-		{
-			FreeRTOS_printf( ( "\n%s is not supported by pcap and cannot be opened %s\n",
-							   pucInterfaceName, errbuf ) );
-		}
-	}
-	else
-	{
-		FreeRTOS_printf( ( "could not open interface: name is null\n" ) );
-	}
+            if( ret == pdPASS )
+            {
+                if( pcap_activate( pxOpenedInterfaceHandle ) == 0 )
+                {
+                    /* Configure the capture filter to allow blocking reads, and to filter
+                     * out packets that are not of interest to this demo. */
+                    ret = prvConfigureCaptureBehaviour();
+                }
+                else
+                {
+                    FreeRTOS_debug_printf( ( "pcap activate error %s\n",
+                                             pcap_geterr( pxOpenedInterfaceHandle ) ) );
+                    ret = pdFAIL;
+                }
+            }
+        }
+        else
+        {
+            FreeRTOS_printf( ( "\n%s is not supported by pcap and cannot be opened %s\n",
+                               pucInterfaceName, errbuf ) );
+        }
+    }
+    else
+    {
+        FreeRTOS_printf( ( "could not open interface: name is null\n" ) );
+    }
 
-	return ret;
+    return ret;
 }
 
 /*!
@@ -455,32 +455,32 @@ int ret = pdFAIL;
  * @param [in] pxAllNetworkInterfaces network interface list to choose from
  * @returns pdPASS on success or pdFAIL when something goes wrong
  */
-static int prvOpenSelectedNetworkInterface( pcap_if_t *pxAllNetworkInterfaces )
+static int prvOpenSelectedNetworkInterface( pcap_if_t * pxAllNetworkInterfaces )
 {
-pcap_if_t *pxInterface;
-int32_t x;
-int ret = pdFAIL;
+    pcap_if_t * pxInterface;
+    int32_t x;
+    int ret = pdFAIL;
 
-	/* Walk the list of devices until the selected device is located. */
-	pxInterface = pxAllNetworkInterfaces;
+    /* Walk the list of devices until the selected device is located. */
+    pxInterface = pxAllNetworkInterfaces;
 
-	for( x = 0L; x < ( xConfigNetworkInterfaceToUse - 1L ); x++ )
-	{
-		pxInterface = pxInterface->next;
-	}
+    for( x = 0L; x < ( xConfigNetworkInterfaceToUse - 1L ); x++ )
+    {
+        pxInterface = pxInterface->next;
+    }
 
-	/* Open the selected interface. */
-	if( prvOpenInterface( pxInterface->name ) == pdPASS )
-	{
-		FreeRTOS_debug_printf( ( "Successfully opened interface number %d.\n", x + 1 ) );
-		ret = pdPASS;
-	}
-	else
-	{
-		FreeRTOS_printf( ( "Failed to open interface number %d.\n", x + 1 ) );
-	}
+    /* Open the selected interface. */
+    if( prvOpenInterface( pxInterface->name ) == pdPASS )
+    {
+        FreeRTOS_debug_printf( ( "Successfully opened interface number %d.\n", x + 1 ) );
+        ret = pdPASS;
+    }
+    else
+    {
+        FreeRTOS_printf( ( "Failed to open interface number %d.\n", x + 1 ) );
+    }
 
-	return ret;
+    return ret;
 }
 
 /*!
@@ -491,62 +491,62 @@ int ret = pdFAIL;
  */
 static int prvCreateWorkerThreads( void )
 {
-pthread_t vPcapRecvThreadHandle;
-pthread_t vPcapSendThreadHandle;
-int ret = pdPASS;
+    pthread_t vPcapRecvThreadHandle;
+    pthread_t vPcapSendThreadHandle;
+    int ret = pdPASS;
 
-	if( pvSendEvent == NULL )
-	{
-		FreeRTOS_debug_printf( ( "Creating Threads ..\n" ) );
-		ret = pdFAIL;
-		/* Create event used to signal the  pcap Tx thread. */
-		pvSendEvent = event_create();
+    if( pvSendEvent == NULL )
+    {
+        FreeRTOS_debug_printf( ( "Creating Threads ..\n" ) );
+        ret = pdFAIL;
+        /* Create event used to signal the  pcap Tx thread. */
+        pvSendEvent = event_create();
 
-		do
-		{
-			/* Create the thread that handles pcap  Rx. */
-			ret = pthread_create( &vPcapRecvThreadHandle,
-								  NULL,
-								  prvLinuxPcapRecvThread,
-								  NULL );
+        do
+        {
+            /* Create the thread that handles pcap  Rx. */
+            ret = pthread_create( &vPcapRecvThreadHandle,
+                                  NULL,
+                                  prvLinuxPcapRecvThread,
+                                  NULL );
 
-			if( ret != 0 )
-			{
-				FreeRTOS_printf( ( "pthread error %d", ret ) );
-				break;
-			}
+            if( ret != 0 )
+            {
+                FreeRTOS_printf( ( "pthread error %d", ret ) );
+                break;
+            }
 
-			/* Create the thread that handles pcap  Tx. */
-			ret = pthread_create( &vPcapSendThreadHandle,
-								  NULL,
-								  prvLinuxPcapSendThread,
-								  NULL );
+            /* Create the thread that handles pcap  Tx. */
+            ret = pthread_create( &vPcapSendThreadHandle,
+                                  NULL,
+                                  prvLinuxPcapSendThread,
+                                  NULL );
 
-			if( ret != 0 )
-			{
-				FreeRTOS_printf( ( "pthread error %d", ret ) );
-				break;
-			}
+            if( ret != 0 )
+            {
+                FreeRTOS_printf( ( "pthread error %d", ret ) );
+                break;
+            }
 
-			ret = pdPASS;
-		} while( 0 );
+            ret = pdPASS;
+        } while( 0 );
 
-		/* Create a task that simulates an interrupt in a real system.  This will
-		block waiting for packets, then send a message to the IP task when data
-		is available. */
-		if( xTaskCreate( prvInterruptSimulatorTask,
-						 "MAC_ISR",
-						 configMINIMAL_STACK_SIZE,
-						 NULL,
-						 configMAC_ISR_SIMULATOR_PRIORITY,
-						 NULL ) != pdPASS )
-		{
-			ret = pdFAIL;
-			FreeRTOS_printf( ( "xTaskCreate could not create a new task\n" ) );
-		}
-	}
+        /* Create a task that simulates an interrupt in a real system.  This will
+         * block waiting for packets, then send a message to the IP task when data
+         * is available. */
+        if( xTaskCreate( prvInterruptSimulatorTask,
+                         "MAC_ISR",
+                         configMINIMAL_STACK_SIZE,
+                         NULL,
+                         configMAC_ISR_SIMULATOR_PRIORITY,
+                         NULL ) != pdPASS )
+        {
+            ret = pdFAIL;
+            FreeRTOS_printf( ( "xTaskCreate could not create a new task\n" ) );
+        }
+    }
 
-	return ret;
+    return ret;
 }
 
 /*!
@@ -557,58 +557,58 @@ int ret = pdPASS;
  */
 static int prvConfigureCaptureBehaviour( void )
 {
-	struct bpf_program xFilterCode;
-	uint32_t ulNetMask;
-	char pcap_filter[ 500 ];
-	int ret = pdFAIL;
+    struct bpf_program xFilterCode;
+    uint32_t ulNetMask;
+    char pcap_filter[ 500 ];
+    int ret = pdFAIL;
 
-	FreeRTOS_debug_printf( ( "Configuring Capture behaviour\n" ) );
+    FreeRTOS_debug_printf( ( "Configuring Capture behaviour\n" ) );
 
-	/* Set up a filter so only the packets of interest are passed to the IP
-	stack.  errbuf is used for convenience to create the string.  Don't
-	confuse this with an error message. */
-	sprintf( pcap_filter, "broadcast or multicast or ether host %x:%x:%x:%x:%x:%x",
-			 ucMACAddress[ 0 ],
-			 ucMACAddress[ 1 ],
-			 ucMACAddress[ 2 ],
-			 ucMACAddress[ 3 ],
-			 ucMACAddress[ 4 ],
-			 ucMACAddress[ 5 ] );
-	FreeRTOS_debug_printf( ( "pcap filter to compile: %s\n", pcap_filter ) );
+    /* Set up a filter so only the packets of interest are passed to the IP
+     * stack.  errbuf is used for convenience to create the string.  Don't
+     * confuse this with an error message. */
+    sprintf( pcap_filter, "broadcast or multicast or ether host %x:%x:%x:%x:%x:%x",
+             ucMACAddress[ 0 ],
+             ucMACAddress[ 1 ],
+             ucMACAddress[ 2 ],
+             ucMACAddress[ 3 ],
+             ucMACAddress[ 4 ],
+             ucMACAddress[ 5 ] );
+    FreeRTOS_debug_printf( ( "pcap filter to compile: %s\n", pcap_filter ) );
 
-	ulNetMask = ( configNET_MASK3 << 24UL ) | ( configNET_MASK2 << 16UL ) | ( configNET_MASK1 << 8L ) | configNET_MASK0;
+    ulNetMask = ( configNET_MASK3 << 24UL ) | ( configNET_MASK2 << 16UL ) | ( configNET_MASK1 << 8L ) | configNET_MASK0;
 
-	ret = pcap_compile( pxOpenedInterfaceHandle,
-						&xFilterCode,
-						pcap_filter,
-						1,
-						ulNetMask );
+    ret = pcap_compile( pxOpenedInterfaceHandle,
+                        &xFilterCode,
+                        pcap_filter,
+                        1,
+                        ulNetMask );
 
-	if( ret < 0 )
-	{
-		( void ) printf( "\nThe packet filter string is invalid %s\n",
-						 pcap_geterr( pxOpenedInterfaceHandle ) );
-	}
-	else
-	{
-		ret = pcap_setfilter( pxOpenedInterfaceHandle, &xFilterCode );
+    if( ret < 0 )
+    {
+        ( void ) printf( "\nThe packet filter string is invalid %s\n",
+                         pcap_geterr( pxOpenedInterfaceHandle ) );
+    }
+    else
+    {
+        ret = pcap_setfilter( pxOpenedInterfaceHandle, &xFilterCode );
 
-		if( ret < 0 )
-		{
-			( void ) printf( "\nAn error occurred setting the packet filter. %s\n",
-							 pcap_geterr( pxOpenedInterfaceHandle ) );
-		}
-		else
-		{
-			ret = pdPASS;
-		}
+        if( ret < 0 )
+        {
+            ( void ) printf( "\nAn error occurred setting the packet filter. %s\n",
+                             pcap_geterr( pxOpenedInterfaceHandle ) );
+        }
+        else
+        {
+            ret = pdPASS;
+        }
 
-		/* When pcap_compile() succeeds, it allocates memory for the memory pointed to by the bpf_program struct
-		parameter.pcap_freecode() will free that memory. */
-		pcap_freecode( &xFilterCode );
-	}
+        /* When pcap_compile() succeeds, it allocates memory for the memory pointed to by the bpf_program struct
+         * parameter.pcap_freecode() will free that memory. */
+        pcap_freecode( &xFilterCode );
+    }
 
-	return ret;
+    return ret;
 }
 
 /*!
@@ -619,23 +619,23 @@ static int prvConfigureCaptureBehaviour( void )
  * @param [in] pkt_data received packet data
  * @warning this is called from a Linux thread, do not attempt any FreeRTOS calls
  */
-static void pcap_callback( unsigned char *user,
-						   const struct pcap_pkthdr *pkt_header,
-						   const u_char *pkt_data )
+static void pcap_callback( unsigned char * user,
+                           const struct pcap_pkthdr * pkt_header,
+                           const u_char * pkt_data )
 {
-	FreeRTOS_debug_printf( ( "Receiving < ===========  network callback user: %s len: %d caplen: %d\n",
-							 user,
-							 pkt_header->len,
-							 pkt_header->caplen ) );
-	print_hex( pkt_data, pkt_header->len );
+    FreeRTOS_debug_printf( ( "Receiving < ===========  network callback user: %s len: %d caplen: %d\n",
+                             user,
+                             pkt_header->len,
+                             pkt_header->caplen ) );
+    print_hex( pkt_data, pkt_header->len );
 
-	/* Pass data to the FreeRTOS simulator on a thread safe circular buffer. */
-	if( ( pkt_header->caplen <= ( ipconfigNETWORK_MTU + ipSIZE_OF_ETH_HEADER ) ) &&
-		( uxStreamBufferGetSpace( xRecvBuffer ) >= ( ( ( size_t ) pkt_header->caplen ) + sizeof( *pkt_header ) ) ) )
-	{
-		uxStreamBufferAdd( xRecvBuffer, 0, ( const uint8_t * ) pkt_header, sizeof( *pkt_header ) );
-		uxStreamBufferAdd( xRecvBuffer, 0, ( const uint8_t * ) pkt_data, ( size_t ) pkt_header->caplen );
-	}
+    /* Pass data to the FreeRTOS simulator on a thread safe circular buffer. */
+    if( ( pkt_header->caplen <= ( ipconfigNETWORK_MTU + ipSIZE_OF_ETH_HEADER ) ) &&
+        ( uxStreamBufferGetSpace( xRecvBuffer ) >= ( ( ( size_t ) pkt_header->caplen ) + sizeof( *pkt_header ) ) ) )
+    {
+        uxStreamBufferAdd( xRecvBuffer, 0, ( const uint8_t * ) pkt_header, sizeof( *pkt_header ) );
+        uxStreamBufferAdd( xRecvBuffer, 0, ( const uint8_t * ) pkt_data, ( size_t ) pkt_header->caplen );
+    }
 }
 
 /*!
@@ -646,33 +646,34 @@ static void pcap_callback( unsigned char *user,
  * @remarks This function disables signal, to prevent it from being put into
  *          sleep byt the posix port
  */
-static void * prvLinuxPcapRecvThread( void *pvParam )
+static void * prvLinuxPcapRecvThread( void * pvParam )
 {
-int ret;
+    int ret;
 
-	( void ) pvParam;
+    ( void ) pvParam;
 
-	/* Disable signals to this thread since this is a Linux pthread to be able to
-	 * printf and other blocking operations without being interruped and put in
-	 * suspension mode by the linux port signals
-	 */
-	sigset_t set;
-	sigfillset( &set );
-	pthread_sigmask( SIG_SETMASK, &set, NULL );
+    /* Disable signals to this thread since this is a Linux pthread to be able to
+     * printf and other blocking operations without being interruped and put in
+     * suspension mode by the linux port signals
+     */
+    sigset_t set;
 
-	for( ; ; )
-	{
-		ret = pcap_dispatch( pxOpenedInterfaceHandle, 1,
-							 pcap_callback, ( u_char * ) "mydata" );
+    sigfillset( &set );
+    pthread_sigmask( SIG_SETMASK, &set, NULL );
 
-		if( ret == -1 )
-		{
-			FreeRTOS_printf( ( "pcap_dispatch error received: %s\n",
-							   pcap_geterr( pxOpenedInterfaceHandle ) ) );
-		}
-	}
+    for( ; ; )
+    {
+        ret = pcap_dispatch( pxOpenedInterfaceHandle, 1,
+                             pcap_callback, ( u_char * ) "mydata" );
 
-	return NULL;
+        if( ret == -1 )
+        {
+            FreeRTOS_printf( ( "pcap_dispatch error received: %s\n",
+                               pcap_geterr( pxOpenedInterfaceHandle ) ) );
+        }
+    }
+
+    return NULL;
 }
 
 /*!
@@ -682,43 +683,44 @@ int ret;
  * @returns NULL
  * @warning this is called from a Linux thread, do not attempt any FreeRTOS calls
  */
-static void * prvLinuxPcapSendThread( void *pvParam )
+static void * prvLinuxPcapSendThread( void * pvParam )
 {
-size_t xLength;
-uint8_t ucBuffer[ ipconfigNETWORK_MTU + ipSIZE_OF_ETH_HEADER ];
-const time_t xMaxMSToWait = 1000;
+    size_t xLength;
+    uint8_t ucBuffer[ ipconfigNETWORK_MTU + ipSIZE_OF_ETH_HEADER ];
+    const time_t xMaxMSToWait = 1000;
 
-	( void ) pvParam;
+    ( void ) pvParam;
 
-	/* disable signals to avoid treating this thread as a FreeRTOS task and puting
-	 * it to sleep by the scheduler */
-	sigset_t set;
-	sigfillset( &set );
-	pthread_sigmask( SIG_SETMASK, &set, NULL );
+    /* disable signals to avoid treating this thread as a FreeRTOS task and puting
+     * it to sleep by the scheduler */
+    sigset_t set;
 
-	for( ; ; )
-	{
-		/* Wait until notified of something to send. */
-		event_wait_timed( pvSendEvent, xMaxMSToWait );
+    sigfillset( &set );
+    pthread_sigmask( SIG_SETMASK, &set, NULL );
 
-		/* Is there more than the length value stored in the circular buffer
-		used to pass data from the FreeRTOS simulator into this pthread?*/
-		while( uxStreamBufferGetSize( xSendBuffer ) > sizeof( xLength ) )
-		{
-			uxStreamBufferGet( xSendBuffer, 0, ( uint8_t * ) &xLength, sizeof( xLength ), pdFALSE );
-			uxStreamBufferGet( xSendBuffer, 0, ( uint8_t * ) ucBuffer, xLength, pdFALSE );
-			FreeRTOS_debug_printf( ( "Sending  ========== > data pcap_sendpadcket %lu\n", xLength ) );
-			print_hex( ucBuffer, xLength );
+    for( ; ; )
+    {
+        /* Wait until notified of something to send. */
+        event_wait_timed( pvSendEvent, xMaxMSToWait );
 
-			if( pcap_sendpacket( pxOpenedInterfaceHandle, ucBuffer, xLength ) != 0 )
-			{
-				FreeRTOS_printf( ( "pcap_sendpackeet: send failed %d\n", ulPCAPSendFailures ) );
-				ulPCAPSendFailures++;
-			}
-		}
-	}
+        /* Is there more than the length value stored in the circular buffer
+        * used to pass data from the FreeRTOS simulator into this pthread?*/
+        while( uxStreamBufferGetSize( xSendBuffer ) > sizeof( xLength ) )
+        {
+            uxStreamBufferGet( xSendBuffer, 0, ( uint8_t * ) &xLength, sizeof( xLength ), pdFALSE );
+            uxStreamBufferGet( xSendBuffer, 0, ( uint8_t * ) ucBuffer, xLength, pdFALSE );
+            FreeRTOS_debug_printf( ( "Sending  ========== > data pcap_sendpadcket %lu\n", xLength ) );
+            print_hex( ucBuffer, xLength );
 
-	return NULL;
+            if( pcap_sendpacket( pxOpenedInterfaceHandle, ucBuffer, xLength ) != 0 )
+            {
+                FreeRTOS_printf( ( "pcap_sendpackeet: send failed %d\n", ulPCAPSendFailures ) );
+                ulPCAPSendFailures++;
+            }
+        }
+    }
+
+    return NULL;
 }
 
 /*!
@@ -726,111 +728,111 @@ const time_t xMaxMSToWait = 1000;
  *         network stack of the presence of new data
  * @param [in] pvParameters not used
  */
-static void prvInterruptSimulatorTask( void *pvParameters )
+static void prvInterruptSimulatorTask( void * pvParameters )
 {
-	struct pcap_pkthdr xHeader;
-	static struct pcap_pkthdr *pxHeader;
-	const uint8_t *pucPacketData;
-	uint8_t ucRecvBuffer[ ipconfigNETWORK_MTU + ipSIZE_OF_ETH_HEADER ];
-	NetworkBufferDescriptor_t *pxNetworkBuffer;
-	IPStackEvent_t xRxEvent = { eNetworkRxEvent, NULL };
-	eFrameProcessingResult_t eResult;
+    struct pcap_pkthdr xHeader;
+    static struct pcap_pkthdr * pxHeader;
+    const uint8_t * pucPacketData;
+    uint8_t ucRecvBuffer[ ipconfigNETWORK_MTU + ipSIZE_OF_ETH_HEADER ];
+    NetworkBufferDescriptor_t * pxNetworkBuffer;
+    IPStackEvent_t xRxEvent = { eNetworkRxEvent, NULL };
+    eFrameProcessingResult_t eResult;
 
-	/* Remove compiler warnings about unused parameters. */
-	( void ) pvParameters;
+    /* Remove compiler warnings about unused parameters. */
+    ( void ) pvParameters;
 
-	for( ; ; )
-	{
-		/* Does the circular buffer used to pass data from the pthread thread that
-		handles pacap Rx into the FreeRTOS simulator contain another packet? */
-		if( uxStreamBufferGetSize( xRecvBuffer ) > sizeof( xHeader ) )
-		{
-			/* Get the next packet. */
-			uxStreamBufferGet( xRecvBuffer, 0, ( uint8_t * ) &xHeader, sizeof( xHeader ), pdFALSE );
-			uxStreamBufferGet( xRecvBuffer, 0, ( uint8_t * ) ucRecvBuffer, ( size_t ) xHeader.len, pdFALSE );
-			pucPacketData = ucRecvBuffer;
-			pxHeader = &xHeader;
+    for( ; ; )
+    {
+        /* Does the circular buffer used to pass data from the pthread thread that
+         * handles pacap Rx into the FreeRTOS simulator contain another packet? */
+        if( uxStreamBufferGetSize( xRecvBuffer ) > sizeof( xHeader ) )
+        {
+            /* Get the next packet. */
+            uxStreamBufferGet( xRecvBuffer, 0, ( uint8_t * ) &xHeader, sizeof( xHeader ), pdFALSE );
+            uxStreamBufferGet( xRecvBuffer, 0, ( uint8_t * ) ucRecvBuffer, ( size_t ) xHeader.len, pdFALSE );
+            pucPacketData = ucRecvBuffer;
+            pxHeader = &xHeader;
 
-			iptraceNETWORK_INTERFACE_RECEIVE();
+            iptraceNETWORK_INTERFACE_RECEIVE();
 
-			/* Check for minimal size. */
-			if( pxHeader->len >= sizeof( EthernetHeader_t ) )
-			{
-				eResult = ipCONSIDER_FRAME_FOR_PROCESSING( pucPacketData );
-			}
-			else
-			{
-				eResult = eReleaseBuffer;
-			}
+            /* Check for minimal size. */
+            if( pxHeader->len >= sizeof( EthernetHeader_t ) )
+            {
+                eResult = ipCONSIDER_FRAME_FOR_PROCESSING( pucPacketData );
+            }
+            else
+            {
+                eResult = eReleaseBuffer;
+            }
 
-			if( eResult == eProcessBuffer )
-			{
-				/* Will the data fit into the frame buffer? */
-				if( pxHeader->len <= ipTOTAL_ETHERNET_FRAME_SIZE )
-				{
-					/* Obtain a buffer into which the data can be placed.  This
-					is only	an interrupt simulator, not a real interrupt, so it
-					is ok to call the task level function here, but note that
-					some buffer implementations cannot be called from a real
-					interrupt. */
-					pxNetworkBuffer = pxGetNetworkBufferWithDescriptor( pxHeader->len, 0 );
+            if( eResult == eProcessBuffer )
+            {
+                /* Will the data fit into the frame buffer? */
+                if( pxHeader->len <= ipTOTAL_ETHERNET_FRAME_SIZE )
+                {
+                    /* Obtain a buffer into which the data can be placed.  This
+                     * is only	an interrupt simulator, not a real interrupt, so it
+                     * is ok to call the task level function here, but note that
+                     * some buffer implementations cannot be called from a real
+                     * interrupt. */
+                    pxNetworkBuffer = pxGetNetworkBufferWithDescriptor( pxHeader->len, 0 );
 
-					if( pxNetworkBuffer != NULL )
-					{
-						memcpy( pxNetworkBuffer->pucEthernetBuffer, pucPacketData, pxHeader->len );
-						pxNetworkBuffer->xDataLength = ( size_t ) pxHeader->len;
+                    if( pxNetworkBuffer != NULL )
+                    {
+                        memcpy( pxNetworkBuffer->pucEthernetBuffer, pucPacketData, pxHeader->len );
+                        pxNetworkBuffer->xDataLength = ( size_t ) pxHeader->len;
 
-						#if ( niDISRUPT_PACKETS == 1 )
-						{
-							pxNetworkBuffer = vRxFaultInjection( pxNetworkBuffer, pucPacketData );
-						}
-						#endif /* niDISRUPT_PACKETS */
+                        #if ( niDISRUPT_PACKETS == 1 )
+                            {
+                                pxNetworkBuffer = vRxFaultInjection( pxNetworkBuffer, pucPacketData );
+                            }
+                        #endif /* niDISRUPT_PACKETS */
 
-						if( pxNetworkBuffer != NULL )
-						{
-							xRxEvent.pvData = ( void * ) pxNetworkBuffer;
+                        if( pxNetworkBuffer != NULL )
+                        {
+                            xRxEvent.pvData = ( void * ) pxNetworkBuffer;
 
-							/* Data was received and stored.  Send a message to
-							the IP task to let it know. */
-							if( xSendEventStructToIPTask( &xRxEvent, ( TickType_t ) 0 ) == pdFAIL )
-							{
-								/* The buffer could not be sent to the stack so
-								must be released again.  This is only an
-								interrupt simulator, not a real interrupt, so it
-								is ok to use the task level function here, but
-								note no all buffer implementations will allow
-								this function to be executed from a real
-								interrupt. */
-								vReleaseNetworkBufferAndDescriptor( pxNetworkBuffer );
-								iptraceETHERNET_RX_EVENT_LOST();
-							}
-						}
-						else
-						{
-							/* The packet was already released or stored inside
-							vRxFaultInjection().  Don't release it here. */
-						}
-					}
-					else
-					{
-						iptraceETHERNET_RX_EVENT_LOST();
-					}
-				}
-				else
-				{
-					/* Log that a packet was dropped because it would have
-					overflowed the buffer, but there may be more buffers to
-					process. */
-				}
-			}
-		}
-		else
-		{
-			/* There is no real way of simulating an interrupt.  Make sure
-			other tasks can run. */
-			vTaskDelay( configWINDOWS_MAC_INTERRUPT_SIMULATOR_DELAY );
-		}
-	}
+                            /* Data was received and stored.  Send a message to
+                             * the IP task to let it know. */
+                            if( xSendEventStructToIPTask( &xRxEvent, ( TickType_t ) 0 ) == pdFAIL )
+                            {
+                                /* The buffer could not be sent to the stack so
+                                 * must be released again.  This is only an
+                                 * interrupt simulator, not a real interrupt, so it
+                                 * is ok to use the task level function here, but
+                                 * note no all buffer implementations will allow
+                                 * this function to be executed from a real
+                                 * interrupt. */
+                                vReleaseNetworkBufferAndDescriptor( pxNetworkBuffer );
+                                iptraceETHERNET_RX_EVENT_LOST();
+                            }
+                        }
+                        else
+                        {
+                            /* The packet was already released or stored inside
+                             * vRxFaultInjection().  Don't release it here. */
+                        }
+                    }
+                    else
+                    {
+                        iptraceETHERNET_RX_EVENT_LOST();
+                    }
+                }
+                else
+                {
+                    /* Log that a packet was dropped because it would have
+                     * overflowed the buffer, but there may be more buffers to
+                     * process. */
+                }
+            }
+        }
+        else
+        {
+            /* There is no real way of simulating an interrupt.  Make sure
+             * other tasks can run. */
+            vTaskDelay( configWINDOWS_MAC_INTERRUPT_SIMULATOR_DELAY );
+        }
+    }
 }
 
 /*!
@@ -840,33 +842,33 @@ static void prvInterruptSimulatorTask( void *pvParameters )
  * @param [in] pcMessage original message
  * @returns
  */
-static const char * prvRemoveSpaces( char *pcBuffer,
-									 int aBuflen,
-									 const char *pcMessage )
+static const char * prvRemoveSpaces( char * pcBuffer,
+                                     int aBuflen,
+                                     const char * pcMessage )
 {
-char *pcTarget = pcBuffer;
+    char * pcTarget = pcBuffer;
 
-	/* Utility function used to formap messages being printed only. */
-	while( ( *pcMessage != 0 ) && ( pcTarget < ( &pcBuffer[ aBuflen - 1 ] ) ) )
-	{
-		*( pcTarget++ ) = *pcMessage;
+    /* Utility function used to formap messages being printed only. */
+    while( ( *pcMessage != 0 ) && ( pcTarget < ( &pcBuffer[ aBuflen - 1 ] ) ) )
+    {
+        *( pcTarget++ ) = *pcMessage;
 
-		if( isspace( *pcMessage ) != pdFALSE )
-		{
-			while( isspace( *pcMessage ) != pdFALSE )
-			{
-				pcMessage++;
-			}
-		}
-		else
-		{
-			pcMessage++;
-		}
-	}
+        if( isspace( *pcMessage ) != pdFALSE )
+        {
+            while( isspace( *pcMessage ) != pdFALSE )
+            {
+                pcMessage++;
+            }
+        }
+        else
+        {
+            pcMessage++;
+        }
+    }
 
-	*pcTarget = '\0';
+    *pcTarget = '\0';
 
-	return pcBuffer;
+    return pcBuffer;
 }
 
 /*!
@@ -875,15 +877,15 @@ char *pcTarget = pcBuffer;
  * @param [in] len length of the data
  */
 static void print_hex( unsigned const char * const bin_data,
-					   size_t len )
+                       size_t len )
 /*static void print_hex(unsigned char *bin_data, size_t len) */
 {
-size_t i;
+    size_t i;
 
-	for( i = 0; i < len; ++i )
-	{
-		FreeRTOS_debug_printf( ( "%.2X ", bin_data[ i ] ) );
-	}
+    for( i = 0; i < len; ++i )
+    {
+        FreeRTOS_debug_printf( ( "%.2X ", bin_data[ i ] ) );
+    }
 
-	FreeRTOS_debug_printf( ( "\n" ) );
+    FreeRTOS_debug_printf( ( "\n" ) );
 }

--- a/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/portable/NetworkInterface/mw300_rd/NetworkInterface.c
+++ b/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/portable/NetworkInterface/mw300_rd/NetworkInterface.c
@@ -1,27 +1,27 @@
 /*
-FreeRTOS+TCP V2.2.1
-Copyright (C) 2018 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of
-this software and associated documentation files (the "Software"), to deal in
-the Software without restriction, including without limitation the rights to
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
-the Software, and to permit persons to whom the Software is furnished to do so,
-subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
-COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
-IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
- http://aws.amazon.com/freertos
- http://www.FreeRTOS.org
-*/
+ * FreeRTOS+TCP V2.2.1
+ * Copyright (C) 2018 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
 
 /* FreeRTOS includes. */
 #include "FreeRTOS.h"
@@ -43,107 +43,123 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #include <wmlog.h>
 
-#define net_e(...)                             \
-    wmlog_e("freertos_tcp", ##__VA_ARGS__)
-#define net_w(...)                             \
-    wmlog_w("freertos_tcp", ##__VA_ARGS__)
-#define net_d(...)                             \
-    wmlog("freertos_tcp", ##__VA_ARGS__)
+#define net_e( ... ) \
+    wmlog_e( "freertos_tcp", ## __VA_ARGS__ )
+#define net_w( ... ) \
+    wmlog_w( "freertos_tcp", ## __VA_ARGS__ )
+#define net_d( ... ) \
+    wmlog( "freertos_tcp", ## __VA_ARGS__ )
 
-#if 0 //this is lwip structure.
-#define MAX_INTERFACES_SUPPORTED 3
-static struct netif *netif_arr[MAX_INTERFACES_SUPPORTED];
+#if 0 /*this is lwip structure. */
+    #define MAX_INTERFACES_SUPPORTED    3
+    static struct netif * netif_arr[ MAX_INTERFACES_SUPPORTED ];
 #endif
 
 /* If ipconfigETHERNET_DRIVER_FILTERS_FRAME_TYPES is set to 1, then the Ethernet
-driver will filter incoming packets and only pass the stack those packets it
-considers need processing. */
-#if( ipconfigETHERNET_DRIVER_FILTERS_FRAME_TYPES == 0 )
-#define ipCONSIDER_FRAME_FOR_PROCESSING( pucEthernetBuffer ) eProcessBuffer
+ * driver will filter incoming packets and only pass the stack those packets it
+ * considers need processing. */
+#if ( ipconfigETHERNET_DRIVER_FILTERS_FRAME_TYPES == 0 )
+    #define ipCONSIDER_FRAME_FOR_PROCESSING( pucEthernetBuffer )    eProcessBuffer
 #else
-#define ipCONSIDER_FRAME_FOR_PROCESSING( pucEthernetBuffer ) eConsiderFrameForProcessing( ( pucEthernetBuffer ) )
+    #define ipCONSIDER_FRAME_FOR_PROCESSING( pucEthernetBuffer )    eConsiderFrameForProcessing( ( pucEthernetBuffer ) )
 #endif
 
-#define IP_ADDR_ANY         ((ip_addr_t *)&ip_addr_any)
-#define IP_ADDR_BROADCAST   ((ip_addr_t *)&ip_addr_broadcast)
+#define IP_ADDR_ANY          ( ( ip_addr_t * ) &ip_addr_any )
+#define IP_ADDR_BROADCAST    ( ( ip_addr_t * ) &ip_addr_broadcast )
 
 /** 255.255.255.255 */
-#define IPADDR_NONE         ((u32_t)0xffffffffUL)
+#define IPADDR_NONE          ( ( u32_t ) 0xffffffffUL )
 /** 127.0.0.1 */
-#define IPADDR_LOOPBACK     ((u32_t)0x7f000001UL)
+#define IPADDR_LOOPBACK      ( ( u32_t ) 0x7f000001UL )
 /** 0.0.0.0 */
-#define IPADDR_ANY          ((u32_t)0x00000000UL)
+#define IPADDR_ANY           ( ( u32_t ) 0x00000000UL )
 /** 255.255.255.255 */
-#define IPADDR_BROADCAST    ((u32_t)0xffffffffUL)
+#define IPADDR_BROADCAST     ( ( u32_t ) 0xffffffffUL )
 
 /** 255.255.255.255 */
-#define INADDR_NONE         IPADDR_NONE
+#define INADDR_NONE          IPADDR_NONE
 /** 127.0.0.1 */
-#define INADDR_LOOPBACK     IPADDR_LOOPBACK
+#define INADDR_LOOPBACK      IPADDR_LOOPBACK
 /** 0.0.0.0 */
-#define INADDR_ANY          IPADDR_ANY
+#define INADDR_ANY           IPADDR_ANY
 /** 255.255.255.255 */
-#define INADDR_BROADCAST    IPADDR_BROADCAST
+#define INADDR_BROADCAST     IPADDR_BROADCAST
 
-enum if_state_t {
+enum if_state_t
+{
     INTERFACE_DOWN = 0,
     INTERFACE_UP,
 };
-struct ip_addr {
-  u32_t addr;
+struct ip_addr
+{
+    u32_t addr;
 };
 
-#define MLAN_BSS_TYPE_STA 0
+#define MLAN_BSS_TYPE_STA    0
 
-extern uint8_t outbuf[2048];
-extern bool mlan_is_amsdu(const t_u8 *rcvdata);
-extern t_u8 *mlan_get_payload(const t_u8 *rcvdata, t_u16 *payload_len, int *interface);
-extern int wrapper_wlan_handle_amsdu_rx_packet(const t_u8 *rcvdata, const t_u16 datalen);
-extern int wrapper_wlan_handle_rx_packet(const t_u16 datalen, const t_u8 *rcvdata,  NetworkBufferDescriptor_t *pxNetworkBuffer);
-static volatile  uint32_t xInterfaceState = INTERFACE_DOWN;
+extern uint8_t outbuf[ 2048 ];
+extern bool mlan_is_amsdu( const t_u8 * rcvdata );
+extern t_u8 * mlan_get_payload( const t_u8 * rcvdata,
+                                t_u16 * payload_len,
+                                int * interface );
+extern int wrapper_wlan_handle_amsdu_rx_packet( const t_u8 * rcvdata,
+                                                const t_u16 datalen );
+extern int wrapper_wlan_handle_rx_packet( const t_u16 datalen,
+                                          const t_u8 * rcvdata,
+                                          NetworkBufferDescriptor_t * pxNetworkBuffer );
+static volatile uint32_t xInterfaceState = INTERFACE_DOWN;
 
-static int process_data_packet(const t_u8 *databuf, const t_u16 datalen)
+static int process_data_packet( const t_u8 * databuf,
+                                const t_u16 datalen )
 {
     int interface = BSS_TYPE_STA;
-    t_u8 *payload = NULL;
+    t_u8 * payload = NULL;
     t_u16 payload_len = 0;
     const TickType_t xDescriptorWaitTime = pdMS_TO_TICKS( 250 );
 
-    NetworkBufferDescriptor_t *pxNetworkBuffer;
+    NetworkBufferDescriptor_t * pxNetworkBuffer;
     IPStackEvent_t xRxEvent = { eNetworkRxEvent, NULL };
 
-    payload = (t_u8 *)mlan_get_payload(databuf, &payload_len, &interface);
+    payload = ( t_u8 * ) mlan_get_payload( databuf, &payload_len, &interface );
 
-    if( eConsiderFrameForProcessing( payload ) != eProcessBuffer ) {
-	net_d("Dropping packet\r\n");
-	return WM_SUCCESS;
+    if( eConsiderFrameForProcessing( payload ) != eProcessBuffer )
+    {
+        net_d( "Dropping packet\r\n" );
+        return WM_SUCCESS;
     }
 
-    pxNetworkBuffer = pxGetNetworkBufferWithDescriptor(/*payload_len*/datalen, xDescriptorWaitTime);
+    pxNetworkBuffer = pxGetNetworkBufferWithDescriptor( /*payload_len*/ datalen, xDescriptorWaitTime );
 
-    if (pxNetworkBuffer != NULL) {
-	/* Set the packet size, in case a larger buffer was returned. */
-	pxNetworkBuffer->xDataLength = payload_len;
+    if( pxNetworkBuffer != NULL )
+    {
+        /* Set the packet size, in case a larger buffer was returned. */
+        pxNetworkBuffer->xDataLength = payload_len;
 
-	/* Copy the packet data. */
-	memcpy(pxNetworkBuffer->pucEthernetBuffer, payload, payload_len);
+        /* Copy the packet data. */
+        memcpy( pxNetworkBuffer->pucEthernetBuffer, payload, payload_len );
 
-	xRxEvent.pvData = (void *) pxNetworkBuffer;
-	if ( xSendEventStructToIPTask( &xRxEvent, xDescriptorWaitTime) == pdFAIL ) {
-		wmprintf("Failed to enqueue packet to network stack %p, len %d", payload, payload_len);
-		vReleaseNetworkBufferAndDescriptor(pxNetworkBuffer);
-		return WM_FAIL;
-	}
+        xRxEvent.pvData = ( void * ) pxNetworkBuffer;
+
+        if( xSendEventStructToIPTask( &xRxEvent, xDescriptorWaitTime ) == pdFAIL )
+        {
+            wmprintf( "Failed to enqueue packet to network stack %p, len %d", payload, payload_len );
+            vReleaseNetworkBufferAndDescriptor( pxNetworkBuffer );
+            return WM_FAIL;
+        }
     }
+
     return WM_SUCCESS;
 }
 
 /* Callback function called from the wifi module */
-void handle_data_packet(const t_u8 interface, const t_u8 *rcvdata,
-                        const t_u16 datalen)
+void handle_data_packet( const t_u8 interface,
+                         const t_u8 * rcvdata,
+                         const t_u16 datalen )
 {
-    if (interface == BSS_TYPE_STA)
-	process_data_packet(rcvdata, datalen);
+    if( interface == BSS_TYPE_STA )
+    {
+        process_data_packet( rcvdata, datalen );
+    }
 }
 
 BaseType_t xNetworkInterfaceInitialise( void )
@@ -151,12 +167,14 @@ BaseType_t xNetworkInterfaceInitialise( void )
     uint8_t ret;
     mac_addr_t mac_addr;
 
-	ret = wifi_get_device_mac_addr(&mac_addr);
-	if (ret != WM_SUCCESS) {
-		net_d("Failed to get mac address");
-	}
+    ret = wifi_get_device_mac_addr( &mac_addr );
 
-	FreeRTOS_UpdateMACAddress(mac_addr.mac);
+    if( ret != WM_SUCCESS )
+    {
+        net_d( "Failed to get mac address" );
+    }
+
+    FreeRTOS_UpdateMACAddress( mac_addr.mac );
 
     return ( xInterfaceState == INTERFACE_UP && ret == WM_SUCCESS ) ? pdTRUE : pdFALSE;
 }
@@ -174,14 +192,18 @@ BaseType_t xGetPhyLinkStatus( void )
 void vNetworkNotifyIFDown()
 {
     IPStackEvent_t xRxEvent = { eNetworkDownEvent, NULL };
+
     xInterfaceState = INTERFACE_DOWN;
-    if( xSendEventStructToIPTask( &xRxEvent, 0 ) != pdPASS ) {
-	/* Could not send the message, so it is still pending. */
-        net_e("Could not send network down event");
+
+    if( xSendEventStructToIPTask( &xRxEvent, 0 ) != pdPASS )
+    {
+        /* Could not send the message, so it is still pending. */
+        net_e( "Could not send network down event" );
     }
-    else {
-	/* Message was sent so it is not pending. */
-        net_d("Sent network down event");
+    else
+    {
+        /* Message was sent so it is not pending. */
+        net_d( "Sent network down event" );
     }
 }
 
@@ -190,27 +212,33 @@ void vNetworkNotifyIFUp()
     xInterfaceState = INTERFACE_UP;
 }
 
-BaseType_t xNetworkInterfaceOutput( NetworkBufferDescriptor_t *const pxNetworkBuffer, BaseType_t xReleaseAfterSend )
+BaseType_t xNetworkInterfaceOutput( NetworkBufferDescriptor_t * const pxNetworkBuffer,
+                                    BaseType_t xReleaseAfterSend )
 {
     uint8_t pkt_len;
 
-    if (pxNetworkBuffer == NULL ||
-	pxNetworkBuffer->pucEthernetBuffer == NULL ||
-	pxNetworkBuffer->xDataLength == 0) {
-	    net_d("Incorrect params");
-            return pdFALSE;
-    }
-    memset(outbuf, 0x00, sizeof(outbuf));
-    pkt_len = 22 + 4; /* sizeof(TxPD) + INTF_HEADER_LEN */
-    memcpy((u8_t *) outbuf + pkt_len, (u8_t *) pxNetworkBuffer->pucEthernetBuffer,
-		pxNetworkBuffer->xDataLength);
-    int ret = wifi_low_level_output(BSS_TYPE_STA, outbuf + pkt_len, pxNetworkBuffer->xDataLength);
-    if (ret != WM_SUCCESS) {
-	net_e("Failed output %p, length %d, error %d \r\n", pxNetworkBuffer->pucEthernetBuffer, pxNetworkBuffer->xDataLength, ret);
+    if( ( pxNetworkBuffer == NULL ) ||
+        ( pxNetworkBuffer->pucEthernetBuffer == NULL ) ||
+        ( pxNetworkBuffer->xDataLength == 0 ) )
+    {
+        net_d( "Incorrect params" );
+        return pdFALSE;
     }
 
-    if (xReleaseAfterSend != pdFALSE) {
-        vReleaseNetworkBufferAndDescriptor(pxNetworkBuffer);
+    memset( outbuf, 0x00, sizeof( outbuf ) );
+    pkt_len = 22 + 4; /* sizeof(TxPD) + INTF_HEADER_LEN */
+    memcpy( ( u8_t * ) outbuf + pkt_len, ( u8_t * ) pxNetworkBuffer->pucEthernetBuffer,
+            pxNetworkBuffer->xDataLength );
+    int ret = wifi_low_level_output( BSS_TYPE_STA, outbuf + pkt_len, pxNetworkBuffer->xDataLength );
+
+    if( ret != WM_SUCCESS )
+    {
+        net_e( "Failed output %p, length %d, error %d \r\n", pxNetworkBuffer->pucEthernetBuffer, pxNetworkBuffer->xDataLength, ret );
+    }
+
+    if( xReleaseAfterSend != pdFALSE )
+    {
+        vReleaseNetworkBufferAndDescriptor( pxNetworkBuffer );
     }
 
     return ret == WM_SUCCESS ? pdTRUE : pdFALSE;

--- a/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/portable/NetworkInterface/pic32mzef/BufferAllocation_2.c
+++ b/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/portable/NetworkInterface/pic32mzef/BufferAllocation_2.c
@@ -133,8 +133,8 @@ static SemaphoreHandle_t xNetworkBufferSemaphore = NULL;
     /* */
 
     /* MAC packet acknowledgment, once MAC is done with it */
-        static bool PIC32_MacPacketAcknowledge( TCPIP_MAC_PACKET * pPkt,
-                                                const void * param );
+    static bool PIC32_MacPacketAcknowledge( TCPIP_MAC_PACKET * pPkt,
+                                            const void * param );
 
     /* allocates a MAC packet that holds a data buffer that can be used by both: */
     /*  - the FreeRTOSIP (NetworkBufferDescriptor_t->pucEthernetBuffer) */
@@ -221,6 +221,7 @@ static SemaphoreHandle_t xNetworkBufferSemaphore = NULL;
 
         /* make sure this is a properly allocated packet */
         TCPIP_MAC_PACKET ** ppkt = ( TCPIP_MAC_PACKET ** ) ( pPktBuff - PIC32_BUFFER_PKT_PTR_OSSET );
+
         configASSERT( ( ( uint32_t ) ppkt & ( sizeof( uint32_t ) - 1 ) ) == 0 );
 
         if( *ppkt != pRxPkt )
@@ -230,6 +231,7 @@ static SemaphoreHandle_t xNetworkBufferSemaphore = NULL;
 
         /* set the proper descriptor info */
         NetworkBufferDescriptor_t ** ppDcpt = ( NetworkBufferDescriptor_t ** ) ( pPktBuff - ipBUFFER_PADDING );
+
         configASSERT( ( ( uint32_t ) ppDcpt & ( sizeof( uint32_t ) - 1 ) ) == 0 );
         *ppDcpt = pxBufferDescriptor;
     }
@@ -382,9 +384,9 @@ uint8_t * pucGetNetworkBuffer( size_t * pxRequestedSizeBytes )
         /* Enough space is left at the start of the buffer to place a pointer to
          * the network buffer structure that references this Ethernet buffer.
          * Return a pointer to the start of the Ethernet buffer itself. */
-		#ifndef PIC32_USE_ETHERNET
-        	pucEthernetBuffer += ipBUFFER_PADDING;
-		#endif /* #ifndef PIC32_USE_ETHERNET */
+        #ifndef PIC32_USE_ETHERNET
+            pucEthernetBuffer += ipBUFFER_PADDING;
+        #endif /* #ifndef PIC32_USE_ETHERNET */
     }
 
     return pucEthernetBuffer;
@@ -421,19 +423,20 @@ NetworkBufferDescriptor_t * pxGetNetworkBufferWithDescriptor( size_t xRequestedS
         xRequestedSizeBytes = baMINIMAL_BUFFER_SIZE;
     }
 
-	#ifdef PIC32_USE_ETHERNET
-	if( xRequestedSizeBytes != 0u )
-    {
-	#endif /* #ifdef PIC32_USE_ETHERNET */
-    	xRequestedSizeBytes += 2u;
+    #ifdef PIC32_USE_ETHERNET
+        if( xRequestedSizeBytes != 0u )
+        {
+    #endif /* #ifdef PIC32_USE_ETHERNET */
+    xRequestedSizeBytes += 2u;
 
-    	if( ( xRequestedSizeBytes & ( sizeof( size_t ) - 1u ) ) != 0u )
-    	{
-        	xRequestedSizeBytes = ( xRequestedSizeBytes | ( sizeof( size_t ) - 1u ) ) + 1u;
-    	}
-	#ifdef PIC32_USE_ETHERNET
+    if( ( xRequestedSizeBytes & ( sizeof( size_t ) - 1u ) ) != 0u )
+    {
+        xRequestedSizeBytes = ( xRequestedSizeBytes | ( sizeof( size_t ) - 1u ) ) + 1u;
     }
-	#endif /* #ifdef PIC32_USE_ETHERNET */
+
+    #ifdef PIC32_USE_ETHERNET
+}
+    #endif /* #ifdef PIC32_USE_ETHERNET */
 
     /* If there is a semaphore available, there is a network buffer available. */
     if( xSemaphoreTake( xNetworkBufferSemaphore, xBlockTimeTicks ) == pdPASS )
@@ -550,7 +553,7 @@ void vReleaseNetworkBufferAndDescriptor( NetworkBufferDescriptor_t * const pxNet
      */
     if( xListItemAlreadyInFreeList == pdFALSE )
     {
-        if ( xSemaphoreGive( xNetworkBufferSemaphore ) == pdTRUE )
+        if( xSemaphoreGive( xNetworkBufferSemaphore ) == pdTRUE )
         {
             iptraceNETWORK_BUFFER_RELEASED( pxNetworkBuffer );
         }
@@ -587,9 +590,9 @@ NetworkBufferDescriptor_t * pxResizeNetworkBufferWithDescriptor( NetworkBufferDe
         xOriginalLength = pxNetworkBuffer->xDataLength;
     #else
         xOriginalLength = pxNetworkBuffer->xDataLength + ipBUFFER_PADDING;
-		xNewSizeBytes = xNewSizeBytes + ipBUFFER_PADDING;
+        xNewSizeBytes = xNewSizeBytes + ipBUFFER_PADDING;
     #endif /* #ifdef PIC32_USE_ETHERNET */
-	
+
     pucBuffer = pucGetNetworkBuffer( &( xNewSizeBytes ) );
 
     if( pucBuffer == NULL )
@@ -600,6 +603,7 @@ NetworkBufferDescriptor_t * pxResizeNetworkBufferWithDescriptor( NetworkBufferDe
     else
     {
         pxNetworkBuffer->xDataLength = xNewSizeBytes;
+
         if( xNewSizeBytes > xOriginalLength )
         {
             xNewSizeBytes = xOriginalLength;

--- a/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/portable/NetworkInterface/pic32mzef/NetworkInterface_eth.c
+++ b/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/portable/NetworkInterface/pic32mzef/NetworkInterface_eth.c
@@ -71,18 +71,18 @@
 
     typedef enum
     {
-        PIC32_MAC_EVENT_INIT_NONE = 0x000,      /* no event/invalid */
+        PIC32_MAC_EVENT_INIT_NONE = 0x000,  /* no event/invalid */
 
-        PIC32_MAC_EVENT_INIT_DONE = 0x001,      /* initialization done event */
-        PIC32_MAC_EVENT_TIMEOUT = 0x002,        /* periodic timeout event */
-        PIC32_MAC_EVENT_IF_PENDING = 0x004,     /* an interface event signal: RX, TX, errors. etc. */
+        PIC32_MAC_EVENT_INIT_DONE = 0x001,  /* initialization done event */
+        PIC32_MAC_EVENT_TIMEOUT = 0x002,    /* periodic timeout event */
+        PIC32_MAC_EVENT_IF_PENDING = 0x004, /* an interface event signal: RX, TX, errors. etc. */
     } PIC32_MAC_EVENT_TYPE;
 
     typedef enum
     {
-        eMACInit,                               /* Must initialise MAC. */
-        eMACPass,                               /* Initialisation was successful. */
-        eMACFailed,                             /* Initialisation failed. */
+        eMACInit,   /* Must initialise MAC. */
+        eMACPass,   /* Initialisation was successful. */
+        eMACFailed, /* Initialisation failed. */
     } eMAC_INIT_STATUS_TYPE;
 
     static TCPIP_STACK_HEAP_HANDLE macHeapHandle;
@@ -97,7 +97,7 @@
 
     static TimerHandle_t macTmrHandle;
 
-    static bool macLinkStatus;              /* true if link is ON */
+    static bool macLinkStatus; /* true if link is ON */
 
     static eMAC_INIT_STATUS_TYPE xMacInitStatus = eMACInit;
 
@@ -202,8 +202,8 @@
         static const SYS_CMD_DESCRIPTOR macCmdTbl[] =
         {
             { "macinfo", _Command_MacInfo, ": Check MAC statistics" },
-            { "netinfo", _Command_NetInfo, ": Net info" },
-            { "version", _Command_Version, ": Version info" },
+            { "netinfo", _Command_NetInfo, ": Net info"             },
+            { "version", _Command_Version, ": Version info"         },
         };
     #endif /* (PIC32_MAC_DEBUG_COMMANDS != 0) */
 
@@ -211,11 +211,11 @@
     /* FreeRTOS implementation functions */
     BaseType_t xNetworkInterfaceInitialise( void )
     {
-    BaseType_t xResult;
+        BaseType_t xResult;
 
         if( xMacInitStatus == eMACInit )
         {
-			/* This is the first time this function is called. */
+            /* This is the first time this function is called. */
             if( StartInitMac() != false )
             {
                 /* Indicate that the MAC initialisation succeeded. */
@@ -236,7 +236,7 @@
             xResult = pdFAIL;
         }
 
-    	PIC32_MAC_DbgPrint( "xNetworkInterfaceInitialise: %d %d\r\n", ( int ) xMacInitStatus, ( int ) xResult );
+        PIC32_MAC_DbgPrint( "xNetworkInterfaceInitialise: %d %d\r\n", ( int ) xMacInitStatus, ( int ) xResult );
 
         return xResult;
     }
@@ -490,7 +490,7 @@
     static void SetMacCtrl( TCPIP_MAC_MODULE_CTRL * pMacCtrl )
     {
         TCPIP_MAC_ADDR macAdd;
-        uint8_t unsetMACAddr[ 6 ] = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };     /* not set MAC address */
+        uint8_t unsetMACAddr[ 6 ] = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }; /* not set MAC address */
 
         pMacCtrl->nIfs = 1;
 
@@ -877,13 +877,15 @@
             return true;
         }
 
-#include "aws_application_version.h"
+        #include "aws_application_version.h"
 
-static int _Command_Version(SYS_CMD_DEVICE_NODE* pCmdIO, int argc, char** argv)
-{
-    configPRINTF( ( "App version - maj: %d, min: %d, build: %d\r\n",  xAppFirmwareVersion.u.x.ucMajor, xAppFirmwareVersion.u.x.ucMinor, xAppFirmwareVersion.u.x.usBuild) );
-    return 0;
-}
+        static int _Command_Version( SYS_CMD_DEVICE_NODE * pCmdIO,
+                                     int argc,
+                                     char ** argv )
+        {
+            configPRINTF( ( "App version - maj: %d, min: %d, build: %d\r\n", xAppFirmwareVersion.u.x.ucMajor, xAppFirmwareVersion.u.x.ucMinor, xAppFirmwareVersion.u.x.usBuild ) );
+            return 0;
+        }
 
     #endif /* (PIC32_MAC_DEBUG_COMMANDS != 0) */
 #endif /* #ifdef PIC32_USE_ETHERNET */

--- a/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/tools/tcp_dump_packets.c
+++ b/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/tools/tcp_dump_packets.c
@@ -45,614 +45,660 @@
 #include "FreeRTOS_Stream_Buffer.h"
 #include "FreeRTOS_IP_Private.h"
 
-#if( ipconfigUSE_DUMP_PACKETS != 0 )
+#if ( ipconfigUSE_DUMP_PACKETS != 0 )
 
-#include "tcp_dump_packets.h"
+    #include "tcp_dump_packets.h"
 
 /* The priority of the windows thread. */
-#define dumpPROCESS_THREAD_PRIORITY		THREAD_PRIORITY_NORMAL
+    #define dumpPROCESS_THREAD_PRIORITY    THREAD_PRIORITY_NORMAL
 
 /* There is a stream buffer between the FreeRTOS tasks sending network packets,
-and the Windows thread that writes these packets to disk. The macro 'dumpITEM_COUNT'
-determines the number of full-size packets that can be stored in this stream buffer. */
-#ifndef dumpITEM_COUNT
-	#define	dumpITEM_COUNT				32
-#endif
+ * and the Windows thread that writes these packets to disk. The macro 'dumpITEM_COUNT'
+ * determines the number of full-size packets that can be stored in this stream buffer. */
+    #ifndef dumpITEM_COUNT
+        #define dumpITEM_COUNT    32
+    #endif
 
 /* Packets are written in hex notation, no more than 16 bytes on a row. */
-#ifndef dumpBYTES_PER_ROW
-	#define dumpBYTES_PER_ROW			16
-#endif
+    #ifndef dumpBYTES_PER_ROW
+        #define dumpBYTES_PER_ROW    16
+    #endif
 
 /* The TCP port number reserved for a DNS server. */
-#define dnsDNS_PORT						0x0035u
+    #define dnsDNS_PORT        0x0035u
 
 /* Some const values describing the 'flags' in a TCP packet. */
-#define tcpTCP_FLAG_FIN					0x0001u /* No more data from sender */
-#define tcpTCP_FLAG_SYN					0x0002u /* Synchronize sequence numbers */
-#define tcpTCP_FLAG_RST					0x0004u /* Reset the connection */
-#define tcpTCP_FLAG_PSH					0x0008u /* Push function: please push buffered data to the recv application */
-#define tcpTCP_FLAG_ACK					0x0010u /* Acknowledgment field is significant */
+    #define tcpTCP_FLAG_FIN    0x0001u          /* No more data from sender */
+    #define tcpTCP_FLAG_SYN    0x0002u          /* Synchronize sequence numbers */
+    #define tcpTCP_FLAG_RST    0x0004u          /* Reset the connection */
+    #define tcpTCP_FLAG_PSH    0x0008u          /* Push function: please push buffered data to the recv application */
+    #define tcpTCP_FLAG_ACK    0x0010u          /* Acknowledgment field is significant */
 
 /* A macro to add a type, both as a numeric value, as well as a string. */
-#define ADD_TYPE( FLAGS ) \
-	vAddType( flag_##FLAGS, #FLAGS )
+    #define ADD_TYPE( FLAGS ) \
+    vAddType( flag_ ## FLAGS, # FLAGS )
 
 /*-----------------------------------------------------------*/
 
-static char pcTypeString[ 255 ];
-static uint32_t ulTypeMask;
+    static char pcTypeString[ 255 ];
+    static uint32_t ulTypeMask;
 
 /* The name of the C source file to be written. */
-static char pcCodeFileName[ MAX_PATH ];
+    static char pcCodeFileName[ MAX_PATH ];
 
 /* The name of the header file to be written. */
-static char pcHeaderFileName[ MAX_PATH ];
+    static char pcHeaderFileName[ MAX_PATH ];
 
 /* A stream buffer between the FreeRTOS tasks and the Windows thread. */
-static StreamBuffer_t *xPacketBuffer;
+    static StreamBuffer_t * xPacketBuffer;
 
 /* A process handle of the Windows thread. */
-static HANDLE pvProcessHandle;
+    static HANDLE pvProcessHandle;
 
-static UBaseType_t uxNextPacketNumber;
-static BaseType_t xFirstPacket = 1;
+    static UBaseType_t uxNextPacketNumber;
+    static BaseType_t xFirstPacket = 1;
 
 /* Bollean 'xDumpingReady' becomes true once all desired packet have been collected.
-Further packets will be dropped (ignored). */
-static volatile BaseType_t xDumpingReady = pdFALSE;
+ * Further packets will be dropped (ignored). */
+    static volatile BaseType_t xDumpingReady = pdFALSE;
 
-static DumpEntries_t *pxCurrentEntries;
+    static DumpEntries_t * pxCurrentEntries;
 
-static uint16_t usSourcePort;
-static uint16_t usDestinationPort;
+    static uint16_t usSourcePort;
+    static uint16_t usDestinationPort;
 
-typedef struct xBufferheader
-{
-	size_t uxLength;
-	UBaseType_t bIncoming : 1;
-} Bufferheader_t;
+    typedef struct xBufferheader
+    {
+        size_t uxLength;
+        UBaseType_t bIncoming : 1;
+    } Bufferheader_t;
 
-static DumpEntries_t xExampleEntries = {
-	.uxEntryCount = 4,	/* No more than 'dumpMAX_DUMP_ENTRIES' elements. */
-	.xEntries = {
-		{ .ulMask = flag_IN | flag_UDP,   .uxMax = 2u },
-		{ .ulMask = flag_IN | flag_ARP,   .uxMax = 2u },
-		{ .ulMask = flag_IN | flag_TCP,   .uxMax = 5u },
-		{ .ulMask = flag_IN | flag_SYN,   .uxMax = 1u },
-	}
-};
+    static DumpEntries_t xExampleEntries =
+    {
+        .uxEntryCount = 4,                  /* No more than 'dumpMAX_DUMP_ENTRIES' elements. */
+        .xEntries     =
+        {
+            { .ulMask = flag_IN | flag_UDP, .uxMax = 2u },
+            { .ulMask = flag_IN | flag_ARP, .uxMax = 2u },
+            { .ulMask = flag_IN | flag_TCP, .uxMax = 5u },
+            { .ulMask = flag_IN | flag_SYN, .uxMax = 1u },
+        }
+    };
 
-const char pcHeaderCode[] =
-	"/*\n"
-	" * This file was created automatically by 'dump_packets.c'\n"
-	" */\n"
-	"\n"
-	"/* Standard includes. */\n"
-	"#include <stdio.h>\n"
-	"#include <stdint.h>\n"
-	"#include <stdarg.h>\n"
-	"#include <io.h>\n"
-	"#include <ctype.h>\n"
-	"\n"
-	"/* FreeRTOS includes. */\n"
-	"#include <FreeRTOS.h>\n"
-	"#include <task.h>\n\n"
-	"#include \"%s\"\n\n";
+    const char pcHeaderCode[] =
+        "/*\n"
+        " * This file was created automatically by 'dump_packets.c'\n"
+        " */\n"
+        "\n"
+        "/* Standard includes. */\n"
+        "#include <stdio.h>\n"
+        "#include <stdint.h>\n"
+        "#include <stdarg.h>\n"
+        "#include <io.h>\n"
+        "#include <ctype.h>\n"
+        "\n"
+        "/* FreeRTOS includes. */\n"
+        "#include <FreeRTOS.h>\n"
+        "#include <task.h>\n\n"
+        "#include \"%s\"\n\n";
 
-const char pcHeaderHeader[] =
-	"/*\n"
-	" * This file was created automatically by 'dump_packets.c'\n"
-	" */\n"
-	"\n"
-	"#ifndef PACKET_LIST_H\n\n"
-	"#define PACKET_LIST_H\n\n"
-	"typedef struct xDumpPacket\n"
-	"{\n"
-	"	const uint8_t *pucData;\n"
-	"	size_t uxLength;\n"
-	"	uint32_t ulType;\n"
-	"	uint16_t usSource;\n"
-	"	uint16_t usDestination;\n"
-	"} DumpPacket_t;\n\n";
+    const char pcHeaderHeader[] =
+        "/*\n"
+        " * This file was created automatically by 'dump_packets.c'\n"
+        " */\n"
+        "\n"
+        "#ifndef PACKET_LIST_H\n\n"
+        "#define PACKET_LIST_H\n\n"
+        "typedef struct xDumpPacket\n"
+        "{\n"
+        "	const uint8_t *pucData;\n"
+        "	size_t uxLength;\n"
+        "	uint32_t ulType;\n"
+        "	uint16_t usSource;\n"
+        "	uint16_t usDestination;\n"
+        "} DumpPacket_t;\n\n";
 
 /*-----------------------------------------------------------*/
 
 /* The Windows thread that actually writes the network packets to a C source and header file. */
-static DWORD WINAPI prvWritePackets( LPVOID lpParameter );
+    static DWORD WINAPI prvWritePackets( LPVOID lpParameter );
 
-static void vAddProtocolTags( uint8_t *pucEthernetBuffer, BaseType_t xIPType );
-static void vDetermineMessageType( uint8_t *pucBuffer, BaseType_t xIncoming );
-static void vActualDump( uint8_t *pucBuffer, size_t uxLength, BaseType_t xIncoming );
-static void vAddType( uint32_t ulFlags, const char *pcFlagName );
-static void vWriteHeaderFile( void );
+    static void vAddProtocolTags( uint8_t * pucEthernetBuffer,
+                                  BaseType_t xIPType );
+    static void vDetermineMessageType( uint8_t * pucBuffer,
+                                       BaseType_t xIncoming );
+    static void vActualDump( uint8_t * pucBuffer,
+                             size_t uxLength,
+                             BaseType_t xIncoming );
+    static void vAddType( uint32_t ulFlags,
+                          const char * pcFlagName );
+    static void vWriteHeaderFile( void );
 
 /*-----------------------------------------------------------*/
 
-void dump_packet_init( const char *pcFileName, DumpEntries_t *pxEntries )
-{
-size_t uxIndex;
+    void dump_packet_init( const char * pcFileName,
+                           DumpEntries_t * pxEntries )
+    {
+        size_t uxIndex;
 
-	snprintf( pcCodeFileName, sizeof pcCodeFileName, "%s.c", pcFileName );
-	snprintf( pcHeaderFileName, sizeof pcHeaderFileName, "%s.h", pcFileName );
+        snprintf( pcCodeFileName, sizeof pcCodeFileName, "%s.c", pcFileName );
+        snprintf( pcHeaderFileName, sizeof pcHeaderFileName, "%s.h", pcFileName );
 
-	if( pxEntries == NULL )
-	{
-		pxEntries = &( xExampleEntries );
-	}
-	configASSERT( pxEntries->uxEntryCount > 0 );
-	configASSERT( pxEntries->uxEntryCount <= dumpMAX_DUMP_ENTRIES );
+        if( pxEntries == NULL )
+        {
+            pxEntries = &( xExampleEntries );
+        }
 
-	for( uxIndex = 0; uxIndex < pxEntries->uxEntryCount; uxIndex++ )
-	{
-		pxEntries->xEntries[ uxIndex ].uxCount = 0;
-	}
+        configASSERT( pxEntries->uxEntryCount > 0 );
+        configASSERT( pxEntries->uxEntryCount <= dumpMAX_DUMP_ENTRIES );
 
-	pxCurrentEntries = pxEntries;
+        for( uxIndex = 0; uxIndex < pxEntries->uxEntryCount; uxIndex++ )
+        {
+            pxEntries->xEntries[ uxIndex ].uxCount = 0;
+        }
 
-	if( xPacketBuffer == NULL )
-	{
-	size_t uxLength, uxSize;
+        pxCurrentEntries = pxEntries;
 
-		/* Enough space for e.g. 32 buffers and length words. */
-		uxLength = dumpITEM_COUNT * ( sizeof( void * ) + ipconfigNETWORK_MTU + ipSIZE_OF_ETH_HEADER );
-		uxSize = ( sizeof( *xPacketBuffer )  + uxLength ) - sizeof( xPacketBuffer->ucArray );
-		xPacketBuffer = ( StreamBuffer_t * ) pvPortMalloc( uxSize );
-		configASSERT( xPacketBuffer != NULL );
-		vStreamBufferClear( xPacketBuffer );
-		xPacketBuffer->LENGTH = uxLength;
-	}
+        if( xPacketBuffer == NULL )
+        {
+            size_t uxLength, uxSize;
 
-	if( pvProcessHandle == NULL )
-	{
-		pvProcessHandle = CreateThread( NULL, 0, prvWritePackets, NULL, CREATE_SUSPENDED, NULL );
-		if( pvProcessHandle != NULL )
-		{
-			SetThreadPriority( pvProcessHandle, dumpPROCESS_THREAD_PRIORITY );
-			SetThreadPriorityBoost( pvProcessHandle, TRUE );
-			SetThreadAffinityMask( pvProcessHandle, 0x0E );
-			ResumeThread( pvProcessHandle );
-		}
-	}
-}
+            /* Enough space for e.g. 32 buffers and length words. */
+            uxLength = dumpITEM_COUNT * ( sizeof( void * ) + ipconfigNETWORK_MTU + ipSIZE_OF_ETH_HEADER );
+            uxSize = ( sizeof( *xPacketBuffer ) + uxLength ) - sizeof( xPacketBuffer->ucArray );
+            xPacketBuffer = ( StreamBuffer_t * ) pvPortMalloc( uxSize );
+            configASSERT( xPacketBuffer != NULL );
+            vStreamBufferClear( xPacketBuffer );
+            xPacketBuffer->LENGTH = uxLength;
+        }
+
+        if( pvProcessHandle == NULL )
+        {
+            pvProcessHandle = CreateThread( NULL, 0, prvWritePackets, NULL, CREATE_SUSPENDED, NULL );
+
+            if( pvProcessHandle != NULL )
+            {
+                SetThreadPriority( pvProcessHandle, dumpPROCESS_THREAD_PRIORITY );
+                SetThreadPriorityBoost( pvProcessHandle, TRUE );
+                SetThreadAffinityMask( pvProcessHandle, 0x0E );
+                ResumeThread( pvProcessHandle );
+            }
+        }
+    }
 /*-----------------------------------------------------------*/
 
-void dump_packet( const uint8_t *pucBuffer, size_t uxLength, BaseType_t xIncoming )
-{
-	/* This function shall be called from a normal FreeRTOS task only. */
-	if( xPacketBuffer != NULL )
-	{
-		if( xDumpingReady == pdFALSE )
-		{
-		size_t uxSpace = uxStreamBufferGetSpace( xPacketBuffer );
-		size_t uxNeeded = uxLength + sizeof( size_t );
+    void dump_packet( const uint8_t * pucBuffer,
+                      size_t uxLength,
+                      BaseType_t xIncoming )
+    {
+        /* This function shall be called from a normal FreeRTOS task only. */
+        if( xPacketBuffer != NULL )
+        {
+            if( xDumpingReady == pdFALSE )
+            {
+                size_t uxSpace = uxStreamBufferGetSpace( xPacketBuffer );
+                size_t uxNeeded = uxLength + sizeof( size_t );
 
-			if( uxNeeded < uxSpace )
-			{
-			Bufferheader_t xheader;
+                if( uxNeeded < uxSpace )
+                {
+                    Bufferheader_t xheader;
 
-				xheader.uxLength = uxLength;
-				xheader.bIncoming = xIncoming;
-				uxStreamBufferAdd( xPacketBuffer, 0u, ( const uint8_t * ) &( xheader ), sizeof( xheader ) );
-				uxStreamBufferAdd( xPacketBuffer, 0u, pucBuffer, uxLength );
-			}
-			else
-			{
-				/* Drop this packet. */
-			}
-		}
-		else
-		{
-			/* The Windows thread 'prvWritePackets()' had received enough packets.
-			The packet buffer may be freed. */
-			vPortFree( xPacketBuffer );
-			xPacketBuffer = NULL;
-		}
-	}
-}
+                    xheader.uxLength = uxLength;
+                    xheader.bIncoming = xIncoming;
+                    uxStreamBufferAdd( xPacketBuffer, 0u, ( const uint8_t * ) &( xheader ), sizeof( xheader ) );
+                    uxStreamBufferAdd( xPacketBuffer, 0u, pucBuffer, uxLength );
+                }
+                else
+                {
+                    /* Drop this packet. */
+                }
+            }
+            else
+            {
+                /* The Windows thread 'prvWritePackets()' had received enough packets.
+                 * The packet buffer may be freed. */
+                vPortFree( xPacketBuffer );
+                xPacketBuffer = NULL;
+            }
+        }
+    }
 /*-----------------------------------------------------------*/
 
-static DWORD WINAPI prvWritePackets( LPVOID lpParameter )
-{
-	/* This is a Windows thread, not a FreeRTOS task. FreeRTOS API's may not be called. */
-	for( ;; )
-	{
-		Sleep( 100 );
+    static DWORD WINAPI prvWritePackets( LPVOID lpParameter )
+    {
+        /* This is a Windows thread, not a FreeRTOS task. FreeRTOS API's may not be called. */
+        for( ; ; )
+        {
+            Sleep( 100 );
 
-		while( ( xPacketBuffer != NULL ) && ( xDumpingReady == pdFALSE ) )
-		{
-		Bufferheader_t xHeader;
-		size_t uxBytes = uxStreamBufferGetSize( xPacketBuffer );
+            while( ( xPacketBuffer != NULL ) && ( xDumpingReady == pdFALSE ) )
+            {
+                Bufferheader_t xHeader;
+                size_t uxBytes = uxStreamBufferGetSize( xPacketBuffer );
 
-			if( uxBytes <= sizeof( xHeader ) )
-				break;
+                if( uxBytes <= sizeof( xHeader ) )
+                {
+                    break;
+                }
 
-			/* Peek the number of bytes available. */
-			uxStreamBufferGet( xPacketBuffer, 0u, ( uint8_t * ) &( xHeader ), sizeof( xHeader ), pdTRUE );
-			if( uxBytes >= sizeof( xHeader ) + xHeader.uxLength );
-			{
-			size_t xBytesRead;
-			uint8_t pcBuffer[ ipconfigNETWORK_MTU ];
-			size_t xActualCount;
+                /* Peek the number of bytes available. */
+                uxStreamBufferGet( xPacketBuffer, 0u, ( uint8_t * ) &( xHeader ), sizeof( xHeader ), pdTRUE );
 
-				uxStreamBufferGet( xPacketBuffer, 0u, NULL, sizeof( xHeader ), pdFALSE );
-				xActualCount = uxStreamBufferGet( xPacketBuffer, 0u, pcBuffer, xHeader.uxLength, pdFALSE );
-				vActualDump( pcBuffer, xActualCount, xHeader.bIncoming );
-			}
-		}
-	}
-}
+                if( uxBytes >= sizeof( xHeader ) + xHeader.uxLength )
+                {
+                }
+
+                {
+                    size_t xBytesRead;
+                    uint8_t pcBuffer[ ipconfigNETWORK_MTU ];
+                    size_t xActualCount;
+
+                    uxStreamBufferGet( xPacketBuffer, 0u, NULL, sizeof( xHeader ), pdFALSE );
+                    xActualCount = uxStreamBufferGet( xPacketBuffer, 0u, pcBuffer, xHeader.uxLength, pdFALSE );
+                    vActualDump( pcBuffer, xActualCount, xHeader.bIncoming );
+                }
+            }
+        }
+    }
 /*-----------------------------------------------------------*/
 
-static int _fprintf( FILE *pxHandle, const char* pcFormat, ... )
-{
-char pcString[ 255 ];
-BaseType_t iCount;
+    static int _fprintf( FILE * pxHandle,
+                         const char * pcFormat,
+                         ... )
+    {
+        char pcString[ 255 ];
+        BaseType_t iCount;
 
-	va_list args;
-	va_start (args, pcFormat);
-	iCount = vsnprintf( pcString, sizeof pcString, pcFormat, args);
-	va_end (args);
-	fwrite( pcString, 1u, iCount, pxHandle );
+        va_list args;
 
-	return iCount;
-}
+        va_start( args, pcFormat );
+        iCount = vsnprintf( pcString, sizeof pcString, pcFormat, args );
+        va_end( args );
+        fwrite( pcString, 1u, iCount, pxHandle );
+
+        return iCount;
+    }
 /*-----------------------------------------------------------*/
 
-static void vWriteHeaderFile( void )
-{
-FILE *outfile;
+    static void vWriteHeaderFile( void )
+    {
+        FILE * outfile;
 
-	outfile = fopen( pcHeaderFileName, "w" );
-	if( outfile != NULL )
-	{
-		fwrite( pcHeaderHeader, 1u, sizeof( pcHeaderHeader ) - 1u, outfile );
-		_fprintf( outfile, "#define dumpPACKET_COUNT %lu\n\n",
-			( uxNextPacketNumber < 1u ) ? 1u : uxNextPacketNumber );
-		_fprintf( outfile, "extern DumpPacket_t *xPacketList[ dumpPACKET_COUNT ];\n\n" );
-		_fprintf( outfile, "#endif PACKET_LIST_H\n" );
+        outfile = fopen( pcHeaderFileName, "w" );
 
-		fclose ( outfile );
-	}
-}
+        if( outfile != NULL )
+        {
+            fwrite( pcHeaderHeader, 1u, sizeof( pcHeaderHeader ) - 1u, outfile );
+            _fprintf( outfile, "#define dumpPACKET_COUNT %lu\n\n",
+                      ( uxNextPacketNumber < 1u ) ? 1u : uxNextPacketNumber );
+            _fprintf( outfile, "extern DumpPacket_t *xPacketList[ dumpPACKET_COUNT ];\n\n" );
+            _fprintf( outfile, "#endif PACKET_LIST_H\n" );
+
+            fclose( outfile );
+        }
+    }
 /*-----------------------------------------------------------*/
 
-static void vAddType( uint32_t ulFlags, const char *pcFlagName )
-{
-size_t uxLength = strlen( pcTypeString );
-char pcString[ 64 ];
-BaseType_t iCount;
+    static void vAddType( uint32_t ulFlags,
+                          const char * pcFlagName )
+    {
+        size_t uxLength = strlen( pcTypeString );
+        char pcString[ 64 ];
+        BaseType_t iCount;
 
-	ulTypeMask |= ulFlags;
- 
-	if( uxLength == 0 )
-	{
-		snprintf( pcTypeString, sizeof pcTypeString, "%s", pcFlagName );
-	}
-	else
-	{
-		snprintf( pcTypeString + uxLength, sizeof pcTypeString - 1, " | %s", pcFlagName );
-	}
-}
+        ulTypeMask |= ulFlags;
+
+        if( uxLength == 0 )
+        {
+            snprintf( pcTypeString, sizeof pcTypeString, "%s", pcFlagName );
+        }
+        else
+        {
+            snprintf( pcTypeString + uxLength, sizeof pcTypeString - 1, " | %s", pcFlagName );
+        }
+    }
 /*-----------------------------------------------------------*/
 
-static void vAddProtocolTags( uint8_t *pucEthernetBuffer, BaseType_t xIPType )
-{
-ProtocolHeaders_t *pxProtocolHeaders;
-#if( ipconfigUSE_IPv6 != 0 )
-	const IPHeader_IPv6_t * pxIPHeader_IPv6;
-#endif
-UBaseType_t uxHeaderLength;
-uint8_t ucProtocol;
-IPPacket_t * pxIPPacket;
-IPHeader_t * pxIPHeader;
+    static void vAddProtocolTags( uint8_t * pucEthernetBuffer,
+                                  BaseType_t xIPType )
+    {
+        ProtocolHeaders_t * pxProtocolHeaders;
 
-	pxIPPacket = ( IPPacket_t * ) pucEthernetBuffer;
-	pxIPHeader = &( pxIPPacket->xIPHeader );
-	#if( ipconfigUSE_IPv6 != 0 )
-	pxIPHeader_IPv6 = ipPOINTER_CAST( const IPHeader_IPv6_t *, &( pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER ] ) );
-	if( pxIPPacket->xEthernetHeader.usFrameType == ipIPv6_FRAME_TYPE )
-	{
-		uxHeaderLength = ipSIZE_OF_IPv6_HEADER;
-		ucProtocol = pxIPHeader_IPv6->ucNextHeader;
-		pxProtocolHeaders = ipPOINTER_CAST( ProtocolHeaders_t *, &( pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER + ipSIZE_OF_IPv6_HEADER ] ) );
-	}
-	else
-	#endif
-	{
-	size_t uxLength = ( size_t ) pxIPHeader->ucVersionHeaderLength;
+        #if ( ipconfigUSE_IPv6 != 0 )
+            const IPHeader_IPv6_t * pxIPHeader_IPv6;
+        #endif
+        UBaseType_t uxHeaderLength;
+        uint8_t ucProtocol;
+        IPPacket_t * pxIPPacket;
+        IPHeader_t * pxIPHeader;
 
-		/* Check if the IP headers are acceptable and if it has our destination.
-		The lowest four bits of 'ucVersionHeaderLength' indicate the IP-header
-		length in multiples of 4. */
-		uxHeaderLength = ( size_t ) ( ( uxLength & 0x0Fu ) << 2 );
-		ucProtocol = pxIPPacket->xIPHeader.ucProtocol;
-		pxProtocolHeaders = ipPOINTER_CAST( ProtocolHeaders_t *, &( pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER + uxHeaderLength ] ) );
-	}
+        pxIPPacket = ( IPPacket_t * ) pucEthernetBuffer;
+        pxIPHeader = &( pxIPPacket->xIPHeader );
+        #if ( ipconfigUSE_IPv6 != 0 )
+            pxIPHeader_IPv6 = ipPOINTER_CAST( const IPHeader_IPv6_t *, &( pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER ] ) );
 
-	switch( ucProtocol )
-	{
-		case ipPROTOCOL_ICMP :
-			ADD_TYPE( ICMP4 );
-			break;
+            if( pxIPPacket->xEthernetHeader.usFrameType == ipIPv6_FRAME_TYPE )
+            {
+                uxHeaderLength = ipSIZE_OF_IPv6_HEADER;
+                ucProtocol = pxIPHeader_IPv6->ucNextHeader;
+                pxProtocolHeaders = ipPOINTER_CAST( ProtocolHeaders_t *, &( pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER + ipSIZE_OF_IPv6_HEADER ] ) );
+            }
+            else
+        #endif
+        {
+            size_t uxLength = ( size_t ) pxIPHeader->ucVersionHeaderLength;
 
-#if( ipconfigUSE_IPv6 != 0 )
-		case ipPROTOCOL_ICMP_IPv6:
-			ADD_TYPE( ICMP6 );
-			break;
-#endif
+            /* Check if the IP headers are acceptable and if it has our destination.
+             * The lowest four bits of 'ucVersionHeaderLength' indicate the IP-header
+             * length in multiples of 4. */
+            uxHeaderLength = ( size_t ) ( ( uxLength & 0x0Fu ) << 2 );
+            ucProtocol = pxIPPacket->xIPHeader.ucProtocol;
+            pxProtocolHeaders = ipPOINTER_CAST( ProtocolHeaders_t *, &( pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER + uxHeaderLength ] ) );
+        }
 
-		case ipPROTOCOL_UDP :
-			{
-				ADD_TYPE( UDP );
-				usSourcePort = pxProtocolHeaders->xUDPHeader.usSourcePort;
-				usDestinationPort = pxProtocolHeaders->xUDPHeader.usDestinationPort;
-				if( usSourcePort == FreeRTOS_htons( dnsDNS_PORT) )
-				{
-					ADD_TYPE( DNS );
-					ADD_TYPE( REPLY );
-				}
-				else if( usDestinationPort == FreeRTOS_htons( dnsDNS_PORT) )
-				{
-					ADD_TYPE( DNS );
-					ADD_TYPE( REQUEST );
-				}
-			}
-			break;
-#if ipconfigUSE_TCP == 1
-		case ipPROTOCOL_TCP :
-			{
-				ADD_TYPE( TCP );
-				usSourcePort = pxProtocolHeaders->xTCPHeader.usSourcePort;
-				usDestinationPort = pxProtocolHeaders->xTCPHeader.usDestinationPort;
-				if( ( pxProtocolHeaders->xTCPHeader.ucTCPFlags & tcpTCP_FLAG_SYN ) != 0u )
-				{
-					ADD_TYPE( SYN );
-				}
-				if( ( pxProtocolHeaders->xTCPHeader.ucTCPFlags & tcpTCP_FLAG_FIN ) != 0u )
-				{
-					ADD_TYPE( FIN );
-				}
-				if( ( pxProtocolHeaders->xTCPHeader.ucTCPFlags & tcpTCP_FLAG_RST ) != 0u )
-				{
-					ADD_TYPE( RST );
-				}
-				if( ( pxProtocolHeaders->xTCPHeader.ucTCPFlags & tcpTCP_FLAG_ACK ) != 0u )
-				{
-					ADD_TYPE( ACK );
-				}
-			}
-			break;
-#endif
-	}
-}
+        switch( ucProtocol )
+        {
+            case ipPROTOCOL_ICMP:
+                ADD_TYPE( ICMP4 );
+                break;
+
+                #if ( ipconfigUSE_IPv6 != 0 )
+                    case ipPROTOCOL_ICMP_IPv6:
+                        ADD_TYPE( ICMP6 );
+                        break;
+                #endif
+
+            case ipPROTOCOL_UDP:
+                ADD_TYPE( UDP );
+                usSourcePort = pxProtocolHeaders->xUDPHeader.usSourcePort;
+                usDestinationPort = pxProtocolHeaders->xUDPHeader.usDestinationPort;
+
+                if( usSourcePort == FreeRTOS_htons( dnsDNS_PORT ) )
+                {
+                    ADD_TYPE( DNS );
+                    ADD_TYPE( REPLY );
+                }
+                else if( usDestinationPort == FreeRTOS_htons( dnsDNS_PORT ) )
+                {
+                    ADD_TYPE( DNS );
+                    ADD_TYPE( REQUEST );
+                }
+
+                break;
+
+                #if ipconfigUSE_TCP == 1
+                    case ipPROTOCOL_TCP:
+                        ADD_TYPE( TCP );
+                        usSourcePort = pxProtocolHeaders->xTCPHeader.usSourcePort;
+                        usDestinationPort = pxProtocolHeaders->xTCPHeader.usDestinationPort;
+
+                        if( ( pxProtocolHeaders->xTCPHeader.ucTCPFlags & tcpTCP_FLAG_SYN ) != 0u )
+                        {
+                            ADD_TYPE( SYN );
+                        }
+
+                        if( ( pxProtocolHeaders->xTCPHeader.ucTCPFlags & tcpTCP_FLAG_FIN ) != 0u )
+                        {
+                            ADD_TYPE( FIN );
+                        }
+
+                        if( ( pxProtocolHeaders->xTCPHeader.ucTCPFlags & tcpTCP_FLAG_RST ) != 0u )
+                        {
+                            ADD_TYPE( RST );
+                        }
+
+                        if( ( pxProtocolHeaders->xTCPHeader.ucTCPFlags & tcpTCP_FLAG_ACK ) != 0u )
+                        {
+                            ADD_TYPE( ACK );
+                        }
+                        break;
+                #endif /* if ipconfigUSE_TCP == 1 */
+        }
+    }
 /*-----------------------------------------------------------*/
 
-static void vDetermineMessageType( uint8_t *pucBuffer, BaseType_t xIncoming )
-{
-EthernetHeader_t *pxEthernetHeader;
+    static void vDetermineMessageType( uint8_t * pucBuffer,
+                                       BaseType_t xIncoming )
+    {
+        EthernetHeader_t * pxEthernetHeader;
 
-	if( xIncoming != 0 )
-	{
-		ADD_TYPE( IN );
-	}
-	else
-	{
-		ADD_TYPE( OUT );
-	}
-	pxEthernetHeader = ( EthernetHeader_t * ) pucBuffer;
+        if( xIncoming != 0 )
+        {
+            ADD_TYPE( IN );
+        }
+        else
+        {
+            ADD_TYPE( OUT );
+        }
 
-	/* Interpret the received Ethernet packet. */
-	switch( pxEthernetHeader->usFrameType )
-	{
-		case ipARP_FRAME_TYPE :
-			{
-			ARPPacket_t * pxARPFrame;
-			ARPHeader_t *pxARPHeader;
+        pxEthernetHeader = ( EthernetHeader_t * ) pucBuffer;
 
-				/* The Ethernet frame contains an ARP packet. */
-				ADD_TYPE( FRAME_ARP );
-				pxARPFrame = ( ARPPacket_t * ) pucBuffer;
-				pxARPHeader = &( pxARPFrame->xARPHeader );
-				ADD_TYPE( ARP );
-				switch( pxARPHeader->usOperation )
-				{
-				case ipARP_REQUEST:
-					ADD_TYPE( REQUEST );
-					break;
-				case ipARP_REPLY:
-					ADD_TYPE( REPLY );
-					break;
-				default:
-					ADD_TYPE( UNKNOWN );
-					break;
-				}
-			}
-			break;
+        /* Interpret the received Ethernet packet. */
+        switch( pxEthernetHeader->usFrameType )
+        {
+            case ipARP_FRAME_TYPE:
+               {
+                   ARPPacket_t * pxARPFrame;
+                   ARPHeader_t * pxARPHeader;
 
-		case ipIPv4_FRAME_TYPE :
-			{
-				ADD_TYPE( FRAME_4 );
-				vAddProtocolTags( pucBuffer, 4 );
-			}
-			break;
-			
-	#if( ipconfigUSE_IPv6 != 0 )
-		case ipIPv6_FRAME_TYPE :
-			{
-				ADD_TYPE( FRAME_6 );
-				vAddProtocolTags( pucBuffer, 6 );
-			}
-			break;
-	#endif
-		default :
-			/* No other packet types are handled.  Nothing to do. */
-			ADD_TYPE( Unknown_FRAME );
-			break;
-	}
-}
+                   /* The Ethernet frame contains an ARP packet. */
+                   ADD_TYPE( FRAME_ARP );
+                   pxARPFrame = ( ARPPacket_t * ) pucBuffer;
+                   pxARPHeader = &( pxARPFrame->xARPHeader );
+                   ADD_TYPE( ARP );
+
+                   switch( pxARPHeader->usOperation )
+                   {
+                       case ipARP_REQUEST:
+                           ADD_TYPE( REQUEST );
+                           break;
+
+                       case ipARP_REPLY:
+                           ADD_TYPE( REPLY );
+                           break;
+
+                       default:
+                           ADD_TYPE( UNKNOWN );
+                           break;
+                   }
+               }
+               break;
+
+            case ipIPv4_FRAME_TYPE:
+                ADD_TYPE( FRAME_4 );
+                vAddProtocolTags( pucBuffer, 4 );
+                break;
+
+                #if ( ipconfigUSE_IPv6 != 0 )
+                    case ipIPv6_FRAME_TYPE:
+                        ADD_TYPE( FRAME_6 );
+                        vAddProtocolTags( pucBuffer, 6 );
+                        break;
+                #endif
+            default:
+                /* No other packet types are handled.  Nothing to do. */
+                ADD_TYPE( Unknown_FRAME );
+                break;
+        }
+    }
 /*-----------------------------------------------------------*/
 
-static void vActualDump( uint8_t *pucBuffer, size_t uxLength, BaseType_t xIncoming )
-{
-char pcString[ 513 ];
-size_t uxOffset;
-size_t uxIndex;
-size_t uxCompleteCount = 0;
-BaseType_t xUseIt = pdFALSE;
+    static void vActualDump( uint8_t * pucBuffer,
+                             size_t uxLength,
+                             BaseType_t xIncoming )
+    {
+        char pcString[ 513 ];
+        size_t uxOffset;
+        size_t uxIndex;
+        size_t uxCompleteCount = 0;
+        BaseType_t xUseIt = pdFALSE;
 
-	usSourcePort = 0u;
-	usDestinationPort = 0u;
-	pcTypeString[ 0 ] = 0;
-	ulTypeMask = 0uL;
+        usSourcePort = 0u;
+        usDestinationPort = 0u;
+        pcTypeString[ 0 ] = 0;
+        ulTypeMask = 0uL;
 
-	if( pxCurrentEntries == NULL )
-	{
-		return;
-	}
+        if( pxCurrentEntries == NULL )
+        {
+            return;
+        }
 
-	vDetermineMessageType( pucBuffer, xIncoming );
+        vDetermineMessageType( pucBuffer, xIncoming );
 
-	for( uxIndex = 0; uxIndex < pxCurrentEntries->uxEntryCount; uxIndex++ )
-	{
-		if( pxCurrentEntries->xEntries[ uxIndex ].uxCount < pxCurrentEntries->xEntries[ uxIndex ].uxMax )
-		{
-		uint32_t ulMask = pxCurrentEntries->xEntries[ uxIndex ].ulMask;
+        for( uxIndex = 0; uxIndex < pxCurrentEntries->uxEntryCount; uxIndex++ )
+        {
+            if( pxCurrentEntries->xEntries[ uxIndex ].uxCount < pxCurrentEntries->xEntries[ uxIndex ].uxMax )
+            {
+                uint32_t ulMask = pxCurrentEntries->xEntries[ uxIndex ].ulMask;
 
-			if( ( ulMask & ulTypeMask ) == ulMask )
-			{
-				pxCurrentEntries->xEntries[ uxIndex ].uxCount++;
-				xUseIt = pdTRUE;
-			}
-		}
-		else
-		{
-			uxCompleteCount++;
-		}
-	}
-	FreeRTOS_printf( ( "prvWritePackets: done %d/%d : (%d,%d) (%d,%d) (%d,%d) (%d,%d)\n",
-		uxCompleteCount,
-		pxCurrentEntries->uxEntryCount,
-		pxCurrentEntries->xEntries[ 0 ].uxCount, pxCurrentEntries->xEntries[ 0 ].uxMax,
-		pxCurrentEntries->xEntries[ 1 ].uxCount, pxCurrentEntries->xEntries[ 1 ].uxMax,
-		pxCurrentEntries->xEntries[ 2 ].uxCount, pxCurrentEntries->xEntries[ 2 ].uxMax,
-		pxCurrentEntries->xEntries[ 3 ].uxCount, pxCurrentEntries->xEntries[ 3 ].uxMax ) );
-	if( uxCompleteCount >= pxCurrentEntries->uxEntryCount )
-	{
-		FreeRTOS_printf( ( "prvWritePackets: all %lu packets have been collected\n", pxCurrentEntries->uxEntryCount ) );
-		if( pxCurrentEntries != NULL )
-		{
-			FILE *outfile = fopen( pcCodeFileName, ( xFirstPacket != 0 ) ? "w" : "a+" );
-			if ( outfile == NULL )
-			{
-				FreeRTOS_printf( ( "Can not create '%s'\n", pcCodeFileName ) );
-			}
-			else
-			{
-				/*
-					Create a list with pointers to each network packet.
-					DumpPacket_t *xPacketList[ dumpPACKET_COUNT ] =
-					{
-						&xPacket_0000,
-						&xPacket_0001,
-						&xPacket_0002,
-						&xPacket_0003,
-					}
-				*/
-				_fprintf( outfile, "\nDumpPacket_t *xPacketList[ dumpPACKET_COUNT ] =\n{\n" );
-				for( uxIndex = 0; uxIndex < uxNextPacketNumber; uxIndex++ )
-				{
-					_fprintf( outfile, "\t&xPacket_%04lu,\n", uxIndex );
-				}
-				_fprintf( outfile, "};\n" );
-				fclose( outfile );
-				vWriteHeaderFile();
-			}
-			pxCurrentEntries = NULL;
-			/* Tell the thread and the function dump_packet() that packet
-			dumping is ready. */
-			xDumpingReady = pdTRUE;
-		}
-		return;
-	}
-	if( xUseIt == pdFALSE )
-	{
-		return;
-	}
+                if( ( ulMask & ulTypeMask ) == ulMask )
+                {
+                    pxCurrentEntries->xEntries[ uxIndex ].uxCount++;
+                    xUseIt = pdTRUE;
+                }
+            }
+            else
+            {
+                uxCompleteCount++;
+            }
+        }
 
-	printf("prvWritePackets: Read %lu bytes, type %s\n", uxLength, pcTypeString );
+        FreeRTOS_printf( ( "prvWritePackets: done %d/%d : (%d,%d) (%d,%d) (%d,%d) (%d,%d)\n",
+                           uxCompleteCount,
+                           pxCurrentEntries->uxEntryCount,
+                           pxCurrentEntries->xEntries[ 0 ].uxCount, pxCurrentEntries->xEntries[ 0 ].uxMax,
+                           pxCurrentEntries->xEntries[ 1 ].uxCount, pxCurrentEntries->xEntries[ 1 ].uxMax,
+                           pxCurrentEntries->xEntries[ 2 ].uxCount, pxCurrentEntries->xEntries[ 2 ].uxMax,
+                           pxCurrentEntries->xEntries[ 3 ].uxCount, pxCurrentEntries->xEntries[ 3 ].uxMax ) );
 
-	FILE *outfile = fopen( pcCodeFileName, ( xFirstPacket != 0 ) ? "w" : "a+" );
-	if ( outfile == NULL )
-	{
-		FreeRTOS_printf( ( "Can not create '%s'\n", pcCodeFileName ) );
-		return;
-	}
-	if( xFirstPacket != 0 )
-	{
-	char *pcPtr;
-	size_t xLength;
+        if( uxCompleteCount >= pxCurrentEntries->uxEntryCount )
+        {
+            FreeRTOS_printf( ( "prvWritePackets: all %lu packets have been collected\n", pxCurrentEntries->uxEntryCount ) );
 
-		vWriteHeaderFile( pcHeaderFileName );
-		xLength = snprintf( pcString, sizeof pcString, pcHeaderCode, pcHeaderFileName );
-		fwrite( pcString, 1u, xLength, outfile );
-		xFirstPacket = pdFALSE;
-	}
+            if( pxCurrentEntries != NULL )
+            {
+                FILE * outfile = fopen( pcCodeFileName, ( xFirstPacket != 0 ) ? "w" : "a+" );
 
-	_fprintf( outfile, "\n/* Packet_%04d */\n", uxNextPacketNumber );
-	_fprintf( outfile, "uint8_t ucPacket_%04lx[ %lu ] =\n{\n", uxNextPacketNumber, uxLength );
+                if( outfile == NULL )
+                {
+                    FreeRTOS_printf( ( "Can not create '%s'\n", pcCodeFileName ) );
+                }
+                else
+                {
+                    /*
+                     *  Create a list with pointers to each network packet.
+                     *  DumpPacket_t *xPacketList[ dumpPACKET_COUNT ] =
+                     *  {
+                     *      &xPacket_0000,
+                     *      &xPacket_0001,
+                     *      &xPacket_0002,
+                     *      &xPacket_0003,
+                     *  }
+                     */
+                    _fprintf( outfile, "\nDumpPacket_t *xPacketList[ dumpPACKET_COUNT ] =\n{\n" );
 
-	for( uxOffset = 0u; uxOffset < uxLength; )
-	{
-	size_t uxCurLength = 0u;
-	size_t uxLast = uxOffset + dumpBYTES_PER_ROW;
-	BaseType_t xFirst = pdTRUE;
+                    for( uxIndex = 0; uxIndex < uxNextPacketNumber; uxIndex++ )
+                    {
+                        _fprintf( outfile, "\t&xPacket_%04lu,\n", uxIndex );
+                    }
 
-		if( uxLast > uxLength )
-		{
-			uxLast = uxLength;
-		}
-		while( uxOffset < uxLast )
-		{
-			uxCurLength += snprintf( pcString + uxCurLength, sizeof pcString - uxCurLength, "%s0x%02x",
-				( uxCurLength == 0 ) ? "\t" : ", ", pucBuffer[ uxOffset ] );
-			uxOffset++;
-		}
-		if( uxCurLength != 0u )
-		{
-			uxCurLength += snprintf( pcString + uxCurLength, sizeof pcString - uxCurLength, "%s\n",
-				( uxOffset == uxLength )  ? "\n};" : "," );
-			fwrite( pcString, 1u, uxCurLength, outfile );
-		}
-	}
+                    _fprintf( outfile, "};\n" );
+                    fclose( outfile );
+                    vWriteHeaderFile();
+                }
 
-	_fprintf( outfile, "\n");
+                pxCurrentEntries = NULL;
 
-	_fprintf( outfile,
-		"DumpPacket_t xPacket_%04lx =\n{\n"
-		"\t.pucData = ucPacket_%04lx,\n"
-		"\t.uxLength = %lu,\n"
-		"\t.ulType = 0x%lX, /* %s */\n",
-		uxNextPacketNumber, uxNextPacketNumber, uxLength, ulTypeMask, pcTypeString );
+                /* Tell the thread and the function dump_packet() that packet
+                 * dumping is ready. */
+                xDumpingReady = pdTRUE;
+            }
 
-	if( usSourcePort != 0u )
-	{
-		_fprintf( outfile,
-			"\t.usSource = %u,\n", FreeRTOS_ntohs( usSourcePort ) );
-	}
-	if( usSourcePort != 0u )
-	{
-		_fprintf( outfile,
-			"\t.usDestination = %u,\n", FreeRTOS_ntohs( usDestinationPort ) );
-	}
+            return;
+        }
 
-	_fprintf( outfile,
-		"};\n"
-		"/*-----------------------------------------------------------*/\n\n" );
-	fclose( outfile );
-	uxNextPacketNumber++;
-}
+        if( xUseIt == pdFALSE )
+        {
+            return;
+        }
+
+        printf( "prvWritePackets: Read %lu bytes, type %s\n", uxLength, pcTypeString );
+
+        FILE * outfile = fopen( pcCodeFileName, ( xFirstPacket != 0 ) ? "w" : "a+" );
+
+        if( outfile == NULL )
+        {
+            FreeRTOS_printf( ( "Can not create '%s'\n", pcCodeFileName ) );
+            return;
+        }
+
+        if( xFirstPacket != 0 )
+        {
+            char * pcPtr;
+            size_t xLength;
+
+            vWriteHeaderFile( pcHeaderFileName );
+            xLength = snprintf( pcString, sizeof pcString, pcHeaderCode, pcHeaderFileName );
+            fwrite( pcString, 1u, xLength, outfile );
+            xFirstPacket = pdFALSE;
+        }
+
+        _fprintf( outfile, "\n/* Packet_%04d */\n", uxNextPacketNumber );
+        _fprintf( outfile, "uint8_t ucPacket_%04lx[ %lu ] =\n{\n", uxNextPacketNumber, uxLength );
+
+        for( uxOffset = 0u; uxOffset < uxLength; )
+        {
+            size_t uxCurLength = 0u;
+            size_t uxLast = uxOffset + dumpBYTES_PER_ROW;
+            BaseType_t xFirst = pdTRUE;
+
+            if( uxLast > uxLength )
+            {
+                uxLast = uxLength;
+            }
+
+            while( uxOffset < uxLast )
+            {
+                uxCurLength += snprintf( pcString + uxCurLength, sizeof pcString - uxCurLength, "%s0x%02x",
+                                         ( uxCurLength == 0 ) ? "\t" : ", ", pucBuffer[ uxOffset ] );
+                uxOffset++;
+            }
+
+            if( uxCurLength != 0u )
+            {
+                uxCurLength += snprintf( pcString + uxCurLength, sizeof pcString - uxCurLength, "%s\n",
+                                         ( uxOffset == uxLength ) ? "\n};" : "," );
+                fwrite( pcString, 1u, uxCurLength, outfile );
+            }
+        }
+
+        _fprintf( outfile, "\n" );
+
+        _fprintf( outfile,
+                  "DumpPacket_t xPacket_%04lx =\n{\n"
+                  "\t.pucData = ucPacket_%04lx,\n"
+                  "\t.uxLength = %lu,\n"
+                  "\t.ulType = 0x%lX, /* %s */\n",
+                  uxNextPacketNumber, uxNextPacketNumber, uxLength, ulTypeMask, pcTypeString );
+
+        if( usSourcePort != 0u )
+        {
+            _fprintf( outfile,
+                      "\t.usSource = %u,\n", FreeRTOS_ntohs( usSourcePort ) );
+        }
+
+        if( usSourcePort != 0u )
+        {
+            _fprintf( outfile,
+                      "\t.usDestination = %u,\n", FreeRTOS_ntohs( usDestinationPort ) );
+        }
+
+        _fprintf( outfile,
+                  "};\n"
+                  "/*-----------------------------------------------------------*/\n\n" );
+        fclose( outfile );
+        uxNextPacketNumber++;
+    }
 /*-----------------------------------------------------------*/
 
-#endif	/* ( ipconfigUSE_DUMP_PACKETS != 0 ) */
-
+#endif /* ( ipconfigUSE_DUMP_PACKETS != 0 ) */

--- a/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/tools/tcp_mem_stats.c
+++ b/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/tools/tcp_mem_stats.c
@@ -47,379 +47,409 @@
 #include "tcp_mem_stats.h"
 
 #ifndef ipconfigTCP_MEM_STATS_MAX_ALLOCATION
-	#define ipconfigTCP_MEM_STATS_MAX_ALLOCATION     128u
-	#pragma warning "ipconfigTCP_MEM_STATS_MAX_ALLOCATION undefined?"
+    #define ipconfigTCP_MEM_STATS_MAX_ALLOCATION    128u
+    #pragma warning "ipconfigTCP_MEM_STATS_MAX_ALLOCATION undefined?"
 #endif
 
-#if( ipconfigUSE_TCP_MEM_STATS != 0 )
+#if ( ipconfigUSE_TCP_MEM_STATS != 0 )
 
 /* When a streambuffer is allocated, 4 extra bytes will be reserved. */
 
-#define STREAM_BUFFER_ROUNDUP_BYTES		4
+    #define STREAM_BUFFER_ROUNDUP_BYTES    4
 
-#define STATS_PRINTF( MSG ) \
-	xCurrentLine++; \
-	configPRINTF( MSG )
+    #define STATS_PRINTF( MSG ) \
+    xCurrentLine++;             \
+    configPRINTF( MSG )
 
-#define ETH_MAX_PACKET_SIZE		( ( ipconfigNETWORK_MTU + ipSIZE_OF_ETH_HEADER + ipBUFFER_PADDING + 31 ) & ~0x1FuL )
+    #define ETH_MAX_PACKET_SIZE    ( ( ipconfigNETWORK_MTU + ipSIZE_OF_ETH_HEADER + ipBUFFER_PADDING + 31 ) & ~0x1FuL )
 /*-----------------------------------------------------------*/
 
 /* Objects are allocated and deleted. This structure stores the type
-and the size of the object. */
-typedef struct xTCP_ALLOCATION
-{
-	TCP_MEMORY_t xMemType;
-	void *pxObject;
-	UBaseType_t uxNumber;
-	size_t uxSize;
-} TCP_ALLOCATION_t;
+ * and the size of the object. */
+    typedef struct xTCP_ALLOCATION
+    {
+        TCP_MEMORY_t xMemType;
+        void * pxObject;
+        UBaseType_t uxNumber;
+        size_t uxSize;
+    } TCP_ALLOCATION_t;
 /*-----------------------------------------------------------*/
 
 
-static void vWriteHeader( void );
+    static void vWriteHeader( void );
 
-static size_t uxCurrentMallocSize;
-static TCP_ALLOCATION_t xAllocations[ ipconfigTCP_MEM_STATS_MAX_ALLOCATION ];
-static size_t uxAllocationCount;
-static BaseType_t xFirstItem = pdTRUE;
-UBaseType_t uxNextObjectNumber;
-static BaseType_t xCurrentLine = 0;
-static BaseType_t xFirstDumpLine = 0;
-static BaseType_t xLastHeaderLineNr = 0;
-static BaseType_t xLoggingStopped = 0;
+    static size_t uxCurrentMallocSize;
+    static TCP_ALLOCATION_t xAllocations[ ipconfigTCP_MEM_STATS_MAX_ALLOCATION ];
+    static size_t uxAllocationCount;
+    static BaseType_t xFirstItem = pdTRUE;
+    UBaseType_t uxNextObjectNumber;
+    static BaseType_t xCurrentLine = 0;
+    static BaseType_t xFirstDumpLine = 0;
+    static BaseType_t xLastHeaderLineNr = 0;
+    static BaseType_t xLoggingStopped = 0;
 /*-----------------------------------------------------------*/
 
-static void vAddAllocation( TCP_MEMORY_t xMemType, void *pxObject, size_t uxSize )
-{
-size_t uxIndex;
+    static void vAddAllocation( TCP_MEMORY_t xMemType,
+                                void * pxObject,
+                                size_t uxSize )
+    {
+        size_t uxIndex;
 
-	vTaskSuspendAll();
-	{
-		for( uxIndex = 0; uxIndex < uxAllocationCount; uxIndex++ )
-		{
-			if( xAllocations[ uxIndex ].pxObject == pxObject )
-			{
-				/* Already added, strange. */
-				FreeRTOS_printf( ( "vAddAllocation: Pointer %p already added\n", pxObject ) );
-				return;
-			}
-		}
-		if( uxAllocationCount >= ipconfigTCP_MEM_STATS_MAX_ALLOCATION )
-		{
-			/* The table is full. */
-			return;
-		}
-		xAllocations[ uxIndex ].pxObject = pxObject;
-		xAllocations[ uxIndex ].xMemType = xMemType;
-		xAllocations[ uxIndex ].uxSize = uxSize;
-		xAllocations[ uxIndex ].uxNumber = uxNextObjectNumber++;
-		uxAllocationCount++;
-	}
-	xTaskResumeAll();
-}
+        vTaskSuspendAll();
+        {
+            for( uxIndex = 0; uxIndex < uxAllocationCount; uxIndex++ )
+            {
+                if( xAllocations[ uxIndex ].pxObject == pxObject )
+                {
+                    /* Already added, strange. */
+                    FreeRTOS_printf( ( "vAddAllocation: Pointer %p already added\n", pxObject ) );
+                    return;
+                }
+            }
+
+            if( uxAllocationCount >= ipconfigTCP_MEM_STATS_MAX_ALLOCATION )
+            {
+                /* The table is full. */
+                return;
+            }
+
+            xAllocations[ uxIndex ].pxObject = pxObject;
+            xAllocations[ uxIndex ].xMemType = xMemType;
+            xAllocations[ uxIndex ].uxSize = uxSize;
+            xAllocations[ uxIndex ].uxNumber = uxNextObjectNumber++;
+            uxAllocationCount++;
+        }
+        xTaskResumeAll();
+    }
 /*-----------------------------------------------------------*/
 
-static TCP_ALLOCATION_t *pxRemoveAllocation( void *pxObject )
-{
-size_t uxSource = 0, uxTarget = 0;
-static TCP_ALLOCATION_t xAllocation = { 0 };
-BaseType_t xFound = pdFALSE;
-TCP_ALLOCATION_t *pxReturn;
+    static TCP_ALLOCATION_t * pxRemoveAllocation( void * pxObject )
+    {
+        size_t uxSource = 0, uxTarget = 0;
+        static TCP_ALLOCATION_t xAllocation = { 0 };
+        BaseType_t xFound = pdFALSE;
+        TCP_ALLOCATION_t * pxReturn;
 
-	vTaskSuspendAll();
-	{
-		for( ; uxSource < uxAllocationCount; uxSource++ )
-		{
-			if( xAllocations[ uxSource ].pxObject == pxObject )
-			{
-				/* This is entry will be removed. */
-				( void ) memcpy( &( xAllocation ), &( xAllocations[ uxSource ] ), sizeof xAllocation );
-				xFound = pdTRUE;
-			}
-			else
-			{
-				xAllocations[ uxTarget ] = xAllocations[ uxSource ];
-				uxTarget++;
-			}
-		}
-		if( xFound != pdFALSE )
-		{
-			uxAllocationCount--;
-			pxReturn = &( xAllocation );
-		}
-		else
-		{
-			pxReturn = NULL;
-		}
-	}
-	xTaskResumeAll();
-	return pxReturn;
-}
+        vTaskSuspendAll();
+        {
+            for( ; uxSource < uxAllocationCount; uxSource++ )
+            {
+                if( xAllocations[ uxSource ].pxObject == pxObject )
+                {
+                    /* This is entry will be removed. */
+                    ( void ) memcpy( &( xAllocation ), &( xAllocations[ uxSource ] ), sizeof xAllocation );
+                    xFound = pdTRUE;
+                }
+                else
+                {
+                    xAllocations[ uxTarget ] = xAllocations[ uxSource ];
+                    uxTarget++;
+                }
+            }
+
+            if( xFound != pdFALSE )
+            {
+                uxAllocationCount--;
+                pxReturn = &( xAllocation );
+            }
+            else
+            {
+                pxReturn = NULL;
+            }
+        }
+        xTaskResumeAll();
+        return pxReturn;
+    }
 /*-----------------------------------------------------------*/
 
-static const char *pcTypeName( TCP_MEMORY_t xMemType )
-{
-	switch( xMemType )
-	{
-	case tcpSOCKET_TCP:         return "TCP-Socket";
-	case tcpSOCKET_UDP:         return "UDP-Socket";
-	case tcpSOCKET_SET:			return "SocketSet";
-	case tcpSEMAPHORE:          return "Semaphore";
-	case tcpRX_STREAM_BUFFER:   return "RX-Buffer";
-	case tcpTX_STREAM_BUFFER:   return "TX-Buffer";
-	case tcpNETWORK_BUFFER:     return "networkBuffer";
-	}
-	return "Unknown object";
-}
+    static const char * pcTypeName( TCP_MEMORY_t xMemType )
+    {
+        switch( xMemType )
+        {
+            case tcpSOCKET_TCP:
+                return "TCP-Socket";
+
+            case tcpSOCKET_UDP:
+                return "UDP-Socket";
+
+            case tcpSOCKET_SET:
+                return "SocketSet";
+
+            case tcpSEMAPHORE:
+                return "Semaphore";
+
+            case tcpRX_STREAM_BUFFER:
+                return "RX-Buffer";
+
+            case tcpTX_STREAM_BUFFER:
+                return "TX-Buffer";
+
+            case tcpNETWORK_BUFFER:
+                return "networkBuffer";
+        }
+
+        return "Unknown object";
+    }
 /*-----------------------------------------------------------*/
 
-static void vWriteHeader()
-{
-size_t uxPacketSize;
-size_t uxTXSize;
-size_t uxStaticSize = 0;
-BaseType_t xFirstLineNr = 0;
+    static void vWriteHeader()
+    {
+        size_t uxPacketSize;
+        size_t uxTXSize;
+        size_t uxStaticSize = 0;
+        BaseType_t xFirstLineNr = 0;
 
-char pucComment[ 64 ] = "";
-StreamBuffer_t *pxBuffer = NULL;
-size_t uxTara = sizeof( *pxBuffer ) - sizeof( pxBuffer->ucArray );
+        char pucComment[ 64 ] = "";
+        StreamBuffer_t * pxBuffer = NULL;
+        size_t uxTara = sizeof( *pxBuffer ) - sizeof( pxBuffer->ucArray );
 
-	/* The approximate size of a buffer for a Network Packet. */
-	STATS_PRINTF( ( "TCPMemStat,Some important ipconfig items:\n" ) );
-	STATS_PRINTF( ( "TCPMemStat,ipconfig item,Value,Comment\n" ) );
-	STATS_PRINTF( ( "TCPMemStat,NETWORK_MTU,%u\n",						ipconfigNETWORK_MTU ) );
-	STATS_PRINTF( ( "TCPMemStat,TCP_MSS,%u\n",							ipconfigTCP_MSS ) );
-	STATS_PRINTF( ( "TCPMemStat,USE_TCP,%u\n",							ipconfigUSE_TCP ) );
-	STATS_PRINTF( ( "TCPMemStat,USE_TCP_WIN,%u\n",						ipconfigUSE_TCP_WIN ) );
+        /* The approximate size of a buffer for a Network Packet. */
+        STATS_PRINTF( ( "TCPMemStat,Some important ipconfig items:\n" ) );
+        STATS_PRINTF( ( "TCPMemStat,ipconfig item,Value,Comment\n" ) );
+        STATS_PRINTF( ( "TCPMemStat,NETWORK_MTU,%u\n", ipconfigNETWORK_MTU ) );
+        STATS_PRINTF( ( "TCPMemStat,TCP_MSS,%u\n", ipconfigTCP_MSS ) );
+        STATS_PRINTF( ( "TCPMemStat,USE_TCP,%u\n", ipconfigUSE_TCP ) );
+        STATS_PRINTF( ( "TCPMemStat,USE_TCP_WIN,%u\n", ipconfigUSE_TCP_WIN ) );
 
-	uxTXSize = ( size_t ) FreeRTOS_round_up( ipconfigTCP_TX_BUFFER_LENGTH, ipconfigTCP_MSS );
+        uxTXSize = ( size_t ) FreeRTOS_round_up( ipconfigTCP_TX_BUFFER_LENGTH, ipconfigTCP_MSS );
 
-	STATS_PRINTF( ( "TCPMemStat,TCP_RX_BUFFER_LENGTH,%u,Plus %u bytes\n", ipconfigTCP_RX_BUFFER_LENGTH, uxTara + STREAM_BUFFER_ROUNDUP_BYTES ) );
-	if( uxTXSize > ipconfigTCP_TX_BUFFER_LENGTH )
-	{
-		snprintf( pucComment, sizeof pucComment, ",Rounded up to %u x MSS (plus %u bytes)", uxTXSize / ipconfigTCP_MSS, uxTara + STREAM_BUFFER_ROUNDUP_BYTES );
-	}
-	STATS_PRINTF( ( "TCPMemStat,TCP_TX_BUFFER_LENGTH,%u%s\n",			ipconfigTCP_TX_BUFFER_LENGTH, pucComment ) );
-	STATS_PRINTF( ( "TCPMemStat,USE_DHCP,%u\n",							ipconfigUSE_DHCP ) );
+        STATS_PRINTF( ( "TCPMemStat,TCP_RX_BUFFER_LENGTH,%u,Plus %u bytes\n", ipconfigTCP_RX_BUFFER_LENGTH, uxTara + STREAM_BUFFER_ROUNDUP_BYTES ) );
 
-	/*
-	 * Start of fixed RAM allocations.
-	 */
+        if( uxTXSize > ipconfigTCP_TX_BUFFER_LENGTH )
+        {
+            snprintf( pucComment, sizeof pucComment, ",Rounded up to %u x MSS (plus %u bytes)", uxTXSize / ipconfigTCP_MSS, uxTara + STREAM_BUFFER_ROUNDUP_BYTES );
+        }
 
-	STATS_PRINTF( ( "TCPMemStat,\n" ) );
-	STATS_PRINTF( ( "TCPMemStat,RAM that is always allocated either statically or on the heap:\n" ) );
-	STATS_PRINTF( ( "TCPMemStat,ipconfig item,Value,PerUnit,Total\n" ) );
-	xFirstLineNr = xCurrentLine;
-	if( xBufferAllocFixedSize != 0 )
-	{
-	size_t uxBytes;
+        STATS_PRINTF( ( "TCPMemStat,TCP_TX_BUFFER_LENGTH,%u%s\n", ipconfigTCP_TX_BUFFER_LENGTH, pucComment ) );
+        STATS_PRINTF( ( "TCPMemStat,USE_DHCP,%u\n", ipconfigUSE_DHCP ) );
 
-		/* Using BufferAllocation_1.c */
-		uxPacketSize = ( ipconfigNETWORK_MTU + ipSIZE_OF_ETH_HEADER + ipBUFFER_PADDING + 31 ) & ~0x1FuL;
-		uxBytes = ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS * ( uxPacketSize + sizeof( NetworkBufferDescriptor_t ) );
+        /*
+         * Start of fixed RAM allocations.
+         */
 
-		STATS_PRINTF( ( "TCPMemStat,NUM_NETWORK_BUFFER_DESCRIPTORS,%u,%u,=B%d*C%d,Descriptors + buffers\n",
-			ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS,
-			uxPacketSize + sizeof( NetworkBufferDescriptor_t ),
-			xCurrentLine,
-			xCurrentLine ) );
-		uxStaticSize += uxBytes;
-	}
-	else
-	{
-	size_t uxBytes;
+        STATS_PRINTF( ( "TCPMemStat,\n" ) );
+        STATS_PRINTF( ( "TCPMemStat,RAM that is always allocated either statically or on the heap:\n" ) );
+        STATS_PRINTF( ( "TCPMemStat,ipconfig item,Value,PerUnit,Total\n" ) );
+        xFirstLineNr = xCurrentLine;
 
-		/* Using BufferAllocation_2.c */
-		uxBytes = ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS * sizeof( NetworkBufferDescriptor_t );
-		STATS_PRINTF( ( "TCPMemStat,NUM_NETWORK_BUFFER_DESCRIPTORS,%u,%u,=B%d*C%d,Descriptors only\n",
-			ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS,
-			sizeof( NetworkBufferDescriptor_t ),
-			xCurrentLine,
-			xCurrentLine ) );
-		uxStaticSize += uxBytes;
-	}
-	{
-		#if( ipconfigUSE_TCP_WIN != 0 )
-		{
-			STATS_PRINTF( ( "TCPMemStat,TCP_WIN_SEG_COUNT,%u,%u,=B%d*C%d\n",
-				ipconfigTCP_WIN_SEG_COUNT, sizeof( TCPSegment_t ), xCurrentLine, xCurrentLine ) );
-		}
-		#else
-		{
-			STATS_PRINTF( ( "TCPMemStat,TCP_WIN_SEG_COUNT,%u,%u\n",			0, 0 ) );
-		}
-		#endif
-	}
-	{
-	size_t uxBytes;
-	size_t uxEntrySize;
+        if( xBufferAllocFixedSize != 0 )
+        {
+            size_t uxBytes;
 
-		uxBytes = ipconfigEVENT_QUEUE_LENGTH * sizeof( IPStackEvent_t );
-		STATS_PRINTF( ( "TCPMemStat,EVENT_QUEUE_LENGTH,%u,%u,=B%d*C%d\n",
-			ipconfigEVENT_QUEUE_LENGTH,
-			sizeof( IPStackEvent_t ),
-			xCurrentLine,
-			xCurrentLine ) );
-		uxStaticSize += uxBytes;
+            /* Using BufferAllocation_1.c */
+            uxPacketSize = ( ipconfigNETWORK_MTU + ipSIZE_OF_ETH_HEADER + ipBUFFER_PADDING + 31 ) & ~0x1FuL;
+            uxBytes = ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS * ( uxPacketSize + sizeof( NetworkBufferDescriptor_t ) );
 
-		uxBytes = ipconfigIP_TASK_STACK_SIZE_WORDS * sizeof( void *);
-		STATS_PRINTF( ( "TCPMemStat,IP_TASK_STACK_SIZE_WORDS,%u,%u,=B%d*C%d\n",
-			ipconfigIP_TASK_STACK_SIZE_WORDS,
-			sizeof( void *),
-			xCurrentLine,
-			xCurrentLine ) );
-		uxStaticSize += uxBytes;
+            STATS_PRINTF( ( "TCPMemStat,NUM_NETWORK_BUFFER_DESCRIPTORS,%u,%u,=B%d*C%d,Descriptors + buffers\n",
+                            ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS,
+                            uxPacketSize + sizeof( NetworkBufferDescriptor_t ),
+                            xCurrentLine,
+                            xCurrentLine ) );
+            uxStaticSize += uxBytes;
+        }
+        else
+        {
+            size_t uxBytes;
 
-		uxBytes = ipconfigARP_CACHE_ENTRIES * sizeof( ARPCacheRow_t );
-		STATS_PRINTF( ( "TCPMemStat,ARP_CACHE_ENTRIES,%u,%u,=B%d*C%d\n",
-			ipconfigARP_CACHE_ENTRIES,
-			sizeof( ARPCacheRow_t ),
-			xCurrentLine,
-			xCurrentLine ) );
-		uxStaticSize += uxBytes;
+            /* Using BufferAllocation_2.c */
+            uxBytes = ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS * sizeof( NetworkBufferDescriptor_t );
+            STATS_PRINTF( ( "TCPMemStat,NUM_NETWORK_BUFFER_DESCRIPTORS,%u,%u,=B%d*C%d,Descriptors only\n",
+                            ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS,
+                            sizeof( NetworkBufferDescriptor_t ),
+                            xCurrentLine,
+                            xCurrentLine ) );
+            uxStaticSize += uxBytes;
+        }
 
-		#if( ipconfigUSE_DNS_CACHE == 1 )
-		{
-			uxEntrySize = 3u * sizeof( uint32_t ) + ( ( ipconfigDNS_CACHE_NAME_LENGTH + 3 ) & ~0x3u );
-			STATS_PRINTF( ( "TCPMemStat,DNS_CACHE_ENTRIES,%u,%u,=B%d*C%d\n",
-				ipconfigDNS_CACHE_ENTRIES,
-				uxEntrySize,
-				xCurrentLine,
-				xCurrentLine ) );
-		}
-		#endif
-	}
-	/*
-	 * End of fixed RAM allocations.
-	 */
-	if( xBufferAllocFixedSize != 0 )
-	{
-		pucComment[0] = 0;
-	}
-	else
-	{
-	size_t uxBytes;
+        {
+            #if ( ipconfigUSE_TCP_WIN != 0 )
+                {
+                    STATS_PRINTF( ( "TCPMemStat,TCP_WIN_SEG_COUNT,%u,%u,=B%d*C%d\n",
+                                    ipconfigTCP_WIN_SEG_COUNT, sizeof( TCPSegment_t ), xCurrentLine, xCurrentLine ) );
+                }
+            #else
+                {
+                    STATS_PRINTF( ( "TCPMemStat,TCP_WIN_SEG_COUNT,%u,%u\n", 0, 0 ) );
+                }
+            #endif
+        }
+        {
+            size_t uxBytes;
+            size_t uxEntrySize;
 
-		/* BufferAllocation_2.c uses HEAP to store network packets. */
-		uxPacketSize = ( ipconfigNETWORK_MTU + ipSIZE_OF_ETH_HEADER + ipBUFFER_PADDING + 3 ) & ~0x03uL;
-		uxBytes = ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS * uxPacketSize;
-		STATS_PRINTF( ( "TCPMemStat,Network buffers in HEAP,%u,%u,=B%d*C%d\n",
-			ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS,
-			uxPacketSize,
-			xCurrentLine,
-			xCurrentLine ) );
-		uxStaticSize += uxBytes;
-		snprintf( pucComment, sizeof pucComment, "Actual size fluctuates because BufferAllocation_2.c is used" );
-	}
-	xLastHeaderLineNr = xCurrentLine;
+            uxBytes = ipconfigEVENT_QUEUE_LENGTH * sizeof( IPStackEvent_t );
+            STATS_PRINTF( ( "TCPMemStat,EVENT_QUEUE_LENGTH,%u,%u,=B%d*C%d\n",
+                            ipconfigEVENT_QUEUE_LENGTH,
+                            sizeof( IPStackEvent_t ),
+                            xCurrentLine,
+                            xCurrentLine ) );
+            uxStaticSize += uxBytes;
 
-	STATS_PRINTF( ( "TCPMemStat,Total,,,=SUM(D%d:D%d),%s\n", xFirstLineNr + 1, xLastHeaderLineNr, pucComment ) );
+            uxBytes = ipconfigIP_TASK_STACK_SIZE_WORDS * sizeof( void * );
+            STATS_PRINTF( ( "TCPMemStat,IP_TASK_STACK_SIZE_WORDS,%u,%u,=B%d*C%d\n",
+                            ipconfigIP_TASK_STACK_SIZE_WORDS,
+                            sizeof( void * ),
+                            xCurrentLine,
+                            xCurrentLine ) );
+            uxStaticSize += uxBytes;
 
-	STATS_PRINTF( ( "TCPMemStat,\n" ) );
-	STATS_PRINTF( ( "TCPMemStat,\n" ) );
-	STATS_PRINTF( ( "TCPMemStat,The following allocations are done on the heap while running:\n" ) );
-	STATS_PRINTF( ( "TCPMemStat,Create/Remove,Object,Size,Heap use,Pointer,Heap-min,Heap-Cur,comment\n" ) );
-}
+            uxBytes = ipconfigARP_CACHE_ENTRIES * sizeof( ARPCacheRow_t );
+            STATS_PRINTF( ( "TCPMemStat,ARP_CACHE_ENTRIES,%u,%u,=B%d*C%d\n",
+                            ipconfigARP_CACHE_ENTRIES,
+                            sizeof( ARPCacheRow_t ),
+                            xCurrentLine,
+                            xCurrentLine ) );
+            uxStaticSize += uxBytes;
+
+            #if ( ipconfigUSE_DNS_CACHE == 1 )
+                {
+                    uxEntrySize = 3u * sizeof( uint32_t ) + ( ( ipconfigDNS_CACHE_NAME_LENGTH + 3 ) & ~0x3u );
+                    STATS_PRINTF( ( "TCPMemStat,DNS_CACHE_ENTRIES,%u,%u,=B%d*C%d\n",
+                                    ipconfigDNS_CACHE_ENTRIES,
+                                    uxEntrySize,
+                                    xCurrentLine,
+                                    xCurrentLine ) );
+                }
+            #endif
+        }
+
+        /*
+         * End of fixed RAM allocations.
+         */
+        if( xBufferAllocFixedSize != 0 )
+        {
+            pucComment[ 0 ] = 0;
+        }
+        else
+        {
+            size_t uxBytes;
+
+            /* BufferAllocation_2.c uses HEAP to store network packets. */
+            uxPacketSize = ( ipconfigNETWORK_MTU + ipSIZE_OF_ETH_HEADER + ipBUFFER_PADDING + 3 ) & ~0x03uL;
+            uxBytes = ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS * uxPacketSize;
+            STATS_PRINTF( ( "TCPMemStat,Network buffers in HEAP,%u,%u,=B%d*C%d\n",
+                            ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS,
+                            uxPacketSize,
+                            xCurrentLine,
+                            xCurrentLine ) );
+            uxStaticSize += uxBytes;
+            snprintf( pucComment, sizeof pucComment, "Actual size fluctuates because BufferAllocation_2.c is used" );
+        }
+
+        xLastHeaderLineNr = xCurrentLine;
+
+        STATS_PRINTF( ( "TCPMemStat,Total,,,=SUM(D%d:D%d),%s\n", xFirstLineNr + 1, xLastHeaderLineNr, pucComment ) );
+
+        STATS_PRINTF( ( "TCPMemStat,\n" ) );
+        STATS_PRINTF( ( "TCPMemStat,\n" ) );
+        STATS_PRINTF( ( "TCPMemStat,The following allocations are done on the heap while running:\n" ) );
+        STATS_PRINTF( ( "TCPMemStat,Create/Remove,Object,Size,Heap use,Pointer,Heap-min,Heap-Cur,comment\n" ) );
+    }
 /*-----------------------------------------------------------*/
 
-void vTCPMemStatCreate( TCP_MEMORY_t xMemType, void *pxObject, size_t uxSize )
-{
-	if( xLoggingStopped == pdFALSE )
-	{
-	StreamBuffer_t *pxBuffer = NULL;
-	char pcExtra[ 81 ] = "";
+    void vTCPMemStatCreate( TCP_MEMORY_t xMemType,
+                            void * pxObject,
+                            size_t uxSize )
+    {
+        if( xLoggingStopped == pdFALSE )
+        {
+            StreamBuffer_t * pxBuffer = NULL;
+            char pcExtra[ 81 ] = "";
 
-		if( xFirstItem != pdFALSE )
-		{
-			xFirstItem = pdFALSE;
-			vWriteHeader();
-		}
-		if( ( xMemType == tcpRX_STREAM_BUFFER ) || ( xMemType == tcpTX_STREAM_BUFFER ) )
-		{
-		size_t uxTara = sizeof( *pxBuffer ) - sizeof( pxBuffer->ucArray );
-		size_t uxNett = uxSize - uxTara;
+            if( xFirstItem != pdFALSE )
+            {
+                xFirstItem = pdFALSE;
+                vWriteHeader();
+            }
 
-			snprintf( pcExtra, sizeof pcExtra, ",%u nett", uxNett );
-		}
+            if( ( xMemType == tcpRX_STREAM_BUFFER ) || ( xMemType == tcpTX_STREAM_BUFFER ) )
+            {
+                size_t uxTara = sizeof( *pxBuffer ) - sizeof( pxBuffer->ucArray );
+                size_t uxNett = uxSize - uxTara;
 
-		if( xFirstDumpLine == 0 )
-		{
-			xFirstDumpLine = xCurrentLine + 1;
-		}
+                snprintf( pcExtra, sizeof pcExtra, ",%u nett", uxNett );
+            }
 
-		xCurrentLine++;
-		configPRINTF( ( "TCPMemStat,CREATE,%s,%lu,%lu,%u,%u,%u%s\n",
-			pcTypeName( xMemType ),
-			uxSize,
-			uxCurrentMallocSize + uxSize,
-			uxNextObjectNumber,
-			xPortGetMinimumEverFreeHeapSize(),
-			xPortGetFreeHeapSize(),
-			pcExtra ) );
-		uxCurrentMallocSize += uxSize;
-		vAddAllocation( xMemType, pxObject, uxSize );
-	}
-}
+            if( xFirstDumpLine == 0 )
+            {
+                xFirstDumpLine = xCurrentLine + 1;
+            }
+
+            xCurrentLine++;
+            configPRINTF( ( "TCPMemStat,CREATE,%s,%lu,%lu,%u,%u,%u%s\n",
+                            pcTypeName( xMemType ),
+                            uxSize,
+                            uxCurrentMallocSize + uxSize,
+                            uxNextObjectNumber,
+                            xPortGetMinimumEverFreeHeapSize(),
+                            xPortGetFreeHeapSize(),
+                            pcExtra ) );
+            uxCurrentMallocSize += uxSize;
+            vAddAllocation( xMemType, pxObject, uxSize );
+        }
+    }
 /*-----------------------------------------------------------*/
 
-void vTCPMemStatDelete( void *pxObject )
-{
-	if( xLoggingStopped == pdFALSE )
-	{
-	TCP_ALLOCATION_t *pxFound = pxRemoveAllocation( pxObject );
+    void vTCPMemStatDelete( void * pxObject )
+    {
+        if( xLoggingStopped == pdFALSE )
+        {
+            TCP_ALLOCATION_t * pxFound = pxRemoveAllocation( pxObject );
 
-		if( xFirstDumpLine == 0 )
-		{
-			xFirstDumpLine = xCurrentLine + 1;
-		}
-		if( pxFound == NULL )
-		{
-			FreeRTOS_printf( ( "TCPMemStat: can not find pointer %p\n", pxObject ) );
-		}
-		else
-		{
-			xCurrentLine++;
-			configPRINTF( ( "TCPMemStat,REMOVE,%s,-%lu,%lu,%x,%u,%u\n",
-				pcTypeName( pxFound->xMemType ),
-				pxFound->uxSize,
-				uxCurrentMallocSize - pxFound->uxSize,
-				pxFound->uxNumber,
-				xPortGetMinimumEverFreeHeapSize(),
-				xPortGetFreeHeapSize() ) );
-			if( uxCurrentMallocSize < pxFound->uxSize )
-			{
-				uxCurrentMallocSize = 0uL;
-			}
-			else
-			{
-				uxCurrentMallocSize -= pxFound->uxSize;
-			}
-		}
-	}
-}
+            if( xFirstDumpLine == 0 )
+            {
+                xFirstDumpLine = xCurrentLine + 1;
+            }
+
+            if( pxFound == NULL )
+            {
+                FreeRTOS_printf( ( "TCPMemStat: can not find pointer %p\n", pxObject ) );
+            }
+            else
+            {
+                xCurrentLine++;
+                configPRINTF( ( "TCPMemStat,REMOVE,%s,-%lu,%lu,%x,%u,%u\n",
+                                pcTypeName( pxFound->xMemType ),
+                                pxFound->uxSize,
+                                uxCurrentMallocSize - pxFound->uxSize,
+                                pxFound->uxNumber,
+                                xPortGetMinimumEverFreeHeapSize(),
+                                xPortGetFreeHeapSize() ) );
+
+                if( uxCurrentMallocSize < pxFound->uxSize )
+                {
+                    uxCurrentMallocSize = 0uL;
+                }
+                else
+                {
+                    uxCurrentMallocSize -= pxFound->uxSize;
+                }
+            }
+        }
+    }
 /*-----------------------------------------------------------*/
 
-void vTCPMemStatClose()
-{
-	if( xLoggingStopped == pdFALSE )
-	{
-	// name;object;size;Heap;Ppointer;HeapMin;HeapDur;Comment
-	BaseType_t xLastLineNr = xCurrentLine;
+    void vTCPMemStatClose()
+    {
+        if( xLoggingStopped == pdFALSE )
+        {
+            /* name;object;size;Heap;Ppointer;HeapMin;HeapDur;Comment */
+            BaseType_t xLastLineNr = xCurrentLine;
 
-		xLoggingStopped = pdTRUE;
+            xLoggingStopped = pdTRUE;
 
-		STATS_PRINTF( ( "TCPMemStat,Totals,,,=MAX(D%d:D%d),,=MIN(F%d:F%d),=MAX(G%d:G%d)\n",
-			xFirstDumpLine,
-			xLastLineNr,
-			xFirstDumpLine,
-			xLastLineNr,
-			xFirstDumpLine,
-			xLastLineNr ) );
-		STATS_PRINTF( ( "TCPMemStat,Maximum RAM usage:,,,=SUM(D%d;D%d)\n",
-			xLastHeaderLineNr + 1,
-			xLastLineNr + 1 ) );
-	}
-}
+            STATS_PRINTF( ( "TCPMemStat,Totals,,,=MAX(D%d:D%d),,=MIN(F%d:F%d),=MAX(G%d:G%d)\n",
+                            xFirstDumpLine,
+                            xLastLineNr,
+                            xFirstDumpLine,
+                            xLastLineNr,
+                            xFirstDumpLine,
+                            xLastLineNr ) );
+            STATS_PRINTF( ( "TCPMemStat,Maximum RAM usage:,,,=SUM(D%d;D%d)\n",
+                            xLastHeaderLineNr + 1,
+                            xLastLineNr + 1 ) );
+        }
+    }
 /*-----------------------------------------------------------*/
 
-#endif	/* ( ipconfigUSE_TCP_MEM_STATS != 0 ) */
+#endif /* ( ipconfigUSE_TCP_MEM_STATS != 0 ) */


### PR DESCRIPTION
<!--- Title -->

Description
-----------
Until now, the formatting of the FreeRTOS+TCP source code was a bit different from other AWS libraries.
From now on the same uncrustify config file will be used, e.g. [uncrustify.cfg](https://github.com/FreeRTOS/FreeRTOS/blob/lts-development/tools/uncrustify.cfg).

I applied uncrustify with mentioned config file and pushed the changed source files.

In AWS/FreeRTOS, I submitted the same kind of PR ([#2262](https://github.com/aws/amazon-freertos/pull/2262)).

For those addicted to using tabs ( like me ), you can make the following change in your uncrustify.cfg:
~~~
-indent_with_tabs                = 0        # unsigned number
+indent_with_tabs                = 2        # unsigned number
~~~


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
