### PR TITLE
Add MQTT keep-alive demo

### DIFF
--- a/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_keep_alive/DemoTasks/KeepAliveMQTTExample.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_keep_alive/DemoTasks/KeepAliveMQTTExample.c
@@ -322,7 +322,7 @@ static uint32_t ulPingReqSendTimeMs;
 /**
  * @brief Timeout for a pending PINGRESP from the MQTT broker.
  */
-static uint32_t ulPingRespTimeoutMs = mqttexampleKEEP_ALIVE_TIMEOUT_SECONDS * _MILLISECONDS_PER_SECOND;
+static uint32_t ulPingRespTimeoutMs = ( mqttexampleKEEP_ALIVE_TIMEOUT_SECONDS / 4 ) * _MILLISECONDS_PER_SECOND;
 
 /**
  * @brief Static buffer used to hold an MQTT PINGREQ packet for keep-alive mechanism.

--- a/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_keep_alive/DemoTasks/KeepAliveMQTTExample.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_keep_alive/DemoTasks/KeepAliveMQTTExample.c
@@ -1,0 +1,644 @@
+/*
+ * FreeRTOS Kernel V10.3.0
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://www.FreeRTOS.org
+ * http://aws.amazon.com/freertos
+ *
+ * 1 tab == 4 spaces!
+ */
+
+/*
+ * Demo for showing use of the managed MQTT API.
+ *
+ * The Example shown below uses this API to create MQTT messages and
+ * send them over the connection established using FreeRTOS sockets.
+ * The example is single threaded and uses statically allocated memory;
+ * it uses QOS0 and therefore does not implement any retransmission
+ * mechanism for Publish messages.
+ *
+ * !!! NOTE !!!
+ * This MQTT demo does not authenticate the server nor the client.
+ * Hence, this demo should not be used as production ready code.
+ */
+
+/* Standard includes. */
+#include <string.h>
+#include <stdio.h>
+
+/* Kernel includes. */
+#include "FreeRTOS.h"
+#include "task.h"
+
+/* FreeRTOS+TCP includes. */
+#include "FreeRTOS_IP.h"
+#include "FreeRTOS_Sockets.h"
+
+/* Demo Specific configs. */
+#include "demo_config.h"
+
+/* MQTT library includes. */
+#include "mqtt.h"
+
+/* Transport interface include. */
+#include "plaintext_freertos.h"
+
+/*-----------------------------------------------------------*/
+
+/* Compile time error for undefined configs. */
+#ifndef democonfigMQTT_BROKER_ENDPOINT
+    #error "Define the config democonfigMQTT_BROKER_ENDPOINT by following the instructions in file demo_config.h."
+#endif
+
+/*-----------------------------------------------------------*/
+
+/* Default values for configs. */
+#ifndef democonfigCLIENT_IDENTIFIER
+
+/**
+ * @brief The MQTT client identifier used in this example.  Each client identifier
+ * must be unique so edit as required to ensure no two clients connecting to the
+ * same broker use the same client identifier.
+ *
+ * @note Appending __TIME__ to the client id string will reduce the possibility of a
+ * client id collision in the broker. Note that the appended time is the compilation
+ * time. This client id can cause collision, if more than one instance of the same
+ * binary is used at the same time to connect to the broker.
+ */
+    #define democonfigCLIENT_IDENTIFIER    "testClient"__TIME__
+#endif
+
+#ifndef democonfigMQTT_BROKER_PORT
+
+/**
+ * @brief The port to use for the demo.
+ */
+    #define democonfigMQTT_BROKER_PORT    ( 1883 )
+#endif
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Timeout for receiving CONNACK packet in milliseconds.
+ */
+#define mqttexampleCONNACK_RECV_TIMEOUT_MS          ( 1000U )
+
+/**
+ * @brief The topic to subscribe and publish to in the example.
+ *
+ * The topic name starts with the client identifier to ensure that each demo
+ * interacts with a unique topic name.
+ */
+#define mqttexampleTOPIC                            democonfigCLIENT_IDENTIFIER "/example/topic"
+
+/**
+ * @brief The MQTT message published in this example.
+ */
+#define mqttexampleMESSAGE                          "Hello World!"
+
+/**
+ * @brief Dimensions a file scope buffer currently used to send and receive MQTT data
+ * from a socket.
+ */
+#define mqttexampleSHARED_BUFFER_SIZE               ( 500U )
+
+/**
+ * @brief Time to wait between each cycle of the demo implemented by prvMQTTDemoTask().
+ */
+#define mqttexampleDELAY_BETWEEN_DEMO_ITERATIONS    ( pdMS_TO_TICKS( 5000U ) )
+
+/**
+ * @brief Timeout for MQTT_ReceiveLoop in milliseconds.
+ */
+#define mqttexampleRECEIVE_LOOP_TIMEOUT_MS          ( 500U )
+
+/**
+ * @brief Keep alive time reported to the broker while establishing an MQTT connection.
+ *
+ * It is the responsibility of the Client to ensure that the interval between
+ * Control Packets being sent does not exceed the this Keep Alive value. In the
+ * absence of sending any other Control Packets, the Client MUST send a
+ * PINGREQ Packet.
+ */
+#define mqttexampleKEEP_ALIVE_TIMEOUT_SECONDS       ( 60U )
+
+/**
+ * @brief Delay between MQTT publishes. Note that the process loop also has a
+ * timeout, so the total time between publishes is the sum of the two delays.
+ */
+#define mqttexampleDELAY_BETWEEN_PUBLISHES          ( pdMS_TO_TICKS( 500U ) )
+
+/**
+ * @brief Transport timeout in milliseconds for transport send and receive.
+ */
+#define TRANSPORT_SEND_RECV_TIMEOUT_MS              ( 200U )
+
+#define _MILLISECONDS_PER_SECOND                    ( 1000U )                                         /**< @brief Milliseconds per second. */
+#define _MILLISECONDS_PER_TICK                      ( _MILLISECONDS_PER_SECOND / configTICK_RATE_HZ ) /**< Milliseconds per FreeRTOS tick. */
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief The task used to demonstrate the MQTT API.
+ *
+ * @param[in] pvParameters Parameters as passed at the time of task creation. Not
+ * used in this example.
+ */
+static void prvMQTTDemoTask( void * pvParameters );
+
+/**
+ * @brief Sends an MQTT Connect packet over the already connected TCP socket.
+ *
+ * @param pxMQTTContext MQTT context pointer.
+ * @param xNetworkContext network context.
+ *
+ */
+static void prvCreateMQTTConnectionWithBroker( MQTTContext_t * pxMQTTContext,
+                                               NetworkContext_t * pxNetworkContext );
+
+/**
+ * @brief Subscribes to the topic as specified in mqttexampleTOPIC at the top of
+ * this file.
+ *
+ * @param pxMQTTContext MQTT context pointer.
+ */
+static void prvMQTTSubscribeToTopic( MQTTContext_t * pxMQTTContext );
+
+/**
+ * @brief  Publishes a message mqttexampleMESSAGE on mqttexampleTOPIC topic.
+ *
+ * @param pxMQTTContext MQTT context pointer.
+ */
+static void prvMQTTPublishToTopic( MQTTContext_t * pxMQTTContext );
+
+/**
+ * @brief Unsubscribes from the previously subscribed topic as specified
+ * in mqttexampleTOPIC.
+ *
+ * @param pxMQTTContext MQTT context pointer.
+ */
+static void prvMQTTUnsubscribeFromTopic( MQTTContext_t * pxMQTTContext );
+
+/**
+ * @brief The timer query function provided to the MQTT context.
+ *
+ * @return Time in milliseconds.
+ */
+static uint32_t prvGetTimeMs( void );
+
+/**
+ * @brief Process a response or ack to an MQTT request (PING, SUBSCRIBE
+ * or UNSUBSCRIBE). This function processes PINGRESP, SUBACK, UNSUBACK
+ *
+ * @param pxIncomingPacket is a pointer to structure containing deserialized
+ * MQTT response.
+ * @param usPacketId is the packet identifier from the ack received.
+ */
+static void prvMQTTProcessResponse( MQTTPacketInfo_t * pxIncomingPacket,
+                                    uint16_t usPacketId );
+
+/**
+ * @brief Process incoming Publish message.
+ *
+ * @param pxPublishInfo is a pointer to structure containing deserialized
+ * Publish message.
+ */
+static void prvMQTTProcessIncomingPublish( MQTTPublishInfo_t * pxPublishInfo );
+
+/**
+ * @brief The application callback function for getting the incoming publish
+ * and incoming acks reported from the MQTT library.
+ *
+ * @param pxMQTTContext MQTT context pointer.
+ * @param pxPacketInfo Packet Info pointer for the incoming packet.
+ * @param usPacketIdentifier Packet identifier of the incoming packet.
+ * @param pxPublishInfo Deserialized publish info pointer for the incoming
+ * packet.
+ */
+static void prvEventCallback( MQTTContext_t * pxMQTTContext,
+                              MQTTPacketInfo_t * pxPacketInfo,
+                              uint16_t usPacketIdentifier,
+                              MQTTPublishInfo_t * pxPublishInfo );
+
+/*-----------------------------------------------------------*/
+
+/* @brief Static buffer used to hold MQTT messages being sent and received. */
+static uint8_t ucSharedBuffer[ mqttexampleSHARED_BUFFER_SIZE ];
+
+/**
+ * @brief Global entry time into the application to use as a reference timestamp
+ * in the #prvGetTimeMs function. #prvGetTimeMs will always return the difference
+ * between the current time and the global entry time. This will reduce the chances
+ * of overflow for the 32 bit unsigned integer used for holding the timestamp.
+ */
+static uint32_t ulGlobalEntryTimeMs;
+
+/**
+ * @brief Packet Identifier generated when Subscribe request was sent to the broker;
+ * it is used to match received Subscribe ACK to the transmitted ACK.
+ */
+static uint16_t usSubscribePacketIdentifier;
+
+/**
+ * @brief Packet Identifier generated when Unsubscribe request was sent to the broker;
+ * it is used to match received Unsubscribe response to the transmitted unsubscribe
+ * request.
+ */
+static uint16_t usUnsubscribePacketIdentifier;
+
+
+/** @brief Static buffer used to hold MQTT messages being sent and received. */
+static MQTTFixedBuffer_t xBuffer =
+{
+    .pBuffer = ucSharedBuffer,
+    .size    = mqttexampleSHARED_BUFFER_SIZE
+};
+
+/*-----------------------------------------------------------*/
+
+/*
+ * @brief Create the task that demonstrates the Plain text MQTT API Demo.
+ */
+void vStartSimpleMQTTDemo( void )
+{
+    /* This example uses a single application task, which in turn is used to
+     * connect, subscribe, publish, unsubscribe and disconnect from the MQTT
+     * broker. */
+    xTaskCreate( prvMQTTDemoTask,          /* Function that implements the task. */
+                 "MQTTDemo",               /* Text name for the task - only used for debugging. */
+                 democonfigDEMO_STACKSIZE, /* Size of stack (in words, not bytes) to allocate for the task. */
+                 NULL,                     /* Task parameter - not used in this case. */
+                 tskIDLE_PRIORITY,         /* Task priority, must be between 0 and configMAX_PRIORITIES - 1. */
+                 NULL );                   /* Used to pass out a handle to the created task - not used in this case. */
+}
+/*-----------------------------------------------------------*/
+
+static void prvMQTTDemoTask( void * pvParameters )
+{
+    uint32_t ulPublishCount = 0U;
+    const uint32_t ulMaxPublishCount = 5UL;
+    NetworkContext_t xNetworkContext = { 0 };
+    MQTTContext_t xMQTTContext;
+    MQTTStatus_t xMQTTStatus;
+    BaseType_t xNetworkStatus;
+
+    /* Remove compiler warnings about unused parameters. */
+    ( void ) pvParameters;
+
+    ulGlobalEntryTimeMs = prvGetTimeMs();
+
+    for( ; ; )
+    {
+        /****************************** Connect. ******************************/
+
+        /* Establish a TCP connection with the MQTT broker. This example connects to
+         * the MQTT broker as specified in democonfigMQTT_BROKER_ENDPOINT and
+         * democonfigMQTT_BROKER_PORT at the top of this file. */
+        LogInfo( ( "Create a TCP connection to %s.\r\n", democonfigMQTT_BROKER_ENDPOINT ) );
+        xNetworkStatus = Plaintext_FreeRTOS_Connect( &xNetworkContext,
+                                                     democonfigMQTT_BROKER_ENDPOINT,
+                                                     democonfigMQTT_BROKER_PORT,
+                                                     TRANSPORT_SEND_RECV_TIMEOUT_MS,
+                                                     TRANSPORT_SEND_RECV_TIMEOUT_MS );
+        configASSERT( xNetworkStatus == 0 );
+
+        /* Sends an MQTT Connect packet over the already connected TCP socket,
+         * and waits for connection acknowledgment (CONNACK) packet. */
+        LogInfo( ( "Creating an MQTT connection to %s.\r\n", democonfigMQTT_BROKER_ENDPOINT ) );
+        prvCreateMQTTConnectionWithBroker( &xMQTTContext, &xNetworkContext );
+
+        /**************************** Subscribe. ******************************/
+
+        /* The client is now connected to the broker. Subscribe to the topic
+         * as specified in mqttexampleTOPIC at the top of this file by sending a
+         * subscribe packet then waiting for a subscribe acknowledgment (SUBACK).
+         * This client will then publish to the same topic it subscribed to, so it
+         * will expect all the messages it sends to the broker to be sent back to it
+         * from the broker. This demo uses QOS0 in Subscribe, therefore, the Publish
+         * messages received from the broker will have QOS0. */
+        LogInfo( ( "Attempt to subscribe to the MQTT topic %s.\r\n", mqttexampleTOPIC ) );
+        prvMQTTSubscribeToTopic( &xMQTTContext );
+
+        /* Process incoming packet from the broker. After sending the subscribe, the
+         * client may receive a publish before it receives a subscribe ack. Therefore,
+         * call generic incoming packet processing function. Since this demo is
+         * subscribing to the topic to which no one is publishing, probability of
+         * receiving Publish message before subscribe ack is zero; but application
+         * must be ready to receive any packet.  This demo uses the generic packet
+         * processing function everywhere to highlight this fact. */
+        xMQTTStatus = MQTT_ReceiveLoop( &xMQTTContext, mqttexampleRECEIVE_LOOP_TIMEOUT_MS );
+        configASSERT( xMQTTStatus == MQTTSuccess );
+
+        /**************************** Publish and Keep Alive Loop. ******************************/
+        /* Publish messages with QOS0, send and process Keep alive messages. */
+        for( ulPublishCount = 0; ulPublishCount < ulMaxPublishCount; ulPublishCount++ )
+        {
+            LogInfo( ( "Publish to the MQTT topic %s.\r\n", mqttexampleTOPIC ) );
+            prvMQTTPublishToTopic( &xMQTTContext );
+
+            /* Process incoming publish echo, since application subscribed to the same
+             * topic the broker will send publish message back to the application. */
+            LogInfo( ( "Attempt to receive publish message from broker.\r\n" ) );
+            xMQTTStatus = MQTT_ReceiveLoop( &xMQTTContext, mqttexampleRECEIVE_LOOP_TIMEOUT_MS );
+            configASSERT( xMQTTStatus == MQTTSuccess );
+
+            /* Leave Connection Idle for some time. */
+            LogInfo( ( "Keeping Connection Idle...\r\n\r\n" ) );
+            vTaskDelay( mqttexampleDELAY_BETWEEN_PUBLISHES );
+        }
+
+        /************************ Unsubscribe from the topic. **************************/
+        LogInfo( ( "Unsubscribe from the MQTT topic %s.\r\n", mqttexampleTOPIC ) );
+        prvMQTTUnsubscribeFromTopic( &xMQTTContext );
+
+        /* Process Incoming packet from the broker. */
+        xMQTTStatus = MQTT_ReceiveLoop( &xMQTTContext, mqttexampleRECEIVE_LOOP_TIMEOUT_MS );
+        configASSERT( xMQTTStatus == MQTTSuccess );
+
+        /**************************** Disconnect. ******************************/
+
+        /* Send an MQTT Disconnect packet over the already connected TCP socket.
+         * There is no corresponding response for the disconnect packet. After sending
+         * disconnect, client must close the network connection. */
+        LogInfo( ( "Disconnecting the MQTT connection with %s.\r\n", democonfigMQTT_BROKER_ENDPOINT ) );
+        MQTT_Disconnect( &xMQTTContext );
+
+        /* Close the network connection.  */
+        Plaintext_FreeRTOS_Disconnect( &xNetworkContext );
+
+        /* Wait for some time between two iterations to ensure that we do not
+         * bombard the public test mosquitto broker. */
+        LogInfo( ( "prvMQTTDemoTask() completed an iteration successfully. Total free heap is %u.\r\n", xPortGetFreeHeapSize() ) );
+        LogInfo( ( "Demo completed successfully.\r\n" ) );
+        LogInfo( ( "Short delay before starting the next iteration.... \r\n\r\n" ) );
+        vTaskDelay( mqttexampleDELAY_BETWEEN_DEMO_ITERATIONS );
+    }
+}
+/*-----------------------------------------------------------*/
+
+static void prvCreateMQTTConnectionWithBroker( MQTTContext_t * pxMQTTContext,
+                                               NetworkContext_t * pxNetworkContext )
+{
+    MQTTStatus_t xResult;
+    MQTTConnectInfo_t xConnectInfo;
+    bool xSessionPresent;
+    TransportInterface_t xTransport;
+    MQTTApplicationCallbacks_t xCallbacks;
+
+    /***
+     * For readability, error handling in this function is restricted to the use of
+     * asserts().
+     ***/
+
+    /* Fill in Transport Interface send and receive function pointers. */
+    xTransport.pNetworkContext = pxNetworkContext;
+    xTransport.send = Plaintext_FreeRTOS_send;
+    xTransport.recv = Plaintext_FreeRTOS_recv;
+
+    /* Application callbacks for receiving incoming published and incoming acks
+     * from MQTT library. */
+    xCallbacks.appCallback = prvEventCallback;
+    xCallbacks.getTime = prvGetTimeMs;
+
+    /* Initialize MQTT library. */
+    xResult = MQTT_Init( pxMQTTContext, &xTransport, &xCallbacks, &xBuffer );
+    configASSERT( xResult == MQTTSuccess );
+
+    /* Many fields not used in this demo so start with everything at 0. */
+    memset( ( void * ) &xConnectInfo, 0x00, sizeof( xConnectInfo ) );
+
+    /* Start with a clean session i.e. direct the MQTT broker to discard any
+     * previous session data. Also, establishing a connection with clean session
+     * will ensure that the broker does not store any data when this client
+     * gets disconnected. */
+    xConnectInfo.cleanSession = true;
+
+    /* The client identifier is used to uniquely identify this MQTT client to
+     * the MQTT broker. In a production device the identifier can be something
+     * unique, such as a device serial number. */
+    xConnectInfo.pClientIdentifier = democonfigCLIENT_IDENTIFIER;
+    xConnectInfo.clientIdentifierLength = ( uint16_t ) strlen( democonfigCLIENT_IDENTIFIER );
+
+    /* Set MQTT keep-alive period. It is the responsibility of the application to ensure
+     * that the interval between Control Packets being sent does not exceed the Keep Alive value.
+     * In the absence of sending any other Control Packets, the Client MUST send a PINGREQ Packet. */
+    xConnectInfo.keepAliveSeconds = mqttexampleKEEP_ALIVE_TIMEOUT_SECONDS;
+
+    /* Send MQTT CONNECT packet to broker. LWT is not used in this demo, so it
+     * is passed as NULL. */
+    xResult = MQTT_Connect( pxMQTTContext,
+                            &xConnectInfo,
+                            NULL,
+                            mqttexampleCONNACK_RECV_TIMEOUT_MS,
+                            &xSessionPresent );
+
+    if( xResult != MQTTSuccess )
+    {
+        LogError( ( "Connection with MQTT broker failed.\r\n" ) );
+    }
+}
+/*-----------------------------------------------------------*/
+
+static void prvMQTTSubscribeToTopic( MQTTContext_t * pxMQTTContext )
+{
+    MQTTStatus_t xResult;
+    MQTTSubscribeInfo_t xMQTTSubscription[ 1 ];
+
+    /***
+     * For readability, error handling in this function is restricted to the use of
+     * asserts().
+     ***/
+
+    /* Some fields not used by this demo so start with everything at 0. */
+    ( void ) memset( ( void * ) &xMQTTSubscription, 0x00, sizeof( xMQTTSubscription ) );
+
+    /* Subscribe to the mqttexampleTOPIC topic filter. This example subscribes to
+     * only one topic and uses QOS0. */
+    xMQTTSubscription[ 0 ].qos = MQTTQoS0;
+    xMQTTSubscription[ 0 ].pTopicFilter = mqttexampleTOPIC;
+    xMQTTSubscription[ 0 ].topicFilterLength = ( uint16_t ) strlen( mqttexampleTOPIC );
+
+    /* Get a unique packet id. */
+    usSubscribePacketIdentifier = MQTT_GetPacketId( pxMQTTContext );
+
+    /* Send SUBSCRIBE packet. */
+    xResult = MQTT_Subscribe( pxMQTTContext,
+                              xMQTTSubscription,
+                              sizeof( xMQTTSubscription ) / sizeof( MQTTSubscribeInfo_t ),
+                              usSubscribePacketIdentifier );
+
+    configASSERT( xResult == MQTTSuccess );
+}
+/*-----------------------------------------------------------*/
+
+static void prvMQTTPublishToTopic( MQTTContext_t * pxMQTTContext )
+{
+    MQTTStatus_t xResult;
+    MQTTPublishInfo_t xMQTTPublishInfo;
+
+
+    /***
+     * For readability, error handling in this function is restricted to the use of
+     * asserts().
+     ***/
+
+    /* Some fields not used by this demo so start with everything at 0. */
+    ( void ) memset( ( void * ) &xMQTTPublishInfo, 0x00, sizeof( xMQTTPublishInfo ) );
+
+    /* This demo uses QOS0 */
+    xMQTTPublishInfo.qos = MQTTQoS0;
+    xMQTTPublishInfo.retain = false;
+    xMQTTPublishInfo.pTopicName = mqttexampleTOPIC;
+    xMQTTPublishInfo.topicNameLength = ( uint16_t ) strlen( mqttexampleTOPIC );
+    xMQTTPublishInfo.pPayload = mqttexampleMESSAGE;
+    xMQTTPublishInfo.payloadLength = strlen( mqttexampleMESSAGE );
+
+    /* Send PUBLISH packet. Packet ID is not used for a QoS0 publish. */
+    xResult = MQTT_Publish( pxMQTTContext, &xMQTTPublishInfo, 0U );
+
+    configASSERT( xResult == MQTTSuccess );
+}
+/*-----------------------------------------------------------*/
+
+static void prvMQTTUnsubscribeFromTopic( MQTTContext_t * pxMQTTContext )
+{
+    MQTTStatus_t xResult;
+    MQTTSubscribeInfo_t xMQTTSubscription[ 1 ];
+
+    /* Some fields not used by this demo so start with everything at 0. */
+    memset( ( void * ) &xMQTTSubscription, 0x00, sizeof( xMQTTSubscription ) );
+
+    /* Unsubscribe to the mqttexampleTOPIC topic filter. */
+    xMQTTSubscription[ 0 ].qos = MQTTQoS0;
+    xMQTTSubscription[ 0 ].pTopicFilter = mqttexampleTOPIC;
+    xMQTTSubscription[ 0 ].topicFilterLength = ( uint16_t ) strlen( mqttexampleTOPIC );
+
+    /* Get next unique packet identifier */
+    usUnsubscribePacketIdentifier = MQTT_GetPacketId( pxMQTTContext );
+    /* Make sure the packet id obtained is valid. */
+    configASSERT( usUnsubscribePacketIdentifier != 0 );
+
+    /* Send UNSUBSCRIBE packet. */
+    xResult = MQTT_Unsubscribe( pxMQTTContext,
+                                xMQTTSubscription,
+                                sizeof( xMQTTSubscription ) / sizeof( MQTTSubscribeInfo_t ),
+                                usUnsubscribePacketIdentifier );
+
+    configASSERT( xResult == MQTTSuccess );
+}
+/*-----------------------------------------------------------*/
+
+static void prvMQTTProcessResponse( MQTTPacketInfo_t * pxIncomingPacket,
+                                    uint16_t usPacketId )
+{
+    switch( pxIncomingPacket->type )
+    {
+        case MQTT_PACKET_TYPE_SUBACK:
+            LogInfo( ( "Subscribed to the topic %s.\r\n", mqttexampleTOPIC ) );
+            /* Make sure ACK packet identifier matches with Request packet identifier. */
+            configASSERT( usSubscribePacketIdentifier == usPacketId );
+            break;
+
+        case MQTT_PACKET_TYPE_UNSUBACK:
+            LogInfo( ( "Unsubscribed from the topic %s.\r\n", mqttexampleTOPIC ) );
+            /* Make sure ACK packet identifier matches with Request packet identifier. */
+            configASSERT( usUnsubscribePacketIdentifier == usPacketId );
+            break;
+
+        case MQTT_PACKET_TYPE_PINGRESP:
+            LogInfo( ( "Ping Response successfully received.\r\n" ) );
+            break;
+
+        /* Any other packet type is invalid. */
+        default:
+            LogWarn( ( "prvMQTTProcessResponse() called with unknown packet type:(%02X).\r\n",
+                       pxIncomingPacket->type ) );
+    }
+}
+
+/*-----------------------------------------------------------*/
+
+static void prvMQTTProcessIncomingPublish( MQTTPublishInfo_t * pxPublishInfo )
+{
+    configASSERT( pxPublishInfo != NULL );
+
+    /* Process incoming Publish. */
+    LogInfo( ( "Incoming QoS : %d\n", pxPublishInfo->qos ) );
+
+    /* Verify the received publish is for the we have subscribed to. */
+    if( ( pxPublishInfo->topicNameLength == strlen( mqttexampleTOPIC ) ) &&
+        ( 0 == strncmp( mqttexampleTOPIC, pxPublishInfo->pTopicName, pxPublishInfo->topicNameLength ) ) )
+    {
+        LogInfo( ( "\r\nIncoming Publish Topic Name: %.*s matches subscribed topic.\r\n"
+                   "Incoming Publish Message : %.*s\r\n",
+                   pxPublishInfo->topicNameLength,
+                   pxPublishInfo->pTopicName,
+                   pxPublishInfo->payloadLength,
+                   pxPublishInfo->pPayload ) );
+    }
+    else
+    {
+        LogInfo( ( "Incoming Publish Topic Name: %.*s does not match subscribed topic.\r\n",
+                   pxPublishInfo->topicNameLength,
+                   pxPublishInfo->pTopicName ) );
+    }
+}
+
+/*-----------------------------------------------------------*/
+
+static void prvEventCallback( MQTTContext_t * pxMQTTContext,
+                              MQTTPacketInfo_t * pxPacketInfo,
+                              uint16_t usPacketIdentifier,
+                              MQTTPublishInfo_t * pxPublishInfo )
+{
+    /* The MQTT context is not used for this demo. */
+    ( void ) pxMQTTContext;
+
+    if( ( pxPacketInfo->type & 0xF0U ) == MQTT_PACKET_TYPE_PUBLISH )
+    {
+        prvMQTTProcessIncomingPublish( pxPublishInfo );
+    }
+    else
+    {
+        prvMQTTProcessResponse( pxPacketInfo, usPacketIdentifier );
+    }
+}
+
+/*-----------------------------------------------------------*/
+
+static uint32_t prvGetTimeMs( void )
+{
+    TickType_t xTickCount = 0;
+    uint32_t ulTimeMs = 0UL;
+
+    /* Get the current tick count. */
+    xTickCount = xTaskGetTickCount();
+
+    /* Convert the ticks to milliseconds. */
+    ulTimeMs = ( uint32_t ) xTickCount * _MILLISECONDS_PER_TICK;
+
+    /* Reduce ulGlobalEntryTimeMs from obtained time so as to always return the
+     * elapsed time in the application. */
+    ulTimeMs = ( uint32_t ) ( ulTimeMs - ulGlobalEntryTimeMs );
+
+    return ulTimeMs;
+}
+
+/*-----------------------------------------------------------*/

