### PR TITLE
Update plain text demo to use local broker

### DIFF
--- a/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_light_weight/demo_config.h
+++ b/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_light_weight/demo_config.h
@@ -75,19 +75,28 @@
  * https://github.com/eclipse/mosquitto/blob/master/readme-windows.txt and
  * https://github.com/eclipse/mosquitto/blob/master/readme.md
  * 3. Verify that Mosquitto server is running locally and listening on port
- * 1883 by
- *     a. Opening Power Shell.
- *     b. Typing in command `netstat -a -p TCP | grep 1883` to check if there
+ * 1883 by following the steps below.
+ *     a. Open Power Shell.
+ *     b. Type in command `netstat -a -p TCP | grep 1883` to check if there
  *        is an active connection listening on port 1883.
  *     c. Verify that there is an output as shown below
  *        `TCP    0.0.0.0:1883           <HOST-NAME>:0       LISTENING`
- *     d. If there is no output please go through the Mosquitto documentation
+ *     d. If there is no output on step c,go through the Mosquitto documentation
  *        listed above to check if the installation was successful.
- * 4.After verifying that a Mosquitto broker is running successfully, update
+ * 4. Make sure the Mosquitto broker is allowed to communicate through
+ * Windows Firewall. The instructions for allowing an application on Windows 10
+ * Defender Firewall can be found at the link below.
+ * https://support.microsoft.com/en-us/help/4558235/windows-10-allow-an-app-through-microsoft-defender-firewall 
+ * After running this MQTT example, consider disabling the Mosquitto broker to
+ * communicate through Windows Firewall for avoiding unwanted network traffic
+ * to your machine.
+ * 5. After verifying that a Mosquitto broker is running successfully, update
  * the config democonfigMQTT_BROKER_ENDPOINT to the local IP address of the
  * Windows host machine. Please note that "localhost" or address "127.0.0.1"
  * will not work as this example is running on a Windows Simulator and not on
- * Windows host natively.
+ * Windows host natively. Also note that, if the Windows host is using a
+ * Virtual Private Network(VPN), connection to the Mosquitto broker may not
+ * work.
  *
  * As an alternative option, a publicly hosted Mosquitto broker can also be
  * used as an MQTT broker end point. This can be done by updating the config

--- a/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_light_weight/demo_config.h
+++ b/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_light_weight/demo_config.h
@@ -86,7 +86,7 @@
  * 4. Make sure the Mosquitto broker is allowed to communicate through
  * Windows Firewall. The instructions for allowing an application on Windows 10
  * Defender Firewall can be found at the link below.
- * https://support.microsoft.com/en-us/help/4558235/windows-10-allow-an-app-through-microsoft-defender-firewall 
+ * https://support.microsoft.com/en-us/help/4558235/windows-10-allow-an-app-through-microsoft-defender-firewall
  * After running this MQTT example, consider disabling the Mosquitto broker to
  * communicate through Windows Firewall for avoiding unwanted network traffic
  * to your machine.

--- a/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_plain_text/DemoTasks/PlaintextMQTTExample.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_plain_text/DemoTasks/PlaintextMQTTExample.c
@@ -60,6 +60,14 @@
 /* Transport interface include. */
 #include "transport_interface_freertos.h"
 
+/*-----------------------------------------------------------*/
+
+/* Compile time error for undefined configs. */
+#ifndef democonfigMQTT_BROKER_ENDPOINT
+    #error "Define the config democonfigMQTT_BROKER_ENDPOINT by following the instructions in file demo_config.h."
+#endif
+
+/*-----------------------------------------------------------*/
 
 /* Default values for configs. */
 #ifndef democonfigCLIENT_IDENTIFIER
@@ -76,13 +84,7 @@
  */
     #define democonfigCLIENT_IDENTIFIER    "testClient"__TIME__
 #endif
-#ifndef democonfigMQTT_BROKER_ENDPOINT
 
-/**
- * @brief Details of the MQTT broker to connect to.
- */
-    #define democonfigMQTT_BROKER_ENDPOINT    "test.mosquitto.org"
-#endif
 #ifndef democonfigMQTT_BROKER_PORT
 
 /**
@@ -90,6 +92,8 @@
  */
     #define democonfigMQTT_BROKER_PORT    ( 1883 )
 #endif
