### PR TITLE
FreeRTOS+TCP Zynq: check frame type before calculating ICMP checksum

### DIFF
--- a/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/portable/NetworkInterface/Zynq/NetworkInterface.c
+++ b/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/portable/NetworkInterface/Zynq/NetworkInterface.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS V202007.00
+ * FreeRTOS V202002.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of


### PR DESCRIPTION
Description
-----------
This ia a resubmit of my earlier PR #148, which I will close.

Beside the check for the frametype in `xNetworkInterfaceOutput()`, it will call `vPrintResourceStats()` from FreeRTOS_IP.c, in stead of a local function `prvMonitorResources()`, which I removed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