--- a/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_keep_alive/DemoTasks/KeepAliveMQTTExample.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_keep_alive/DemoTasks/KeepAliveMQTTExample.c
@@ -408,9 +408,7 @@ static void prvMQTTDemoTask( void * pvParameters )
                                               &xKeepAliveTimerBuffer );
         configASSERT( xKeepAliveTimer );
 
-        /* Start the timer for keep alive.  No block time is specified, and even
-         * if one was it would be ignored because the RTOS scheduler has not yet
-         * been started. */
+        /* Start the timer for keep alive. */
         xTimerStatus = xTimerStart( xKeepAliveTimer, 0 );
         configASSERT( xTimerStatus == pdPASS );
 
@@ -470,12 +468,12 @@ static void prvMQTTDemoTask( void * pvParameters )
         LogInfo( ( "Disconnecting the MQTT connection with %s.\r\n", democonfigMQTT_BROKER_ENDPOINT ) );
         MQTT_Disconnect( &xMQTTContext );
 
-        /* Close the network connection.  */
-        Plaintext_FreeRTOS_Disconnect( &xNetworkContext );
-
         /* Stop the keep-alive timer for the next iteration. */
         xTimerStatus = xTimerStop( xKeepAliveTimer, 0 );
         configASSERT( xTimerStatus == pdPASS );