+
+/*-----------------------------------------------------------*/
 
 /**
  * @brief Timeout for receiving CONNACK packet in milliseconds.

--- a/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_plain_text/demo_config.h
+++ b/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_plain_text/demo_config.h
@@ -86,7 +86,7 @@
  * 4. Make sure the Mosquitto broker is allowed to communicate through
  * Windows Firewall. The instructions for allowing an application on Windows 10
  * Defender Firewall can be found at the link below.
- * https://support.microsoft.com/en-us/help/4558235/windows-10-allow-an-app-through-microsoft-defender-firewall 
+ * https://support.microsoft.com/en-us/help/4558235/windows-10-allow-an-app-through-microsoft-defender-firewall
  * After running this MQTT example, consider disabling the Mosquitto broker to
  * communicate through Windows Firewall for avoiding unwanted network traffic
  * to your machine.

--- a/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_plain_text/demo_config.h
+++ b/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_plain_text/demo_config.h
@@ -65,6 +65,45 @@
 /**
  * @brief MQTT broker end point to connect to.
  *
+ * @note For running this demo an MQTT broker, which can be run locally on
+ * the same host is recommended. Any MQTT broker, which can be run on a Windows
+ * host can be used for this demo. However, the instructions below are for
+ * setting up a local Mosquitto broker on a Windows host.
+ * 1. Download Mosquitto from https://mosquitto.org/download/
+ * 2. Install Mosquitto as a Windows service by running the installer.
+ * More details about installing as a Windows service can be found at
+ * https://github.com/eclipse/mosquitto/blob/master/readme-windows.txt and
+ * https://github.com/eclipse/mosquitto/blob/master/readme.md
+ * 3. Verify that Mosquitto server is running locally and listening on port
+ * 1883 by following the steps below.
+ *     a. Open Power Shell.
+ *     b. Type in command `netstat -a -p TCP | grep 1883` to check if there
+ *        is an active connection listening on port 1883.
+ *     c. Verify that there is an output as shown below
+ *        `TCP    0.0.0.0:1883           <HOST-NAME>:0       LISTENING`
+ *     d. If there is no output on step c,go through the Mosquitto documentation
+ *        listed above to check if the installation was successful.
+ * 4. Make sure the Mosquitto broker is allowed to communicate through
+ * Windows Firewall. The instructions for allowing an application on Windows 10
+ * Defender Firewall can be found at the link below.
+ * https://support.microsoft.com/en-us/help/4558235/windows-10-allow-an-app-through-microsoft-defender-firewall 
+ * After running this MQTT example, consider disabling the Mosquitto broker to
+ * communicate through Windows Firewall for avoiding unwanted network traffic
+ * to your machine.
+ * 5. After verifying that a Mosquitto broker is running successfully, update
+ * the config democonfigMQTT_BROKER_ENDPOINT to the local IP address of the
+ * Windows host machine. Please note that "localhost" or address "127.0.0.1"
+ * will not work as this example is running on a Windows Simulator and not on
+ * Windows host natively. Also note that, if the Windows host is using a
+ * Virtual Private Network(VPN), connection to the Mosquitto broker may not
+ * work.
+ *
+ * As an alternative option, a publicly hosted Mosquitto broker can also be
+ * used as an MQTT broker end point. This can be done by updating the config
+ * democonfigMQTT_BROKER_ENDPOINT to "test.mosquitto.org". However, this is not
+ * recommended due the possible downtimes of the broker as indicated by the
+ * documentation in https://test.mosquitto.org/.
+ *
  * #define democonfigMQTT_BROKER_ENDPOINT				"insert here."
  */
 

--- a/FreeRTOS-Plus/Source/FreeRTOS-IoT-Libraries-LTS-Beta2/abstractions/platform/freertos/transport_interface_freertos.c
+++ b/FreeRTOS-Plus/Source/FreeRTOS-IoT-Libraries-LTS-Beta2/abstractions/platform/freertos/transport_interface_freertos.c
@@ -57,20 +57,6 @@ BaseType_t Transport_FreeRTOS_Connect( NetworkContext_t * pNetworkContext,
         LogError( ( "Failed to create new socket." ) );
         socketStatus = -1;
     }
-    else
-    {
-        LogDebug( ( "Created new TCP socket." ) );
-        socketStatus = FreeRTOS_setsockopt( tcpSocket,
-                                            0,
-                                            FREERTOS_SO_RCVTIMEO,
-                                            &receiveTimeout,
-                                            sizeof( TickType_t ) );
-
-        if( socketStatus != 0 )
-        {
-            LogError( ( "Failed to set socket receive timeout." ) );
-        }
-    }
 
     if( socketStatus == 0 )
     {
@@ -91,6 +77,27 @@ BaseType_t Transport_FreeRTOS_Connect( NetworkContext_t * pNetworkContext,
     if( socketStatus == 0 )
     {
         socketStatus = FreeRTOS_connect( tcpSocket, &serverAddress, sizeof( serverAddress ) );
+
+        if( socketStatus != 0 )
+        {
+            LogError( ( "Failed to connect to %s. FreeRTOS_connect returned with status=%d.",
+                        pHostName,
+                        socketStatus ) );
+        }
+    }
+
+    if( socketStatus == 0 )
+    {
+        socketStatus = FreeRTOS_setsockopt( tcpSocket,
+                                            0,
+                                            FREERTOS_SO_RCVTIMEO,
+                                            &receiveTimeout,
+                                            sizeof( TickType_t ) );
+
+        if( socketStatus != 0 )
+        {
+            LogError( ( "Failed to set socket receive timeout." ) );
+        }
     }
 
     /* Clean up on failure. */


### PR DESCRIPTION
Update plain text demo to use local broker

Description
-----------
The change includes
1. Update plain text demo to use local broker.
2. Update the transport implementation to set the socket options for receive timeout after a connect is successful. This is needed as the local connection is failing if reversed the order. Will be following up with TCP team for this issue separately.

Test Steps
-----------
Ran the light weight demo and plain text demo successfully.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