+
+        /* Close the network connection.  */
+        Plaintext_FreeRTOS_Disconnect( &xNetworkContext );
 
         /* Wait for some time between two iterations to ensure that we do not
          * bombard the public test mosquitto broker. */

--- a/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_keep_alive/DemoTasks/KeepAliveMQTTExample.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_keep_alive/DemoTasks/KeepAliveMQTTExample.c
@@ -311,17 +311,17 @@ static StaticTimer_t xKeepAliveTimerBuffer;
 /**
  * @brief Set to true when PINGREQ is sent then false when PINGRESP is received.
  */
-static volatile bool _waitingForPingResp = false;
+static volatile bool xWaitingForPingResp = false;
 
 /**
  * @brief The last time when a PINGREQ was sent over the network.
  */
-static uint32_t _pingReqSendTimeMs;
+static uint32_t ulPingReqSendTimeMs;
 
 /**
  * @brief Timeout for a pending PINGRESP from the MQTT broker.
  */
-static uint32_t _pingRespTimeoutMs = mqttexampleKEEP_ALIVE_TIMEOUT_SECONDS * _MILLISECONDS_PER_SECOND;
+static uint32_t ulPingRespTimeoutMs = mqttexampleKEEP_ALIVE_TIMEOUT_SECONDS * _MILLISECONDS_PER_SECOND;
 
 /**
  * @brief Static buffer used to hold an MQTT PINGREQ packet for keep-alive mechanism.
@@ -341,7 +341,7 @@ static MQTTFixedBuffer_t xBuffer =
 
 /*-----------------------------------------------------------*/
 
-/*
+/**
  * @brief Create the task that demonstrates the Plain text MQTT API Demo.
  */
 void vStartSimpleMQTTDemo( void )
@@ -663,7 +663,7 @@ static void prvMQTTProcessResponse( MQTTPacketInfo_t * pxIncomingPacket,
             break;
 
         case MQTT_PACKET_TYPE_PINGRESP:
-            _waitingForPingResp = false;
+            xWaitingForPingResp = false;
             LogInfo( ( "Ping Response successfully received.\r\n" ) );
             break;
 
@@ -712,11 +712,11 @@ static void prvKeepAliveTimerCallback( TimerHandle_t pxTimer )
 
     pxTransport = ( TransportInterface_t * ) pvTimerGetTimerID( pxTimer );
 
-    if( _waitingForPingResp == true )
+    if( xWaitingForPingResp == true )
     {
         now = prvGetTimeMs();
         /* Assert that the PINGRESP timeout has not expired. */
-        configASSERT( ( now - _pingReqSendTimeMs ) <= _pingRespTimeoutMs );
+        configASSERT( ( now - ulPingReqSendTimeMs ) <= ulPingRespTimeoutMs );
     }
     else
     {
@@ -727,8 +727,8 @@ static void prvKeepAliveTimerCallback( TimerHandle_t pxTimer )
                                               xPingReqBuffer.size );
         configASSERT( ( size_t ) xTransportStatus == xPingReqBuffer.size );
 
-        _pingReqSendTimeMs = prvGetTimeMs();
-        _waitingForPingResp = true;
+        ulPingReqSendTimeMs = prvGetTimeMs();
+        xWaitingForPingResp = true;
     }
 }
 

--- a/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_keep_alive/FreeRTOSConfig.h
+++ b/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_keep_alive/FreeRTOSConfig.h
@@ -1,0 +1,216 @@
+/*
+ * FreeRTOS Kernel V10.3.0
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://www.FreeRTOS.org
+ * http://aws.amazon.com/freertos
+ *
+ * 1 tab == 4 spaces!
+ */
+
+#ifndef FREERTOS_CONFIG_H
+#define FREERTOS_CONFIG_H
+
+/*-----------------------------------------------------------
+* Application specific definitions.
+*
+* These definitions should be adjusted for your particular hardware and
+* application requirements.
+*
+* THESE PARAMETERS ARE DESCRIBED WITHIN THE 'CONFIGURATION' SECTION OF THE
+* FreeRTOS API DOCUMENTATION AVAILABLE ON THE FreeRTOS.org WEB SITE.
+* http://www.freertos.org/a00110.html
+*
+* The bottom of this file contains some constants specific to running the UDP
+* stack in this demo.  Constants specific to FreeRTOS+TCP itself (rather than
+* the demo) are contained in FreeRTOSIPConfig.h.
+*----------------------------------------------------------*/
+#define configUSE_PREEMPTION                       1
+#define configUSE_PORT_OPTIMISED_TASK_SELECTION    1
+#define configMAX_PRIORITIES                       ( 7 )
+#define configTICK_RATE_HZ                         ( 1000 )                  /* In this non-real time simulated environment the tick frequency has to be at least a multiple of the Win32 tick frequency, and therefore very slow. */
+#define configMINIMAL_STACK_SIZE                   ( ( unsigned short ) 60 ) /* In this simulated case, the stack only has to hold one small structure as the real stack is part of the Win32 thread. */
+#define configTOTAL_HEAP_SIZE                      ( ( size_t ) ( 2048U * 1024U ) )
+#define configMAX_TASK_NAME_LEN                    ( 15 )
+#define configUSE_TRACE_FACILITY                   0
+#define configUSE_16_BIT_TICKS                     0
+#define configIDLE_SHOULD_YIELD                    1
+#define configUSE_CO_ROUTINES                      0
+#define configUSE_MUTEXES                          1
+#define configUSE_RECURSIVE_MUTEXES                1
+#define configQUEUE_REGISTRY_SIZE                  0
+#define configUSE_APPLICATION_TASK_TAG             0
+#define configUSE_COUNTING_SEMAPHORES              1
+#define configUSE_ALTERNATIVE_API                  0
+#define configNUM_THREAD_LOCAL_STORAGE_POINTERS    0
+#define configENABLE_BACKWARD_COMPATIBILITY        1
+#define configSUPPORT_STATIC_ALLOCATION            1
+
+/* Hook function related definitions. */
+#define configUSE_TICK_HOOK                        0
+#define configUSE_IDLE_HOOK                        0
+#define configUSE_MALLOC_FAILED_HOOK               0
+#define configCHECK_FOR_STACK_OVERFLOW             0 /* Not applicable to the Win32 port. */
+
+/* Software timer related definitions. */
+#define configUSE_TIMERS                           1
+#define configTIMER_TASK_PRIORITY                  ( configMAX_PRIORITIES - 1 )
+#define configTIMER_QUEUE_LENGTH                   5
+#define configTIMER_TASK_STACK_DEPTH               ( configMINIMAL_STACK_SIZE * 2 )
+
+/* Event group related definitions. */
+#define configUSE_EVENT_GROUPS                     1
+
+/* Run time stats gathering configuration options. */
+#define configGENERATE_RUN_TIME_STATS              0
+
+/* Co-routine definitions. */
+#define configUSE_CO_ROUTINES                      0
+#define configMAX_CO_ROUTINE_PRIORITIES            ( 2 )
+
+/* Set the following definitions to 1 to include the API function, or zero
+ * to exclude the API function. */
+#define INCLUDE_vTaskPrioritySet                   1
+#define INCLUDE_uxTaskPriorityGet                  1
+#define INCLUDE_vTaskDelete                        1
+#define INCLUDE_vTaskCleanUpResources              0
+#define INCLUDE_vTaskSuspend                       1
+#define INCLUDE_vTaskDelayUntil                    1
+#define INCLUDE_vTaskDelay                         1
+#define INCLUDE_uxTaskGetStackHighWaterMark        1
+#define INCLUDE_xTaskGetSchedulerState             1
+#define INCLUDE_xTimerGetTimerTaskHandle           0
+#define INCLUDE_xTaskGetIdleTaskHandle             0
+#define INCLUDE_xQueueGetMutexHolder               1
+#define INCLUDE_eTaskGetState                      1
+#define INCLUDE_xEventGroupSetBitsFromISR          1
+#define INCLUDE_xTimerPendFunctionCall             1
+#define INCLUDE_pcTaskGetTaskName                  1
+
+/* This demo makes use of one or more example stats formatting functions.  These
+ * format the raw data provided by the uxTaskGetSystemState() function in to human
+ * readable ASCII form.  See the notes in the implementation of vTaskList() within
+ * FreeRTOS/Source/tasks.c for limitations.  configUSE_STATS_FORMATTING_FUNCTIONS
+ * is set to 2 so the formatting functions are included without the stdio.h being
+ * included in tasks.c.  That is because this project defines its own sprintf()
+ * functions. */
+#define configUSE_STATS_FORMATTING_FUNCTIONS       1
+
+/* Assert call defined for debug builds. */
+#ifdef _DEBUG
+    extern void vAssertCalled( const char * pcFile,
+                               uint32_t ulLine );
+    #define configASSERT( x )    if( ( x ) == 0 ) vAssertCalled( __FILE__, __LINE__ )
+#endif /* _DEBUG */
+
+
+
+/* Application specific definitions follow. **********************************/
+
+/* Only used when running in the FreeRTOS Windows simulator.  Defines the
+ * priority of the task used to simulate Ethernet interrupts. */
+#define configMAC_ISR_SIMULATOR_PRIORITY          ( configMAX_PRIORITIES - 1 )
+
+/* This demo creates a virtual network connection by accessing the raw Ethernet
+ * or WiFi data to and from a real network connection.  Many computers have more
+ * than one real network port, and configNETWORK_INTERFACE_TO_USE is used to tell
+ * the demo which real port should be used to create the virtual port.  The ports
+ * available are displayed on the console when the application is executed.  For
+ * example, on my development laptop setting configNETWORK_INTERFACE_TO_USE to 4
+ * results in the wired network being used, while setting
+ * configNETWORK_INTERFACE_TO_USE to 2 results in the wireless network being
+ * used. */
+#define configNETWORK_INTERFACE_TO_USE            1L
+
+/* The address to which logging is sent should UDP logging be enabled. */
+#define configUDP_LOGGING_ADDR0                   192
+#define configUDP_LOGGING_ADDR1                   168
+#define configUDP_LOGGING_ADDR2                   0
+#define configUDP_LOGGING_ADDR3                   11
+
+/* Default MAC address configuration.  The demo creates a virtual network
+ * connection that uses this MAC address by accessing the raw Ethernet/WiFi data
+ * to and from a real network connection on the host PC.  See the
+ * configNETWORK_INTERFACE_TO_USE definition above for information on how to
+ * configure the real network connection to use. */
+#define configMAC_ADDR0                           0x00
+#define configMAC_ADDR1                           0x11
+#define configMAC_ADDR2                           0x11
+#define configMAC_ADDR3                           0x11
+#define configMAC_ADDR4                           0x11
+#define configMAC_ADDR5                           0x41
+
+/* Default IP address configuration.  Used in ipconfigUSE_DNS is set to 0, or
+ * ipconfigUSE_DNS is set to 1 but a DNS server cannot be contacted. */
+#define configIP_ADDR0                            10
+#define configIP_ADDR1                            10
+#define configIP_ADDR2                            10
+#define configIP_ADDR3                            200
+
+/* Default gateway IP address configuration.  Used in ipconfigUSE_DNS is set to
+ * 0, or ipconfigUSE_DNS is set to 1 but a DNS server cannot be contacted. */
+#define configGATEWAY_ADDR0                       10
+#define configGATEWAY_ADDR1                       10
+#define configGATEWAY_ADDR2                       10
+#define configGATEWAY_ADDR3                       1
+
+/* Default DNS server configuration.  OpenDNS addresses are 208.67.222.222 and
+ * 208.67.220.220.  Used in ipconfigUSE_DNS is set to 0, or ipconfigUSE_DNS is set
+ * to 1 but a DNS server cannot be contacted.*/
+#define configDNS_SERVER_ADDR0                    208
+#define configDNS_SERVER_ADDR1                    67
+#define configDNS_SERVER_ADDR2                    222
+#define configDNS_SERVER_ADDR3                    222
+
+/* Default netmask configuration.  Used in ipconfigUSE_DNS is set to 0, or
+ * ipconfigUSE_DNS is set to 1 but a DNS server cannot be contacted. */
+#define configNET_MASK0                           255
+#define configNET_MASK1                           0
+#define configNET_MASK2                           0
+#define configNET_MASK3                           0
+
+/* The UDP port to which print messages are sent. */
+#define configPRINT_PORT                          ( 15000 )
+
+/* Task pool definitions for the demos of IoT Libraries. */
+#define configTASKPOOL_ENABLE_ASSERTS             1
+#define configTASKPOOL_NUMBER_OF_WORKERS          1
+#define configTASKPOOL_WORKER_PRIORITY            tskIDLE_PRIORITY
+#define configTASKPOOL_WORKER_STACK_SIZE_BYTES    2048
+
+#if ( defined( _MSC_VER ) && ( _MSC_VER <= 1600 ) && !defined( snprintf ) )
+    /* Map to Windows names. */
+    #define snprintf     _snprintf
+    #define vsnprintf    _vsnprintf
+#endif
+
+/* Visual studio does not have an implementation of strcasecmp(). */
+#define strcasecmp     _stricmp
+#define strncasecmp    _strnicmp
+#define strcmpi        _strcmpi
+
+/* Prototype for the function used to print out.  In this case it prints to the
+ * console before the network is connected then a UDP port after the network has
+ * connected. */
+extern void vLoggingPrintf( const char * pcFormatString,
+                            ... );
+#define configPRINTF( X )    vLoggingPrintf X
+
+#endif /* FREERTOS_CONFIG_H */

--- a/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_keep_alive/FreeRTOSIPConfig.h
+++ b/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_keep_alive/FreeRTOSIPConfig.h
@@ -1,0 +1,311 @@
+/*
+ * FreeRTOS Kernel V10.3.0
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://www.FreeRTOS.org
+ * http://aws.amazon.com/freertos
+ *
+ * 1 tab == 4 spaces!
+ */
+
+
+/*****************************************************************************
+*
+* See the following URL for configuration information.
+* http://www.freertos.org/FreeRTOS-Plus/FreeRTOS_Plus_TCP/TCP_IP_Configuration.html
+*
+*****************************************************************************/
+
+#ifndef FREERTOS_IP_CONFIG_H
+#define FREERTOS_IP_CONFIG_H
+
+/* Prototype for the function used to print out.  In this case it prints to the
+ * console before the network is connected then a UDP port after the network has
+ * connected. */
+extern void vLoggingPrintf( const char * pcFormatString,
+                            ... );
+
+/* Set to 1 to print out debug messages.  If ipconfigHAS_DEBUG_PRINTF is set to
+ * 1 then FreeRTOS_debug_printf should be defined to the function used to print
+ * out the debugging messages. */
+#define ipconfigHAS_DEBUG_PRINTF    0
+#if ( ipconfigHAS_DEBUG_PRINTF == 1 )
+    #define FreeRTOS_debug_printf( X )    vLoggingPrintf X
+#endif
+
+/* Set to 1 to print out non debugging messages, for example the output of the
+ * FreeRTOS_netstat() command, and ping replies.  If ipconfigHAS_PRINTF is set to 1
+ * then FreeRTOS_printf should be set to the function used to print out the
+ * messages. */
+#define ipconfigHAS_PRINTF    1
+#if ( ipconfigHAS_PRINTF == 1 )
+    #define FreeRTOS_printf( X )    vLoggingPrintf X
+#endif
+
+/* Define the byte order of the target MCU (the MCU FreeRTOS+TCP is executing
+ * on).  Valid options are pdFREERTOS_BIG_ENDIAN and pdFREERTOS_LITTLE_ENDIAN. */
+#define ipconfigBYTE_ORDER                         pdFREERTOS_LITTLE_ENDIAN
+
+/* If the network card/driver includes checksum offloading (IP/TCP/UDP checksums)
+ * then set ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM to 1 to prevent the software
+ * stack repeating the checksum calculations. */
+#define ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM     1
+
+/* Several API's will block until the result is known, or the action has been
+ * performed, for example FreeRTOS_send() and FreeRTOS_recv().  The timeouts can be
+ * set per socket, using setsockopt().  If not set, the times below will be
+ * used as defaults. */
+#define ipconfigSOCK_DEFAULT_RECEIVE_BLOCK_TIME    ( 2000 )
+#define ipconfigSOCK_DEFAULT_SEND_BLOCK_TIME       ( 5000 )
+
+/* Include support for LLMNR: Link-local Multicast Name Resolution
+ * (non-Microsoft) */
+#define ipconfigUSE_LLMNR                          ( 0 )
+
+/* Include support for NBNS: NetBIOS Name Service (Microsoft) */
+#define ipconfigUSE_NBNS                           ( 0 )
+
+/* Include support for DNS caching.  For TCP, having a small DNS cache is very
+ * useful.  When a cache is present, ipconfigDNS_REQUEST_ATTEMPTS can be kept low
+ * and also DNS may use small timeouts.  If a DNS reply comes in after the DNS
+ * socket has been destroyed, the result will be stored into the cache.  The next
+ * call to FreeRTOS_gethostbyname() will return immediately, without even creating
+ * a socket. */
+#define ipconfigUSE_DNS_CACHE                      ( 1 )
+#define ipconfigDNS_CACHE_NAME_LENGTH              ( 32 )
+#define ipconfigDNS_CACHE_ENTRIES                  ( 4 )
+#define ipconfigDNS_REQUEST_ATTEMPTS               ( 2 )
+
+/* The IP stack executes it its own task (although any application task can make
+ * use of its services through the published sockets API). ipconfigUDP_TASK_PRIORITY
+ * sets the priority of the task that executes the IP stack.  The priority is a
+ * standard FreeRTOS task priority so can take any value from 0 (the lowest
+ * priority) to (configMAX_PRIORITIES - 1) (the highest priority).
+ * configMAX_PRIORITIES is a standard FreeRTOS configuration parameter defined in
+ * FreeRTOSConfig.h, not FreeRTOSIPConfig.h. Consideration needs to be given as to
+ * the priority assigned to the task executing the IP stack relative to the
+ * priority assigned to tasks that use the IP stack. */
+#define ipconfigIP_TASK_PRIORITY                   ( configMAX_PRIORITIES - 2 )
+
+/* The size, in words (not bytes), of the stack allocated to the FreeRTOS+TCP
+ * task.  This setting is less important when the FreeRTOS Win32 simulator is used
+ * as the Win32 simulator only stores a fixed amount of information on the task
+ * stack.  FreeRTOS includes optional stack overflow detection, see:
+ * http://www.freertos.org/Stacks-and-stack-overflow-checking.html */
+#define ipconfigIP_TASK_STACK_SIZE_WORDS           ( configMINIMAL_STACK_SIZE * 5 )
+
+/* ipconfigRAND32() is called by the IP stack to generate random numbers for
+ * things such as a DHCP transaction number or initial sequence number.  Random
+ * number generation is performed via this macro to allow applications to use their
+ * own random number generation method.  For example, it might be possible to
+ * generate a random number by sampling noise on an analogue input. */
+extern UBaseType_t uxRand();
+#define ipconfigRAND32()    uxRand()
+
+/* If ipconfigUSE_NETWORK_EVENT_HOOK is set to 1 then FreeRTOS+TCP will call the
+ * network event hook at the appropriate times.  If ipconfigUSE_NETWORK_EVENT_HOOK
+ * is not set to 1 then the network event hook will never be called.  See
+ * http://www.FreeRTOS.org/FreeRTOS-Plus/FreeRTOS_Plus_UDP/API/vApplicationIPNetworkEventHook.shtml
+ */
+#define ipconfigUSE_NETWORK_EVENT_HOOK                        1
+
+/* Sockets have a send block time attribute.  If FreeRTOS_sendto() is called but
+ * a network buffer cannot be obtained then the calling task is held in the Blocked
+ * state (so other tasks can continue to executed) until either a network buffer
+ * becomes available or the send block time expires.  If the send block time expires
+ * then the send operation is aborted.  The maximum allowable send block time is
+ * capped to the value set by ipconfigMAX_SEND_BLOCK_TIME_TICKS.  Capping the
+ * maximum allowable send block time prevents prevents a deadlock occurring when
+ * all the network buffers are in use and the tasks that process (and subsequently
+ * free) the network buffers are themselves blocked waiting for a network buffer.
+ * ipconfigMAX_SEND_BLOCK_TIME_TICKS is specified in RTOS ticks.  A time in
+ * milliseconds can be converted to a time in ticks by dividing the time in
+ * milliseconds by portTICK_PERIOD_MS. */
+#define ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS                 ( 5000 / portTICK_PERIOD_MS )
+
+/* If ipconfigUSE_DHCP is 1 then FreeRTOS+TCP will attempt to retrieve an IP
+ * address, netmask, DNS server address and gateway address from a DHCP server.  If
+ * ipconfigUSE_DHCP is 0 then FreeRTOS+TCP will use a static IP address.  The
+ * stack will revert to using the static IP address even when ipconfigUSE_DHCP is
+ * set to 1 if a valid configuration cannot be obtained from a DHCP server for any
+ * reason.  The static configuration used is that passed into the stack by the
+ * FreeRTOS_IPInit() function call. */
+#define ipconfigUSE_DHCP                                      1
+
+/* When ipconfigUSE_DHCP is set to 1, DHCP requests will be sent out at
+ * increasing time intervals until either a reply is received from a DHCP server
+ * and accepted, or the interval between transmissions reaches
+ * ipconfigMAXIMUM_DISCOVER_TX_PERIOD.  The IP stack will revert to using the
+ * static IP address passed as a parameter to FreeRTOS_IPInit() if the
+ * re-transmission time interval reaches ipconfigMAXIMUM_DISCOVER_TX_PERIOD without
+ * a DHCP reply being received. */
+#define ipconfigMAXIMUM_DISCOVER_TX_PERIOD                    ( 120000 / portTICK_PERIOD_MS )
+
+/* The ARP cache is a table that maps IP addresses to MAC addresses.  The IP
+ * stack can only send a UDP message to a remove IP address if it knowns the MAC
+ * address associated with the IP address, or the MAC address of the router used to
+ * contact the remote IP address.  When a UDP message is received from a remote IP
+ * address the MAC address and IP address are added to the ARP cache.  When a UDP
+ * message is sent to a remote IP address that does not already appear in the ARP
+ * cache then the UDP message is replaced by a ARP message that solicits the
+ * required MAC address information.  ipconfigARP_CACHE_ENTRIES defines the maximum
+ * number of entries that can exist in the ARP table at any one time. */
+#define ipconfigARP_CACHE_ENTRIES                             6
+
+/* ARP requests that do not result in an ARP response will be re-transmitted a
+ * maximum of ipconfigMAX_ARP_RETRANSMISSIONS times before the ARP request is
+ * aborted. */
+#define ipconfigMAX_ARP_RETRANSMISSIONS                       ( 5 )
+
+/* ipconfigMAX_ARP_AGE defines the maximum time between an entry in the ARP
+ * table being created or refreshed and the entry being removed because it is stale.
+ * New ARP requests are sent for ARP cache entries that are nearing their maximum
+ * age.  ipconfigMAX_ARP_AGE is specified in tens of seconds, so a value of 150 is
+ * equal to 1500 seconds (or 25 minutes). */
+#define ipconfigMAX_ARP_AGE                                   150
+
+/* Implementing FreeRTOS_inet_addr() necessitates the use of string handling
+ * routines, which are relatively large.  To save code space the full
+ * FreeRTOS_inet_addr() implementation is made optional, and a smaller and faster
+ * alternative called FreeRTOS_inet_addr_quick() is provided.  FreeRTOS_inet_addr()
+ * takes an IP in decimal dot format (for example, "192.168.0.1") as its parameter.
+ * FreeRTOS_inet_addr_quick() takes an IP address as four separate numerical octets
+ * (for example, 192, 168, 0, 1) as its parameters.  If
+ * ipconfigINCLUDE_FULL_INET_ADDR is set to 1 then both FreeRTOS_inet_addr() and
+ * FreeRTOS_indet_addr_quick() are available.  If ipconfigINCLUDE_FULL_INET_ADDR is
+ * not set to 1 then only FreeRTOS_indet_addr_quick() is available. */
+#define ipconfigINCLUDE_FULL_INET_ADDR                        1
+
+/* ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS defines the total number of network buffer that
+ * are available to the IP stack.  The total number of network buffers is limited
+ * to ensure the total amount of RAM that can be consumed by the IP stack is capped
+ * to a pre-determinable value. */
+#define ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS                60
+
+/* A FreeRTOS queue is used to send events from application tasks to the IP
+ * stack.  ipconfigEVENT_QUEUE_LENGTH sets the maximum number of events that can
+ * be queued for processing at any one time.  The event queue must be a minimum of
+ * 5 greater than the total number of network buffers. */
+#define ipconfigEVENT_QUEUE_LENGTH                            ( ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS + 5 )
+
+/* The address of a socket is the combination of its IP address and its port
+ * number.  FreeRTOS_bind() is used to manually allocate a port number to a socket
+ * (to 'bind' the socket to a port), but manual binding is not normally necessary
+ * for client sockets (those sockets that initiate outgoing connections rather than
+ * wait for incoming connections on a known port number).  If
+ * ipconfigALLOW_SOCKET_SEND_WITHOUT_BIND is set to 1 then calling
+ * FreeRTOS_sendto() on a socket that has not yet been bound will result in the IP
+ * stack automatically binding the socket to a port number from the range
+ * socketAUTO_PORT_ALLOCATION_START_NUMBER to 0xffff.  If
+ * ipconfigALLOW_SOCKET_SEND_WITHOUT_BIND is set to 0 then calling FreeRTOS_sendto()
+ * on a socket that has not yet been bound will result in the send operation being
+ * aborted. */
+#define ipconfigALLOW_SOCKET_SEND_WITHOUT_BIND                1
+
+/* Defines the Time To Live (TTL) values used in outgoing UDP packets. */
+#define ipconfigUDP_TIME_TO_LIVE                              128
+#define ipconfigTCP_TIME_TO_LIVE                              128 /* also defined in FreeRTOSIPConfigDefaults.h */
+
+/* USE_TCP: Use TCP and all its features */
+#define ipconfigUSE_TCP                                       ( 1 )
+
+/* Use the TCP socket wake context with a callback. */
+#define ipconfigSOCKET_HAS_USER_WAKE_CALLBACK_WITH_CONTEXT    ( 1 )
+
+/* USE_WIN: Let TCP use windowing mechanism. */
+#define ipconfigUSE_TCP_WIN                                   ( 1 )
+
+/* The MTU is the maximum number of bytes the payload of a network frame can
+ * contain.  For normal Ethernet V2 frames the maximum MTU is 1500.  Setting a
+ * lower value can save RAM, depending on the buffer management scheme used.  If
+ * ipconfigCAN_FRAGMENT_OUTGOING_PACKETS is 1 then (ipconfigNETWORK_MTU - 28) must
+ * be divisible by 8. */
+#define ipconfigNETWORK_MTU                                   1200
+
+/* Set ipconfigUSE_DNS to 1 to include a basic DNS client/resolver.  DNS is used
+ * through the FreeRTOS_gethostbyname() API function. */
+#define ipconfigUSE_DNS                                       1
+
+/* If ipconfigREPLY_TO_INCOMING_PINGS is set to 1 then the IP stack will
+ * generate replies to incoming ICMP echo (ping) requests. */
+#define ipconfigREPLY_TO_INCOMING_PINGS                       1
+
+/* If ipconfigSUPPORT_OUTGOING_PINGS is set to 1 then the
+ * FreeRTOS_SendPingRequest() API function is available. */
+#define ipconfigSUPPORT_OUTGOING_PINGS                        0
+
+/* If ipconfigSUPPORT_SELECT_FUNCTION is set to 1 then the FreeRTOS_select()
+ * (and associated) API function is available. */
+#define ipconfigSUPPORT_SELECT_FUNCTION                       1
+
+/* If ipconfigFILTER_OUT_NON_ETHERNET_II_FRAMES is set to 1 then Ethernet frames
+ * that are not in Ethernet II format will be dropped.  This option is included for
+ * potential future IP stack developments. */
+#define ipconfigFILTER_OUT_NON_ETHERNET_II_FRAMES             1
+
+/* If ipconfigETHERNET_DRIVER_FILTERS_FRAME_TYPES is set to 1 then it is the
+ * responsibility of the Ethernet interface to filter out packets that are of no
+ * interest.  If the Ethernet interface does not implement this functionality, then
+ * set ipconfigETHERNET_DRIVER_FILTERS_FRAME_TYPES to 0 to have the IP stack
+ * perform the filtering instead (it is much less efficient for the stack to do it
+ * because the packet will already have been passed into the stack).  If the
+ * Ethernet driver does all the necessary filtering in hardware then software
+ * filtering can be removed by using a value other than 1 or 0. */
+#define ipconfigETHERNET_DRIVER_FILTERS_FRAME_TYPES           1
+
+/* The windows simulator cannot really simulate MAC interrupts, and needs to
+ * block occasionally to allow other tasks to run. */
+#define configWINDOWS_MAC_INTERRUPT_SIMULATOR_DELAY           ( 20 / portTICK_PERIOD_MS )
+
+/* Advanced only: in order to access 32-bit fields in the IP packets with
+ * 32-bit memory instructions, all packets will be stored 32-bit-aligned, plus 16-bits.
+ * This has to do with the contents of the IP-packets: all 32-bit fields are
+ * 32-bit-aligned, plus 16-bit(!) */
+#define ipconfigPACKET_FILLER_SIZE                            2
+
+/* Define the size of the pool of TCP window descriptors.  On the average, each
+ * TCP socket will use up to 2 x 6 descriptors, meaning that it can have 2 x 6
+ * outstanding packets (for Rx and Tx).  When using up to 10 TP sockets
+ * simultaneously, one could define TCP_WIN_SEG_COUNT as 120. */
+#define ipconfigTCP_WIN_SEG_COUNT                             240
+
+/* Each TCP socket has a circular buffers for Rx and Tx, which have a fixed
+ * maximum size.  Define the size of Rx buffer for TCP sockets. */
+#define ipconfigTCP_RX_BUFFER_LENGTH                          ( 1000 )
+
+/* Define the size of Tx buffer for TCP sockets. */
+#define ipconfigTCP_TX_BUFFER_LENGTH                          ( 1000 )
+
+/* When using call-back handlers, the driver may check if the handler points to
+ * real program memory (RAM or flash) or just has a random non-zero value. */
+#define ipconfigIS_VALID_PROG_ADDRESS( x )    ( ( x ) != NULL )
+
+/* Include support for TCP hang protection.  All sockets in a connecting or
+ * disconnecting stage will timeout after a period of non-activity. */
+#define ipconfigTCP_HANG_PROTECTION         ( 1 )
+#define ipconfigTCP_HANG_PROTECTION_TIME    ( 30 )
+
+/* Include support for TCP keep-alive messages. */
+#define ipconfigTCP_KEEP_ALIVE              ( 1 )
+#define ipconfigTCP_KEEP_ALIVE_INTERVAL     ( 20 ) /* in seconds */
+
+#define portINLINE                          __inline
+
+#endif /* FREERTOS_IP_CONFIG_H */

--- a/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_keep_alive/READ_ME_INSTRUCTIONS.url
+++ b/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_keep_alive/READ_ME_INSTRUCTIONS.url
@@ -1,0 +1,5 @@
+[{000214A0-0000-0000-C000-000000000046}]
+Prop3=19,11
+[InternetShortcut]
+IDList=
+URL=https://www.freertos.org/mqtt_lts/

--- a/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_keep_alive/WIN32.vcxproj
+++ b/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_keep_alive/WIN32.vcxproj
@@ -1,0 +1,205 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{C686325E-3261-42F7-AEB1-DDE5280E1CEB}</ProjectGuid>
+    <ProjectName>RTOSDemo</ProjectName>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseOfMfc>false</UseOfMfc>
+    <CharacterSet>MultiByte</CharacterSet>
+    <PlatformToolset>v142</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseOfMfc>false</UseOfMfc>
+    <CharacterSet>MultiByte</CharacterSet>
+    <PlatformToolset>v141</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="$(VCTargetsPath)Microsoft.CPP.UpgradeFromVC60.props" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="$(VCTargetsPath)Microsoft.CPP.UpgradeFromVC60.props" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup>
+    <_ProjectFileVersion>10.0.30319.1</_ProjectFileVersion>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">.\Debug\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">.\Debug\</IntDir>
+    <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</LinkIncremental>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">.\Release\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">.\Release\</IntDir>
+    <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">false</LinkIncremental>
+    <CodeAnalysisRuleSet Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">AllRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Midl>
+      <TypeLibraryName>.\Debug/WIN32.tlb</TypeLibraryName>
+      <HeaderFileName>
+      </HeaderFileName>
+    </Midl>
+    <ClCompile>
+      <Optimization>Disabled</Optimization>
+      <AdditionalIncludeDirectories>..\..\..\..\Source\FreeRTOS-Plus-Trace\Include;..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\include;..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\portable\BufferManagement;..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\portable\Compiler\MSVC;..\..\common\logging-stack;..\common\WinPCap;..\..\..\..\..\FreeRTOS\Source\include;..\..\..\..\..\FreeRTOS\Source\portable\MSVC-MingW;..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\standard\mqtt\include;..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\platform\include;..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\platform\freertos\transport\include;.;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;_WIN32_WINNT=0x0500;WINVER=0x400;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <MinimalRebuild>false</MinimalRebuild>
+      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <PrecompiledHeaderOutputFile>.\Debug/WIN32.pch</PrecompiledHeaderOutputFile>
+      <AssemblerListingLocation>.\Debug/</AssemblerListingLocation>
+      <ObjectFileName>.\Debug/</ObjectFileName>
+      <ProgramDataBaseFileName>.\Debug/</ProgramDataBaseFileName>
+      <WarningLevel>Level4</WarningLevel>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <DisableLanguageExtensions>false</DisableLanguageExtensions>
+      <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
+      <AdditionalOptions>/wd4210 /wd4127 /wd4214 /wd4201 /wd4244  /wd4310 /wd4200 %(AdditionalOptions)</AdditionalOptions>
+      <BrowseInformation>true</BrowseInformation>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <ExceptionHandling>false</ExceptionHandling>
+      <CompileAs>CompileAsC</CompileAs>
+    </ClCompile>
+    <ResourceCompile>
+      <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <Culture>0x0c09</Culture>
+    </ResourceCompile>
+    <Link>
+      <OutputFile>.\Debug/RTOSDemo.exe</OutputFile>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <ProgramDatabaseFile>.\Debug/WIN32.pdb</ProgramDatabaseFile>
+      <SubSystem>Console</SubSystem>
+      <TargetMachine>MachineX86</TargetMachine>
+      <AdditionalDependencies>wpcap.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>..\common\WinPCap</AdditionalLibraryDirectories>
+      <Profile>false</Profile>
+      <ImageHasSafeExceptionHandlers>false</ImageHasSafeExceptionHandlers>
+    </Link>
+    <Bscmake>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <OutputFile>.\Debug/WIN32.bsc</OutputFile>
+    </Bscmake>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Midl>
+      <TypeLibraryName>.\Release/WIN32.tlb</TypeLibraryName>
+      <HeaderFileName>
+      </HeaderFileName>
+    </Midl>
+    <ClCompile>
+      <Optimization>MaxSpeed</Optimization>
+      <InlineFunctionExpansion>OnlyExplicitInline</InlineFunctionExpansion>
+      <PreprocessorDefinitions>_WINSOCKAPI_;WIN32;NDEBUG;_CONSOLE;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <StringPooling>true</StringPooling>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <PrecompiledHeaderOutputFile>.\Release/WIN32.pch</PrecompiledHeaderOutputFile>
+      <AssemblerListingLocation>.\Release/</AssemblerListingLocation>
+      <ObjectFileName>.\Release/</ObjectFileName>
+      <ProgramDataBaseFileName>.\Release/</ProgramDataBaseFileName>
+      <WarningLevel>Level3</WarningLevel>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <AdditionalIncludeDirectories>..\Common\Utils;..\Common\ethernet\lwip-1.4.0\ports\win32\WinPCap;..\Common\ethernet\lwip-1.4.0\src\include\ipv4;..\Common\ethernet\lwip-1.4.0\src\include;..\..\..\Source\include;..\..\..\Source\portable\MSVC-MingW;..\Common\ethernet\lwip-1.4.0\ports\win32\include;..\Common\Include;.\lwIP_Apps;.;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <ResourceCompile>
+      <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <Culture>0x0c09</Culture>
+    </ResourceCompile>
+    <Link>
+      <OutputFile>.\Release/RTOSDemo.exe</OutputFile>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <ProgramDatabaseFile>.\Release/WIN32.pdb</ProgramDatabaseFile>
+      <SubSystem>Console</SubSystem>
+      <TargetMachine>MachineX86</TargetMachine>
+      <AdditionalLibraryDirectories>..\Common\ethernet\lwip-1.4.0\ports\win32\WinPCap</AdditionalLibraryDirectories>
+      <AdditionalDependencies>wpcap.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+    <Bscmake>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <OutputFile>.\Release/WIN32.bsc</OutputFile>
+    </Bscmake>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\..\..\..\FreeRTOS\Source\event_groups.c" />
+    <ClCompile Include="..\..\..\..\..\FreeRTOS\Source\list.c" />
+    <ClCompile Include="..\..\..\..\..\FreeRTOS\Source\portable\MemMang\heap_4.c" />
+    <ClCompile Include="..\..\..\..\..\FreeRTOS\Source\portable\MSVC-MingW\port.c" />
+    <ClCompile Include="..\..\..\..\..\FreeRTOS\Source\queue.c" />
+    <ClCompile Include="..\..\..\..\..\FreeRTOS\Source\stream_buffer.c" />
+    <ClCompile Include="..\..\..\..\..\FreeRTOS\Source\tasks.c" />
+    <ClCompile Include="..\..\..\..\..\FreeRTOS\Source\timers.c" />
+    <ClCompile Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\FreeRTOS_ARP.c" />
+    <ClCompile Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\FreeRTOS_DHCP.c" />
+    <ClCompile Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\FreeRTOS_DNS.c" />
+    <ClCompile Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\FreeRTOS_IP.c" />
+    <ClCompile Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\FreeRTOS_Sockets.c" />
+    <ClCompile Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\FreeRTOS_Stream_Buffer.c" />
+    <ClCompile Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\FreeRTOS_TCP_IP.c" />
+    <ClCompile Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\FreeRTOS_TCP_WIN.c" />
+    <ClCompile Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\FreeRTOS_UDP_IP.c" />
+    <ClCompile Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\portable\BufferManagement\BufferAllocation_2.c" />
+    <ClCompile Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\portable\NetworkInterface\WinPCap\NetworkInterface.c" />
+    <ClCompile Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\platform\freertos\transport\src\plaintext_freertos.c" />
+    <ClCompile Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\standard\mqtt\src\mqtt_lightweight.c" />
+    <ClCompile Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\standard\mqtt\src\mqtt_state.c" />
+    <ClCompile Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\standard\mqtt\src\mqtt.c" />
+    <ClCompile Include="..\common\demo_logging.c" />
+    <ClCompile Include="..\common\main.c" />
+    <ClCompile Include="DemoTasks\KeepAliveMQTTExample.c" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\..\..\..\FreeRTOS\Source\include\event_groups.h" />
+    <ClInclude Include="..\..\..\..\..\FreeRTOS\Source\include\FreeRTOS.h" />
+    <ClInclude Include="..\..\..\..\..\FreeRTOS\Source\include\portable.h" />
+    <ClInclude Include="..\..\..\..\..\FreeRTOS\Source\include\projdefs.h" />
+    <ClInclude Include="..\..\..\..\..\FreeRTOS\Source\include\queue.h" />
+    <ClInclude Include="..\..\..\..\..\FreeRTOS\Source\include\semphr.h" />
+    <ClInclude Include="..\..\..\..\..\FreeRTOS\Source\include\task.h" />
+    <ClInclude Include="..\..\..\..\..\FreeRTOS\Source\include\timers.h" />
+    <ClInclude Include="..\..\..\..\..\FreeRTOS\Source\portable\MSVC-MingW\portmacro.h" />
+    <ClInclude Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\include\FreeRTOSIPConfigDefaults.h" />
+    <ClInclude Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\include\FreeRTOS_ARP.h" />
+    <ClInclude Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\include\FreeRTOS_DHCP.h" />
+    <ClInclude Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\include\FreeRTOS_DNS.h" />
+    <ClInclude Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\include\FreeRTOS_IP.h" />
+    <ClInclude Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\include\FreeRTOS_IP_Private.h" />
+    <ClInclude Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\include\FreeRTOS_Sockets.h" />
+    <ClInclude Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\include\FreeRTOS_Stream_Buffer.h" />
+    <ClInclude Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\include\FreeRTOS_TCP_IP.h" />
+    <ClInclude Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\include\FreeRTOS_TCP_WIN.h" />
+    <ClInclude Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\include\FreeRTOS_UDP_IP.h" />
+    <ClInclude Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\include\IPTraceMacroDefaults.h" />
+    <ClInclude Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\include\NetworkBufferManagement.h" />
+    <ClInclude Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\include\NetworkInterface.h" />
+    <ClInclude Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\platform\freertos\transport\include\plaintext_freertos.h" />
+    <ClInclude Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\platform\include\transport_interface.h" />
+    <ClInclude Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\standard\mqtt\include\mqtt_lightweight.h" />
+    <ClInclude Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\standard\mqtt\include\mqtt_state.h" />
+    <ClInclude Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\standard\mqtt\include\mqtt.h" />
+    <ClInclude Include="demo_config.h" />
+    <ClInclude Include="FreeRTOSConfig.h" />
+    <ClInclude Include="FreeRTOSIPConfig.h" />
+    <ClInclude Include="mqtt_config.h" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_keep_alive/WIN32.vcxproj.filters
+++ b/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_keep_alive/WIN32.vcxproj.filters
@@ -1,0 +1,217 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="FreeRTOS">
+      <UniqueIdentifier>{af3445a1-4908-4170-89ed-39345d90d30c}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="FreeRTOS\Source">
+      <UniqueIdentifier>{f32be356-4763-4cae-9020-974a2638cb08}</UniqueIdentifier>
+      <Extensions>*.c</Extensions>
+    </Filter>
+    <Filter Include="FreeRTOS\Source\Portable">
+      <UniqueIdentifier>{88f409e6-d396-4ac5-94bd-7a99c914be46}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="FreeRTOS+">
+      <UniqueIdentifier>{e5ad4ec7-23dc-4295-8add-2acaee488f5a}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="FreeRTOS\Source\include">
+      <UniqueIdentifier>{d2dcd641-8d91-492b-852f-5563ffadaec6}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="FreeRTOS+\FreeRTOS+TCP">
+      <UniqueIdentifier>{8672fa26-b119-481f-8b8d-086419c01a3e}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="FreeRTOS+\FreeRTOS+TCP\portable">
+      <UniqueIdentifier>{4570be11-ec96-4b55-ac58-24b50ada980a}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="FreeRTOS+\FreeRTOS+TCP\include">
+      <UniqueIdentifier>{5d93ed51-023a-41ad-9243-8d230165d34b}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="DemoTasks">
+      <UniqueIdentifier>{b71e974a-9f28-4815-972b-d930ba8a34d0}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="FreeRTOS+\FreeRTOS IoT Libraries">
+      <UniqueIdentifier>{60717407-397f-4ea5-8492-3314acdd25f0}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="FreeRTOS+\FreeRTOS IoT Libraries\standard">
+      <UniqueIdentifier>{8a90222f-d723-4b4e-8e6e-c57afaf7fa92}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="FreeRTOS+\FreeRTOS IoT Libraries\standard\mqtt">
+      <UniqueIdentifier>{2d17d5e6-ed70-4e42-9693-f7a63baf4948}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="FreeRTOS+\FreeRTOS IoT Libraries\standard\mqtt\src">
+      <UniqueIdentifier>{7158b0be-01e7-42d1-8d3f-c75118a596a2}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="FreeRTOS+\FreeRTOS IoT Libraries\standard\mqtt\include">
+      <UniqueIdentifier>{6ad56e6d-c330-4830-8f4b-c75b05dfa866}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="FreeRTOS+\FreeRTOS IoT Libraries\platform">
+      <UniqueIdentifier>{84613aa2-91dc-4e1a-a3b3-823b6d7bf0e0}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\..\..\..\FreeRTOS\Source\portable\MSVC-MingW\port.c">
+      <Filter>FreeRTOS\Source\Portable</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\FreeRTOS\Source\timers.c">
+      <Filter>FreeRTOS\Source</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\FreeRTOS\Source\list.c">
+      <Filter>FreeRTOS\Source</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\FreeRTOS\Source\queue.c">
+      <Filter>FreeRTOS\Source</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\FreeRTOS\Source\tasks.c">
+      <Filter>FreeRTOS\Source</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\FreeRTOS_UDP_IP.c">
+      <Filter>FreeRTOS+\FreeRTOS+TCP</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\FreeRTOS_DHCP.c">
+      <Filter>FreeRTOS+\FreeRTOS+TCP</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\FreeRTOS_DNS.c">
+      <Filter>FreeRTOS+\FreeRTOS+TCP</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\FreeRTOS_Sockets.c">
+      <Filter>FreeRTOS+\FreeRTOS+TCP</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\portable\BufferManagement\BufferAllocation_2.c">
+      <Filter>FreeRTOS+\FreeRTOS+TCP\portable</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\portable\NetworkInterface\WinPCap\NetworkInterface.c">
+      <Filter>FreeRTOS+\FreeRTOS+TCP\portable</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\FreeRTOS_ARP.c">
+      <Filter>FreeRTOS+\FreeRTOS+TCP</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\FreeRTOS_IP.c">
+      <Filter>FreeRTOS+\FreeRTOS+TCP</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\FreeRTOS_TCP_IP.c">
+      <Filter>FreeRTOS+\FreeRTOS+TCP</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\FreeRTOS_TCP_WIN.c">
+      <Filter>FreeRTOS+\FreeRTOS+TCP</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\FreeRTOS\Source\event_groups.c">
+      <Filter>FreeRTOS\Source</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\FreeRTOS\Source\portable\MemMang\heap_4.c">
+      <Filter>FreeRTOS\Source\Portable</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\FreeRTOS_Stream_Buffer.c">
+      <Filter>FreeRTOS+\FreeRTOS+TCP</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\FreeRTOS\Source\stream_buffer.c">
+      <Filter>FreeRTOS\Source</Filter>
+    </ClCompile>
+    <ClCompile Include="..\common\demo_logging.c" />
+    <ClCompile Include="..\common\main.c" />
+    <ClCompile Include="DemoTasks\KeepAliveMQTTExample.c">
+      <Filter>DemoTasks</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\standard\mqtt\src\mqtt_lightweight.c">
+      <Filter>FreeRTOS+\FreeRTOS IoT Libraries\standard\mqtt\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\standard\mqtt\src\mqtt_state.c">
+      <Filter>FreeRTOS+\FreeRTOS IoT Libraries\standard\mqtt\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\standard\mqtt\src\mqtt.c">
+      <Filter>FreeRTOS+\FreeRTOS IoT Libraries\standard\mqtt\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\platform\freertos\transport\src\plaintext_freertos.c">
+      <Filter>FreeRTOS+\FreeRTOS IoT Libraries\platform</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\include\NetworkInterface.h">
+      <Filter>FreeRTOS+\FreeRTOS+TCP\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\include\FreeRTOS_DNS.h">
+      <Filter>FreeRTOS+\FreeRTOS+TCP\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\include\FreeRTOS_Sockets.h">
+      <Filter>FreeRTOS+\FreeRTOS+TCP\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\include\FreeRTOS_UDP_IP.h">
+      <Filter>FreeRTOS+\FreeRTOS+TCP\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\FreeRTOS\Source\include\timers.h">
+      <Filter>FreeRTOS\Source\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\FreeRTOS\Source\include\event_groups.h">
+      <Filter>FreeRTOS\Source\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\FreeRTOS\Source\include\FreeRTOS.h">
+      <Filter>FreeRTOS\Source\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\FreeRTOS\Source\include\queue.h">
+      <Filter>FreeRTOS\Source\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\FreeRTOS\Source\include\semphr.h">
+      <Filter>FreeRTOS\Source\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\FreeRTOS\Source\include\task.h">
+      <Filter>FreeRTOS\Source\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\FreeRTOS\Source\portable\MSVC-MingW\portmacro.h">
+      <Filter>FreeRTOS\Source\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\include\FreeRTOS_IP_Private.h">
+      <Filter>FreeRTOS+\FreeRTOS+TCP\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\include\NetworkBufferManagement.h">
+      <Filter>FreeRTOS+\FreeRTOS+TCP\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\include\FreeRTOS_ARP.h">
+      <Filter>FreeRTOS+\FreeRTOS+TCP\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\include\FreeRTOS_DHCP.h">
+      <Filter>FreeRTOS+\FreeRTOS+TCP\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\include\FreeRTOS_IP.h">
+      <Filter>FreeRTOS+\FreeRTOS+TCP\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\include\FreeRTOS_TCP_IP.h">
+      <Filter>FreeRTOS+\FreeRTOS+TCP\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\include\FreeRTOS_TCP_WIN.h">
+      <Filter>FreeRTOS+\FreeRTOS+TCP\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\include\FreeRTOSIPConfigDefaults.h">
+      <Filter>FreeRTOS+\FreeRTOS+TCP\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\include\IPTraceMacroDefaults.h">
+      <Filter>FreeRTOS+\FreeRTOS+TCP\include</Filter>
+    </ClInclude>
+    <ClInclude Include="FreeRTOSConfig.h" />
+    <ClInclude Include="FreeRTOSIPConfig.h" />
+    <ClInclude Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\include\FreeRTOS_Stream_Buffer.h">
+      <Filter>FreeRTOS+\FreeRTOS+TCP\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\FreeRTOS\Source\include\portable.h">
+      <Filter>FreeRTOS\Source\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\FreeRTOS\Source\include\projdefs.h">
+      <Filter>FreeRTOS\Source\include</Filter>
+    </ClInclude>
+    <ClInclude Include="demo_config.h" />
+    <ClInclude Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\standard\mqtt\include\mqtt_lightweight.h">
+      <Filter>FreeRTOS+\FreeRTOS IoT Libraries\standard\mqtt\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\standard\mqtt\include\mqtt_state.h">
+      <Filter>FreeRTOS+\FreeRTOS IoT Libraries\standard\mqtt\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\standard\mqtt\include\mqtt.h">
+      <Filter>FreeRTOS+\FreeRTOS IoT Libraries\standard\mqtt\include</Filter>
+    </ClInclude>
+    <ClInclude Include="mqtt_config.h" />
+    <ClInclude Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\platform\freertos\transport\include\plaintext_freertos.h">
+      <Filter>FreeRTOS+\FreeRTOS IoT Libraries\platform</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\platform\include\transport_interface.h">
+      <Filter>FreeRTOS+\FreeRTOS IoT Libraries\platform</Filter>
+    </ClInclude>
+  </ItemGroup>
+</Project>

--- a/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_keep_alive/demo_config.h
+++ b/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_keep_alive/demo_config.h
@@ -1,0 +1,126 @@
+/*
+ * FreeRTOS Kernel V10.3.0
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://www.FreeRTOS.org
+ * http://aws.amazon.com/freertos
+ *
+ * 1 tab == 4 spaces!
+ */
+
+#ifndef DEMO_CONFIG_H
+#define DEMO_CONFIG_H
+
+/**************************************************/
+/******* DO NOT CHANGE the following order ********/
+/**************************************************/
+
+/* Include logging header files and define logging macros in the following order:
+ * 1. Include the header file "logging_levels.h".
+ * 2. Define the LIBRARY_LOG_NAME and LIBRARY_LOG_LEVEL macros depending on
+ * the logging configuration for DEMO.
+ * 3. Include the header file "logging_stack.h", if logging is enabled for DEMO.
+ */
+
+#include "logging_levels.h"
+
+/* Logging configuration for the Demo. */
+#ifndef LIBRARY_LOG_NAME
+    #define LIBRARY_LOG_NAME    "MQTTDemo"
+#endif
+
+#ifndef LIBRARY_LOG_LEVEL
+    #define LIBRARY_LOG_LEVEL    LOG_INFO
+#endif
+#include "logging_stack.h"
+
+/************ End of logging configuration ****************/
+
+/**
+ * @brief The MQTT client identifier used in this example.  Each client identifier
+ * must be unique so edit as required to ensure no two clients connecting to the
+ * same broker use the same client identifier.
+ *
+ * #define democonfigCLIENT_IDENTIFIER				"insert here."
+ */
+
+
+/**
+ * @brief MQTT broker end point to connect to.
+ *
+ * @note For running this demo an MQTT broker, which can be run locally on
+ * the same host is recommended. Any MQTT broker, which can be run on a Windows
+ * host can be used for this demo. However, the instructions below are for
+ * setting up a local Mosquitto broker on a Windows host.
+ * 1. Download Mosquitto from https://mosquitto.org/download/
+ * 2. Install Mosquitto as a Windows service by running the installer.
+ * More details about installing as a Windows service can be found at
+ * https://github.com/eclipse/mosquitto/blob/master/readme-windows.txt and
+ * https://github.com/eclipse/mosquitto/blob/master/readme.md
+ * 3. Verify that Mosquitto server is running locally and listening on port
+ * 1883 by following the steps below.
+ *     a. Open Power Shell.
+ *     b. Type in command `netstat -a -p TCP | grep 1883` to check if there
+ *        is an active connection listening on port 1883.
+ *     c. Verify that there is an output as shown below
+ *        `TCP    0.0.0.0:1883           <HOST-NAME>:0       LISTENING`
+ *     d. If there is no output on step c,go through the Mosquitto documentation
+ *        listed above to check if the installation was successful.
+ * 4. Make sure the Mosquitto broker is allowed to communicate through
+ * Windows Firewall. The instructions for allowing an application on Windows 10
+ * Defender Firewall can be found at the link below.
+ * https://support.microsoft.com/en-us/help/4558235/windows-10-allow-an-app-through-microsoft-defender-firewall
+ * After running this MQTT example, consider disabling the Mosquitto broker to
+ * communicate through Windows Firewall for avoiding unwanted network traffic
+ * to your machine.
+ * 5. After verifying that a Mosquitto broker is running successfully, update
+ * the config democonfigMQTT_BROKER_ENDPOINT to the local IP address of the
+ * Windows host machine. Please note that "localhost" or address "127.0.0.1"
+ * will not work as this example is running on a Windows Simulator and not on
+ * Windows host natively. Also note that, if the Windows host is using a
+ * Virtual Private Network(VPN), connection to the Mosquitto broker may not
+ * work.
+ *
+ * As an alternative option, a publicly hosted Mosquitto broker can also be
+ * used as an MQTT broker end point. This can be done by updating the config
+ * democonfigMQTT_BROKER_ENDPOINT to "test.mosquitto.org". However, this is not
+ * recommended due the possible downtimes of the broker as indicated by the
+ * documentation in https://test.mosquitto.org/.
+ *
+ * #define democonfigMQTT_BROKER_ENDPOINT				"insert here."
+ */
+
+
+/**
+ * @brief The port to use for the demo.
+ *
+ * #define democonfigMQTT_BROKER_PORT					( insert here. )
+ */
+
+
+/**
+ * @brief Set the stack size of the main demo task.
+ *
+ * In the Windows port, this stack only holds a structure. The actual
+ * stack is created by an operating system thread.
+ */
+#define democonfigDEMO_STACKSIZE    configMINIMAL_STACK_SIZE
+
+#endif /* DEMO_CONFIG_H */

--- a/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_keep_alive/mqtt_config.h
+++ b/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_keep_alive/mqtt_config.h
@@ -1,0 +1,67 @@
+/*
+ * FreeRTOS Kernel V10.3.0
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://www.FreeRTOS.org
+ * http://aws.amazon.com/freertos
+ *
+ * 1 tab == 4 spaces!
+ */
+#ifndef MQTT_CONFIG_H_
+#define MQTT_CONFIG_H_
+
+/**************************************************/
+/******* DO NOT CHANGE the following order ********/
+/**************************************************/
+
+/* Include logging header files and define logging macros in the following order:
+ * 1. Include the header file "logging_levels.h".
+ * 2. Define the LIBRARY_LOG_NAME and LIBRARY_LOG_LEVEL macros depending on
+ * the logging configuration for MQTT.
+ * 3. Include the header file "logging_stack.h", if logging is enabled for MQTT.
+ */
+
+#include "logging_levels.h"
+
+/* Logging configuration for the MQTT library. */
+#ifndef LIBRARY_LOG_NAME
+    #define LIBRARY_LOG_NAME    "MQTT"
+#endif
+
+#ifndef LIBRARY_LOG_LEVEL
+    #define LIBRARY_LOG_LEVEL    LOG_NONE
+#endif
+
+#include "logging_stack.h"
+/************ End of logging configuration ****************/
+
+/**
+ * @brief The maximum number of MQTT PUBLISH messages that may be pending
+ * acknowledgement at any time.
+ *
+ * QoS 1 and 2 MQTT PUBLISHes require acknowledgment from the server before
+ * they can be completed. While they are awaiting the acknowledgment, the
+ * client must maintain information about their state. The value of this
+ * macro sets the limit on how many simultaneous PUBLISH states an MQTT
+ * context maintains.
+ */
+#define MQTT_STATE_ARRAY_MAX_COUNT    10U
+
+#endif /* ifndef MQTT_CONFIG_H_ */

--- a/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_keep_alive/mqtt_keep_alive_demo.sln
+++ b/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_keep_alive/mqtt_keep_alive_demo.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29215.179
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "RTOSDemo", "WIN32.vcxproj", "{C686325E-3261-42F7-AEB1-DDE5280E1CEB}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Win32 = Debug|Win32
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{C686325E-3261-42F7-AEB1-DDE5280E1CEB}.Debug|Win32.ActiveCfg = Debug|Win32
+		{C686325E-3261-42F7-AEB1-DDE5280E1CEB}.Debug|Win32.Build.0 = Debug|Win32
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {150F08BF-9D61-4CC2-8DBF-1335172A1EA4}
+	EndGlobalSection
+	GlobalSection(TestCaseManagementSettings) = postSolution
+		CategoryFile = FreeRTOS_Plus_TCP_Minimal.vsmdi
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
<!--- Title -->
MQTT keep-alive demo with QoS0

Description
-----------
<!--- Describe your changes in detail. -->
The MQTT keep-alive demo is similar to the plaintext demo with QoS0. The only difference is that it creates an auto-reload timer that invokes a callback responsible for sending a PINGREQ packet. The timer is reset whenever a control packet is sent. Because the keep-alive mechanism is handled by the application, MQTT_ReceiveLoop is used in place of MQTT_ProcessLoop. 

Test Steps
-----------
<!-- Describe the steps to reproduce. -->
Just open mqtt_keep_alive_demo.sln and build and run as you normally would.

Related Issue
-----------
<!-- If any, please provide issue ID. -->
N/A

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
