### PR TITLE
Connection Sharing Demo

### DIFF
--- a/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_multitask/DemoTasks/MultitaskMQTTExample.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_multitask/DemoTasks/MultitaskMQTTExample.c
@@ -1,4 +1,5 @@
 /*
+ * FreeRTOS Kernel V10.3.0
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
@@ -17,18 +18,19 @@
  * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
  * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://www.FreeRTOS.org
+ * http://aws.amazon.com/freertos
+ *
+ * 1 tab == 4 spaces!
  */
 
 /*
- * Demo for showing the use of MQTT APIs to establish an MQTT session,
- * subscribe to a topic, publish to a topic, receive incoming publishes,
- * unsubscribe from a topic and disconnect the MQTT session.
+ * Demo for showing use of the managed MQTT API shared between multiple tasks.
  *
- * The example shown below uses MQTT APIs to send and receive MQTT packets
- * over the TCP connection established using POSIX sockets.
- * The example is single threaded and uses statically allocated memory;
- * it uses QOS0 and therefore does not implement any retransmission
- * mechanism for Publish messages.
+ * !!! NOTE !!!
+ * This MQTT demo does not authenticate the server nor the client.
+ * Hence, this demo should not be used as production ready code.
  */
 
 /* Standard includes. */
@@ -54,15 +56,8 @@
 /* Transport interface include. */
 #include "plaintext_freertos.h"
 
-
-#define BROKER_ENDPOINT      "10.0.0.127"
-
-#define BROKER_PORT          ( 1883 )
-
-#define CLIENT_IDENTIFIER    "testclient"
-
 /**
- * These configuration settings are required to run the plaintext demo.
+ * These configuration settings are required to run the demo.
  * Throw compilation error if the below configs are not defined.
  */
 #ifndef CLIENT_IDENTIFIER
@@ -96,32 +91,9 @@
 #define CONNACK_RECV_TIMEOUT_MS             ( 1000U )
 
 /**
- * @brief The topic to subscribe and publish to in the example.
- *
- * The topic name starts with the client identifier to ensure that each demo
- * interacts with a unique topic name.
- */
-#define MQTT_EXAMPLE_TOPIC                  CLIENT_IDENTIFIER "/example/topic"
-
-/**
- * @brief Length of client MQTT topic.
- */
-#define MQTT_EXAMPLE_TOPIC_LENGTH           ( ( uint16_t ) ( sizeof( MQTT_EXAMPLE_TOPIC ) - 1 ) )
-
-/**
- * @brief The MQTT message published in this example.
- */
-#define MQTT_EXAMPLE_MESSAGE                "Hello World!"
-
-/**
- * @brief The length of the MQTT message published in this example.
- */
-#define MQTT_EXAMPLE_MESSAGE_LENGTH         ( ( uint16_t ) ( sizeof( MQTT_EXAMPLE_MESSAGE ) - 1 ) )
-
-/**
  * @brief Timeout for MQTT_ProcessLoop function in milliseconds.
  */
-#define MQTT_PROCESS_LOOP_TIMEOUT_MS        ( 500U )
+#define MQTT_PROCESS_LOOP_TIMEOUT_MS        ( 200U )
 
 /**
  * @brief The maximum time interval in seconds which is allowed to elapse
@@ -135,148 +107,62 @@
 #define MQTT_KEEP_ALIVE_INTERVAL_SECONDS    ( 60U )
 
 /**
- * @brief Delay between MQTT publishes in milliseconds.
- */
-#define DELAY_BETWEEN_PUBLISHES_MS     ( 50U )
-
-/**
  * @brief Transport timeout in milliseconds for transport send and receive.
  */
 #define TRANSPORT_SEND_RECV_TIMEOUT_MS      ( 20 )
 
 #define _MILLISECONDS_PER_SECOND                    ( 1000U )                                         /**< @brief Milliseconds per second. */
 #define _MILLISECONDS_PER_TICK                      ( _MILLISECONDS_PER_SECOND / configTICK_RATE_HZ ) /**< Milliseconds per FreeRTOS tick. */
-#define TICKS_TO_WAIT                       pdMS_TO_TICKS( 1000 )
 
-#ifndef EXIT_SUCCESS
-    #define EXIT_SUCCESS 0
-#endif
-#ifndef EXIT_FAILURE
-    #define EXIT_FAILURE 1
-#endif
+/* Ticks to wait for task notifications. */
+#define DEMO_TICKS_TO_WAIT                  pdMS_TO_TICKS( 1000 )
 
-/*-----------------------------------------------------------*/
+/* Maximum number of operations awaiting an ack packet from the broker. */
+#define PENDING_ACKS_MAX_SIZE       20
+/* Maximum number of subscriptions to store in the subscription list. */
+#define SUBSCRIPTIONS_MAX_COUNT     10
+/* Number of publishes done by the publisher in this demo. */
+#define PUBLISH_COUNT               16
 
-/**
- * @brief The network buffer must remain valid for the lifetime of the MQTT context.
- */
-static uint8_t buffer[ NETWORK_BUFFER_SIZE ];
+/* Size of statically allocated buffers in this demo. */
+#define DEMO_BUFFER_SIZE            100
+/* Size of dynamically allocated buffers in this demo. */
+#define DYNAMIC_BUFFER_SIZE         25
 
-/*-----------------------------------------------------------*/
+/* Max number of commands that can be enqueued. */
+#define COMMAND_QUEUE_SIZE          25
+/* Max number of received publishes that can be enqueued for a task. */
+#define PUBLISH_QUEUE_SIZE          20
 
-/**
- * @brief Sends an MQTT CONNECT packet over the already connected TCP socket.
- *
- * @param[in] pMqttContext MQTT context pointer.
- * @param[in] pNetworkContext Pointer to the network context created using Plaintext_Connect.
- *
- * @return EXIT_SUCCESS if an MQTT session is established;
- * EXIT_FAILURE otherwise.
- */
-static int establishMqttSession( MQTTContext_t * pMqttContext,
-                                 NetworkContext_t * pNetworkContext );
+/* Delay for the subscriber task when no publishes are waiting in the queue. */
+#define SUBSCRIBE_TASK_DELAY_MS     400U
+/* Delay for the publisher task between synchronous publishes. */
+#define PUBLISH_DELAY_SYNC_MS       500U
+/* Delay for the publisher task between asynchronous publishes. */
+#define PUBLISH_DELAY_ASYNC_MS      50U
 
-static void subscriptionManager( MQTTContext_t * pMqttContext,
-                                 MQTTPacketInfo_t * pPacketInfo,
-                                 uint16_t packetIdentifier,
-                                 MQTTPublishInfo_t * pPublishInfo );
+/* Notification bit indicating completion of publisher task. */
+#define TASK1_COMPLETE_BIT          ( 1U << 1 )
+/* Notification bit indicating completion of subscriber task. */
+#define TASK2_COMPLETE_BIT          ( 1U << 2 )
+/* Notification bit used by subscriber task for subscribe operation. */
+#define SUBSCRIBE_BIT               ( 1U << 0 )
+/* Notification bit used by subscriber task for unsubscribe operation. */
+#define UNSUBSCRIBE_BIT             ( 1U << 1 )
 
-static uint32_t prvGetTimeMs( void );
+/* Maximum number of loop iterations to wait for a task notification. */
+#define MAX_WAIT_ITERATIONS         5
 
-/*-----------------------------------------------------------*/
-
-/**
- * @brief Global entry time into the application to use as a reference timestamp
- * in the #prvGetTimeMs function. #prvGetTimeMs will always return the difference
- * between the current time and the global entry time. This will reduce the chances
- * of overflow for the 32 bit unsigned integer used for holding the timestamp.
- */
-static uint32_t ulGlobalEntryTimeMs;
-
-/*-----------------------------------------------------------*/
-
-static int establishMqttSession( MQTTContext_t * pMqttContext,
-                                 NetworkContext_t * pNetworkContext )
-{
-    int returnStatus = EXIT_SUCCESS;
-    MQTTStatus_t mqttStatus;
-    MQTTConnectInfo_t connectInfo;
-    bool sessionPresent;
-    MQTTFixedBuffer_t networkBuffer;
-    TransportInterface_t transport;
-
-    assert( pMqttContext != NULL );
-    assert( pNetworkContext != NULL );
-
-    /* Fill in TransportInterface send and receive function pointers.
-     * For this demo, TCP sockets are used to send and receive data
-     * from network. Network context is socket file descriptor.*/
-    transport.pNetworkContext = pNetworkContext;
-    transport.send = Plaintext_FreeRTOS_send;
-    transport.recv = Plaintext_FreeRTOS_recv;
-
-    /* Fill the values for network buffer. */
-    networkBuffer.pBuffer = buffer;
-    networkBuffer.size = NETWORK_BUFFER_SIZE;
-
-    /* Initialize MQTT library. */
-    mqttStatus = MQTT_Init( pMqttContext, &transport, prvGetTimeMs, subscriptionManager, &networkBuffer );
-
-    if( mqttStatus != MQTTSuccess )
-    {
-        returnStatus = EXIT_FAILURE;
-        LogError( ( "MQTT init failed with status %u.", mqttStatus ) );
-    }
-    else
-    {
-        /* Establish MQTT session by sending a CONNECT packet. */
-
-        /* Start with a clean session i.e. direct the MQTT broker to discard any
-         * previous session data. Also, establishing a connection with clean session
-         * will ensure that the broker does not store any data when this client
-         * gets disconnected. */
-        connectInfo.cleanSession = true;
-
-        /* The client identifier is used to uniquely identify this MQTT client to
-         * the MQTT broker. In a production device the identifier can be something
-         * unique, such as a device serial number. */
-        connectInfo.pClientIdentifier = CLIENT_IDENTIFIER;
-        connectInfo.clientIdentifierLength = CLIENT_IDENTIFIER_LENGTH;
-
-        /* The maximum time interval in seconds which is allowed to elapse
-         * between two Control Packets.
-         * It is the responsibility of the Client to ensure that the interval between
-         * Control Packets being sent does not exceed the this Keep Alive value. In the
-         * absence of sending any other Control Packets, the Client MUST send a
-         * PINGREQ Packet. */
-        connectInfo.keepAliveSeconds = MQTT_KEEP_ALIVE_INTERVAL_SECONDS;
-
-        /* Username and password for authentication. Not used in this demo. */
-        connectInfo.pUserName = NULL;
-        connectInfo.userNameLength = 0U;
-        connectInfo.pPassword = NULL;
-        connectInfo.passwordLength = 0U;
-
-        /* Send MQTT CONNECT packet to broker. */
-        mqttStatus = MQTT_Connect( pMqttContext, &connectInfo, NULL, CONNACK_RECV_TIMEOUT_MS, &sessionPresent );
-
-        if( mqttStatus != MQTTSuccess )
-        {
-            returnStatus = EXIT_FAILURE;
-            LogError( ( "Connection with MQTT broker failed with status %u.", mqttStatus ) );
-        }
-        else
-        {
-            LogInfo( ( "MQTT connection successfully established with broker.\n\n" ) );
-        }
-    }
-
-    return returnStatus;
-}
+/* Topic filter used by the subscriber task. */
+#define SUBSCRIBE_TOPIC_FILTER      "publish/+/filter"
+/* Format string used by the publisher task for topic names. */
+#define PUBLISH_TOPIC_FORMAT_STRING "publish/%i/filter"
+/* Format string used by the publisher task for payloads. */
+#define PUBLISH_PAYLOAD_FORMAT      "Hello World! %d"
 
 /*-----------------------------------------------------------*/
 
-typedef enum operationType {
+typedef enum CommandType {
     PROCESSLOOP,
     PUBLISH,
     SUBSCRIBE,
@@ -314,144 +200,427 @@ typedef struct ackInfo {
 } AckInfo_t;
 
 typedef struct subscriptionElement {
-    char pTopicFilter[ 100 ];
+    char pTopicFilter[ DEMO_BUFFER_SIZE ];
     uint16_t topicFilterLength;
-    QueueHandle_t responseQueue;
+    QueueHandle_t pResponseQueue;
 } SubscriptionElement_t;
 
 typedef struct publishElement {
     MQTTPublishInfo_t publishInfo;
-    uint8_t pPayload[ 100 ];
-    uint8_t pTopicName[ 100 ];
+    uint8_t pPayload[ DEMO_BUFFER_SIZE ];
+    uint8_t pTopicName[ DEMO_BUFFER_SIZE ];
 } PublishElement_t;
 
-#define PENDING_ACKS_MAX_SIZE       20
-#define SUBSCRIPTIONS_MAX_COUNT     10
-#define PUBLISH_COUNT               12
-#define DEMO_BUFFER_SIZE            100
-#define COMMAND_QUEUE_SIZE          25
-#define PUBLISH_QUEUE_SIZE          20
-#define TASK1_COMPLETE_BIT          ( 1 << 1 )
-#define TASK2_COMPLETE_BIT          ( 1 << 2 )
+/*-----------------------------------------------------------*/
 
+/**
+ * @brief Sends an MQTT Connect packet over the already connected TCP socket.
+ *
+ * @param[in] pxMQTTContext MQTT context pointer.
+ * @param[in] xNetworkContext network context.
+ */
+static void prvCreateMQTTConnectionWithBroker( MQTTContext_t * pxMQTTContext,
+                                               NetworkContext_t * pxNetworkContext );
+
+/**
+ * @brief Initialize context for a command.
+ *
+ * @param[in] pxContext Context to initialize.
+ */
+static void prvInitializeCommandContext( CommandContext_t * pxContext );
+
+/**
+ * @brief Add an operation to the list of pending acks.
+ *
+ * @param[in] usPacketId Packet ID of pending ack.
+ * @param[in] pxContext Command context of operation.
+ * @param[in] xCallback Callback from command.
+ */
+static void prvAddAck( uint16_t usPacketId,
+                           CommandContext_t * pxContext,
+                           CommandCallback_t xCallback );
+
+/**
+ * @brief Remove an operation from the list of pending acks and return it.
+ *
+ * @param[in] usPacketId Packet ID of incoming ack.
+ *
+ * @return Stored information about the operation awaiting the ack.
+ */
+static AckInfo_t prvPopAck( uint16_t usPacketId );
+
+/**
+ * @brief Add a subscription to the subscription list.
+ *
+ * @param[in] pTopicFilter Topic filter of subscription.
+ * @param[in] topicFilterLength Length of topic filter.
+ * @param[in] pxQueue Response queue in which to enqueue received publishes.
+ */
+static void prvAddSubscription( const char * pTopicFilter, uint16_t topicFilterLength, QueueHandle_t pxQueue );
+
+/**
+ * @brief Remove a subscription from the subscription list.
+ *
+ * @param[in] pTopicFilter Topic filter of subscription.
+ * @param[in] topicFilterLength Length of topic filter.
+ * @param[in] pxQueue Response queue for received publishes.
+ */
+static void prvRemoveSubscription( const char * pTopicFilter, size_t topicFilterLength, QueueHandle_t pxQueue );
+
+/**
+ * @brief Populate the parameters of a #Command_t
+ *
+ * @param[in] xCommandType Type of command.
+ * @param[in] pxContext Context and necessary structs for command.
+ * @param[in] xCallback Callback for when command completes.
+ * @param[out] pxCommand Pointer to initialized command.
+ *
+ * @return `true` if all necessary structs for the command exist in pxContext,
+ * else `false`
+ */
+static bool prvCreateCommand( CommandType_t xCommandType,
+                                  CommandContext_t * pxContext,
+                                  CommandCallback_t xCallback,
+                                  Command_t * pxCommand );
+
+/**
+ * @brief Add a command to the global command queue.
+ *
+ * @param[in] pxCommand Pointer to command to copy to queue.
+ */
+static void prvAddCommandToQueue( Command_t * pxCommand );
+
+/**
+ * @brief Copy an incoming publish to a response queue.
+ *
+ * @param[in] pPublishInfo Info of incoming publish.
+ * @param[in] pResponseQueue Queue to which the publish is copied.
+ */
+static void prvCopyPublishToQueue( MQTTPublishInfo_t * pPublishInfo, QueueHandle_t pResponseQueue );
+
+/**
+ * @brief Process a #Command_t.
+ *
+ * @param[in] pxCommand Pointer to command to process.
+ *
+ * @return return status of MQTT library API call.
+ */
+static MQTTStatus_t prvProcessCommand( Command_t * pxCommand );
+
+/**
+ * @brief Dispatch incoming publishes and acks to response queues and
+ * command callbacks.
+ *
+ * @param[in] pMqttContext MQTT Context
+ * @param[in] pPacketInfo Pointer to incoming packet.
+ * @param[in] pDeserializedInfo Pointer to deserialized information from
+ * the incoming packet.
+ */
+static void prvSubscriptionManager( MQTTContext_t * pMqttContext,
+                                 MQTTPacketInfo_t * pPacketInfo,
+                                 uint16_t packetIdentifier,
+                                 MQTTPublishInfo_t * pPublishInfo );
+
+/**
+ * @brief Process commands from the command queue in a loop.
+ *
+ * This demo requires a process loop command to be enqueued before calling this
+ * function, and will re-add a process loop command every time one is processed.
+ * This demo will exit the loop after receiving an unsubscribe operation.
+ */
+static void prvCommandLoop();
+
+/**
+ * @brief Common callback for commands in this demo.
+ * 
+ * This callback marks the command as complete and notifies the calling task.
+ *
+ * @param[in] pxContext Context of the initial command.
+ */
+static void prvCommandCallback( CommandContext_t * pxContext );
+
+/**
+ * @brief The task used to create various publish operations.
+ *
+ * @param[in] pvParameters Parameters as passed at the time of task creation. Not
+ * used in this example.
+ */
+void prvPublishTask( void * pvParameters );
+
+/**
+ * @brief The task used to wait for incoming publishes.
+ *
+ * @param[in] pvParameters Parameters as passed at the time of task creation. Not
+ * used in this example.
+ */
+void prvSubscribeTask( void * pvParameters );
+
+/**
+ * @brief The main task used in the MQTT demo.
+ *
+ * @param[in] pvParameters Parameters as passed at the time of task creation. Not
+ * used in this example.
+ */
+static void prvMQTTDemoTask( void * pvParameters );
+
+/**
+ * @brief The timer query function provided to the MQTT context.
+ *
+ * @return Time in milliseconds.
+ */
+static uint32_t prvGetTimeMs( void );
+
+/*-----------------------------------------------------------*/
+
+/* Global MQTT context. */
 static MQTTContext_t globalMqttContext;
-static AckInfo_t pendingAcks[ PENDING_ACKS_MAX_SIZE ];
-static SubscriptionElement_t subscriptions[ SUBSCRIPTIONS_MAX_COUNT ];
 
-static QueueHandle_t pCommandQueue;
-static QueueHandle_t pResponseQueue1;
-static QueueHandle_t pResponseQueue2;
+/* List of operations that are awaiting an ack from the broker. */
+static AckInfo_t pxPendingAcks[ PENDING_ACKS_MAX_SIZE ];
 
-static TaskHandle_t mainTask;
-static TaskHandle_t task1;
-static TaskHandle_t task2;
+/* List of active subscriptions. */
+static SubscriptionElement_t pxSubscriptions[ SUBSCRIPTIONS_MAX_COUNT ];
 
-static void initializeCommandContext( CommandContext_t * pContext )
+/**
+ * @brief Queue for main task to handle MQTT operations.
+ */
+static QueueHandle_t xCommandQueue;
+/**
+ * @brief Response queue for prvPublishTask.
+ */
+static QueueHandle_t xResponseQueue1;
+/**
+ * @brief Response queue for prvSubscribeTask.
+ */
+static QueueHandle_t xResponseQueue2;
+
+/**
+ * @brief Handle for prvMQTTDemoTask.
+ */
+static TaskHandle_t xMainTask;
+
+/**
+ * @brief Handle for prvPublishTask.
+ */
+static TaskHandle_t xTask1;
+
+/**
+ * @brief Handle for prvSubscribeTask.
+ */
+static TaskHandle_t xTask2;
+
+/**
+ * @brief The network buffer must remain valid for the lifetime of the MQTT context.
+ */
+static uint8_t buffer[ NETWORK_BUFFER_SIZE ];
+
+/**
+ * @brief Global entry time into the application to use as a reference timestamp
+ * in the #prvGetTimeMs function. #prvGetTimeMs will always return the difference
+ * between the current time and the global entry time. This will reduce the chances
+ * of overflow for the 32 bit unsigned integer used for holding the timestamp.
+ */
+static uint32_t ulGlobalEntryTimeMs;
+
+/*-----------------------------------------------------------*/
+
+/*
+ * @brief Create the task that demonstrates the MQTT Connection sharing demo.
+ */
+void vStartSimpleMQTTDemo( void )
 {
-    pContext->complete = false;
-    pContext->pResponseQueue = NULL;
-    pContext->returnStatus = MQTTSuccess;
-    pContext->pPublishInfo = NULL;
-    pContext->pSubscribeInfo = NULL;
+    /* This example uses a single application task, which in turn is used to
+     * connect, subscribe, publish, unsubscribe and disconnect from the MQTT
+     * broker. */
+    xTaskCreate( prvMQTTDemoTask,          /* Function that implements the task. */
+                 "MQTTDemo",               /* Text name for the task - only used for debugging. */
+                 democonfigDEMO_STACKSIZE, /* Size of stack (in words, not bytes) to allocate for the task. */
+                 NULL,                     /* Task parameter - not used in this case. */
+                 tskIDLE_PRIORITY,         /* Task priority, must be between 0 and configMAX_PRIORITIES - 1. */
+                 &xMainTask );              /* Used to pass out a handle to the created task. */
+}
+/*-----------------------------------------------------------*/
+
+static void prvCreateMQTTConnectionWithBroker( MQTTContext_t * pxMQTTContext,
+                                               NetworkContext_t * pxNetworkContext )
+{
+    MQTTStatus_t xResult;
+    MQTTConnectInfo_t xConnectInfo;
+    bool xSessionPresent;
+    TransportInterface_t xTransport;
+    MQTTFixedBuffer_t xNetworkBuffer;
+    /* Fill the values for network buffer. */
+    xNetworkBuffer.pBuffer = buffer;
+    xNetworkBuffer.size = NETWORK_BUFFER_SIZE;
+
+    /***
+     * For readability, error handling in this function is restricted to the use of
+     * asserts().
+     ***/
+
+    /* Fill in Transport Interface send and receive function pointers. */
+    xTransport.pNetworkContext = pxNetworkContext;
+    xTransport.send = Plaintext_FreeRTOS_send;
+    xTransport.recv = Plaintext_FreeRTOS_recv;
+
+    /* Initialize MQTT library. */
+    xResult = MQTT_Init( pxMQTTContext, &xTransport, prvGetTimeMs, prvSubscriptionManager, &xNetworkBuffer );
+    configASSERT( xResult == MQTTSuccess );
+
+    /* Many fields not used in this demo so start with everything at 0. */
+    memset( ( void * ) &xConnectInfo, 0x00, sizeof( xConnectInfo ) );
+
+    /* Start with a clean session i.e. direct the MQTT broker to discard any
+     * previous session data. Also, establishing a connection with clean session
+     * will ensure that the broker does not store any data when this client
+     * gets disconnected. */
+    xConnectInfo.cleanSession = true;
+
+    /* The client identifier is used to uniquely identify this MQTT client to
+     * the MQTT broker. In a production device the identifier can be something
+     * unique, such as a device serial number. */
+    xConnectInfo.pClientIdentifier = CLIENT_IDENTIFIER;
+    xConnectInfo.clientIdentifierLength = ( uint16_t ) strlen( CLIENT_IDENTIFIER );
+
+    /* Set MQTT keep-alive period. It is the responsibility of the application to ensure
+     * that the interval between Control Packets being sent does not exceed the Keep Alive value.
+     * In the absence of sending any other Control Packets, the Client MUST send a PINGREQ Packet. */
+    xConnectInfo.keepAliveSeconds = MQTT_KEEP_ALIVE_INTERVAL_SECONDS;
+
+    /* Send MQTT CONNECT packet to broker. LWT is not used in this demo, so it
+     * is passed as NULL. */
+    xResult = MQTT_Connect( pxMQTTContext,
+                            &xConnectInfo,
+                            NULL,
+                            CONNACK_RECV_TIMEOUT_MS,
+                            &xSessionPresent );
+
+    if( xResult != MQTTSuccess )
+    {
+        LogError( ( "Connection with MQTT broker failed.\r\n" ) );
+    }
 }
 
-static void destroyCommandContext( CommandContext_t * pContext )
+/*-----------------------------------------------------------*/
+
+static void prvInitializeCommandContext( CommandContext_t * pxContext )
 {
-    ( void ) pContext;
+    pxContext->complete = false;
+    pxContext->pResponseQueue = NULL;
+    pxContext->returnStatus = MQTTSuccess;
+    pxContext->pPublishInfo = NULL;
+    pxContext->pSubscribeInfo = NULL;
 }
 
-static void addPendingAck( uint16_t packetId,
-                           CommandContext_t * pContext,
-                           CommandCallback_t callback )
+/*-----------------------------------------------------------*/
+
+static void prvDestroyCommandContext( CommandContext_t * pxContext )
+{
+    ( void ) pxContext;
+}
+
+/*-----------------------------------------------------------*/
+
+static void prvAddAck( uint16_t usPacketId,
+                           CommandContext_t * pxContext,
+                           CommandCallback_t xCallback )
 {
     int32_t i = 0;
     for( i = 0; i < PENDING_ACKS_MAX_SIZE; i++ )
     {
-        if( pendingAcks[ i ].packetId == MQTT_PACKET_ID_INVALID )
+        if( pxPendingAcks[ i ].packetId == MQTT_PACKET_ID_INVALID )
         {
-            pendingAcks[ i ].packetId = packetId;
-            pendingAcks[ i ].pCommandContext = pContext;
-            pendingAcks[ i ].callback = callback;
+            pxPendingAcks[ i ].packetId = usPacketId;
+            pxPendingAcks[ i ].pCommandContext = pxContext;
+            pxPendingAcks[ i ].callback = xCallback;
             break;
         }
     }
 }
 
-static AckInfo_t popAck( uint16_t packetId )
+/*-----------------------------------------------------------*/
+
+static AckInfo_t prvPopAck( uint16_t usPacketId )
 {
     int32_t i = 0;
-    AckInfo_t ret = { 0 };
+    AckInfo_t xFoundAck = { 0 };
     for( i = 0; i < PENDING_ACKS_MAX_SIZE; i++ )
     {
-        if( pendingAcks[ i ].packetId == packetId )
+        if( pxPendingAcks[ i ].packetId == usPacketId )
         {
-            ret = pendingAcks[ i ];
-            pendingAcks[ i ].packetId = MQTT_PACKET_ID_INVALID;
-            pendingAcks[ i ].pCommandContext = NULL;
-            pendingAcks[ i ].callback = NULL;
+            xFoundAck = pxPendingAcks[ i ];
+            pxPendingAcks[ i ].packetId = MQTT_PACKET_ID_INVALID;
+            pxPendingAcks[ i ].pCommandContext = NULL;
+            pxPendingAcks[ i ].callback = NULL;
             break;
         }
     }
-    return ret;
+    return xFoundAck;
 }
 
-static void addSubscription( const char * pTopicFilter, uint16_t topicFilterLength, QueueHandle_t pQueue )
+/*-----------------------------------------------------------*/
+
+static void prvAddSubscription( const char * pTopicFilter, uint16_t topicFilterLength, QueueHandle_t pxQueue )
 {
     int32_t i = 0;
     for( i = 0; i < SUBSCRIPTIONS_MAX_COUNT; i++ )
     {
-        if( subscriptions[ i ].topicFilterLength == 0 )
+        if( pxSubscriptions[ i ].topicFilterLength == 0 )
         {
-            subscriptions[ i ].topicFilterLength = topicFilterLength;
-            subscriptions[ i ].responseQueue = pQueue;
-            memcpy( subscriptions[ i ].pTopicFilter, pTopicFilter, topicFilterLength );
+            pxSubscriptions[ i ].topicFilterLength = topicFilterLength;
+            pxSubscriptions[ i ].pResponseQueue = pxQueue;
+            memcpy( pxSubscriptions[ i ].pTopicFilter, pTopicFilter, topicFilterLength );
             break;
         }
     }
 }
 
-static void removeSubscription( const char * pTopicFilter, size_t topicFilterLength, QueueHandle_t pQueue )
+/*-----------------------------------------------------------*/
+
+static void prvRemoveSubscription( const char * pTopicFilter, size_t topicFilterLength, QueueHandle_t pxQueue )
 {
     /* TODO: Unused for now, but can be used to remove a single subscription
      * when multiple apps are subscribed to the same topic. */
-    ( void ) pQueue;
+    ( void ) pxQueue;
     int32_t i = 0;
-    for( i = 0; i< SUBSCRIPTIONS_MAX_COUNT; i++ )
+    for( i = 0; i < SUBSCRIPTIONS_MAX_COUNT; i++ )
     {
-        if( subscriptions[ i ].topicFilterLength == topicFilterLength )
+        if( pxSubscriptions[ i ].topicFilterLength == topicFilterLength )
         {
-            if( ( strncmp( subscriptions[ i ].pTopicFilter, pTopicFilter, topicFilterLength ) == 0 ) && true )
+            if( ( strncmp( pxSubscriptions[ i ].pTopicFilter, pTopicFilter, topicFilterLength ) == 0 ) && true )
             {
-                subscriptions[ i ].topicFilterLength = 0;
-                subscriptions[ i ].responseQueue = NULL;
-                memset( ( void * ) subscriptions[ i ].pTopicFilter, 0x00, sizeof( subscriptions[ i ].pTopicFilter ) );
+                pxSubscriptions[ i ].topicFilterLength = 0;
+                pxSubscriptions[ i ].pResponseQueue = NULL;
+                memset( ( void * ) pxSubscriptions[ i ].pTopicFilter, 0x00, sizeof( pxSubscriptions[ i ].pTopicFilter ) );
                 break;
             }
         }
     }
 }
 
-static bool createCommand( CommandType_t commandType,
-                                  CommandContext_t * context,
-                                  CommandCallback_t callback,
-                                  Command_t * pCommand )
-{
-    bool isValid = true;
-    memset( ( void * ) pCommand, 0x00, sizeof( Command_t ) );
-    pCommand->commandType = commandType;
-    pCommand->pContext = context;
-    pCommand->callback = callback;
+/*-----------------------------------------------------------*/
 
-    /* Determine if all required parameters are present. */
-    switch( commandType )
+static bool prvCreateCommand( CommandType_t xCommandType,
+                                  CommandContext_t * pxContext,
+                                  CommandCallback_t xCallback,
+                                  Command_t * pxCommand )
+{
+    bool xIsValid = true;
+    memset( ( void * ) pxCommand, 0x00, sizeof( Command_t ) );
+    pxCommand->commandType = xCommandType;
+    pxCommand->pContext = pxContext;
+    pxCommand->callback = xCallback;
+
+    /* Determine if required parameters are present in context. */
+    switch( xCommandType )
     {
         case PUBLISH:
-            isValid = ( context != NULL ) ? ( context->pPublishInfo != NULL ) : false;
+            xIsValid = ( pxContext != NULL ) ? ( pxContext->pPublishInfo != NULL ) : false;
             break;
 
         case SUBSCRIBE:
         case UNSUBSCRIBE:
-            isValid = ( context != NULL ) ? ( context->pSubscribeInfo != NULL ) : false;
+            xIsValid = ( pxContext != NULL ) ? ( pxContext->pSubscribeInfo != NULL ) : false;
             break;
 
         default:
@@ -459,118 +628,136 @@ static bool createCommand( CommandType_t commandType,
             break;
     }
 
-    return isValid;
+    return xIsValid;
 }
 
-static void addCommandToQueue( Command_t * pCommand )
+/*-----------------------------------------------------------*/
+
+static void prvAddCommandToQueue( Command_t * pxCommand )
 {
-    xQueueSend( pCommandQueue, pCommand, TICKS_TO_WAIT );
+    xQueueSend( xCommandQueue, pxCommand, DEMO_TICKS_TO_WAIT );
 }
 
-static void copyPublishToQueue( MQTTPublishInfo_t * pPublishInfo, QueueHandle_t pResponseQueue )
+/*-----------------------------------------------------------*/
+
+static void prvCopyPublishToQueue( MQTTPublishInfo_t * pPublishInfo, QueueHandle_t pResponseQueue )
 {
-    PublishElement_t copiedPublish;
-    MQTTPublishInfo_t * pCopiedPublish = NULL;
-    memset( ( void * ) &copiedPublish, 0x00, sizeof( copiedPublish ) );
-    pCopiedPublish = &( copiedPublish.publishInfo );
-    memcpy( &( copiedPublish.publishInfo ), pPublishInfo, sizeof( MQTTPublishInfo_t ) );
+    PublishElement_t xCopiedPublish;
+    MQTTPublishInfo_t * pxCopiedPublishInfo = NULL;
+    memset( ( void * ) &xCopiedPublish, 0x00, sizeof( xCopiedPublish ) );
+    pxCopiedPublishInfo = &( xCopiedPublish.publishInfo );
+    memcpy( &( xCopiedPublish.publishInfo ), pPublishInfo, sizeof( MQTTPublishInfo_t ) );
     /* Since adding an MQTTPublishInfo_t to a queue will not copy its string buffers,
      * we need to add buffers to a struct and copy the entire structure. */
-    memcpy( copiedPublish.pTopicName, pPublishInfo->pTopicName, pPublishInfo->topicNameLength );
-    memcpy( copiedPublish.pPayload, pPublishInfo->pPayload, pPublishInfo->payloadLength );
-    pCopiedPublish->pTopicName = ( const char * ) copiedPublish.pTopicName;
-    pCopiedPublish->pPayload = copiedPublish.pPayload;
-    xQueueSendToBack( pResponseQueue, pCopiedPublish, TICKS_TO_WAIT );
+    memcpy( xCopiedPublish.pTopicName, pPublishInfo->pTopicName, pPublishInfo->topicNameLength );
+    memcpy( xCopiedPublish.pPayload, pPublishInfo->pPayload, pPublishInfo->payloadLength );
+    pxCopiedPublishInfo->pTopicName = ( const char * ) xCopiedPublish.pTopicName;
+    pxCopiedPublishInfo->pPayload = xCopiedPublish.pPayload;
+
+    /* Add to response queue. */
+    xQueueSendToBack( pResponseQueue, pxCopiedPublishInfo, DEMO_TICKS_TO_WAIT );
 }
 
-static MQTTStatus_t processCommand( Command_t * pCommand )
-{
-    MQTTStatus_t status = MQTTSuccess;
-    uint16_t packetId = MQTT_PACKET_ID_INVALID;
-    bool addAckToList = false;
-    MQTTPublishInfo_t * pPublishInfo;
-    MQTTSubscribeInfo_t * pSubscribeInfo;
+/*-----------------------------------------------------------*/
 
-    switch( pCommand->commandType )
+static MQTTStatus_t prvProcessCommand( Command_t * pxCommand )
+{
+    MQTTStatus_t xStatus = MQTTSuccess;
+    uint16_t usPacketId = MQTT_PACKET_ID_INVALID;
+    bool xAddAckToList = false;
+    MQTTPublishInfo_t * pxPublishInfo;
+    MQTTSubscribeInfo_t * pxSubscribeInfo;
+
+    switch( pxCommand->commandType )
     {
         case PROCESSLOOP:
             LogInfo( ( "Running Process Loop." ) );
-            status = MQTT_ProcessLoop( &globalMqttContext, MQTT_PROCESS_LOOP_TIMEOUT_MS );
+            xStatus = MQTT_ProcessLoop( &globalMqttContext, MQTT_PROCESS_LOOP_TIMEOUT_MS );
             break;
         case PUBLISH:
-            assert( pCommand->pContext != NULL );
-            pPublishInfo = pCommand->pContext->pPublishInfo;
-            assert( pPublishInfo != NULL );
-            if( pPublishInfo->qos != MQTTQoS0 )
+            assert( pxCommand->pContext != NULL );
+            pxPublishInfo = pxCommand->pContext->pPublishInfo;
+            assert( pxPublishInfo != NULL );
+            if( pxPublishInfo->qos != MQTTQoS0 )
             {
-                packetId = MQTT_GetPacketId( &globalMqttContext );
+                usPacketId = MQTT_GetPacketId( &globalMqttContext );
             }
-            LogInfo( ( "Publishing message to %.*s.", ( int ) pPublishInfo->topicNameLength, pPublishInfo->pTopicName ) );
-            status = MQTT_Publish( &globalMqttContext, pPublishInfo, packetId );
-            pCommand->pContext->returnStatus = status;
+            LogInfo( ( "Publishing message to %.*s.", ( int ) pxPublishInfo->topicNameLength, pxPublishInfo->pTopicName ) );
+            xStatus = MQTT_Publish( &globalMqttContext, pxPublishInfo, usPacketId );
+            pxCommand->pContext->returnStatus = xStatus;
 
             /* Add to pending ack list, or call callback if QoS 0. */
-            addAckToList = ( pPublishInfo->qos != MQTTQoS0 ) && ( status == MQTTSuccess );
+            xAddAckToList = ( pxPublishInfo->qos != MQTTQoS0 ) && ( xStatus == MQTTSuccess );
             break;
         /* TODO: Option to subscribe/unsubscribe without sending a packet,
          * e.g. for Shadow topics. */   
         case SUBSCRIBE:
         case UNSUBSCRIBE:
-            assert( pCommand->pContext != NULL );
-            pSubscribeInfo = pCommand->pContext->pSubscribeInfo;
-            assert( pSubscribeInfo != NULL );
-            assert( pSubscribeInfo->pTopicFilter != NULL );
-            packetId = MQTT_GetPacketId( &globalMqttContext );
-            if( pCommand->commandType == SUBSCRIBE )
+            assert( pxCommand->pContext != NULL );
+            pxSubscribeInfo = pxCommand->pContext->pSubscribeInfo;
+            assert( pxSubscribeInfo != NULL );
+            assert( pxSubscribeInfo->pTopicFilter != NULL );
+            usPacketId = MQTT_GetPacketId( &globalMqttContext );
+            if( pxCommand->commandType == SUBSCRIBE )
             {
-                LogInfo( ( "Subscribing to %.*s", pSubscribeInfo->topicFilterLength, pSubscribeInfo->pTopicFilter ) );
-                status = MQTT_Subscribe( &globalMqttContext, pSubscribeInfo, pCommand->pContext->subscriptionCount, packetId );
+                LogInfo( ( "Subscribing to %.*s",
+                           pxSubscribeInfo->topicFilterLength,
+                           pxSubscribeInfo->pTopicFilter ) );
+                xStatus = MQTT_Subscribe( &globalMqttContext,
+                                          pxSubscribeInfo,
+                                          pxCommand->pContext->subscriptionCount,
+                                          usPacketId );
             }
             else
             {
-                LogInfo( ( "Unsubscribing from %.*s", pSubscribeInfo->topicFilterLength, pSubscribeInfo->pTopicFilter ) );
-                status = MQTT_Unsubscribe( &globalMqttContext, pSubscribeInfo, pCommand->pContext->subscriptionCount, packetId );
+                LogInfo( ( "Unsubscribing from %.*s", pxSubscribeInfo->topicFilterLength, pxSubscribeInfo->pTopicFilter ) );
+                xStatus = MQTT_Unsubscribe( &globalMqttContext,
+                                            pxSubscribeInfo,
+                                            pxCommand->pContext->subscriptionCount,
+                                            usPacketId );
             }
-            pCommand->pContext->returnStatus = status;
-            addAckToList = ( status == MQTTSuccess );
+            pxCommand->pContext->returnStatus = xStatus;
+            xAddAckToList = ( xStatus == MQTTSuccess );
             break;
             
         case PING:
-            status = MQTT_Ping( &globalMqttContext );
-            if( pCommand->pContext != NULL )
+            xStatus = MQTT_Ping( &globalMqttContext );
+            if( pxCommand->pContext != NULL )
             {
-                pCommand->pContext->returnStatus = status;
+                pxCommand->pContext->returnStatus = xStatus;
             }
             break;
 
         case DISCONNECT:
-            status = MQTT_Disconnect( &globalMqttContext );
-            if( pCommand->pContext != NULL )
+            xStatus = MQTT_Disconnect( &globalMqttContext );
+            if( pxCommand->pContext != NULL )
             {
-                pCommand->pContext->returnStatus = status;
+                pxCommand->pContext->returnStatus = xStatus;
             }
             break;
         case CONNECT:
             /* TODO: Reconnect. */
-            LogInfo( (" Processed Connect Command") );
+            LogInfo( ("Processed Connect Command") );
         default:
             break;
     }
 
-    if( addAckToList )
+    if( xAddAckToList )
     {
-        addPendingAck( packetId, pCommand->pContext, pCommand->callback );
+        prvAddAck( usPacketId, pxCommand->pContext, pxCommand->callback );
     }
     else
     {
-        if( pCommand->callback != NULL )
+        if( pxCommand->callback != NULL )
         {
-            pCommand->callback( pCommand->pContext );
+            pxCommand->callback( pxCommand->pContext );
         }
     }
-    
-    return status;
+
+    return xStatus;
 }
+
+/*-----------------------------------------------------------*/
 
 static bool matchEndWildcards( const char * pTopicFilter,
                                 uint16_t topicNameLength,
@@ -705,18 +892,20 @@ static bool topicFilterMatch( const char * pTopicName,
     return status;
 }
 
-static void subscriptionManager( MQTTContext_t * pMqttContext,
+/*-----------------------------------------------------------*/
+
+static void prvSubscriptionManager( MQTTContext_t * pMqttContext,
                                  MQTTPacketInfo_t * pPacketInfo,
                                  uint16_t packetIdentifier,
                                  MQTTPublishInfo_t * pPublishInfo )
 {
     assert( pMqttContext != NULL );
     assert( pPacketInfo != NULL );
-    AckInfo_t ackInfo;
-    MQTTStatus_t status = MQTTSuccess;
-    bool isMatched = false;
+    AckInfo_t xAckInfo;
+    MQTTStatus_t xStatus = MQTTSuccess;
+    bool xIsMatched = false;
     size_t i;
-    MQTTSubscribeInfo_t * pSubscribeInfo = NULL;
+    MQTTSubscribeInfo_t * pxSubscribeInfo = NULL;
 
     /* Handle incoming publish. The lower 4 bits of the publish packet
      * type is used for the dup, QoS, and retain flags. Hence masking
@@ -726,16 +915,18 @@ static void subscriptionManager( MQTTContext_t * pMqttContext,
         assert( pPublishInfo != NULL );
         for( i = 0; i < SUBSCRIPTIONS_MAX_COUNT; i++ )
         {
-            if( subscriptions[ i ].topicFilterLength > 0 )
+            if( pxSubscriptions[ i ].topicFilterLength > 0 )
             {
-                isMatched = topicFilterMatch( pPublishInfo->pTopicName,
+                xIsMatched = topicFilterMatch( pPublishInfo->pTopicName,
                                               pPublishInfo->topicNameLength,
-                                              subscriptions[ i ].pTopicFilter,
-                                              subscriptions[ i ].topicFilterLength );
-                if( isMatched )
+                                              pxSubscriptions[ i ].pTopicFilter,
+                                              pxSubscriptions[ i ].topicFilterLength );
+                if( xIsMatched )
                 {
-                    LogInfo( ( "Adding publish to response queue for %.*s", subscriptions[ i ].topicFilterLength, subscriptions[ i ].pTopicFilter ) );
-                    copyPublishToQueue( pPublishInfo, subscriptions[ i ].responseQueue );
+                    LogInfo( ( "Adding publish to response queue for %.*s",
+                               pxSubscriptions[ i ].topicFilterLength,
+                               pxSubscriptions[ i ].pTopicFilter ) );
+                    prvCopyPublishToQueue( pPublishInfo, pxSubscriptions[ i ].pResponseQueue );
                 }
             }
         }
@@ -747,67 +938,67 @@ static void subscriptionManager( MQTTContext_t * pMqttContext,
         {
             case MQTT_PACKET_TYPE_PUBACK:
             case MQTT_PACKET_TYPE_PUBCOMP:
-                ackInfo = popAck( packetIdentifier );
-                if( ackInfo.packetId == packetIdentifier )
+                xAckInfo = prvPopAck( packetIdentifier );
+                if( xAckInfo.packetId == packetIdentifier )
                 {
-                    ackInfo.pCommandContext->returnStatus = status;
-                    if( ackInfo.callback != NULL )
+                    xAckInfo.pCommandContext->returnStatus = xStatus;
+                    if( xAckInfo.callback != NULL )
                     {
-                        ackInfo.callback( ackInfo.pCommandContext );
+                        xAckInfo.callback( xAckInfo.pCommandContext );
                     }
                 }
                 break;
 
             case MQTT_PACKET_TYPE_SUBACK:
-                ackInfo = popAck( packetIdentifier );
-                if( ackInfo.packetId == packetIdentifier )
+                xAckInfo = prvPopAck( packetIdentifier );
+                if( xAckInfo.packetId == packetIdentifier )
                 {
-                    pSubscribeInfo = ackInfo.pCommandContext->pSubscribeInfo;
-                    for( i = 0; i < ackInfo.pCommandContext->subscriptionCount; i++ )
+                    pxSubscribeInfo = xAckInfo.pCommandContext->pSubscribeInfo;
+                    for( i = 0; i < xAckInfo.pCommandContext->subscriptionCount; i++ )
                     {
                         LogInfo( ( "Adding subscription to %.*s",
-                                   pSubscribeInfo[ i ].topicFilterLength,
-                                   pSubscribeInfo[ i ].pTopicFilter ) );
-                        LogInfo( ( "Filter length: %u", pSubscribeInfo[ i ].topicFilterLength ) );
-                        addSubscription( pSubscribeInfo[ i ].pTopicFilter,
-                                         pSubscribeInfo[ i ].topicFilterLength,
-                                         ackInfo.pCommandContext->pResponseQueue );
+                                   pxSubscribeInfo[ i ].topicFilterLength,
+                                   pxSubscribeInfo[ i ].pTopicFilter ) );
+                        LogInfo( ( "Filter length: %u", pxSubscribeInfo[ i ].topicFilterLength ) );
+                        prvAddSubscription( pxSubscribeInfo[ i ].pTopicFilter,
+                                         pxSubscribeInfo[ i ].topicFilterLength,
+                                         xAckInfo.pCommandContext->pResponseQueue );
                     }
                 }
                 else
                 {
-                    status = MQTTBadResponse;
+                    xStatus = MQTTBadResponse;
                 }
-                ackInfo.pCommandContext->returnStatus = status;
-                if( ackInfo.callback != NULL )
+                xAckInfo.pCommandContext->returnStatus = xStatus;
+                if( xAckInfo.callback != NULL )
                 {
-                    ackInfo.callback( ackInfo.pCommandContext );
+                    xAckInfo.callback( xAckInfo.pCommandContext );
                 }
                 break;
 
             case MQTT_PACKET_TYPE_UNSUBACK:
-                ackInfo = popAck( packetIdentifier );
-                if( ackInfo.packetId == packetIdentifier )
+                xAckInfo = prvPopAck( packetIdentifier );
+                if( xAckInfo.packetId == packetIdentifier )
                 {
-                    pSubscribeInfo = ackInfo.pCommandContext->pSubscribeInfo;
-                    for( i = 0; i < ackInfo.pCommandContext->subscriptionCount; i++ )
+                    pxSubscribeInfo = xAckInfo.pCommandContext->pSubscribeInfo;
+                    for( i = 0; i < xAckInfo.pCommandContext->subscriptionCount; i++ )
                     {
                         LogInfo( ( "Removing subscription to %.*s",
-                                   pSubscribeInfo[ i ].topicFilterLength,
-                                   pSubscribeInfo[ i ].pTopicFilter ) );
-                        removeSubscription( pSubscribeInfo[ i ].pTopicFilter,
-                                            pSubscribeInfo[ i ].topicFilterLength,
-                                            ackInfo.pCommandContext->pResponseQueue );
+                                   pxSubscribeInfo[ i ].topicFilterLength,
+                                   pxSubscribeInfo[ i ].pTopicFilter ) );
+                        prvRemoveSubscription( pxSubscribeInfo[ i ].pTopicFilter,
+                                            pxSubscribeInfo[ i ].topicFilterLength,
+                                            xAckInfo.pCommandContext->pResponseQueue );
                     }
                 }
                 else
                 {
-                    status = MQTTBadResponse;
+                    xStatus = MQTTBadResponse;
                 }
-                ackInfo.pCommandContext->returnStatus = status;
-                if( ackInfo.callback != NULL )
+                xAckInfo.pCommandContext->returnStatus = xStatus;
+                if( xAckInfo.callback != NULL )
                 {
-                    ackInfo.callback( ackInfo.pCommandContext );
+                    xAckInfo.callback( xAckInfo.pCommandContext );
                 }
                 
                 break;
@@ -832,246 +1023,281 @@ static void subscriptionManager( MQTTContext_t * pMqttContext,
     }
 }
 
-static void commandLoop()
+/*-----------------------------------------------------------*/
+
+static void prvCommandLoop()
 {
-    Command_t command;
-    Command_t newCommand;
-    Command_t * pCommand;
-    static int numProcessed = 0;
-    bool breakOnNextProcessLoop = false;
-    bool subscribeProcessed = false;
+    Command_t xCommand;
+    Command_t xNewCommand;
+    Command_t * pxCommand;
+    MQTTStatus_t xStatus = MQTTSuccess;
+    static int lNumProcessed = 0;
+    bool xBreakOnNextProcessLoop = false;
+    bool xSubscribeProcessed = false;
     while( 1 )
     {
-        while( xQueueReceive( pCommandQueue, &command, TICKS_TO_WAIT ) )
+        while( xQueueReceive( xCommandQueue, &xCommand, DEMO_TICKS_TO_WAIT ) )
         {
-            pCommand = &command;
+            pxCommand = &xCommand;
             /* This demo requires the subscription to be present before the first publish. */
-            if( pCommand->commandType == PUBLISH )
+            if( pxCommand->commandType == PUBLISH )
             {
-                if( !subscribeProcessed )
+                if( !xSubscribeProcessed )
                 {
                     LogInfo( ( "Publish in queue before subscribe. Sending to back of queue." ) );
-                    addCommandToQueue( pCommand );
+                    prvAddCommandToQueue( pxCommand );
                     continue;
                 }
             }
 
-            processCommand( pCommand );
-            numProcessed++;
+            xStatus = prvProcessCommand( pxCommand );
+            /* TODO: After reconnect implemented, add connect operation to front
+             * of queue if status was not successful. */
+            configASSERT( xStatus == MQTTSuccess );
+            lNumProcessed++;
 
-            if( pCommand->commandType == PROCESSLOOP )
+            if( pxCommand->commandType == PROCESSLOOP )
             {
                 /* Add process loop back to end of queue. */
-                createCommand( PROCESSLOOP, NULL, NULL, &newCommand );
-                addCommandToQueue( &newCommand );
-                numProcessed--;
-                if( breakOnNextProcessLoop )
+                prvCreateCommand( PROCESSLOOP, NULL, NULL, &xNewCommand );
+                prvAddCommandToQueue( &xNewCommand );
+                lNumProcessed--;
+                if( xBreakOnNextProcessLoop )
                 {
                     break;
                 }
             }
 
             /* Mark subscribed as being processed. */
-            if( pCommand->commandType == SUBSCRIBE )
+            if( pxCommand->commandType == SUBSCRIBE )
             {
-                subscribeProcessed = true;
+                xSubscribeProcessed = true;
             }
 
             /* In this demo, exit after unsubscribing. */
-            if( pCommand->commandType == UNSUBSCRIBE )
+            if( pxCommand->commandType == UNSUBSCRIBE )
             {
-                breakOnNextProcessLoop = true;
+                xBreakOnNextProcessLoop = true;
             }
         }
         vTaskDelay( pdMS_TO_TICKS( 200 ) );
 
         /* We have PUBLISH_COUNT publishes + 1 subscription */
-        if( numProcessed >= PUBLISH_COUNT + 1)
+        if( lNumProcessed >= PUBLISH_COUNT + 1)
         {
             break;
         }
     }
     LogInfo( ( "Creating Disconnect operation" ) );
-    createCommand( DISCONNECT, NULL, NULL, &newCommand );
-    processCommand( &newCommand );
+    prvCreateCommand( DISCONNECT, NULL, NULL, &xNewCommand );
+    prvProcessCommand( &xNewCommand );
     LogInfo( ( "Disconnected from broker" ) );
     return;
 }
 
-static void comCallback( CommandContext_t * pContext )
+static void prvCommandCallback( CommandContext_t * pxContext )
 {
-    pContext->complete = true;
-    xTaskNotify( pContext->taskToNotify, pContext->notificationBit, eSetBits );
+    pxContext->complete = true;
+    xTaskNotify( pxContext->taskToNotify, pxContext->notificationBit, eSetBits );
     return;
 }
 
-void thread1( void * args )
+/*-----------------------------------------------------------*/
+
+void prvPublishTask( void * pvParameters )
 {
-    ( void ) args;
-    Command_t command;
-    MQTTPublishInfo_t publishInfo = { 0 };
-    MQTTPublishInfo_t publishes[ PUBLISH_COUNT ];
+    ( void ) pvParameters;
+    Command_t xCommand;
+    MQTTPublishInfo_t xPublishInfo = { 0 };
+    MQTTPublishInfo_t pxPublishes[ PUBLISH_COUNT ];
     char payloadBuf[ DEMO_BUFFER_SIZE ];
     char topicBuf[ DEMO_BUFFER_SIZE ];
     char * payloadBuffers[ PUBLISH_COUNT ];
     char * topicBuffers[ PUBLISH_COUNT ];
+    CommandContext_t xContext;
+    CommandContext_t * pxContexts[ PUBLISH_COUNT ] = { 0 };
+    uint32_t ulNotification;
 
-    publishInfo.qos = MQTTQoS2;
-    publishInfo.pTopicName = topicBuf;
-    publishInfo.pPayload = payloadBuf;
+    xPublishInfo.qos = MQTTQoS2;
+    xPublishInfo.pTopicName = topicBuf;
+    xPublishInfo.pPayload = payloadBuf;
 
-    CommandContext_t context;
-    CommandContext_t * contexts[PUBLISH_COUNT] = { 0 };
-    uint32_t notification;
-
+    /* Do synchronous publishes for first half. */
     for( int i = 0; i < PUBLISH_COUNT / 2; i++ )
     {
-        snprintf( payloadBuf, DEMO_BUFFER_SIZE, "Hello World! %d", i+1 );
-        publishInfo.payloadLength = ( uint16_t ) strlen( payloadBuf );
-        snprintf( topicBuf, DEMO_BUFFER_SIZE, "thread/1/%i/filter", i+1 );
-        publishInfo.topicNameLength = ( uint16_t ) strlen( topicBuf );
-        initializeCommandContext( &context );
-        context.pResponseQueue = pResponseQueue1;
-        context.taskToNotify = xTaskGetCurrentTaskHandle();
-        context.notificationBit = 1 << i;
-        context.pPublishInfo = &publishInfo;
-        LogInfo( (  "Adding publish operation for message %s \non topic %.*s\n", payloadBuf, publishInfo.topicNameLength, publishInfo.pTopicName ) );
-        createCommand( PUBLISH, &context, comCallback, &command );
-        addCommandToQueue( &command );
+        snprintf( payloadBuf, DEMO_BUFFER_SIZE, PUBLISH_PAYLOAD_FORMAT, i+1 );
+        xPublishInfo.payloadLength = ( uint16_t ) strlen( payloadBuf );
+        snprintf( topicBuf, DEMO_BUFFER_SIZE, PUBLISH_TOPIC_FORMAT_STRING, i+1 );
+        xPublishInfo.topicNameLength = ( uint16_t ) strlen( topicBuf );
+
+        prvInitializeCommandContext( &xContext );
+        xContext.pResponseQueue = xResponseQueue1;
+        xContext.taskToNotify = xTaskGetCurrentTaskHandle();
+        xContext.notificationBit = 1 << i;
+        xContext.pPublishInfo = &xPublishInfo;
+        LogInfo( (  "Adding publish operation for message %s \non topic %.*s\n", payloadBuf, xPublishInfo.topicNameLength, xPublishInfo.pTopicName ) );
+        prvCreateCommand( PUBLISH, &xContext, prvCommandCallback, &xCommand );
+        prvAddCommandToQueue( &xCommand );
 
         LogInfo( ( "Waiting for publish %d to complete.\n", i+1 ) );
-        xTaskNotifyWait( 0, 1 << i, &notification, TICKS_TO_WAIT );
-        configASSERT( ( notification & ( 1U << i ) ) == ( 1U << i ) );
-        destroyCommandContext( &context );
+        xTaskNotifyWait( 0, 1 << i, &ulNotification, DEMO_TICKS_TO_WAIT );
+        configASSERT( ( ulNotification & ( 1U << i ) ) == ( 1U << i ) );
+        prvDestroyCommandContext( &xContext );
         LogInfo( ( "Publish operation complete.\n" ) );
-        LogInfo( ( "\tPublish operation complete. Sleeping for %d ms.\n", 500 ) );
-        vTaskDelay( pdMS_TO_TICKS( 500 ) );
+        LogInfo( ( "Publish operation complete. Sleeping for %d ms.\n", PUBLISH_DELAY_SYNC_MS ) );
+        vTaskDelay( pdMS_TO_TICKS( PUBLISH_DELAY_SYNC_MS ) );
     }
 
+    /* Asynchronous publishes for second half. Although not necessary, we use dynamic
+     * memory here to avoid declaring many static buffers. */
     for( int i = PUBLISH_COUNT >> 1; i < PUBLISH_COUNT; i++ )
     {
-        contexts[ i ] = ( CommandContext_t * ) pvPortMalloc( sizeof( CommandContext_t ) );
-        initializeCommandContext( contexts[ i ] );
-        contexts[ i ]->pResponseQueue = pResponseQueue1;
-        contexts[ i ]->taskToNotify = xTaskGetCurrentTaskHandle();
-        contexts[ i ]->notificationBit = 1 << i;
-        payloadBuffers[ i ] = ( char * ) pvPortMalloc( 25 );
-        topicBuffers[ i ] = ( char * ) pvPortMalloc( 25 );
-        snprintf( payloadBuffers[ i ], 25, "Hello World! %d", i+1 );
-        snprintf( topicBuffers[ i ], 25, "thread/1/%i/filter", i+1 );
+        pxContexts[ i ] = ( CommandContext_t * ) pvPortMalloc( sizeof( CommandContext_t ) );
+        prvInitializeCommandContext( pxContexts[ i ] );
+        pxContexts[ i ]->pResponseQueue = xResponseQueue1;
+        pxContexts[ i ]->taskToNotify = xTaskGetCurrentTaskHandle();
+        /* Set the notification bit to be the publish number. This prevents this demo
+         * from having more than 32 publishes. If many publishes are desired, semaphores
+         * can be used instead of task notifications. */
+        pxContexts[ i ]->notificationBit = 1U << i;
+        payloadBuffers[ i ] = ( char * ) pvPortMalloc( DYNAMIC_BUFFER_SIZE );
+        topicBuffers[ i ] = ( char * ) pvPortMalloc( DYNAMIC_BUFFER_SIZE );
+        snprintf( payloadBuffers[ i ], DYNAMIC_BUFFER_SIZE, PUBLISH_PAYLOAD_FORMAT, i+1 );
+        snprintf( topicBuffers[ i ], DYNAMIC_BUFFER_SIZE, PUBLISH_TOPIC_FORMAT_STRING, i+1 );
         /* Set publish info. */
-        memset( ( void * ) &( publishes[ i ] ), 0x00, sizeof( MQTTPublishInfo_t ) );
-        publishes[ i ].pPayload = payloadBuffers[ i ];
-        publishes[ i ].payloadLength = strlen( payloadBuffers[ i ] );
-        publishes[ i ].pTopicName = topicBuffers[i ];
-        publishes[ i ].topicNameLength = ( uint16_t ) strlen( topicBuffers[ i ] );
-        publishes[ i ].qos = MQTTQoS2;
-        contexts[ i ]->pPublishInfo = &( publishes[ i ] );
-        LogInfo( (  "Adding publish operation for message %s \non topic %.*s\n", payloadBuffers[ i ], publishes[ i ].topicNameLength, publishes[ i ].pTopicName ) );
-        createCommand( PUBLISH, contexts[ i ], comCallback, &command );
-        addCommandToQueue( &command );
-        LogInfo( ( "\tPublish operation complete. Sleeping for %d ms.\n", 50 ) );
-        vTaskDelay( pdMS_TO_TICKS( 50 ) );
+        memset( ( void * ) &( pxPublishes[ i ] ), 0x00, sizeof( MQTTPublishInfo_t ) );
+        pxPublishes[ i ].pPayload = payloadBuffers[ i ];
+        pxPublishes[ i ].payloadLength = strlen( payloadBuffers[ i ] );
+        pxPublishes[ i ].pTopicName = topicBuffers[i ];
+        pxPublishes[ i ].topicNameLength = ( uint16_t ) strlen( topicBuffers[ i ] );
+        pxPublishes[ i ].qos = MQTTQoS2;
+        pxContexts[ i ]->pPublishInfo = &( pxPublishes[ i ] );
+        LogInfo( (  "Adding publish operation for message %s \non topic %.*s\n",
+                    payloadBuffers[ i ],
+                    pxPublishes[ i ].topicNameLength,
+                    pxPublishes[ i ].pTopicName ) );
+        prvCreateCommand( PUBLISH, pxContexts[ i ], prvCommandCallback, &xCommand );
+        prvAddCommandToQueue( &xCommand );
+        LogInfo( ( "Publish operation queued. Sleeping for %d ms.\n", PUBLISH_DELAY_ASYNC_MS ) );
+        vTaskDelay( pdMS_TO_TICKS( PUBLISH_DELAY_ASYNC_MS ) );
     }
 
     LogInfo( ( "Finished publishing\n" ) );
     for( int i = 0; i < PUBLISH_COUNT; i++)
     {
-        if( contexts[i] == NULL )
+        if( pxContexts[i] == NULL )
         {
+            /* Don't try to free anything that wasn't initialized. */
             continue;
         }
         LogInfo( ( "Waiting to free publish context %d.", i ) );
-        xTaskNotifyWait( 0, 1 << i, &notification, TICKS_TO_WAIT );
-        configASSERT( ( notification & ( 1U << i ) ) == ( 1U << i ) );
-        destroyCommandContext( contexts[ i ] );
-        vPortFree( contexts[ i ] );
+        xTaskNotifyWait( 0, ( 1U << i ), &ulNotification, DEMO_TICKS_TO_WAIT );
+        configASSERT( ( ulNotification & ( 1U << i ) ) == ( 1U << i ) );
+        prvDestroyCommandContext( pxContexts[ i ] );
+        vPortFree( pxContexts[ i ] );
         vPortFree( topicBuffers[ i ] );
         vPortFree( payloadBuffers[ i ] );
         LogInfo( ( "Publish context %d freed.", i ) );
-        contexts[ i ] = NULL;
+        pxContexts[ i ] = NULL;
     }
     /* Notify main task this task can be deleted. */
-    xTaskNotify( mainTask, TASK1_COMPLETE_BIT, eSetBits );
+    xTaskNotify( xMainTask, TASK1_COMPLETE_BIT, eSetBits );
 
     return;
 }
 
-void thread2( void * args )
-{
-    ( void ) args;
-    MQTTSubscribeInfo_t subscribeInfo;
-    Command_t command;
-    MQTTPublishInfo_t * pReceivedPublish = NULL;
-    static int subCounter = 0;
-    subscribeInfo.qos = MQTTQoS0;
-    subscribeInfo.pTopicFilter = "thread/1/+/filter";
-    subscribeInfo.topicFilterLength = ( uint16_t ) strlen( subscribeInfo.pTopicFilter );
-    LogInfo( ( "Topic filter: %.*s", subscribeInfo.topicFilterLength, subscribeInfo.pTopicFilter ) );
-    LogInfo( ( "Filter length: %d", subscribeInfo.topicFilterLength ) );
+/*-----------------------------------------------------------*/
 
-    CommandContext_t context;
-    initializeCommandContext( &context );
-    context.pResponseQueue = pResponseQueue2;
-    context.taskToNotify = xTaskGetCurrentTaskHandle();
-    context.notificationBit = 1;
-    context.subscriptionCount = 1;
-    context.pSubscribeInfo = &subscribeInfo;
+void prvSubscribeTask( void * pvParameters )
+{
+    ( void ) pvParameters;
+    MQTTSubscribeInfo_t xSubscribeInfo;
+    Command_t xCommand;
+    MQTTPublishInfo_t * pxReceivedPublish = NULL;
+    static uint16_t usNumReceived = 0;
+    uint32_t ulNotification;
+    CommandContext_t xContext;
+    PublishElement_t xReceivedPublish;
+    uint16_t usWaitCounter = 0;
+
+    xSubscribeInfo.qos = MQTTQoS0;
+    xSubscribeInfo.pTopicFilter = SUBSCRIBE_TOPIC_FILTER;
+    xSubscribeInfo.topicFilterLength = ( uint16_t ) strlen( xSubscribeInfo.pTopicFilter );
+    LogInfo( ( "Topic filter: %.*s", xSubscribeInfo.topicFilterLength, xSubscribeInfo.pTopicFilter ) );
+    LogInfo( ( "Filter length: %d", xSubscribeInfo.topicFilterLength ) );
+
+    /* Create the context and subscribe command. */
+    prvInitializeCommandContext( &xContext );
+    xContext.pResponseQueue = xResponseQueue2;
+    xContext.taskToNotify = xTaskGetCurrentTaskHandle();
+    xContext.notificationBit = 1;
+    xContext.subscriptionCount = 1;
+    xContext.pSubscribeInfo = &xSubscribeInfo;
     LogInfo( ( "Adding subscribe operation" ) );
-    createCommand( SUBSCRIBE, &context, comCallback, &command );
-    addCommandToQueue( &command );
-    uint32_t notification;
+    prvCreateCommand( SUBSCRIBE, &xContext, prvCommandCallback, &xCommand );
+    prvAddCommandToQueue( &xCommand );
 
     LogInfo( ("Starting wait on operation.\n" ) );
-    xTaskNotifyWait( 0, 1, &notification, TICKS_TO_WAIT );
-    configASSERT( ( notification & 1 ) == 1 );
-    destroyCommandContext( &context );
+    xTaskNotifyWait( 0, SUBSCRIBE_BIT, &ulNotification, DEMO_TICKS_TO_WAIT );
+    configASSERT( ( ulNotification & SUBSCRIBE_BIT ) == SUBSCRIBE_BIT );
+    prvDestroyCommandContext( &xContext );
     LogInfo( ("Operation wait complete.\n" ) );
-
-    PublishElement_t receivedPublish;
 
     while( 1 )
     {
-        while( xQueueReceive( pResponseQueue2, &receivedPublish, TICKS_TO_WAIT ) )
+        while( xQueueReceive( xResponseQueue2, &xReceivedPublish, DEMO_TICKS_TO_WAIT ) )
         {
-            pReceivedPublish = &( receivedPublish.publishInfo );
-            pReceivedPublish->pTopicName = ( const char * ) receivedPublish.pTopicName;
-            pReceivedPublish->pPayload = receivedPublish.pPayload;
-            LogInfo( ( "Received publish on topic %.*s\n", pReceivedPublish->topicNameLength, pReceivedPublish->pTopicName ) );
-            LogInfo( ( "Message payload: %.*s\n", ( int ) pReceivedPublish->payloadLength, ( const char * ) pReceivedPublish->pPayload ) );
-            subCounter++;
+            pxReceivedPublish = &( xReceivedPublish.publishInfo );
+            pxReceivedPublish->pTopicName = ( const char * ) xReceivedPublish.pTopicName;
+            pxReceivedPublish->pPayload = xReceivedPublish.pPayload;
+            LogInfo( ( "Received publish on topic %.*s\n", pxReceivedPublish->topicNameLength, pxReceivedPublish->pTopicName ) );
+            LogInfo( ( "Message payload: %.*s\n", ( int ) pxReceivedPublish->payloadLength, ( const char * ) pxReceivedPublish->pPayload ) );
+            usNumReceived++;
             /* Break if all publishes have been received. */
-            if( subCounter >= PUBLISH_COUNT )
+            if( usNumReceived >= PUBLISH_COUNT )
             {
                 break;
             }
         }
-        if( subCounter >= PUBLISH_COUNT )
+        /* Break if all publishes have been received. */
+        if( usNumReceived >= PUBLISH_COUNT )
         {
             break;
         }
 
-        LogInfo( ("    No messages queued, received %d publishes, sleeping for %d ms\n", subCounter, 400 ) );
-        vTaskDelay( pdMS_TO_TICKS( 400 ) );
+        LogInfo( ( "No messages queued, received %u publishes, sleeping for %d ms\n",
+                   usNumReceived,
+                   SUBSCRIBE_TASK_DELAY_MS ) );
+        vTaskDelay( pdMS_TO_TICKS( SUBSCRIBE_TASK_DELAY_MS ) );
     }
 
     LogInfo( ("Finished receiving\n" ) );
-    createCommand( UNSUBSCRIBE, &context, comCallback, &command );
-    initializeCommandContext( &context );
-    context.pResponseQueue = pResponseQueue2;
-    context.taskToNotify = xTaskGetCurrentTaskHandle();
-    context.notificationBit = 2;
-    context.pSubscribeInfo = &subscribeInfo;
+    prvCreateCommand( UNSUBSCRIBE, &xContext, prvCommandCallback, &xCommand );
+    prvInitializeCommandContext( &xContext );
+    xContext.pResponseQueue = xResponseQueue2;
+    xContext.taskToNotify = xTaskGetCurrentTaskHandle();
+    xContext.notificationBit = UNSUBSCRIBE_BIT;
+    xContext.pSubscribeInfo = &xSubscribeInfo;
     LogInfo( ("Adding unsubscribe operation\n" ) );
-    addCommandToQueue( &command );
+    prvAddCommandToQueue( &xCommand );
     LogInfo( ("Starting wait on operation\n" ) );
-    xTaskNotifyWait( 0, 2, &notification, 2 * TICKS_TO_WAIT );
-    configASSERT( ( notification & 2 ) == 2 );
-    destroyCommandContext( &context );
+    while( ( ulNotification & UNSUBSCRIBE_BIT ) != UNSUBSCRIBE_BIT )
+    {
+        LogInfo( ( "Waiting for unsubscribe operation to complete." ) );
+        xTaskNotifyWait( 0, UNSUBSCRIBE_BIT, &ulNotification, DEMO_TICKS_TO_WAIT );
+
+        /* It's possible we disconnected before receiving the UNSUBACK if the
+         * process loop has a low timeout. */
+        if( ++usWaitCounter > MAX_WAIT_ITERATIONS )
+        {
+            break;
+        }
+    }
+    prvDestroyCommandContext( &xContext );
     LogInfo( ("Operation wait complete.\n" ) );
 
     /* Notify main task this task can be deleted. */
-    xTaskNotify( mainTask, TASK2_COMPLETE_BIT, eSetBits );
+    xTaskNotify( xMainTask, TASK2_COMPLETE_BIT, eSetBits );
 
     return;
 }
@@ -1082,79 +1308,68 @@ static void prvMQTTDemoTask( void * pvParameters )
 {
     NetworkContext_t xNetworkContext = { 0 };
     BaseType_t xNetworkStatus;
+    BaseType_t xResult;
     uint32_t ulNotification = 0;
+    Command_t xCommand;
 
     ( void ) pvParameters;
 
     ulGlobalEntryTimeMs = prvGetTimeMs();
 
-    pCommandQueue = xQueueCreate( COMMAND_QUEUE_SIZE, sizeof( Command_t ) );
-    pResponseQueue2 = xQueueCreate( PUBLISH_QUEUE_SIZE, sizeof( PublishElement_t ) );
-    /* Task 1 doesn't receive anything in this demo, so it doesn't need a large queue. */
-    pResponseQueue1 = xQueueCreate( 1, sizeof( PublishElement_t ) );
+    xCommandQueue = xQueueCreate( COMMAND_QUEUE_SIZE, sizeof( Command_t ) );
+    xResponseQueue2 = xQueueCreate( PUBLISH_QUEUE_SIZE, sizeof( PublishElement_t ) );
+    /* Publish task doesn't receive anything in this demo, so it doesn't need a large queue. */
+    xResponseQueue1 = xQueueCreate( 1, sizeof( PublishElement_t ) );
 
-    // for( ; ; )
-    // {
+    memset( ( void * ) pxPendingAcks, 0x00, PENDING_ACKS_MAX_SIZE * sizeof( AckInfo_t ) );
+    memset( ( void * ) pxSubscriptions, 0x00, SUBSCRIPTIONS_MAX_COUNT * sizeof( SubscriptionElement_t ) );
 
-        /* Create inital process loop command. */
-        Command_t command;
-        createCommand( PROCESSLOOP, NULL, NULL, &command );
-        addCommandToQueue( &command );
+    /* Create inital process loop command. */
+    prvCreateCommand( PROCESSLOOP, NULL, NULL, &xCommand );
+    prvAddCommandToQueue( &xCommand );
 
-        LogInfo( ( "Create a TCP connection to %s.\r\n", BROKER_ENDPOINT ) );
-        xNetworkStatus = Plaintext_FreeRTOS_Connect( &xNetworkContext,
-                                                     BROKER_ENDPOINT,
-                                                     BROKER_PORT,
-                                                     TRANSPORT_SEND_RECV_TIMEOUT_MS,
-                                                     TRANSPORT_SEND_RECV_TIMEOUT_MS );
-        configASSERT( xNetworkStatus == 0 );
-        establishMqttSession( &globalMqttContext, &xNetworkContext );
+    LogInfo( ( "Creating a TCP connection to %s.\r\n", BROKER_ENDPOINT ) );
 
-        xTaskCreate( thread2, "Thread2", democonfigDEMO_STACKSIZE, NULL, tskIDLE_PRIORITY, &task2 );
-        vTaskDelay( pdMS_TO_TICKS( 100 ) );
-        xTaskCreate( thread1, "Thread1", democonfigDEMO_STACKSIZE, NULL, tskIDLE_PRIORITY, &task1 );
+    /* TODO: Use TLS to connect to the broker. */
+    xNetworkStatus = Plaintext_FreeRTOS_Connect( &xNetworkContext,
+                                                    BROKER_ENDPOINT,
+                                                    BROKER_PORT,
+                                                    TRANSPORT_SEND_RECV_TIMEOUT_MS,
+                                                    TRANSPORT_SEND_RECV_TIMEOUT_MS );
+    configASSERT( xNetworkStatus == 0 );
+    prvCreateMQTTConnectionWithBroker( &globalMqttContext, &xNetworkContext );
+    configASSERT( globalMqttContext.connectStatus = MQTTConnected );
 
-        LogInfo( ( "Running command loop" ) );
-        commandLoop();
-    // }
+    xResult = xTaskCreate( prvSubscribeTask, "Subscriber", democonfigDEMO_STACKSIZE, NULL, tskIDLE_PRIORITY, &xTask2 );
+    vTaskDelay( pdMS_TO_TICKS( 100 ) );
+    xResult = xTaskCreate( prvPublishTask, "Publisher", democonfigDEMO_STACKSIZE, NULL, tskIDLE_PRIORITY, &xTask1 );
+
+    LogInfo( ( "Running command loop" ) );
+    prvCommandLoop();
 
     /* Delete created tasks and queues. */
     while( ( ulNotification & TASK2_COMPLETE_BIT ) != TASK2_COMPLETE_BIT )
     {
-        LogInfo( ( "Waiting for task 2 to exit." ) );
-        xTaskNotifyWait( 0, TASK2_COMPLETE_BIT, &ulNotification, TICKS_TO_WAIT );
+        LogInfo( ( "Waiting for subscribe task to exit." ) );
+        xTaskNotifyWait( 0, TASK2_COMPLETE_BIT, &ulNotification, DEMO_TICKS_TO_WAIT );
     }
     configASSERT( ( ulNotification & TASK2_COMPLETE_BIT ) == TASK2_COMPLETE_BIT );
-    vTaskDelete( task2 );
-    LogInfo( ( "Task 2 Deleted." ) );
+    vTaskDelete( xTask2 );
+    LogInfo( ( "Subscribe task Deleted." ) );
     while( ( ulNotification & TASK1_COMPLETE_BIT ) != TASK1_COMPLETE_BIT )
     {
-        LogInfo( ( "Waiting for task 1 to exit." ) );
-        xTaskNotifyWait( 0, TASK1_COMPLETE_BIT, &ulNotification, TICKS_TO_WAIT );
+        LogInfo( ( "Waiting for publish task to exit." ) );
+        xTaskNotifyWait( 0, TASK1_COMPLETE_BIT, &ulNotification, DEMO_TICKS_TO_WAIT );
     }
     configASSERT( ( ulNotification & TASK1_COMPLETE_BIT ) == TASK1_COMPLETE_BIT );
-    vTaskDelete( task1 );
-    LogInfo( ( "Task 1 Deleted." ) );
-    vQueueDelete( pCommandQueue );
-    vQueueDelete( pResponseQueue1 );
-    vQueueDelete( pResponseQueue2 );
+    vTaskDelete( xTask1 );
+    LogInfo( ( "Publish task Deleted." ) );
+
+    vQueueDelete( xCommandQueue );
+    vQueueDelete( xResponseQueue1 );
+    vQueueDelete( xResponseQueue2 );
 }
 
-/*
- * @brief Create the task that demonstrates the Plain text MQTT API Demo.
- */
-void vStartSimpleMQTTDemo( void )
-{
-    /* This example uses a single application task, which in turn is used to
-     * connect, subscribe, publish, unsubscribe and disconnect from the MQTT
-     * broker. */
-    xTaskCreate( prvMQTTDemoTask,          /* Function that implements the task. */
-                 "MQTTDemo",               /* Text name for the task - only used for debugging. */
-                 democonfigDEMO_STACKSIZE, /* Size of stack (in words, not bytes) to allocate for the task. */
-                 NULL,                     /* Task parameter - not used in this case. */
-                 tskIDLE_PRIORITY,         /* Task priority, must be between 0 and configMAX_PRIORITIES - 1. */
-                 &mainTask );              /* Used to pass out a handle to the created task. */
-}
 /*-----------------------------------------------------------*/
 
 static uint32_t prvGetTimeMs( void )

--- a/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_multitask/DemoTasks/MultitaskMQTTExample.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_multitask/DemoTasks/MultitaskMQTTExample.c
@@ -1,0 +1,1222 @@
+/*
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/*
+ * Demo for showing the use of MQTT APIs to establish an MQTT session,
+ * subscribe to a topic, publish to a topic, receive incoming publishes,
+ * unsubscribe from a topic and disconnect the MQTT session.
+ *
+ * The example shown below uses MQTT APIs to send and receive MQTT packets
+ * over the TCP connection established using POSIX sockets.
+ * The example is single threaded and uses statically allocated memory;
+ * it uses QOS0 and therefore does not implement any retransmission
+ * mechanism for Publish messages.
+ */
+
+/* Standard includes. */
+#include <string.h>
+#include <stdio.h>
+#include <assert.h>
+
+/* Kernel includes. */
+#include "FreeRTOS.h"
+#include "task.h"
+#include "queue.h"
+
+/* FreeRTOS+TCP includes. */
+#include "FreeRTOS_IP.h"
+#include "FreeRTOS_Sockets.h"
+
+/* Demo Specific configs. */
+#include "demo_config.h"
+
+/* MQTT library includes. */
+#include "mqtt.h"
+
+/* Transport interface include. */
+#include "plaintext_freertos.h"
+
+
+#define BROKER_ENDPOINT      "localhost"
+
+#define BROKER_PORT          ( 1883 )
+
+#define CLIENT_IDENTIFIER    "testclient"
+
+/**
+ * These configuration settings are required to run the plaintext demo.
+ * Throw compilation error if the below configs are not defined.
+ */
+#ifndef CLIENT_IDENTIFIER
+    #error "Please define a unique CLIENT_IDENTIFIER."
+#endif
+
+/**
+ * Provide default values for undefined configuration settings.
+ */
+#ifndef BROKER_PORT
+    #define BROKER_PORT    ( 1883 )
+#endif
+
+#ifndef NETWORK_BUFFER_SIZE
+    #define NETWORK_BUFFER_SIZE    ( 1024U )
+#endif
+
+/**
+ * @brief Length of client identifier.
+ */
+#define CLIENT_IDENTIFIER_LENGTH            ( ( uint16_t ) ( sizeof( CLIENT_IDENTIFIER ) - 1 ) )
+
+/**
+ * @brief Length of MQTT server host name.
+ */
+#define BROKER_ENDPOINT_LENGTH              ( ( uint16_t ) ( sizeof( BROKER_ENDPOINT ) - 1 ) )
+
+/**
+ * @brief Timeout for receiving CONNACK packet in milliseconds.
+ */
+#define CONNACK_RECV_TIMEOUT_MS             ( 1000U )
+
+/**
+ * @brief The topic to subscribe and publish to in the example.
+ *
+ * The topic name starts with the client identifier to ensure that each demo
+ * interacts with a unique topic name.
+ */
+#define MQTT_EXAMPLE_TOPIC                  CLIENT_IDENTIFIER "/example/topic"
+
+/**
+ * @brief Length of client MQTT topic.
+ */
+#define MQTT_EXAMPLE_TOPIC_LENGTH           ( ( uint16_t ) ( sizeof( MQTT_EXAMPLE_TOPIC ) - 1 ) )
+
+/**
+ * @brief The MQTT message published in this example.
+ */
+#define MQTT_EXAMPLE_MESSAGE                "Hello World!"
+
+/**
+ * @brief The length of the MQTT message published in this example.
+ */
+#define MQTT_EXAMPLE_MESSAGE_LENGTH         ( ( uint16_t ) ( sizeof( MQTT_EXAMPLE_MESSAGE ) - 1 ) )
+
+/**
+ * @brief Timeout for MQTT_ProcessLoop function in milliseconds.
+ */
+#define MQTT_PROCESS_LOOP_TIMEOUT_MS        ( 500U )
+
+/**
+ * @brief The maximum time interval in seconds which is allowed to elapse
+ *  between two Control Packets.
+ *
+ *  It is the responsibility of the Client to ensure that the interval between
+ *  Control Packets being sent does not exceed the this Keep Alive value. In the
+ *  absence of sending any other Control Packets, the Client MUST send a
+ *  PINGREQ Packet.
+ */
+#define MQTT_KEEP_ALIVE_INTERVAL_SECONDS    ( 60U )
+
+/**
+ * @brief Delay between MQTT publishes in seconds.
+ */
+#define DELAY_BETWEEN_PUBLISHES_SECONDS     ( 1U )
+
+/**
+ * @brief Number of PUBLISH messages sent per iteration.
+ */
+#define MQTT_PUBLISH_COUNT_PER_LOOP         ( 5U )
+
+/**
+ * @brief Delay in seconds between two iterations of subscribePublishLoop().
+ */
+#define MQTT_SUBPUB_LOOP_DELAY_SECONDS      ( 5U )
+
+/**
+ * @brief Transport timeout in milliseconds for transport send and receive.
+ */
+#define TRANSPORT_SEND_RECV_TIMEOUT_MS      ( 20 )
+
+#define _MILLISECONDS_PER_SECOND                    ( 1000U )                                         /**< @brief Milliseconds per second. */
+#define _MILLISECONDS_PER_TICK                      ( _MILLISECONDS_PER_SECOND / configTICK_RATE_HZ ) /**< Milliseconds per FreeRTOS tick. */
+#define TICKS_TO_WAIT                       ( TickType_t ) 1000
+
+#ifndef EXIT_SUCCESS
+    #define EXIT_SUCCESS 0
+#endif
+#ifndef EXIT_FAILURE
+    #define EXIT_FAILURE 1
+#endif
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief The network buffer must remain valid for the lifetime of the MQTT context.
+ */
+static uint8_t buffer[ NETWORK_BUFFER_SIZE ];
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Sends an MQTT CONNECT packet over the already connected TCP socket.
+ *
+ * @param[in] pMqttContext MQTT context pointer.
+ * @param[in] pNetworkContext Pointer to the network context created using Plaintext_Connect.
+ *
+ * @return EXIT_SUCCESS if an MQTT session is established;
+ * EXIT_FAILURE otherwise.
+ */
+static int establishMqttSession( MQTTContext_t * pMqttContext,
+                                 NetworkContext_t * pNetworkContext );
+
+static void subscriptionManager( MQTTContext_t * pMqttContext,
+                                 MQTTPacketInfo_t * pPacketInfo,
+                                 uint16_t packetIdentifier,
+                                 MQTTPublishInfo_t * pPublishInfo );
+
+static uint32_t prvGetTimeMs( void );
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Global entry time into the application to use as a reference timestamp
+ * in the #prvGetTimeMs function. #prvGetTimeMs will always return the difference
+ * between the current time and the global entry time. This will reduce the chances
+ * of overflow for the 32 bit unsigned integer used for holding the timestamp.
+ */
+static uint32_t ulGlobalEntryTimeMs;
+
+/*-----------------------------------------------------------*/
+
+static int establishMqttSession( MQTTContext_t * pMqttContext,
+                                 NetworkContext_t * pNetworkContext )
+{
+    int returnStatus = EXIT_SUCCESS;
+    MQTTStatus_t mqttStatus;
+    MQTTConnectInfo_t connectInfo;
+    bool sessionPresent;
+    MQTTFixedBuffer_t networkBuffer;
+    MQTTApplicationCallbacks_t callbacks;
+    TransportInterface_t transport;
+
+    assert( pMqttContext != NULL );
+    assert( pNetworkContext != NULL );
+
+    /* Fill in TransportInterface send and receive function pointers.
+     * For this demo, TCP sockets are used to send and receive data
+     * from network. Network context is socket file descriptor.*/
+    transport.pNetworkContext = pNetworkContext;
+    transport.send = Plaintext_FreeRTOS_send;
+    transport.recv = Plaintext_FreeRTOS_recv;
+
+    /* Fill the values for network buffer. */
+    networkBuffer.pBuffer = buffer;
+    networkBuffer.size = NETWORK_BUFFER_SIZE;
+
+    /* Initialize MQTT library. */
+    mqttStatus = MQTT_Init( pMqttContext, &transport, prvGetTimeMs, subscriptionManager, &networkBuffer );
+
+    if( mqttStatus != MQTTSuccess )
+    {
+        returnStatus = EXIT_FAILURE;
+        LogError( ( "MQTT init failed with status %u.", mqttStatus ) );
+    }
+    else
+    {
+        /* Establish MQTT session by sending a CONNECT packet. */
+
+        /* Start with a clean session i.e. direct the MQTT broker to discard any
+         * previous session data. Also, establishing a connection with clean session
+         * will ensure that the broker does not store any data when this client
+         * gets disconnected. */
+        connectInfo.cleanSession = true;
+
+        /* The client identifier is used to uniquely identify this MQTT client to
+         * the MQTT broker. In a production device the identifier can be something
+         * unique, such as a device serial number. */
+        connectInfo.pClientIdentifier = CLIENT_IDENTIFIER;
+        connectInfo.clientIdentifierLength = CLIENT_IDENTIFIER_LENGTH;
+
+        /* The maximum time interval in seconds which is allowed to elapse
+         * between two Control Packets.
+         * It is the responsibility of the Client to ensure that the interval between
+         * Control Packets being sent does not exceed the this Keep Alive value. In the
+         * absence of sending any other Control Packets, the Client MUST send a
+         * PINGREQ Packet. */
+        connectInfo.keepAliveSeconds = MQTT_KEEP_ALIVE_INTERVAL_SECONDS;
+
+        /* Username and password for authentication. Not used in this demo. */
+        connectInfo.pUserName = NULL;
+        connectInfo.userNameLength = 0U;
+        connectInfo.pPassword = NULL;
+        connectInfo.passwordLength = 0U;
+
+        /* Send MQTT CONNECT packet to broker. */
+        mqttStatus = MQTT_Connect( pMqttContext, &connectInfo, NULL, CONNACK_RECV_TIMEOUT_MS, &sessionPresent );
+
+        if( mqttStatus != MQTTSuccess )
+        {
+            returnStatus = EXIT_FAILURE;
+            LogError( ( "Connection with MQTT broker failed with status %u.", mqttStatus ) );
+        }
+        else
+        {
+            LogInfo( ( "MQTT connection successfully established with broker.\n\n" ) );
+        }
+    }
+
+    return returnStatus;
+}
+
+/*-----------------------------------------------------------*/
+
+static int disconnectMqttSession( MQTTContext_t * pMqttContext )
+{
+    MQTTStatus_t mqttStatus = MQTTSuccess;
+    int returnStatus = EXIT_SUCCESS;
+
+    assert( pMqttContext != NULL );
+
+    /* Send DISCONNECT. */
+    mqttStatus = MQTT_Disconnect( pMqttContext );
+
+    if( mqttStatus != MQTTSuccess )
+    {
+        LogError( ( "Sending MQTT DISCONNECT failed with status=%u.",
+                    mqttStatus ) );
+        returnStatus = EXIT_FAILURE;
+    }
+
+    return returnStatus;
+}
+
+/*-----------------------------------------------------------*/
+
+typedef enum operationType {
+    PROCESSLOOP,
+    PUBLISH,
+    SUBSCRIBE,
+    UNSUBSCRIBE,
+    PING,
+    DISCONNECT,
+    CONNECT
+} CommandType_t;
+
+typedef struct CommandContext {
+    /* Synchronization for boolean, not return status. */
+    SemaphoreHandle_t semaphore;
+    TaskHandle_t taskToNotify;
+    uint32_t notificationBit;
+    bool complete;
+    MQTTPublishInfo_t * pPublishInfo;
+    MQTTSubscribeInfo_t * pSubscribeInfo;
+    MQTTStatus_t returnStatus;
+    QueueHandle_t pResponseQueue;
+} CommandContext_t;
+
+typedef void (* CommandCallback_t )( CommandContext_t * );
+
+typedef struct Command {
+    CommandType_t commandType;
+    MQTTPublishInfo_t publishInfo;
+    MQTTSubscribeInfo_t subscribeInfo;
+    size_t subscriptionCount;
+    char pTopicName[ 100 ];
+    uint8_t pPublishPayload[ 100 ];
+    CommandContext_t * pContext;
+    CommandCallback_t callback;
+} Command_t;
+
+typedef struct ackInfo {
+    uint16_t packetId;
+    //TODO a single subscribe can be for multiple topics, so to avoid dynamic allocation
+    //this should be moved to the command context.
+    char pTopicFilter[ 100 ];
+    uint16_t topicFilterLength;
+    CommandContext_t * pCommandContext;
+    CommandCallback_t callback;
+} AckInfo_t;
+
+typedef struct subscriptionElement {
+    char pTopicFilter[ 100 ];
+    uint16_t topicFilterLength;
+    QueueHandle_t responseQueue;
+} SubscriptionElement_t;
+
+typedef struct publishElement {
+    MQTTPublishInfo_t publishInfo;
+    uint8_t pPayload[ 100 ];
+    uint8_t pTopicName[ 100 ];
+} PublishElement_t;
+
+#define PENDING_ACKS_MAX_SIZE       20
+#define SUBSCRIPTIONS_MAX_COUNT     10
+#define PUBLISH_COUNT               32
+
+static MQTTContext_t globalMqttContext;
+static AckInfo_t pendingAcks[ PENDING_ACKS_MAX_SIZE ];
+static SubscriptionElement_t subscriptions[ 10 ];
+
+static QueueHandle_t pCommandQueue;
+static QueueHandle_t pResponseQueue1;
+static QueueHandle_t pResponseQueue2;
+
+static TaskHandle_t task1;
+static TaskHandle_t task2;
+
+static void initializeCommandContext( CommandContext_t * pContext )
+{
+    pContext->complete = false;
+    pContext->pResponseQueue = NULL;
+    pContext->returnStatus = MQTTSuccess;
+    pContext->pPublishInfo = NULL;
+    pContext->pSubscribeInfo = NULL;
+}
+
+static void destroyCommandContext( CommandContext_t * pContext )
+{
+}
+
+static void addPendingAck( uint16_t packetId,
+                           const char * pTopicFilter,
+                           size_t topicFilterLength,
+                           CommandContext_t * pContext,
+                           CommandCallback_t callback )
+{
+    int32_t i = 0;
+    for( i = 0; i < PENDING_ACKS_MAX_SIZE; i++ )
+    {
+        if( pendingAcks[ i ].packetId == MQTT_PACKET_ID_INVALID )
+        {
+            pendingAcks[ i ].packetId = packetId;
+            pendingAcks[ i ].pCommandContext = pContext;
+            pendingAcks[ i ].callback = callback;
+            memcpy( pendingAcks[ i ].pTopicFilter, pTopicFilter, topicFilterLength );
+            pendingAcks[ i ].topicFilterLength = topicFilterLength;
+            break;
+        }
+    }
+}
+
+static AckInfo_t popAck( uint16_t packetId )
+{
+    int32_t i = 0;
+    AckInfo_t ret = { 0 };
+    for( i = 0; i < PENDING_ACKS_MAX_SIZE; i++ )
+    {
+        if( pendingAcks[ i ].packetId == packetId )
+        {
+            ret = pendingAcks[ i ];
+            pendingAcks[ i ].packetId = MQTT_PACKET_ID_INVALID;
+            pendingAcks[ i ].topicFilterLength = 0;
+            pendingAcks[ i ].pCommandContext = NULL;
+            pendingAcks[ i ].callback = NULL;
+            break;
+        }
+    }
+    return ret;
+}
+
+static void addSubscription( const char * pTopicFilter, size_t topicFilterLength, QueueHandle_t pQueue )
+{
+    int32_t i = 0;
+    for( i = 0; i < SUBSCRIPTIONS_MAX_COUNT; i++ )
+    {
+        if( subscriptions[ i ].topicFilterLength == 0 )
+        {
+            subscriptions[ i ].topicFilterLength = topicFilterLength;
+            subscriptions[ i ].responseQueue = pQueue;
+            memcpy( subscriptions[ i ].pTopicFilter, pTopicFilter, topicFilterLength );
+            break;
+        }
+    }
+}
+
+static void removeSubscription( const char * pTopicFilter, size_t topicFilterLength, QueueHandle_t pQueue )
+{
+    ( void ) pQueue;
+    int32_t i = 0;
+    for( i = 0; i< SUBSCRIPTIONS_MAX_COUNT; i++ )
+    {
+        if( subscriptions[ i ].topicFilterLength == topicFilterLength )
+        {
+            if( ( strncmp( subscriptions[ i ].pTopicFilter, pTopicFilter, topicFilterLength ) == 0 ) && true )
+            {
+                subscriptions[ i ].topicFilterLength = 0;
+                subscriptions[ i ].responseQueue = NULL;
+                break;
+            }
+        }
+    }
+}
+
+static Command_t * createCommand( CommandType_t commandType,
+                                  MQTTPublishInfo_t * pPublishInfo,
+                                  MQTTSubscribeInfo_t * pSubscriptionInfo,
+                                  size_t subscriptionCount,
+                                  CommandContext_t * context,
+                                  CommandCallback_t callback,
+                                  Command_t * pCommand )
+{
+    memset( ( void * ) pCommand, 0x00, sizeof( Command_t ) );
+    pCommand->commandType = commandType;
+    pCommand->subscriptionCount = subscriptionCount;
+    pCommand->pContext = context;
+    pCommand->callback = callback;
+
+    /* Copy publish info. */
+    if( pPublishInfo != NULL )
+    {
+        pCommand->publishInfo = *pPublishInfo;
+        pCommand->publishInfo.pTopicName = pCommand->pTopicName;
+        pCommand->publishInfo.pPayload = pCommand->pPublishPayload;
+        memcpy( pCommand->pTopicName, pPublishInfo->pTopicName, pPublishInfo->topicNameLength );
+        memcpy( pCommand->pPublishPayload, pPublishInfo->pPayload, pPublishInfo->payloadLength );
+    }
+
+    /* Copy subscription info. */
+    if( pSubscriptionInfo != NULL )
+    {
+        pCommand->subscribeInfo = *pSubscriptionInfo;
+        pCommand->subscribeInfo.pTopicFilter = pCommand->pTopicName;
+        memcpy( pCommand->pTopicName, pSubscriptionInfo->pTopicFilter, pSubscriptionInfo->topicFilterLength );
+        pCommand->subscribeInfo.pTopicFilter = pCommand->pTopicName;
+        //memcpy( &( pCommand->subscribeInfo ), pSubscriptionInfo, sizeof( MQTTSubscribeInfo_t ) * subscriptionCount );
+    }
+    return pCommand;
+}
+
+static void addCommandToQueue( Command_t * pCommand )
+{
+    xQueueSend( pCommandQueue, *pCommand, TICKS_TO_WAIT );
+}
+
+static void destroyPublishInfo( void * pPublish )
+{
+    MQTTPublishInfo_t * pPublishInfo = ( MQTTPublishInfo_t * ) pPublish;
+    free( ( void * ) pPublishInfo->pTopicName );
+    free( ( void * ) pPublishInfo->pPayload );
+    free( pPublishInfo );
+}
+
+static void copyPublishToQueue( MQTTPublishInfo_t * pPublishInfo, QueueHandle_t pResponseQueue )
+{
+    PublishElement_t copiedPublish;
+    MQTTPublishInfo_t * pCopiedPublish = NULL;
+    memset( ( void * ) &copiedPublish, 0x00, sizeof( copiedPublish ) );
+    pCopiedPublish = &( copiedPublish.publishInfo );
+    memcpy( &( copiedPublish.publishInfo ), pPublishInfo, sizeof( MQTTPublishInfo_t ) );
+    memcpy( copiedPublish.pTopicName, pPublishInfo->pTopicName, pPublishInfo->topicNameLength );
+    memcpy( copiedPublish.pPayload, pPublishInfo->pPayload, pPublishInfo->payloadLength );
+    pCopiedPublish->pTopicName = copiedPublish.pTopicName;
+    pCopiedPublish->pPayload = copiedPublish.pPayload;
+    xQueueSendToBack( pResponseQueue, pCopiedPublish, TICKS_TO_WAIT );
+}
+
+static MQTTStatus_t processCommand( Command_t * pCommand )
+{
+    MQTTStatus_t status = MQTTSuccess;
+    uint16_t packetId = MQTT_PACKET_ID_INVALID;
+    size_t topicFilterLength = 0;
+    const char * pTopicFilter = NULL;
+    bool addAckToList = false;
+
+    switch( pCommand->commandType )
+    {
+        case PROCESSLOOP:
+            LogInfo( ( "Running Process Loop." ) );
+            status = MQTT_ProcessLoop( &globalMqttContext, MQTT_PROCESS_LOOP_TIMEOUT_MS );
+            break;
+        case PUBLISH:
+            if( pCommand->publishInfo.qos != MQTTQoS0 )
+            {
+                packetId = MQTT_GetPacketId( &globalMqttContext );
+            }
+            LogInfo( ( "Publishing message to %.*s.", ( int ) pCommand->publishInfo.topicNameLength, pCommand->publishInfo.pTopicName ) );
+            status = MQTT_Publish( &globalMqttContext, &( pCommand->publishInfo ), packetId );
+            pCommand->pContext->returnStatus = status;
+
+            /* Add to pending ack list, or call callback if QoS 0. */
+            addAckToList = ( pCommand->publishInfo.qos != MQTTQoS0 ) && ( status == MQTTSuccess );
+            break;
+            
+        case SUBSCRIBE:
+        case UNSUBSCRIBE:
+            assert( pCommand->subscribeInfo.pTopicFilter != NULL );
+            packetId = MQTT_GetPacketId( &globalMqttContext );
+            if( pCommand->commandType == SUBSCRIBE )
+            {
+                LogInfo( ( "Subscribing to %.*s", pCommand->subscribeInfo.topicFilterLength, pCommand->subscribeInfo.pTopicFilter ) );
+                status = MQTT_Subscribe( &globalMqttContext, &( pCommand->subscribeInfo ), pCommand->subscriptionCount, packetId );
+            }
+            else
+            {
+                LogInfo( ( "Unsubscribing from %.*s", pCommand->subscribeInfo.topicFilterLength, pCommand->subscribeInfo.pTopicFilter ) );
+                status = MQTT_Unsubscribe( &globalMqttContext, &( pCommand->subscribeInfo ), pCommand->subscriptionCount, packetId );
+            }
+            pCommand->pContext->returnStatus = status;
+            addAckToList = ( status == MQTTSuccess );
+            topicFilterLength = pCommand->subscribeInfo.topicFilterLength;
+            pTopicFilter = pCommand->subscribeInfo.pTopicFilter;
+            break;
+            
+        case PING:
+            status = MQTT_Ping( &globalMqttContext );
+            pCommand->pContext->returnStatus = status;
+            break;
+
+        case DISCONNECT:
+            status = MQTT_Disconnect( &globalMqttContext );
+            //pCommand->pContext->returnStatus = status;
+            break;
+        case CONNECT:
+            /* TODO: Reconnect. I just used this as a generic command while testing to make sure the command loop works. */
+            LogInfo( (" Processed Connect Command") );
+        default:
+            break;
+    }
+
+    if( addAckToList )
+    {
+        addPendingAck( packetId, pTopicFilter, topicFilterLength, pCommand->pContext, pCommand->callback );
+    }
+    else
+    {
+        if( pCommand->callback != NULL )
+        {
+            pCommand->callback( pCommand->pContext );
+        }
+    }
+    
+    return status;
+}
+
+static bool matchEndWildcards( const char * pTopicFilter,
+                                uint16_t topicNameLength,
+                                uint16_t topicFilterLength,
+                                uint16_t nameIndex,
+                                uint16_t filterIndex,
+                                bool * pMatch )
+{
+    bool status = false, endChar = false;
+
+    /* Determine if the last character is reached for both topic name and topic
+     * filter for the '#' wildcard. */
+    endChar = ( nameIndex == ( topicNameLength - 1U ) ) && ( filterIndex == ( topicFilterLength - 3U ) );
+
+    if( endChar == true )
+    {
+        /* Determine if the topic filter ends with the '#' wildcard. */
+        status = ( pTopicFilter[ filterIndex + 2U ] == '#' );
+    }
+
+    if( status == false )
+    {
+        /* Determine if the last character is reached for both topic name and topic
+         * filter for the '+' wildcard. */
+        endChar = ( nameIndex == ( topicNameLength - 1U ) ) && ( filterIndex == ( topicFilterLength - 2U ) );
+
+        if( endChar == true )
+        {
+            /* Filter "sport/+" also matches the "sport/" but not "sport". */
+            status = ( pTopicFilter[ filterIndex + 1U ] == '+' );
+        }
+    }
+
+    *pMatch = status;
+
+    return status;
+}
+
+/*-----------------------------------------------------------*/
+
+static bool matchWildcards( const char * pTopicFilter,
+                             const char * pTopicName,
+                             uint16_t topicNameLength,
+                             uint16_t filterIndex,
+                             uint16_t * pNameIndex,
+                             bool * pMatch )
+{
+    bool status = false;
+
+    /* Check for wildcards. */
+    if( pTopicFilter[ filterIndex ] == '+' )
+    {
+        /* Move topic name index to the end of the current level.
+         * This is identified by '/'. */
+        while( ( *pNameIndex < topicNameLength ) && ( pTopicName[ *pNameIndex ] != '/' ) )
+        {
+            ( *pNameIndex )++;
+        }
+
+        ( *pNameIndex )--;
+    }
+    else if( pTopicFilter[ filterIndex ] == '#' )
+    {
+        /* Subsequent characters don't need to be checked for the
+         * multi-level wildcard. */
+        *pMatch = true;
+        status = true;
+    }
+    else
+    {
+        /* Any character mismatch other than '+' or '#' means the topic
+         * name does not match the topic filter. */
+        *pMatch = false;
+        status = true;
+    }
+
+    return status;
+}
+
+/*-----------------------------------------------------------*/
+
+static bool topicFilterMatch( const char * pTopicName,
+                               uint16_t topicNameLength,
+                               const char * pTopicFilter,
+                               uint16_t topicFilterLength )
+{
+    bool status = false, matchFound = false;
+    uint16_t nameIndex = 0, filterIndex = 0;
+
+    while( ( nameIndex < topicNameLength ) && ( filterIndex < topicFilterLength ) )
+    {
+        /* Check if the character in the topic name matches the corresponding
+         * character in the topic filter string. */
+        if( pTopicName[ nameIndex ] == pTopicFilter[ filterIndex ] )
+        {
+            /* Handle special corner cases regarding wildcards at the end of
+             * topic filters, as documented by the MQTT protocol spec. */
+            matchFound = matchEndWildcards( pTopicFilter,
+                                             topicNameLength,
+                                             topicFilterLength,
+                                             nameIndex,
+                                             filterIndex,
+                                             &status );
+        }
+        else
+        {
+            /* Check for matching wildcards. */
+            matchFound = matchWildcards( pTopicFilter,
+                                          pTopicName,
+                                          topicNameLength,
+                                          filterIndex,
+                                          &nameIndex,
+                                          &status );
+        }
+
+        if( matchFound == true )
+        {
+            break;
+        }
+
+        /* Increment indexes. */
+        nameIndex++;
+        filterIndex++;
+    }
+
+    if( status == false )
+    {
+        /* If the end of both strings has been reached, they match. */
+        status = ( ( nameIndex == topicNameLength ) && ( filterIndex == topicFilterLength ) );
+    }
+
+    return status;
+}
+
+static void subscriptionManager( MQTTContext_t * pMqttContext,
+                                 MQTTPacketInfo_t * pPacketInfo,
+                                 uint16_t packetIdentifier,
+                                 MQTTPublishInfo_t * pPublishInfo )
+{
+    assert( pMqttContext != NULL );
+    assert( pPacketInfo != NULL );
+    AckInfo_t ackInfo;
+    MQTTStatus_t status = MQTTSuccess;
+    bool isMatched = false;
+
+    /* Handle incoming publish. The lower 4 bits of the publish packet
+     * type is used for the dup, QoS, and retain flags. Hence masking
+     * out the lower bits to check if the packet is publish. */
+    if( ( pPacketInfo->type & 0xF0U ) == MQTT_PACKET_TYPE_PUBLISH )
+    {
+        assert( pPublishInfo != NULL );
+        /* Handle incoming publish. */
+        //handleIncomingPublish( pPublishInfo, packetIdentifier );
+        for( int i = 0; i < SUBSCRIPTIONS_MAX_COUNT; i++ )
+        {
+            if( subscriptions[ i ].topicFilterLength > 0 )
+            {
+                isMatched = topicFilterMatch( pPublishInfo->pTopicName, pPublishInfo->topicNameLength, subscriptions[ i ].pTopicFilter, subscriptions[ i ].topicFilterLength );
+                if( isMatched )
+                {
+                    LogInfo( ( "Adding publish to response queue for %.*s", subscriptions[ i ].topicFilterLength, subscriptions[ i ].pTopicFilter ) );
+                    copyPublishToQueue( pPublishInfo, subscriptions[ i ].responseQueue );
+                }
+                // if( strncmp( subscriptions[ i ].pTopicFilter, pPublishInfo->pTopicName, pPublishInfo->topicNameLength ) == 0 )
+                // {
+                //     LogInfo( ( "Adding publish to response queue for %.*s", pPublishInfo->topicNameLength, pPublishInfo->pTopicName ) );
+                //     copyPublishToQueue( pPublishInfo, subscriptions[ i ].responseQueue );
+                // }
+            }
+        }
+    }
+    else
+    {
+        /* Handle other packets. */
+        switch( pPacketInfo->type )
+        {
+            case MQTT_PACKET_TYPE_PUBACK:
+            case MQTT_PACKET_TYPE_PUBCOMP:
+                ackInfo = popAck( packetIdentifier );
+                if( ackInfo.packetId == packetIdentifier )
+                {
+                    ackInfo.pCommandContext->returnStatus = status;
+                    if( ackInfo.callback != NULL )
+                    {
+                        ackInfo.callback( ackInfo.pCommandContext );
+                    }
+                }
+                break;
+
+            case MQTT_PACKET_TYPE_SUBACK:
+                ackInfo = popAck( packetIdentifier );
+                if( ackInfo.packetId == packetIdentifier )
+                {
+                    LogInfo( ( "Adding subscription to %.*s", ackInfo.topicFilterLength, ackInfo.pTopicFilter ) );
+                    LogInfo( ( "Filter length: %d", ackInfo.topicFilterLength ) );
+                    addSubscription( ackInfo.pTopicFilter,
+                                     ackInfo.topicFilterLength,
+                                     ackInfo.pCommandContext->pResponseQueue );
+                }
+                else
+                {
+                    status = MQTTBadResponse;
+                }
+                ackInfo.pCommandContext->returnStatus = status;
+                if( ackInfo.callback != NULL )
+                {
+                    ackInfo.callback( ackInfo.pCommandContext );
+                }
+                break;
+
+            case MQTT_PACKET_TYPE_UNSUBACK:
+                ackInfo = popAck( packetIdentifier );
+                if( ackInfo.packetId == packetIdentifier )
+                {
+                    LogInfo( ( "Removing subscription to %.*s", ackInfo.topicFilterLength, ackInfo.pTopicFilter ) );
+                    removeSubscription( ackInfo.pTopicFilter, ackInfo.topicFilterLength, ackInfo.pCommandContext->pResponseQueue );
+                }
+                else
+                {
+                    status = MQTTBadResponse;
+                }
+                ackInfo.pCommandContext->returnStatus = status;
+                if( ackInfo.callback != NULL )
+                {
+                    ackInfo.callback( ackInfo.pCommandContext );
+                }
+                
+                break;
+
+            case MQTT_PACKET_TYPE_PUBREC:
+            case MQTT_PACKET_TYPE_PUBREL:
+                break;
+
+            case MQTT_PACKET_TYPE_PINGRESP:
+
+                /* Nothing to be done from application as library handles
+                 * PINGRESP. */
+                LogWarn( ( "PINGRESP should not be handled by the application "
+                           "callback when using MQTT_ProcessLoop.\n\n" ) );
+                break;
+
+            /* Any other packet type is invalid. */
+            default:
+                LogError( ( "Unknown packet type received:(%02x).\n\n",
+                            pPacketInfo->type ) );
+        }
+    }
+}
+
+static void commandLoop()
+{
+    Command_t * pCommand;
+    Command_t command;
+    Command_t newCommand;
+    Command_t * pNewCommand = NULL;
+    static int counter = 0;
+    int32_t breakCounter = 2;
+    void * pElement = ( void * ) &command;
+    // while ( pElement = DeQueue_PopFront( &commandQueue ) )
+    // {
+    //     pCommand = ( Command_t * ) ( pElement->pData );
+    //     processCommand( pCommand );
+    //     counter++;
+    //     if( pCommand->commandType == PROCESSLOOP )
+    //     {
+    //         pNewCommand = createCommand( PROCESSLOOP, NULL, NULL, 0, NULL, NULL, &command );
+    //         addCommandToQueue( pNewCommand );
+    //     }
+    //     DeQueueElement_Destroy( pElement );
+    // }
+    while( 1 )
+    {
+        while( xQueueReceive( pCommandQueue, &command, TICKS_TO_WAIT ) )
+        {
+            pCommand = &command;
+            processCommand( pCommand );
+            counter++;
+            if( pCommand->commandType == PROCESSLOOP )
+            {
+                pNewCommand = createCommand( PROCESSLOOP, NULL, NULL, 0, NULL, NULL, &newCommand );
+                addCommandToQueue( pNewCommand );
+                counter--;
+            }
+            if( pCommand->commandType == UNSUBSCRIBE )
+            {
+                breakCounter = 1;
+            }
+            //Pretty ugly but it's to signal that we should break after one more iteration.
+            if( breakCounter == 0 )
+            {
+                break;
+            }
+            if( breakCounter == 1 )
+            {
+                breakCounter--;
+            }
+            if( counter >= PUBLISH_COUNT + 1)
+            {
+                //breakCounter = 0;
+            }
+        }
+        vTaskDelay( pdMS_TO_TICKS( 200 ) );
+        if( counter >= PUBLISH_COUNT + 1)
+        {
+            break;
+        }
+    }
+    LogInfo( ( "Creating Disconnect operation" ) );
+    pNewCommand = createCommand( DISCONNECT, NULL, NULL, 0, NULL, NULL, &newCommand );
+    processCommand( pNewCommand );
+    LogInfo( ( "Disconnected from broker" ) );
+    return;
+}
+
+static void comCallback( CommandContext_t * pContext )
+{
+    pContext->complete = true;
+    //xTaskNotify
+    xTaskNotify( pContext->taskToNotify, pContext->notificationBit, eSetBits );
+    return;
+}
+
+void * thread1( void * args )
+{
+    ( void ) args;
+    Command_t * pCommand = NULL;
+    Command_t command;
+    MQTTPublishInfo_t publishInfo = { 0 };
+    char payloadBuf[ 100 ];
+    char topicBuf[ 100 ];
+    publishInfo.qos = MQTTQoS2;
+    //publishInfo.pTopicName = "thread/2/filter";
+    snprintf( topicBuf, 100, "thread/1/1/filter");
+    publishInfo.pTopicName = topicBuf;
+    publishInfo.topicNameLength = strlen( publishInfo.pTopicName );
+    snprintf( payloadBuf, 100, "Hello World! %d", 1 );
+    publishInfo.pPayload = payloadBuf;
+    publishInfo.payloadLength = strlen( publishInfo.pPayload );
+
+    // for( int i = 0; i < 10; i++ )
+    // {
+    //     pCommand = createCommand( CONNECT, NULL, NULL, 0, NULL, NULL );
+    //     LogInfo( ("Adding connect command to queue from thread 1") );
+    //     addCommandToQueue( pCommand );
+    //     LogInfo( ("Thread 1 added connect command") );
+    //     Clock_SleepMs( 250 );
+    // }
+
+    LogInfo( ( "Topic name: %.*s", publishInfo.topicNameLength, publishInfo.pTopicName ) );
+    LogInfo( ( "Name length: %d", publishInfo.topicNameLength ) );
+
+    CommandContext_t context;
+    CommandContext_t * contexts[PUBLISH_COUNT] = { 0 };
+    uint32_t notification;
+
+    for( int i = 0; i < PUBLISH_COUNT / 2; i++ )
+    {
+        // contexts[ i ] = ( CommandContext_t * ) pvPortMalloc( sizeof( CommandContext_t ) );
+        // initializeCommandContext( contexts[ i ] );
+        // contexts[ i ]->pResponseQueue = &responseQueue1;
+
+        snprintf( payloadBuf, 100, "Hello World! %d", i+1 );
+        publishInfo.payloadLength = strlen( payloadBuf );
+        snprintf( topicBuf, 100, "thread/1/%i/filter", i+1 );
+        publishInfo.topicNameLength = strlen( topicBuf );
+        initializeCommandContext( &context );
+        context.pResponseQueue = pResponseQueue1;
+        context.taskToNotify = task1;
+        context.notificationBit = 1 << i;
+        LogInfo( (  "Adding publish operation for message %s \non topic %.*s\n", payloadBuf, publishInfo.topicNameLength, publishInfo.pTopicName ) );
+        pCommand = createCommand( PUBLISH, &publishInfo, NULL, 0, &context, comCallback, &command );
+        //pCommand = createCommand( PUBLISH, &publishInfo, NULL, 0, contexts[ i ], comCallback );
+        addCommandToQueue( pCommand );
+
+        LogInfo( ( "Waiting for publish %d to complete.\n", i+1 ) );
+        xTaskNotifyWait( 0, 1 << i, &notification, TICKS_TO_WAIT );
+        configASSERT( ( notification & ( 1 << i ) ) == ( 1 << i ) );
+        destroyCommandContext( &context );
+        LogInfo( ( "Publish operation complete.\n" ) );
+        LogInfo( ( "\tPublish operation complete. Sleeping for %d ms.\n", 50 ) );
+        vTaskDelay( pdMS_TO_TICKS( 500 ) );
+    }
+
+    for( int i = PUBLISH_COUNT >> 1; i < PUBLISH_COUNT; i++ )
+    {
+        contexts[ i ] = ( CommandContext_t * ) pvPortMalloc( sizeof( CommandContext_t ) );
+        initializeCommandContext( contexts[ i ] );
+        contexts[ i ]->pResponseQueue = pResponseQueue1;
+        contexts[ i ]->taskToNotify = task1;
+        contexts[ i ]->notificationBit = 1 << i;
+        snprintf( payloadBuf, 100, "Hello World! %d", i+1 );
+        publishInfo.payloadLength = strlen( payloadBuf );
+        snprintf( topicBuf, 100, "thread/1/%i/filter", i+1 );
+        publishInfo.topicNameLength = strlen( topicBuf );
+        context.pResponseQueue = pResponseQueue1;
+        LogInfo( (  "Adding publish operation for message %s \non topic %.*s\n", payloadBuf, publishInfo.topicNameLength, publishInfo.pTopicName );
+        pCommand = createCommand( PUBLISH, &publishInfo, NULL, 0, contexts[ i ], comCallback, &command );
+        addCommandToQueue( pCommand );
+        LogInfo( ( "\tPublish operation complete. Sleeping for %d ms.\n", 50 );
+        vTaskDelay( pdMS_TO_TICKS( 50 ) );
+    }
+
+    LogInfo( ( "Finished publishing\n" ) );
+    for( int i = 0; i < PUBLISH_COUNT; i++)
+    {
+        if( contexts[i] == NULL )
+        {
+            continue;
+        }
+        //LogInfo( ( "Locking context %d\n", i ) );
+        xTaskNotifyWait( 0, 1 << i, &notification, TICKS_TO_WAIT );
+        configASSERT( ( notification & ( 1 << i ) ) == ( 1 << i ) );
+        destroyCommandContext( contexts[ i ] );
+        //LogInfo( ( "Freeing context %d\n", i ) );
+        vPortFree( contexts[ i ] );
+        contexts[ i ] = NULL;
+    }
+
+    // for( int i = 0; i < 10; i++ )
+    // {
+    //     fprintf( stdout, "Adding element %d to dequeue\n", i );
+    //     pNewElement = DeQueueElement_Create( NULL, 0, free );
+    //     DeQueue_PushBack( &globalDequeue, pNewElement );
+    //     fprintf( stdout, "Sleeping 0.25 seconds\n");
+    //     Clock_SleepMs( 250 );
+    // }
+    return NULL;
+}
+
+void * thread2( void * args )
+{
+    ( void ) args;
+    MQTTSubscribeInfo_t subscribeInfo;
+    Command_t * pCommand = NULL;
+    MQTTPublishInfo_t * pReceivedPublish = NULL;
+    static int subCounter = 0;
+    subscribeInfo.qos = MQTTQoS0;
+    subscribeInfo.pTopicFilter = "thread/1/+/filter";
+    subscribeInfo.topicFilterLength = strlen( subscribeInfo.pTopicFilter );
+    LogInfo( ( "Topic filter: %.*s", subscribeInfo.topicFilterLength, subscribeInfo.pTopicFilter ) );
+    LogInfo( ( "Filter length: %d", subscribeInfo.topicFilterLength ) );
+
+    CommandContext_t context;
+    initializeCommandContext( &context );
+    context.pResponseQueue = pResponseQueue2;
+    context.taskToNotify = task2;
+    context.notificationBit = 1;
+    LogInfo( ( "Adding subscribe operation" ) );
+    pCommand = createCommand( SUBSCRIBE, NULL, &subscribeInfo, 1, &context, comCallback );
+    LogInfo( ( "Topic filter: %.*s", pCommand->subscribeInfo.topicFilterLength, pCommand->subscribeInfo.pTopicFilter ) );
+    LogInfo( ( "Topic filter: %.*s", pCommand->subscribeInfo.topicFilterLength, pCommand->pTopicName ) );
+    LogInfo( ( "Topic filter: %.*s", pCommand->subscribeInfo.topicFilterLength, subscribeInfo.pTopicFilter ) );
+    LogInfo( ( "Filter length: %d", pCommand->subscribeInfo.topicFilterLength ) );
+    addCommandToQueue( pCommand );
+    uint32_t notification;
+
+    LogInfo( ("Starting wait on operation.\n" ) );
+    xTaskNotifyWait( 0, 1, &notification, TICKS_TO_WAIT );
+    configASSERT( ( notification & 1 ) == 1 );
+    destroyCommandContext( &context );
+    LogInfo( ("Operation wait complete.\n" ) );
+
+    // for( int i = 0; i < 10; i++ )
+    // {
+    //     pCommand = createCommand( CONNECT, NULL, NULL, 0, NULL, NULL );
+    //     LogInfo( ("Adding connect command to queue from thread 2") );
+    //     addCommandToQueue( pCommand );
+    //     LogInfo( ("Thread 2 added connect command") );
+    //     Clock_SleepMs( 100 );
+    // }
+
+    PublishElement_t receivedPublish;
+
+    while( 1 )
+    {
+        while( xQueueReceive( pResponseQueue2, &receivedPublish, TICKS_TO_WAIT ) )
+        {
+            pReceivedPublish = receivedPublish.pPublishInfo;
+            pReceivedPublish->pTopicName = receivedPublish.pTopicName;
+            pReceivedPublish->pPayload = receivedPublish.pPayload;
+            LogInfo( ( "Received publish on topic %.*s\n", pReceivedPublish->topicNameLength, pReceivedPublish->pTopicName ) );
+            LogInfo( ( "Message payload: %.*s\n", ( int ) pReceivedPublish->payloadLength, ( const char * ) pReceivedPublish->pPayload ) );
+            subCounter++;
+            if( subCounter >= PUBLISH_COUNT )
+            {
+                break;
+            }
+        }
+        LogInfo( ("    No messages queued, received %d publishes, sleeping for %d ms\n", subCounter, 400 ) );
+        vTaskDelay( pdMS_TO_TICKS( 400 ) );
+        if( subCounter >= PUBLISH_COUNT )
+        {
+            break;
+        }
+    }
+
+    LogInfo( ("Finished receiving\n" ) );
+    pCommand = createCommand( UNSUBSCRIBE, NULL, &subscribeInfo, 1, &context, comCallback );
+    initializeCommandContext( &context );
+    context.pResponseQueue = pResponseQueue2;
+    context.taskToNotify = task2;
+    context.notificationBit = 2;
+    LogInfo( ("Adding unsubscribe operation\n" ) );
+    addCommandToQueue( pCommand );
+    LogInfo( ("Starting wait on operation\n" ) );
+    xTaskNotifyWait( 0, 2, &notification, TICKS_TO_WAIT );
+    configASSERT( ( notification & 2 ) == 2 );
+    destroyCommandContext( &context );
+    LogInfo( ("Operation wait complete.\n" ) );
+
+    // for( int i = 0; i < 10; i++ )
+    // {
+    //     fprintf( stdout, "Removing element %d from dequeue\n", i );
+    //     pRemovedElement = DeQueue_PopFront( &globalDequeue );
+    //     if( pRemovedElement != NULL )
+    //     {
+    //         DeQueueElement_Destroy( pRemovedElement );
+    //     }
+    //     else
+    //     {
+    //         fprintf( stdout, "Removed NULL\n");
+    //         i--;
+    //     }
+    //     fprintf( stdout, "Sleeping 0.5 seconds\n");
+    //     Clock_SleepMs( 250 );
+        
+    // }
+    return NULL;
+}
+
+/*-----------------------------------------------------------*/
+
+static void prvMQTTDemoTask( void * pvParameters )
+{
+    uint32_t ulPublishCount = 0U;
+    const uint32_t ulMaxPublishCount = 5UL;
+    NetworkContext_t xNetworkContext = { 0 };
+    MQTTContext_t xMQTTContext;
+    MQTTStatus_t xMQTTStatus;
+    BaseType_t xNetworkStatus;
+
+    ulGlobalEntryTimeMs = prvGetTimeMs();
+
+    pCommandQueue = xQueueCreate( 25, sizeof( Command_t ) );
+    pResponseQueue1 = xQueueCreate( 20, sizeof( PublishElement_t ) );
+    pResponseQueue2 = xQueueCreate( 20, sizeof( PublishElement_t ) );
+
+    // for( ; ; )
+    // {
+
+        /* Create inital process loop command. */
+        Command_t command;
+        Command_t * pCommand = createCommand( PROCESSLOOP, NULL, NULL, 0, NULL, NULL, &command );
+        addCommandToQueue( pCommand );
+
+        LogInfo( ( "Create a TCP connection to %s.\r\n", democonfigMQTT_BROKER_ENDPOINT ) );
+        xNetworkStatus = Plaintext_FreeRTOS_Connect( &xNetworkContext,
+                                                     BROKER_ENDPOINT,
+                                                     BROKER_PORT,
+                                                     TRANSPORT_SEND_RECV_TIMEOUT_MS,
+                                                     TRANSPORT_SEND_RECV_TIMEOUT_MS );
+        configASSERT( xNetworkStatus == 0 );
+        establishMqttSession( &xMQTTContext, &xNetworkContext );
+
+        task2 = xTaskCreate( thread2, "Thread2", democonfigDEMO_STACKSIZE, NULL, tskIDLE_PRIORITY, NULL );
+        vTaskDelay( pdMS_TO_TICKS( 100 ) );
+        task1 = xTaskCreate( thread1, "Thread1", democonfigDEMO_STACKSIZE, NULL, tskIDLE_PRIORITY, NULL );
+
+        LogInfo( ( "Calling command loop" ) );
+        commandLoop();
+    // }
+
+    vQueueDelete( pCommandQueue );
+    vQueueDelete( pResponseQueue1 );
+    vQueueDelete( pResponseQueue2 );
+}
+
+/*
+ * @brief Create the task that demonstrates the Plain text MQTT API Demo.
+ */
+void vStartSimpleMQTTDemo( void )
+{
+    /* This example uses a single application task, which in turn is used to
+     * connect, subscribe, publish, unsubscribe and disconnect from the MQTT
+     * broker. */
+    xTaskCreate( prvMQTTDemoTask,          /* Function that implements the task. */
+                 "MQTTDemo",               /* Text name for the task - only used for debugging. */
+                 democonfigDEMO_STACKSIZE, /* Size of stack (in words, not bytes) to allocate for the task. */
+                 NULL,                     /* Task parameter - not used in this case. */
+                 tskIDLE_PRIORITY,         /* Task priority, must be between 0 and configMAX_PRIORITIES - 1. */
+                 NULL );                   /* Used to pass out a handle to the created task - not used in this case. */
+}
+/*-----------------------------------------------------------*/
+
+static uint32_t prvGetTimeMs( void )
+{
+    TickType_t xTickCount = 0;
+    uint32_t ulTimeMs = 0UL;
+
+    /* Get the current tick count. */
+    xTickCount = xTaskGetTickCount();
+
+    /* Convert the ticks to milliseconds. */
+    ulTimeMs = ( uint32_t ) xTickCount * _MILLISECONDS_PER_TICK;
+
+    /* Reduce ulGlobalEntryTimeMs from obtained time so as to always return the
+     * elapsed time in the application. */
+    ulTimeMs = ( uint32_t ) ( ulTimeMs - ulGlobalEntryTimeMs );
+
+    return ulTimeMs;
+}
+
+/*-----------------------------------------------------------*/

--- a/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_multitask/DemoTasks/MultitaskMQTTExample.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_multitask/DemoTasks/MultitaskMQTTExample.c
@@ -122,50 +122,99 @@
 #define _MILLISECONDS_PER_SECOND            ( 1000U )                                                 /**< @brief Milliseconds per second. */
 #define _MILLISECONDS_PER_TICK              ( _MILLISECONDS_PER_SECOND / configTICK_RATE_HZ )         /**< Milliseconds per FreeRTOS tick. */
 
-/* Ticks to wait for task notifications. */
+/**
+ * @brief Ticks to wait for task notifications.
+ */
 #define DEMO_TICKS_TO_WAIT                  pdMS_TO_TICKS( 1000 )
 
-/* Maximum number of operations awaiting an ack packet from the broker. */
+/**
+ * @brief Maximum number of operations awaiting an ack packet from the broker.
+ */
 #define PENDING_ACKS_MAX_SIZE               20
-/* Maximum number of subscriptions to store in the subscription list. */
+
+/**
+ * @brief Maximum number of subscriptions to store in the subscription list.
+ */
 #define SUBSCRIPTIONS_MAX_COUNT             10
-/* Number of publishes done by the publisher in this demo. */
+
+/**
+ * @brief Number of publishes done by the publisher in this demo.
+ */
 #define PUBLISH_COUNT                       16
 
-/* Size of statically allocated buffers for holding topic names and payloads in this demo. */
+/**
+ * @brief Size of statically allocated buffers for holding topic names and payloads in this demo.
+ */
 #define DEMO_BUFFER_SIZE                    100
-/* Size of dynamically allocated buffers for holding topic names and payloads in this demo. */
+
+/**
+ * @brief Size of dynamically allocated buffers for holding topic names and payloads in this demo.
+ */
 #define DYNAMIC_BUFFER_SIZE                 25
 
-/* Max number of commands that can be enqueued. */
+/**
+ * @brief Max number of commands that can be enqueued.
+ */
 #define COMMAND_QUEUE_SIZE                  25
-/* Max number of received publishes that can be enqueued for a task. */
+
+/**
+ * @brief Max number of received publishes that can be enqueued for a task.
+ */
 #define PUBLISH_QUEUE_SIZE                  20
 
-/* Delay for the subscriber task when no publishes are waiting in the queue. */
+/**
+ * @brief Delay for the subscriber task when no publishes are waiting in the queue.
+ */
 #define SUBSCRIBE_TASK_DELAY_MS             400U
-/* Delay for the publisher task between synchronous publishes. */
+
+/**
+ * @brief Delay for the publisher task between synchronous publishes.
+ */
 #define PUBLISH_DELAY_SYNC_MS               500U
-/* Delay for the publisher task between asynchronous publishes. */
+
+/**
+ * @brief Delay for the publisher task between asynchronous publishes.
+ */
 #define PUBLISH_DELAY_ASYNC_MS              50U
 
-/* Notification bit indicating completion of publisher task. */
+/**
+ * @brief Notification bit indicating completion of publisher task.
+ */
 #define PUBLISHER_TASK_COMPLETE_BIT         ( 1U << 1 )
-/* Notification bit indicating completion of subscriber task. */
+
+/**
+ * @brief Notification bit indicating completion of subscriber task.
+ */
 #define SUBSCRIBE_TASK_COMPLETE_BIT         ( 1U << 2 )
-/* Notification bit used by subscriber task for subscribe operation. */
+
+/**
+ * @brief Notification bit used by subscriber task for subscribe operation.
+ */
 #define SUBSCRIBE_COMPLETE_BIT              ( 1U << 0 )
-/* Notification bit used by subscriber task for unsubscribe operation. */
+
+/**
+ * @brief Notification bit used by subscriber task for unsubscribe operation.
+ */
 #define UNSUBSCRIBE_COMPLETE_BIT            ( 1U << 1 )
 
-/* Maximum number of loop iterations to wait for a task notification. */
+/**
+ * @brief Maximum number of loop iterations to wait for a task notification.
+ */
 #define MAX_WAIT_ITERATIONS                 5
 
-/* Topic filter used by the subscriber task. */
+/**
+ * @brief Topic filter used by the subscriber task.
+ */
 #define SUBSCRIBE_TOPIC_FILTER              "publish/+/filter"
-/* Format string used by the publisher task for topic names. */
+
+/**
+ * @brief Format string used by the publisher task for topic names.
+ */
 #define PUBLISH_TOPIC_FORMAT_STRING         "publish/%i/filter"
-/* Format string used by the publisher task for payloads. */
+
+/**
+ * @brief Format string used by the publisher task for payloads.
+ */
 #define PUBLISH_PAYLOAD_FORMAT              "Hello World! %d"
 
 /*-----------------------------------------------------------*/
@@ -434,13 +483,19 @@ static uint32_t prvGetTimeMs( void );
 
 /*-----------------------------------------------------------*/
 
-/* Global MQTT context. */
+/**
+ * @brief Global MQTT context.
+ */
 static MQTTContext_t globalMqttContext;
 
-/* List of operations that are awaiting an ack from the broker. */
+/**
+ * @brief List of operations that are awaiting an ack from the broker.
+ */
 static AckInfo_t pxPendingAcks[ PENDING_ACKS_MAX_SIZE ];
 
-/* List of active subscriptions. */
+/**
+ * @brief List of active subscriptions.
+ */
 static SubscriptionElement_t pxSubscriptions[ SUBSCRIPTIONS_MAX_COUNT ];
 
 /**
@@ -459,7 +514,7 @@ static QueueHandle_t xPublisherResponseQueue;
 static QueueHandle_t xSubscriberResponseQueue;
 
 /**
- * @brief Response queue for publishes received on unsubscribed topics.
+ * @brief Response queue for publishes received on non-subscribed topics.
  */
 static QueueHandle_t xDefaultResponseQueue;
 

--- a/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_multitask/DemoTasks/MultitaskMQTTExample.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_multitask/DemoTasks/MultitaskMQTTExample.c
@@ -111,58 +111,59 @@
  */
 #define TRANSPORT_SEND_RECV_TIMEOUT_MS      ( 20 )
 
-#define _MILLISECONDS_PER_SECOND                    ( 1000U )                                         /**< @brief Milliseconds per second. */
-#define _MILLISECONDS_PER_TICK                      ( _MILLISECONDS_PER_SECOND / configTICK_RATE_HZ ) /**< Milliseconds per FreeRTOS tick. */
+#define _MILLISECONDS_PER_SECOND            ( 1000U )                                                 /**< @brief Milliseconds per second. */
+#define _MILLISECONDS_PER_TICK              ( _MILLISECONDS_PER_SECOND / configTICK_RATE_HZ )         /**< Milliseconds per FreeRTOS tick. */
 
 /* Ticks to wait for task notifications. */
 #define DEMO_TICKS_TO_WAIT                  pdMS_TO_TICKS( 1000 )
 
 /* Maximum number of operations awaiting an ack packet from the broker. */
-#define PENDING_ACKS_MAX_SIZE       20
+#define PENDING_ACKS_MAX_SIZE               20
 /* Maximum number of subscriptions to store in the subscription list. */
-#define SUBSCRIPTIONS_MAX_COUNT     10
+#define SUBSCRIPTIONS_MAX_COUNT             10
 /* Number of publishes done by the publisher in this demo. */
-#define PUBLISH_COUNT               16
+#define PUBLISH_COUNT                       16
 
 /* Size of statically allocated buffers in this demo. */
-#define DEMO_BUFFER_SIZE            100
+#define DEMO_BUFFER_SIZE                    100
 /* Size of dynamically allocated buffers in this demo. */
-#define DYNAMIC_BUFFER_SIZE         25
+#define DYNAMIC_BUFFER_SIZE                 25
 
 /* Max number of commands that can be enqueued. */
-#define COMMAND_QUEUE_SIZE          25
+#define COMMAND_QUEUE_SIZE                  25
 /* Max number of received publishes that can be enqueued for a task. */
-#define PUBLISH_QUEUE_SIZE          20
+#define PUBLISH_QUEUE_SIZE                  20
 
 /* Delay for the subscriber task when no publishes are waiting in the queue. */
-#define SUBSCRIBE_TASK_DELAY_MS     400U
+#define SUBSCRIBE_TASK_DELAY_MS             400U
 /* Delay for the publisher task between synchronous publishes. */
-#define PUBLISH_DELAY_SYNC_MS       500U
+#define PUBLISH_DELAY_SYNC_MS               500U
 /* Delay for the publisher task between asynchronous publishes. */
-#define PUBLISH_DELAY_ASYNC_MS      50U
+#define PUBLISH_DELAY_ASYNC_MS              50U
 
 /* Notification bit indicating completion of publisher task. */
-#define TASK1_COMPLETE_BIT          ( 1U << 1 )
+#define TASK1_COMPLETE_BIT                  ( 1U << 1 )
 /* Notification bit indicating completion of subscriber task. */
-#define TASK2_COMPLETE_BIT          ( 1U << 2 )
+#define TASK2_COMPLETE_BIT                  ( 1U << 2 )
 /* Notification bit used by subscriber task for subscribe operation. */
-#define SUBSCRIBE_BIT               ( 1U << 0 )
+#define SUBSCRIBE_BIT                       ( 1U << 0 )
 /* Notification bit used by subscriber task for unsubscribe operation. */
-#define UNSUBSCRIBE_BIT             ( 1U << 1 )
+#define UNSUBSCRIBE_BIT                     ( 1U << 1 )
 
 /* Maximum number of loop iterations to wait for a task notification. */
-#define MAX_WAIT_ITERATIONS         5
+#define MAX_WAIT_ITERATIONS                 5
 
 /* Topic filter used by the subscriber task. */
-#define SUBSCRIBE_TOPIC_FILTER      "publish/+/filter"
+#define SUBSCRIBE_TOPIC_FILTER              "publish/+/filter"
 /* Format string used by the publisher task for topic names. */
-#define PUBLISH_TOPIC_FORMAT_STRING "publish/%i/filter"
+#define PUBLISH_TOPIC_FORMAT_STRING         "publish/%i/filter"
 /* Format string used by the publisher task for payloads. */
-#define PUBLISH_PAYLOAD_FORMAT      "Hello World! %d"
+#define PUBLISH_PAYLOAD_FORMAT              "Hello World! %d"
 
 /*-----------------------------------------------------------*/
 
-typedef enum CommandType {
+typedef enum CommandType
+{
     PROCESSLOOP,
     PUBLISH,
     SUBSCRIBE,
@@ -172,7 +173,8 @@ typedef enum CommandType {
     CONNECT
 } CommandType_t;
 
-typedef struct CommandContext {
+typedef struct CommandContext
+{
     MQTTPublishInfo_t * pPublishInfo;
     MQTTSubscribeInfo_t * pSubscribeInfo;
     size_t subscriptionCount;
@@ -187,25 +189,29 @@ typedef struct CommandContext {
 
 typedef void (* CommandCallback_t )( CommandContext_t * );
 
-typedef struct Command {
+typedef struct Command
+{
     CommandType_t commandType;
     CommandContext_t * pContext;
     CommandCallback_t callback;
 } Command_t;
 
-typedef struct ackInfo {
+typedef struct ackInfo
+{
     uint16_t packetId;
     CommandContext_t * pCommandContext;
     CommandCallback_t callback;
 } AckInfo_t;
 
-typedef struct subscriptionElement {
+typedef struct subscriptionElement
+{
     char pTopicFilter[ DEMO_BUFFER_SIZE ];
     uint16_t topicFilterLength;
     QueueHandle_t pResponseQueue;
 } SubscriptionElement_t;
 
-typedef struct publishElement {
+typedef struct publishElement
+{
     MQTTPublishInfo_t publishInfo;
     uint8_t pPayload[ DEMO_BUFFER_SIZE ];
     uint8_t pTopicName[ DEMO_BUFFER_SIZE ];
@@ -237,8 +243,8 @@ static void prvInitializeCommandContext( CommandContext_t * pxContext );
  * @param[in] xCallback Callback from command.
  */
 static void prvAddAck( uint16_t usPacketId,
-                           CommandContext_t * pxContext,
-                           CommandCallback_t xCallback );
+                       CommandContext_t * pxContext,
+                       CommandCallback_t xCallback );
 
 /**
  * @brief Remove an operation from the list of pending acks and return it.
@@ -256,7 +262,9 @@ static AckInfo_t prvPopAck( uint16_t usPacketId );
  * @param[in] topicFilterLength Length of topic filter.
  * @param[in] pxQueue Response queue in which to enqueue received publishes.
  */
-static void prvAddSubscription( const char * pTopicFilter, uint16_t topicFilterLength, QueueHandle_t pxQueue );
+static void prvAddSubscription( const char * pTopicFilter,
+                                uint16_t topicFilterLength,
+                                QueueHandle_t pxQueue );
 
 /**
  * @brief Remove a subscription from the subscription list.
@@ -265,7 +273,9 @@ static void prvAddSubscription( const char * pTopicFilter, uint16_t topicFilterL
  * @param[in] topicFilterLength Length of topic filter.
  * @param[in] pxQueue Response queue for received publishes.
  */
-static void prvRemoveSubscription( const char * pTopicFilter, size_t topicFilterLength, QueueHandle_t pxQueue );
+static void prvRemoveSubscription( const char * pTopicFilter,
+                                   size_t topicFilterLength,
+                                   QueueHandle_t pxQueue );
 
 /**
  * @brief Populate the parameters of a #Command_t
@@ -279,9 +289,9 @@ static void prvRemoveSubscription( const char * pTopicFilter, size_t topicFilter
  * else `false`
  */
 static bool prvCreateCommand( CommandType_t xCommandType,
-                                  CommandContext_t * pxContext,
-                                  CommandCallback_t xCallback,
-                                  Command_t * pxCommand );
+                              CommandContext_t * pxContext,
+                              CommandCallback_t xCallback,
+                              Command_t * pxCommand );
 
 /**
  * @brief Add a command to the global command queue.
@@ -296,7 +306,8 @@ static void prvAddCommandToQueue( Command_t * pxCommand );
  * @param[in] pPublishInfo Info of incoming publish.
  * @param[in] pResponseQueue Queue to which the publish is copied.
  */
-static void prvCopyPublishToQueue( MQTTPublishInfo_t * pPublishInfo, QueueHandle_t pResponseQueue );
+static void prvCopyPublishToQueue( MQTTPublishInfo_t * pPublishInfo,
+                                   QueueHandle_t pResponseQueue );
 
 /**
  * @brief Process a #Command_t.
@@ -317,9 +328,9 @@ static MQTTStatus_t prvProcessCommand( Command_t * pxCommand );
  * the incoming packet.
  */
 static void prvSubscriptionManager( MQTTContext_t * pMqttContext,
-                                 MQTTPacketInfo_t * pPacketInfo,
-                                 uint16_t packetIdentifier,
-                                 MQTTPublishInfo_t * pPublishInfo );
+                                    MQTTPacketInfo_t * pPacketInfo,
+                                    uint16_t packetIdentifier,
+                                    MQTTPublishInfo_t * pPublishInfo );
 
 /**
  * @brief Process commands from the command queue in a loop.
@@ -332,7 +343,7 @@ static void prvCommandLoop();
 
 /**
  * @brief Common callback for commands in this demo.
- * 
+ *
  * This callback marks the command as complete and notifies the calling task.
  *
  * @param[in] pxContext Context of the initial command.
@@ -385,10 +396,12 @@ static SubscriptionElement_t pxSubscriptions[ SUBSCRIPTIONS_MAX_COUNT ];
  * @brief Queue for main task to handle MQTT operations.
  */
 static QueueHandle_t xCommandQueue;
+
 /**
  * @brief Response queue for prvPublishTask.
  */
 static QueueHandle_t xResponseQueue1;
+
 /**
  * @brief Response queue for prvSubscribeTask.
  */
@@ -437,7 +450,7 @@ void vStartSimpleMQTTDemo( void )
                  democonfigDEMO_STACKSIZE, /* Size of stack (in words, not bytes) to allocate for the task. */
                  NULL,                     /* Task parameter - not used in this case. */
                  tskIDLE_PRIORITY,         /* Task priority, must be between 0 and configMAX_PRIORITIES - 1. */
-                 &xMainTask );              /* Used to pass out a handle to the created task. */
+                 &xMainTask );             /* Used to pass out a handle to the created task. */
 }
 /*-----------------------------------------------------------*/
 
@@ -449,6 +462,7 @@ static void prvCreateMQTTConnectionWithBroker( MQTTContext_t * pxMQTTContext,
     bool xSessionPresent;
     TransportInterface_t xTransport;
     MQTTFixedBuffer_t xNetworkBuffer;
+
     /* Fill the values for network buffer. */
     xNetworkBuffer.pBuffer = buffer;
     xNetworkBuffer.size = NETWORK_BUFFER_SIZE;
@@ -522,10 +536,11 @@ static void prvDestroyCommandContext( CommandContext_t * pxContext )
 /*-----------------------------------------------------------*/
 
 static void prvAddAck( uint16_t usPacketId,
-                           CommandContext_t * pxContext,
-                           CommandCallback_t xCallback )
+                       CommandContext_t * pxContext,
+                       CommandCallback_t xCallback )
 {
     int32_t i = 0;
+
     for( i = 0; i < PENDING_ACKS_MAX_SIZE; i++ )
     {
         if( pxPendingAcks[ i ].packetId == MQTT_PACKET_ID_INVALID )
@@ -544,6 +559,7 @@ static AckInfo_t prvPopAck( uint16_t usPacketId )
 {
     int32_t i = 0;
     AckInfo_t xFoundAck = { 0 };
+
     for( i = 0; i < PENDING_ACKS_MAX_SIZE; i++ )
     {
         if( pxPendingAcks[ i ].packetId == usPacketId )
@@ -555,14 +571,18 @@ static AckInfo_t prvPopAck( uint16_t usPacketId )
             break;
         }
     }
+
     return xFoundAck;
 }
 
 /*-----------------------------------------------------------*/
 
-static void prvAddSubscription( const char * pTopicFilter, uint16_t topicFilterLength, QueueHandle_t pxQueue )
+static void prvAddSubscription( const char * pTopicFilter,
+                                uint16_t topicFilterLength,
+                                QueueHandle_t pxQueue )
 {
     int32_t i = 0;
+
     for( i = 0; i < SUBSCRIPTIONS_MAX_COUNT; i++ )
     {
         if( pxSubscriptions[ i ].topicFilterLength == 0 )
@@ -577,12 +597,15 @@ static void prvAddSubscription( const char * pTopicFilter, uint16_t topicFilterL
 
 /*-----------------------------------------------------------*/
 
-static void prvRemoveSubscription( const char * pTopicFilter, size_t topicFilterLength, QueueHandle_t pxQueue )
+static void prvRemoveSubscription( const char * pTopicFilter,
+                                   size_t topicFilterLength,
+                                   QueueHandle_t pxQueue )
 {
     /* TODO: Unused for now, but can be used to remove a single subscription
      * when multiple apps are subscribed to the same topic. */
     ( void ) pxQueue;
     int32_t i = 0;
+
     for( i = 0; i < SUBSCRIPTIONS_MAX_COUNT; i++ )
     {
         if( pxSubscriptions[ i ].topicFilterLength == topicFilterLength )
@@ -601,11 +624,12 @@ static void prvRemoveSubscription( const char * pTopicFilter, size_t topicFilter
 /*-----------------------------------------------------------*/
 
 static bool prvCreateCommand( CommandType_t xCommandType,
-                                  CommandContext_t * pxContext,
-                                  CommandCallback_t xCallback,
-                                  Command_t * pxCommand )
+                              CommandContext_t * pxContext,
+                              CommandCallback_t xCallback,
+                              Command_t * pxCommand )
 {
     bool xIsValid = true;
+
     memset( ( void * ) pxCommand, 0x00, sizeof( Command_t ) );
     pxCommand->commandType = xCommandType;
     pxCommand->pContext = pxContext;
@@ -640,13 +664,16 @@ static void prvAddCommandToQueue( Command_t * pxCommand )
 
 /*-----------------------------------------------------------*/
 
-static void prvCopyPublishToQueue( MQTTPublishInfo_t * pPublishInfo, QueueHandle_t pResponseQueue )
+static void prvCopyPublishToQueue( MQTTPublishInfo_t * pPublishInfo,
+                                   QueueHandle_t pResponseQueue )
 {
     PublishElement_t xCopiedPublish;
     MQTTPublishInfo_t * pxCopiedPublishInfo = NULL;
+
     memset( ( void * ) &xCopiedPublish, 0x00, sizeof( xCopiedPublish ) );
     pxCopiedPublishInfo = &( xCopiedPublish.publishInfo );
     memcpy( &( xCopiedPublish.publishInfo ), pPublishInfo, sizeof( MQTTPublishInfo_t ) );
+
     /* Since adding an MQTTPublishInfo_t to a queue will not copy its string buffers,
      * we need to add buffers to a struct and copy the entire structure. */
     memcpy( xCopiedPublish.pTopicName, pPublishInfo->pTopicName, pPublishInfo->topicNameLength );
@@ -674,14 +701,17 @@ static MQTTStatus_t prvProcessCommand( Command_t * pxCommand )
             LogInfo( ( "Running Process Loop." ) );
             xStatus = MQTT_ProcessLoop( &globalMqttContext, MQTT_PROCESS_LOOP_TIMEOUT_MS );
             break;
+
         case PUBLISH:
             assert( pxCommand->pContext != NULL );
             pxPublishInfo = pxCommand->pContext->pPublishInfo;
             assert( pxPublishInfo != NULL );
+
             if( pxPublishInfo->qos != MQTTQoS0 )
             {
                 usPacketId = MQTT_GetPacketId( &globalMqttContext );
             }
+
             LogInfo( ( "Publishing message to %.*s.", ( int ) pxPublishInfo->topicNameLength, pxPublishInfo->pTopicName ) );
             xStatus = MQTT_Publish( &globalMqttContext, pxPublishInfo, usPacketId );
             pxCommand->pContext->returnStatus = xStatus;
@@ -689,8 +719,9 @@ static MQTTStatus_t prvProcessCommand( Command_t * pxCommand )
             /* Add to pending ack list, or call callback if QoS 0. */
             xAddAckToList = ( pxPublishInfo->qos != MQTTQoS0 ) && ( xStatus == MQTTSuccess );
             break;
+
         /* TODO: Option to subscribe/unsubscribe without sending a packet,
-         * e.g. for Shadow topics. */   
+         * e.g. for Shadow topics. */
         case SUBSCRIBE:
         case UNSUBSCRIBE:
             assert( pxCommand->pContext != NULL );
@@ -698,6 +729,7 @@ static MQTTStatus_t prvProcessCommand( Command_t * pxCommand )
             assert( pxSubscribeInfo != NULL );
             assert( pxSubscribeInfo->pTopicFilter != NULL );
             usPacketId = MQTT_GetPacketId( &globalMqttContext );
+
             if( pxCommand->commandType == SUBSCRIBE )
             {
                 LogInfo( ( "Subscribing to %.*s",
@@ -716,28 +748,35 @@ static MQTTStatus_t prvProcessCommand( Command_t * pxCommand )
                                             pxCommand->pContext->subscriptionCount,
                                             usPacketId );
             }
+
             pxCommand->pContext->returnStatus = xStatus;
             xAddAckToList = ( xStatus == MQTTSuccess );
             break;
-            
+
         case PING:
             xStatus = MQTT_Ping( &globalMqttContext );
+
             if( pxCommand->pContext != NULL )
             {
                 pxCommand->pContext->returnStatus = xStatus;
             }
+
             break;
 
         case DISCONNECT:
             xStatus = MQTT_Disconnect( &globalMqttContext );
+
             if( pxCommand->pContext != NULL )
             {
                 pxCommand->pContext->returnStatus = xStatus;
             }
+
             break;
+
         case CONNECT:
             /* TODO: Reconnect. */
-            LogInfo( ("Processed Connect Command") );
+            LogInfo( ( "Processed Connect Command" ) );
+
         default:
             break;
     }
@@ -760,11 +799,11 @@ static MQTTStatus_t prvProcessCommand( Command_t * pxCommand )
 /*-----------------------------------------------------------*/
 
 static bool matchEndWildcards( const char * pTopicFilter,
-                                uint16_t topicNameLength,
-                                uint16_t topicFilterLength,
-                                uint16_t nameIndex,
-                                uint16_t filterIndex,
-                                bool * pMatch )
+                               uint16_t topicNameLength,
+                               uint16_t topicFilterLength,
+                               uint16_t nameIndex,
+                               uint16_t filterIndex,
+                               bool * pMatch )
 {
     bool status = false, endChar = false;
 
@@ -799,11 +838,11 @@ static bool matchEndWildcards( const char * pTopicFilter,
 /*-----------------------------------------------------------*/
 
 static bool matchWildcards( const char * pTopicFilter,
-                             const char * pTopicName,
-                             uint16_t topicNameLength,
-                             uint16_t filterIndex,
-                             uint16_t * pNameIndex,
-                             bool * pMatch )
+                            const char * pTopicName,
+                            uint16_t topicNameLength,
+                            uint16_t filterIndex,
+                            uint16_t * pNameIndex,
+                            bool * pMatch )
 {
     bool status = false;
 
@@ -840,9 +879,9 @@ static bool matchWildcards( const char * pTopicFilter,
 /*-----------------------------------------------------------*/
 
 static bool topicFilterMatch( const char * pTopicName,
-                               uint16_t topicNameLength,
-                               const char * pTopicFilter,
-                               uint16_t topicFilterLength )
+                              uint16_t topicNameLength,
+                              const char * pTopicFilter,
+                              uint16_t topicFilterLength )
 {
     bool status = false, matchFound = false;
     uint16_t nameIndex = 0, filterIndex = 0;
@@ -856,21 +895,21 @@ static bool topicFilterMatch( const char * pTopicName,
             /* Handle special corner cases regarding wildcards at the end of
              * topic filters, as documented by the MQTT protocol spec. */
             matchFound = matchEndWildcards( pTopicFilter,
-                                             topicNameLength,
-                                             topicFilterLength,
-                                             nameIndex,
-                                             filterIndex,
-                                             &status );
+                                            topicNameLength,
+                                            topicFilterLength,
+                                            nameIndex,
+                                            filterIndex,
+                                            &status );
         }
         else
         {
             /* Check for matching wildcards. */
             matchFound = matchWildcards( pTopicFilter,
-                                          pTopicName,
-                                          topicNameLength,
-                                          filterIndex,
-                                          &nameIndex,
-                                          &status );
+                                         pTopicName,
+                                         topicNameLength,
+                                         filterIndex,
+                                         &nameIndex,
+                                         &status );
         }
 
         if( matchFound == true )
@@ -895,9 +934,9 @@ static bool topicFilterMatch( const char * pTopicName,
 /*-----------------------------------------------------------*/
 
 static void prvSubscriptionManager( MQTTContext_t * pMqttContext,
-                                 MQTTPacketInfo_t * pPacketInfo,
-                                 uint16_t packetIdentifier,
-                                 MQTTPublishInfo_t * pPublishInfo )
+                                    MQTTPacketInfo_t * pPacketInfo,
+                                    uint16_t packetIdentifier,
+                                    MQTTPublishInfo_t * pPublishInfo )
 {
     assert( pMqttContext != NULL );
     assert( pPacketInfo != NULL );
@@ -913,14 +952,16 @@ static void prvSubscriptionManager( MQTTContext_t * pMqttContext,
     if( ( pPacketInfo->type & 0xF0U ) == MQTT_PACKET_TYPE_PUBLISH )
     {
         assert( pPublishInfo != NULL );
+
         for( i = 0; i < SUBSCRIPTIONS_MAX_COUNT; i++ )
         {
             if( pxSubscriptions[ i ].topicFilterLength > 0 )
             {
                 xIsMatched = topicFilterMatch( pPublishInfo->pTopicName,
-                                              pPublishInfo->topicNameLength,
-                                              pxSubscriptions[ i ].pTopicFilter,
-                                              pxSubscriptions[ i ].topicFilterLength );
+                                               pPublishInfo->topicNameLength,
+                                               pxSubscriptions[ i ].pTopicFilter,
+                                               pxSubscriptions[ i ].topicFilterLength );
+
                 if( xIsMatched )
                 {
                     LogInfo( ( "Adding publish to response queue for %.*s",
@@ -939,21 +980,26 @@ static void prvSubscriptionManager( MQTTContext_t * pMqttContext,
             case MQTT_PACKET_TYPE_PUBACK:
             case MQTT_PACKET_TYPE_PUBCOMP:
                 xAckInfo = prvPopAck( packetIdentifier );
+
                 if( xAckInfo.packetId == packetIdentifier )
                 {
                     xAckInfo.pCommandContext->returnStatus = xStatus;
+
                     if( xAckInfo.callback != NULL )
                     {
                         xAckInfo.callback( xAckInfo.pCommandContext );
                     }
                 }
+
                 break;
 
             case MQTT_PACKET_TYPE_SUBACK:
                 xAckInfo = prvPopAck( packetIdentifier );
+
                 if( xAckInfo.packetId == packetIdentifier )
                 {
                     pxSubscribeInfo = xAckInfo.pCommandContext->pSubscribeInfo;
+
                     for( i = 0; i < xAckInfo.pCommandContext->subscriptionCount; i++ )
                     {
                         LogInfo( ( "Adding subscription to %.*s",
@@ -961,32 +1007,6 @@ static void prvSubscriptionManager( MQTTContext_t * pMqttContext,
                                    pxSubscribeInfo[ i ].pTopicFilter ) );
                         LogInfo( ( "Filter length: %u", pxSubscribeInfo[ i ].topicFilterLength ) );
                         prvAddSubscription( pxSubscribeInfo[ i ].pTopicFilter,
-                                         pxSubscribeInfo[ i ].topicFilterLength,
-                                         xAckInfo.pCommandContext->pResponseQueue );
-                    }
-                }
-                else
-                {
-                    xStatus = MQTTBadResponse;
-                }
-                xAckInfo.pCommandContext->returnStatus = xStatus;
-                if( xAckInfo.callback != NULL )
-                {
-                    xAckInfo.callback( xAckInfo.pCommandContext );
-                }
-                break;
-
-            case MQTT_PACKET_TYPE_UNSUBACK:
-                xAckInfo = prvPopAck( packetIdentifier );
-                if( xAckInfo.packetId == packetIdentifier )
-                {
-                    pxSubscribeInfo = xAckInfo.pCommandContext->pSubscribeInfo;
-                    for( i = 0; i < xAckInfo.pCommandContext->subscriptionCount; i++ )
-                    {
-                        LogInfo( ( "Removing subscription to %.*s",
-                                   pxSubscribeInfo[ i ].topicFilterLength,
-                                   pxSubscribeInfo[ i ].pTopicFilter ) );
-                        prvRemoveSubscription( pxSubscribeInfo[ i ].pTopicFilter,
                                             pxSubscribeInfo[ i ].topicFilterLength,
                                             xAckInfo.pCommandContext->pResponseQueue );
                     }
@@ -995,12 +1015,45 @@ static void prvSubscriptionManager( MQTTContext_t * pMqttContext,
                 {
                     xStatus = MQTTBadResponse;
                 }
+
                 xAckInfo.pCommandContext->returnStatus = xStatus;
+
                 if( xAckInfo.callback != NULL )
                 {
                     xAckInfo.callback( xAckInfo.pCommandContext );
                 }
-                
+
+                break;
+
+            case MQTT_PACKET_TYPE_UNSUBACK:
+                xAckInfo = prvPopAck( packetIdentifier );
+
+                if( xAckInfo.packetId == packetIdentifier )
+                {
+                    pxSubscribeInfo = xAckInfo.pCommandContext->pSubscribeInfo;
+
+                    for( i = 0; i < xAckInfo.pCommandContext->subscriptionCount; i++ )
+                    {
+                        LogInfo( ( "Removing subscription to %.*s",
+                                   pxSubscribeInfo[ i ].topicFilterLength,
+                                   pxSubscribeInfo[ i ].pTopicFilter ) );
+                        prvRemoveSubscription( pxSubscribeInfo[ i ].pTopicFilter,
+                                               pxSubscribeInfo[ i ].topicFilterLength,
+                                               xAckInfo.pCommandContext->pResponseQueue );
+                    }
+                }
+                else
+                {
+                    xStatus = MQTTBadResponse;
+                }
+
+                xAckInfo.pCommandContext->returnStatus = xStatus;
+
+                if( xAckInfo.callback != NULL )
+                {
+                    xAckInfo.callback( xAckInfo.pCommandContext );
+                }
+
                 break;
 
             case MQTT_PACKET_TYPE_PUBREC:
@@ -1034,11 +1087,13 @@ static void prvCommandLoop()
     static int lNumProcessed = 0;
     bool xBreakOnNextProcessLoop = false;
     bool xSubscribeProcessed = false;
+
     while( 1 )
     {
         while( xQueueReceive( xCommandQueue, &xCommand, DEMO_TICKS_TO_WAIT ) )
         {
             pxCommand = &xCommand;
+
             /* This demo requires the subscription to be present before the first publish. */
             if( pxCommand->commandType == PUBLISH )
             {
@@ -1051,6 +1106,7 @@ static void prvCommandLoop()
             }
 
             xStatus = prvProcessCommand( pxCommand );
+
             /* TODO: After reconnect implemented, add connect operation to front
              * of queue if status was not successful. */
             configASSERT( xStatus == MQTTSuccess );
@@ -1062,6 +1118,7 @@ static void prvCommandLoop()
                 prvCreateCommand( PROCESSLOOP, NULL, NULL, &xNewCommand );
                 prvAddCommandToQueue( &xNewCommand );
                 lNumProcessed--;
+
                 if( xBreakOnNextProcessLoop )
                 {
                     break;
@@ -1080,26 +1137,26 @@ static void prvCommandLoop()
                 xBreakOnNextProcessLoop = true;
             }
         }
+
         vTaskDelay( pdMS_TO_TICKS( 200 ) );
 
         /* We have PUBLISH_COUNT publishes + 1 subscription */
-        if( lNumProcessed >= PUBLISH_COUNT + 1)
+        if( lNumProcessed >= PUBLISH_COUNT + 1 )
         {
             break;
         }
     }
+
     LogInfo( ( "Creating Disconnect operation" ) );
     prvCreateCommand( DISCONNECT, NULL, NULL, &xNewCommand );
     prvProcessCommand( &xNewCommand );
     LogInfo( ( "Disconnected from broker" ) );
-    return;
 }
 
 static void prvCommandCallback( CommandContext_t * pxContext )
 {
     pxContext->complete = true;
     xTaskNotify( pxContext->taskToNotify, pxContext->notificationBit, eSetBits );
-    return;
 }
 
 /*-----------------------------------------------------------*/
@@ -1125,9 +1182,9 @@ void prvPublishTask( void * pvParameters )
     /* Do synchronous publishes for first half. */
     for( int i = 0; i < PUBLISH_COUNT / 2; i++ )
     {
-        snprintf( payloadBuf, DEMO_BUFFER_SIZE, PUBLISH_PAYLOAD_FORMAT, i+1 );
+        snprintf( payloadBuf, DEMO_BUFFER_SIZE, PUBLISH_PAYLOAD_FORMAT, i + 1 );
         xPublishInfo.payloadLength = ( uint16_t ) strlen( payloadBuf );
-        snprintf( topicBuf, DEMO_BUFFER_SIZE, PUBLISH_TOPIC_FORMAT_STRING, i+1 );
+        snprintf( topicBuf, DEMO_BUFFER_SIZE, PUBLISH_TOPIC_FORMAT_STRING, i + 1 );
         xPublishInfo.topicNameLength = ( uint16_t ) strlen( topicBuf );
 
         prvInitializeCommandContext( &xContext );
@@ -1135,11 +1192,11 @@ void prvPublishTask( void * pvParameters )
         xContext.taskToNotify = xTaskGetCurrentTaskHandle();
         xContext.notificationBit = 1 << i;
         xContext.pPublishInfo = &xPublishInfo;
-        LogInfo( (  "Adding publish operation for message %s \non topic %.*s\n", payloadBuf, xPublishInfo.topicNameLength, xPublishInfo.pTopicName ) );
+        LogInfo( ( "Adding publish operation for message %s \non topic %.*s\n", payloadBuf, xPublishInfo.topicNameLength, xPublishInfo.pTopicName ) );
         prvCreateCommand( PUBLISH, &xContext, prvCommandCallback, &xCommand );
         prvAddCommandToQueue( &xCommand );
 
-        LogInfo( ( "Waiting for publish %d to complete.\n", i+1 ) );
+        LogInfo( ( "Waiting for publish %d to complete.\n", i + 1 ) );
         xTaskNotifyWait( 0, 1 << i, &ulNotification, DEMO_TICKS_TO_WAIT );
         configASSERT( ( ulNotification & ( 1U << i ) ) == ( 1U << i ) );
         prvDestroyCommandContext( &xContext );
@@ -1156,26 +1213,27 @@ void prvPublishTask( void * pvParameters )
         prvInitializeCommandContext( pxContexts[ i ] );
         pxContexts[ i ]->pResponseQueue = xResponseQueue1;
         pxContexts[ i ]->taskToNotify = xTaskGetCurrentTaskHandle();
+
         /* Set the notification bit to be the publish number. This prevents this demo
          * from having more than 32 publishes. If many publishes are desired, semaphores
          * can be used instead of task notifications. */
         pxContexts[ i ]->notificationBit = 1U << i;
         payloadBuffers[ i ] = ( char * ) pvPortMalloc( DYNAMIC_BUFFER_SIZE );
         topicBuffers[ i ] = ( char * ) pvPortMalloc( DYNAMIC_BUFFER_SIZE );
-        snprintf( payloadBuffers[ i ], DYNAMIC_BUFFER_SIZE, PUBLISH_PAYLOAD_FORMAT, i+1 );
-        snprintf( topicBuffers[ i ], DYNAMIC_BUFFER_SIZE, PUBLISH_TOPIC_FORMAT_STRING, i+1 );
+        snprintf( payloadBuffers[ i ], DYNAMIC_BUFFER_SIZE, PUBLISH_PAYLOAD_FORMAT, i + 1 );
+        snprintf( topicBuffers[ i ], DYNAMIC_BUFFER_SIZE, PUBLISH_TOPIC_FORMAT_STRING, i + 1 );
         /* Set publish info. */
         memset( ( void * ) &( pxPublishes[ i ] ), 0x00, sizeof( MQTTPublishInfo_t ) );
         pxPublishes[ i ].pPayload = payloadBuffers[ i ];
         pxPublishes[ i ].payloadLength = strlen( payloadBuffers[ i ] );
-        pxPublishes[ i ].pTopicName = topicBuffers[i ];
+        pxPublishes[ i ].pTopicName = topicBuffers[ i ];
         pxPublishes[ i ].topicNameLength = ( uint16_t ) strlen( topicBuffers[ i ] );
         pxPublishes[ i ].qos = MQTTQoS2;
         pxContexts[ i ]->pPublishInfo = &( pxPublishes[ i ] );
-        LogInfo( (  "Adding publish operation for message %s \non topic %.*s\n",
-                    payloadBuffers[ i ],
-                    pxPublishes[ i ].topicNameLength,
-                    pxPublishes[ i ].pTopicName ) );
+        LogInfo( ( "Adding publish operation for message %s \non topic %.*s\n",
+                   payloadBuffers[ i ],
+                   pxPublishes[ i ].topicNameLength,
+                   pxPublishes[ i ].pTopicName ) );
         prvCreateCommand( PUBLISH, pxContexts[ i ], prvCommandCallback, &xCommand );
         prvAddCommandToQueue( &xCommand );
         LogInfo( ( "Publish operation queued. Sleeping for %d ms.\n", PUBLISH_DELAY_ASYNC_MS ) );
@@ -1183,13 +1241,15 @@ void prvPublishTask( void * pvParameters )
     }
 
     LogInfo( ( "Finished publishing\n" ) );
-    for( int i = 0; i < PUBLISH_COUNT; i++)
+
+    for( int i = 0; i < PUBLISH_COUNT; i++ )
     {
-        if( pxContexts[i] == NULL )
+        if( pxContexts[ i ] == NULL )
         {
             /* Don't try to free anything that wasn't initialized. */
             continue;
         }
+
         LogInfo( ( "Waiting to free publish context %d.", i ) );
         xTaskNotifyWait( 0, ( 1U << i ), &ulNotification, DEMO_TICKS_TO_WAIT );
         configASSERT( ( ulNotification & ( 1U << i ) ) == ( 1U << i ) );
@@ -1200,10 +1260,9 @@ void prvPublishTask( void * pvParameters )
         LogInfo( ( "Publish context %d freed.", i ) );
         pxContexts[ i ] = NULL;
     }
+
     /* Notify main task this task can be deleted. */
     xTaskNotify( xMainTask, TASK1_COMPLETE_BIT, eSetBits );
-
-    return;
 }
 
 /*-----------------------------------------------------------*/
@@ -1237,11 +1296,11 @@ void prvSubscribeTask( void * pvParameters )
     prvCreateCommand( SUBSCRIBE, &xContext, prvCommandCallback, &xCommand );
     prvAddCommandToQueue( &xCommand );
 
-    LogInfo( ("Starting wait on operation.\n" ) );
+    LogInfo( ( "Starting wait on operation.\n" ) );
     xTaskNotifyWait( 0, SUBSCRIBE_BIT, &ulNotification, DEMO_TICKS_TO_WAIT );
     configASSERT( ( ulNotification & SUBSCRIBE_BIT ) == SUBSCRIBE_BIT );
     prvDestroyCommandContext( &xContext );
-    LogInfo( ("Operation wait complete.\n" ) );
+    LogInfo( ( "Operation wait complete.\n" ) );
 
     while( 1 )
     {
@@ -1253,12 +1312,14 @@ void prvSubscribeTask( void * pvParameters )
             LogInfo( ( "Received publish on topic %.*s\n", pxReceivedPublish->topicNameLength, pxReceivedPublish->pTopicName ) );
             LogInfo( ( "Message payload: %.*s\n", ( int ) pxReceivedPublish->payloadLength, ( const char * ) pxReceivedPublish->pPayload ) );
             usNumReceived++;
+
             /* Break if all publishes have been received. */
             if( usNumReceived >= PUBLISH_COUNT )
             {
                 break;
             }
         }
+
         /* Break if all publishes have been received. */
         if( usNumReceived >= PUBLISH_COUNT )
         {
@@ -1271,16 +1332,17 @@ void prvSubscribeTask( void * pvParameters )
         vTaskDelay( pdMS_TO_TICKS( SUBSCRIBE_TASK_DELAY_MS ) );
     }
 
-    LogInfo( ("Finished receiving\n" ) );
+    LogInfo( ( "Finished receiving\n" ) );
     prvCreateCommand( UNSUBSCRIBE, &xContext, prvCommandCallback, &xCommand );
     prvInitializeCommandContext( &xContext );
     xContext.pResponseQueue = xResponseQueue2;
     xContext.taskToNotify = xTaskGetCurrentTaskHandle();
     xContext.notificationBit = UNSUBSCRIBE_BIT;
     xContext.pSubscribeInfo = &xSubscribeInfo;
-    LogInfo( ("Adding unsubscribe operation\n" ) );
+    LogInfo( ( "Adding unsubscribe operation\n" ) );
     prvAddCommandToQueue( &xCommand );
-    LogInfo( ("Starting wait on operation\n" ) );
+    LogInfo( ( "Starting wait on operation\n" ) );
+
     while( ( ulNotification & UNSUBSCRIBE_BIT ) != UNSUBSCRIBE_BIT )
     {
         LogInfo( ( "Waiting for unsubscribe operation to complete." ) );
@@ -1293,13 +1355,12 @@ void prvSubscribeTask( void * pvParameters )
             break;
         }
     }
+
     prvDestroyCommandContext( &xContext );
-    LogInfo( ("Operation wait complete.\n" ) );
+    LogInfo( ( "Operation wait complete.\n" ) );
 
     /* Notify main task this task can be deleted. */
     xTaskNotify( xMainTask, TASK2_COMPLETE_BIT, eSetBits );
-
-    return;
 }
 
 /*-----------------------------------------------------------*/
@@ -1332,10 +1393,10 @@ static void prvMQTTDemoTask( void * pvParameters )
 
     /* TODO: Use TLS to connect to the broker. */
     xNetworkStatus = Plaintext_FreeRTOS_Connect( &xNetworkContext,
-                                                    BROKER_ENDPOINT,
-                                                    BROKER_PORT,
-                                                    TRANSPORT_SEND_RECV_TIMEOUT_MS,
-                                                    TRANSPORT_SEND_RECV_TIMEOUT_MS );
+                                                 BROKER_ENDPOINT,
+                                                 BROKER_PORT,
+                                                 TRANSPORT_SEND_RECV_TIMEOUT_MS,
+                                                 TRANSPORT_SEND_RECV_TIMEOUT_MS );
     configASSERT( xNetworkStatus == 0 );
     prvCreateMQTTConnectionWithBroker( &globalMqttContext, &xNetworkContext );
     configASSERT( globalMqttContext.connectStatus = MQTTConnected );
@@ -1353,14 +1414,17 @@ static void prvMQTTDemoTask( void * pvParameters )
         LogInfo( ( "Waiting for subscribe task to exit." ) );
         xTaskNotifyWait( 0, TASK2_COMPLETE_BIT, &ulNotification, DEMO_TICKS_TO_WAIT );
     }
+
     configASSERT( ( ulNotification & TASK2_COMPLETE_BIT ) == TASK2_COMPLETE_BIT );
     vTaskDelete( xTask2 );
     LogInfo( ( "Subscribe task Deleted." ) );
+
     while( ( ulNotification & TASK1_COMPLETE_BIT ) != TASK1_COMPLETE_BIT )
     {
         LogInfo( ( "Waiting for publish task to exit." ) );
         xTaskNotifyWait( 0, TASK1_COMPLETE_BIT, &ulNotification, DEMO_TICKS_TO_WAIT );
     }
+
     configASSERT( ( ulNotification & TASK1_COMPLETE_BIT ) == TASK1_COMPLETE_BIT );
     vTaskDelete( xTask1 );
     LogInfo( ( "Publish task Deleted." ) );

--- a/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_multitask/FreeRTOSConfig.h
+++ b/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_multitask/FreeRTOSConfig.h
@@ -1,0 +1,216 @@
+/*
+ * FreeRTOS Kernel V10.3.0
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://www.FreeRTOS.org
+ * http://aws.amazon.com/freertos
+ *
+ * 1 tab == 4 spaces!
+ */
+
+#ifndef FREERTOS_CONFIG_H
+#define FREERTOS_CONFIG_H
+
+/*-----------------------------------------------------------
+* Application specific definitions.
+*
+* These definitions should be adjusted for your particular hardware and
+* application requirements.
+*
+* THESE PARAMETERS ARE DESCRIBED WITHIN THE 'CONFIGURATION' SECTION OF THE
+* FreeRTOS API DOCUMENTATION AVAILABLE ON THE FreeRTOS.org WEB SITE.
+* http://www.freertos.org/a00110.html
+*
+* The bottom of this file contains some constants specific to running the UDP
+* stack in this demo.  Constants specific to FreeRTOS+TCP itself (rather than
+* the demo) are contained in FreeRTOSIPConfig.h.
+*----------------------------------------------------------*/
+#define configUSE_PREEMPTION                       1
+#define configUSE_PORT_OPTIMISED_TASK_SELECTION    1
+#define configMAX_PRIORITIES                       ( 7 )
+#define configTICK_RATE_HZ                         ( 1000 )                  /* In this non-real time simulated environment the tick frequency has to be at least a multiple of the Win32 tick frequency, and therefore very slow. */
+#define configMINIMAL_STACK_SIZE                   ( ( unsigned short ) 60 ) /* In this simulated case, the stack only has to hold one small structure as the real stack is part of the Win32 thread. */
+#define configTOTAL_HEAP_SIZE                      ( ( size_t ) ( 2048U * 1024U ) )
+#define configMAX_TASK_NAME_LEN                    ( 15 )
+#define configUSE_TRACE_FACILITY                   0
+#define configUSE_16_BIT_TICKS                     0
+#define configIDLE_SHOULD_YIELD                    1
+#define configUSE_CO_ROUTINES                      0
+#define configUSE_MUTEXES                          1
+#define configUSE_RECURSIVE_MUTEXES                1
+#define configQUEUE_REGISTRY_SIZE                  0
+#define configUSE_APPLICATION_TASK_TAG             0
+#define configUSE_COUNTING_SEMAPHORES              1
+#define configUSE_ALTERNATIVE_API                  0
+#define configNUM_THREAD_LOCAL_STORAGE_POINTERS    0
+#define configENABLE_BACKWARD_COMPATIBILITY        1
+#define configSUPPORT_STATIC_ALLOCATION            1
+
+/* Hook function related definitions. */
+#define configUSE_TICK_HOOK                        0
+#define configUSE_IDLE_HOOK                        0
+#define configUSE_MALLOC_FAILED_HOOK               0
+#define configCHECK_FOR_STACK_OVERFLOW             0 /* Not applicable to the Win32 port. */
+
+/* Software timer related definitions. */
+#define configUSE_TIMERS                           1
+#define configTIMER_TASK_PRIORITY                  ( configMAX_PRIORITIES - 1 )
+#define configTIMER_QUEUE_LENGTH                   5
+#define configTIMER_TASK_STACK_DEPTH               ( configMINIMAL_STACK_SIZE * 2 )
+
+/* Event group related definitions. */
+#define configUSE_EVENT_GROUPS                     1
+
+/* Run time stats gathering configuration options. */
+#define configGENERATE_RUN_TIME_STATS              0
+
+/* Co-routine definitions. */
+#define configUSE_CO_ROUTINES                      0
+#define configMAX_CO_ROUTINE_PRIORITIES            ( 2 )
+
+/* Set the following definitions to 1 to include the API function, or zero
+ * to exclude the API function. */
+#define INCLUDE_vTaskPrioritySet                   1
+#define INCLUDE_uxTaskPriorityGet                  1
+#define INCLUDE_vTaskDelete                        1
+#define INCLUDE_vTaskCleanUpResources              0
+#define INCLUDE_vTaskSuspend                       1
+#define INCLUDE_vTaskDelayUntil                    1
+#define INCLUDE_vTaskDelay                         1
+#define INCLUDE_uxTaskGetStackHighWaterMark        1
+#define INCLUDE_xTaskGetSchedulerState             1
+#define INCLUDE_xTimerGetTimerTaskHandle           0
+#define INCLUDE_xTaskGetIdleTaskHandle             0
+#define INCLUDE_xQueueGetMutexHolder               1
+#define INCLUDE_eTaskGetState                      1
+#define INCLUDE_xEventGroupSetBitsFromISR          1
+#define INCLUDE_xTimerPendFunctionCall             1
+#define INCLUDE_pcTaskGetTaskName                  1
+
+/* This demo makes use of one or more example stats formatting functions.  These
+ * format the raw data provided by the uxTaskGetSystemState() function in to human
+ * readable ASCII form.  See the notes in the implementation of vTaskList() within
+ * FreeRTOS/Source/tasks.c for limitations.  configUSE_STATS_FORMATTING_FUNCTIONS
+ * is set to 2 so the formatting functions are included without the stdio.h being
+ * included in tasks.c.  That is because this project defines its own sprintf()
+ * functions. */
+#define configUSE_STATS_FORMATTING_FUNCTIONS       1
+
+/* Assert call defined for debug builds. */
+#ifdef _DEBUG
+    extern void vAssertCalled( const char * pcFile,
+                               uint32_t ulLine );
+    #define configASSERT( x )    if( ( x ) == 0 ) vAssertCalled( __FILE__, __LINE__ )
+#endif /* _DEBUG */
+
+
+
+/* Application specific definitions follow. **********************************/
+
+/* Only used when running in the FreeRTOS Windows simulator.  Defines the
+ * priority of the task used to simulate Ethernet interrupts. */
+#define configMAC_ISR_SIMULATOR_PRIORITY          ( configMAX_PRIORITIES - 1 )
+
+/* This demo creates a virtual network connection by accessing the raw Ethernet
+ * or WiFi data to and from a real network connection.  Many computers have more
+ * than one real network port, and configNETWORK_INTERFACE_TO_USE is used to tell
+ * the demo which real port should be used to create the virtual port.  The ports
+ * available are displayed on the console when the application is executed.  For
+ * example, on my development laptop setting configNETWORK_INTERFACE_TO_USE to 4
+ * results in the wired network being used, while setting
+ * configNETWORK_INTERFACE_TO_USE to 2 results in the wireless network being
+ * used. */
+#define configNETWORK_INTERFACE_TO_USE            1L
+
+/* The address to which logging is sent should UDP logging be enabled. */
+#define configUDP_LOGGING_ADDR0                   192
+#define configUDP_LOGGING_ADDR1                   168
+#define configUDP_LOGGING_ADDR2                   0
+#define configUDP_LOGGING_ADDR3                   11
+
+/* Default MAC address configuration.  The demo creates a virtual network
+ * connection that uses this MAC address by accessing the raw Ethernet/WiFi data
+ * to and from a real network connection on the host PC.  See the
+ * configNETWORK_INTERFACE_TO_USE definition above for information on how to
+ * configure the real network connection to use. */
+#define configMAC_ADDR0                           0x00
+#define configMAC_ADDR1                           0x11
+#define configMAC_ADDR2                           0x11
+#define configMAC_ADDR3                           0x11
+#define configMAC_ADDR4                           0x11
+#define configMAC_ADDR5                           0x41
+
+/* Default IP address configuration.  Used in ipconfigUSE_DNS is set to 0, or
+ * ipconfigUSE_DNS is set to 1 but a DNS server cannot be contacted. */
+#define configIP_ADDR0                            10
+#define configIP_ADDR1                            10
+#define configIP_ADDR2                            10
+#define configIP_ADDR3                            200
+
+/* Default gateway IP address configuration.  Used in ipconfigUSE_DNS is set to
+ * 0, or ipconfigUSE_DNS is set to 1 but a DNS server cannot be contacted. */
+#define configGATEWAY_ADDR0                       10
+#define configGATEWAY_ADDR1                       10
+#define configGATEWAY_ADDR2                       10
+#define configGATEWAY_ADDR3                       1
+
+/* Default DNS server configuration.  OpenDNS addresses are 208.67.222.222 and
+ * 208.67.220.220.  Used in ipconfigUSE_DNS is set to 0, or ipconfigUSE_DNS is set
+ * to 1 but a DNS server cannot be contacted.*/
+#define configDNS_SERVER_ADDR0                    208
+#define configDNS_SERVER_ADDR1                    67
+#define configDNS_SERVER_ADDR2                    222
+#define configDNS_SERVER_ADDR3                    222
+
+/* Default netmask configuration.  Used in ipconfigUSE_DNS is set to 0, or
+ * ipconfigUSE_DNS is set to 1 but a DNS server cannot be contacted. */
+#define configNET_MASK0                           255
+#define configNET_MASK1                           0
+#define configNET_MASK2                           0
+#define configNET_MASK3                           0
+
+/* The UDP port to which print messages are sent. */
+#define configPRINT_PORT                          ( 15000 )
+
+/* Task pool definitions for the demos of IoT Libraries. */
+#define configTASKPOOL_ENABLE_ASSERTS             1
+#define configTASKPOOL_NUMBER_OF_WORKERS          1
+#define configTASKPOOL_WORKER_PRIORITY            tskIDLE_PRIORITY
+#define configTASKPOOL_WORKER_STACK_SIZE_BYTES    2048
+
+#if ( defined( _MSC_VER ) && ( _MSC_VER <= 1600 ) && !defined( snprintf ) )
+    /* Map to Windows names. */
+    #define snprintf     _snprintf
+    #define vsnprintf    _vsnprintf
+#endif
+
+/* Visual studio does not have an implementation of strcasecmp(). */
+#define strcasecmp     _stricmp
+#define strncasecmp    _strnicmp
+#define strcmpi        _strcmpi
+
+/* Prototype for the function used to print out.  In this case it prints to the
+ * console before the network is connected then a UDP port after the network has
+ * connected. */
+extern void vLoggingPrintf( const char * pcFormatString,
+                            ... );
+#define configPRINTF( X )    vLoggingPrintf X
+
+#endif /* FREERTOS_CONFIG_H */

--- a/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_multitask/FreeRTOSIPConfig.h
+++ b/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_multitask/FreeRTOSIPConfig.h
@@ -1,0 +1,311 @@
+/*
+ * FreeRTOS Kernel V10.3.0
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://www.FreeRTOS.org
+ * http://aws.amazon.com/freertos
+ *
+ * 1 tab == 4 spaces!
+ */
+
+
+/*****************************************************************************
+*
+* See the following URL for configuration information.
+* http://www.freertos.org/FreeRTOS-Plus/FreeRTOS_Plus_TCP/TCP_IP_Configuration.html
+*
+*****************************************************************************/
+
+#ifndef FREERTOS_IP_CONFIG_H
+#define FREERTOS_IP_CONFIG_H
+
+/* Prototype for the function used to print out.  In this case it prints to the
+ * console before the network is connected then a UDP port after the network has
+ * connected. */
+extern void vLoggingPrintf( const char * pcFormatString,
+                            ... );
+
+/* Set to 1 to print out debug messages.  If ipconfigHAS_DEBUG_PRINTF is set to
+ * 1 then FreeRTOS_debug_printf should be defined to the function used to print
+ * out the debugging messages. */
+#define ipconfigHAS_DEBUG_PRINTF    0
+#if ( ipconfigHAS_DEBUG_PRINTF == 1 )
+    #define FreeRTOS_debug_printf( X )    vLoggingPrintf X
+#endif
+
+/* Set to 1 to print out non debugging messages, for example the output of the
+ * FreeRTOS_netstat() command, and ping replies.  If ipconfigHAS_PRINTF is set to 1
+ * then FreeRTOS_printf should be set to the function used to print out the
+ * messages. */
+#define ipconfigHAS_PRINTF    1
+#if ( ipconfigHAS_PRINTF == 1 )
+    #define FreeRTOS_printf( X )    vLoggingPrintf X
+#endif
+
+/* Define the byte order of the target MCU (the MCU FreeRTOS+TCP is executing
+ * on).  Valid options are pdFREERTOS_BIG_ENDIAN and pdFREERTOS_LITTLE_ENDIAN. */
+#define ipconfigBYTE_ORDER                         pdFREERTOS_LITTLE_ENDIAN
+
+/* If the network card/driver includes checksum offloading (IP/TCP/UDP checksums)
+ * then set ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM to 1 to prevent the software
+ * stack repeating the checksum calculations. */
+#define ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM     1
+
+/* Several API's will block until the result is known, or the action has been
+ * performed, for example FreeRTOS_send() and FreeRTOS_recv().  The timeouts can be
+ * set per socket, using setsockopt().  If not set, the times below will be
+ * used as defaults. */
+#define ipconfigSOCK_DEFAULT_RECEIVE_BLOCK_TIME    ( 2000 )
+#define ipconfigSOCK_DEFAULT_SEND_BLOCK_TIME       ( 5000 )
+
+/* Include support for LLMNR: Link-local Multicast Name Resolution
+ * (non-Microsoft) */
+#define ipconfigUSE_LLMNR                          ( 0 )
+
+/* Include support for NBNS: NetBIOS Name Service (Microsoft) */
+#define ipconfigUSE_NBNS                           ( 0 )
+
+/* Include support for DNS caching.  For TCP, having a small DNS cache is very
+ * useful.  When a cache is present, ipconfigDNS_REQUEST_ATTEMPTS can be kept low
+ * and also DNS may use small timeouts.  If a DNS reply comes in after the DNS
+ * socket has been destroyed, the result will be stored into the cache.  The next
+ * call to FreeRTOS_gethostbyname() will return immediately, without even creating
+ * a socket. */
+#define ipconfigUSE_DNS_CACHE                      ( 1 )
+#define ipconfigDNS_CACHE_NAME_LENGTH              ( 32 )
+#define ipconfigDNS_CACHE_ENTRIES                  ( 4 )
+#define ipconfigDNS_REQUEST_ATTEMPTS               ( 2 )
+
+/* The IP stack executes it its own task (although any application task can make
+ * use of its services through the published sockets API). ipconfigUDP_TASK_PRIORITY
+ * sets the priority of the task that executes the IP stack.  The priority is a
+ * standard FreeRTOS task priority so can take any value from 0 (the lowest
+ * priority) to (configMAX_PRIORITIES - 1) (the highest priority).
+ * configMAX_PRIORITIES is a standard FreeRTOS configuration parameter defined in
+ * FreeRTOSConfig.h, not FreeRTOSIPConfig.h. Consideration needs to be given as to
+ * the priority assigned to the task executing the IP stack relative to the
+ * priority assigned to tasks that use the IP stack. */
+#define ipconfigIP_TASK_PRIORITY                   ( configMAX_PRIORITIES - 2 )
+
+/* The size, in words (not bytes), of the stack allocated to the FreeRTOS+TCP
+ * task.  This setting is less important when the FreeRTOS Win32 simulator is used
+ * as the Win32 simulator only stores a fixed amount of information on the task
+ * stack.  FreeRTOS includes optional stack overflow detection, see:
+ * http://www.freertos.org/Stacks-and-stack-overflow-checking.html */
+#define ipconfigIP_TASK_STACK_SIZE_WORDS           ( configMINIMAL_STACK_SIZE * 5 )
+
+/* ipconfigRAND32() is called by the IP stack to generate random numbers for
+ * things such as a DHCP transaction number or initial sequence number.  Random
+ * number generation is performed via this macro to allow applications to use their
+ * own random number generation method.  For example, it might be possible to
+ * generate a random number by sampling noise on an analogue input. */
+extern UBaseType_t uxRand();
+#define ipconfigRAND32()    uxRand()
+
+/* If ipconfigUSE_NETWORK_EVENT_HOOK is set to 1 then FreeRTOS+TCP will call the
+ * network event hook at the appropriate times.  If ipconfigUSE_NETWORK_EVENT_HOOK
+ * is not set to 1 then the network event hook will never be called.  See
+ * http://www.FreeRTOS.org/FreeRTOS-Plus/FreeRTOS_Plus_UDP/API/vApplicationIPNetworkEventHook.shtml
+ */
+#define ipconfigUSE_NETWORK_EVENT_HOOK                        1
+
+/* Sockets have a send block time attribute.  If FreeRTOS_sendto() is called but
+ * a network buffer cannot be obtained then the calling task is held in the Blocked
+ * state (so other tasks can continue to executed) until either a network buffer
+ * becomes available or the send block time expires.  If the send block time expires
+ * then the send operation is aborted.  The maximum allowable send block time is
+ * capped to the value set by ipconfigMAX_SEND_BLOCK_TIME_TICKS.  Capping the
+ * maximum allowable send block time prevents prevents a deadlock occurring when
+ * all the network buffers are in use and the tasks that process (and subsequently
+ * free) the network buffers are themselves blocked waiting for a network buffer.
+ * ipconfigMAX_SEND_BLOCK_TIME_TICKS is specified in RTOS ticks.  A time in
+ * milliseconds can be converted to a time in ticks by dividing the time in
+ * milliseconds by portTICK_PERIOD_MS. */
+#define ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS                 ( 5000 / portTICK_PERIOD_MS )
+
+/* If ipconfigUSE_DHCP is 1 then FreeRTOS+TCP will attempt to retrieve an IP
+ * address, netmask, DNS server address and gateway address from a DHCP server.  If
+ * ipconfigUSE_DHCP is 0 then FreeRTOS+TCP will use a static IP address.  The
+ * stack will revert to using the static IP address even when ipconfigUSE_DHCP is
+ * set to 1 if a valid configuration cannot be obtained from a DHCP server for any
+ * reason.  The static configuration used is that passed into the stack by the
+ * FreeRTOS_IPInit() function call. */
+#define ipconfigUSE_DHCP                                      1
+
+/* When ipconfigUSE_DHCP is set to 1, DHCP requests will be sent out at
+ * increasing time intervals until either a reply is received from a DHCP server
+ * and accepted, or the interval between transmissions reaches
+ * ipconfigMAXIMUM_DISCOVER_TX_PERIOD.  The IP stack will revert to using the
+ * static IP address passed as a parameter to FreeRTOS_IPInit() if the
+ * re-transmission time interval reaches ipconfigMAXIMUM_DISCOVER_TX_PERIOD without
+ * a DHCP reply being received. */
+#define ipconfigMAXIMUM_DISCOVER_TX_PERIOD                    ( 120000 / portTICK_PERIOD_MS )
+
+/* The ARP cache is a table that maps IP addresses to MAC addresses.  The IP
+ * stack can only send a UDP message to a remove IP address if it knowns the MAC
+ * address associated with the IP address, or the MAC address of the router used to
+ * contact the remote IP address.  When a UDP message is received from a remote IP
+ * address the MAC address and IP address are added to the ARP cache.  When a UDP
+ * message is sent to a remote IP address that does not already appear in the ARP
+ * cache then the UDP message is replaced by a ARP message that solicits the
+ * required MAC address information.  ipconfigARP_CACHE_ENTRIES defines the maximum
+ * number of entries that can exist in the ARP table at any one time. */
+#define ipconfigARP_CACHE_ENTRIES                             6
+
+/* ARP requests that do not result in an ARP response will be re-transmitted a
+ * maximum of ipconfigMAX_ARP_RETRANSMISSIONS times before the ARP request is
+ * aborted. */
+#define ipconfigMAX_ARP_RETRANSMISSIONS                       ( 5 )
+
+/* ipconfigMAX_ARP_AGE defines the maximum time between an entry in the ARP
+ * table being created or refreshed and the entry being removed because it is stale.
+ * New ARP requests are sent for ARP cache entries that are nearing their maximum
+ * age.  ipconfigMAX_ARP_AGE is specified in tens of seconds, so a value of 150 is
+ * equal to 1500 seconds (or 25 minutes). */
+#define ipconfigMAX_ARP_AGE                                   150
+
+/* Implementing FreeRTOS_inet_addr() necessitates the use of string handling
+ * routines, which are relatively large.  To save code space the full
+ * FreeRTOS_inet_addr() implementation is made optional, and a smaller and faster
+ * alternative called FreeRTOS_inet_addr_quick() is provided.  FreeRTOS_inet_addr()
+ * takes an IP in decimal dot format (for example, "192.168.0.1") as its parameter.
+ * FreeRTOS_inet_addr_quick() takes an IP address as four separate numerical octets
+ * (for example, 192, 168, 0, 1) as its parameters.  If
+ * ipconfigINCLUDE_FULL_INET_ADDR is set to 1 then both FreeRTOS_inet_addr() and
+ * FreeRTOS_indet_addr_quick() are available.  If ipconfigINCLUDE_FULL_INET_ADDR is
+ * not set to 1 then only FreeRTOS_indet_addr_quick() is available. */
+#define ipconfigINCLUDE_FULL_INET_ADDR                        1
+
+/* ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS defines the total number of network buffer that
+ * are available to the IP stack.  The total number of network buffers is limited
+ * to ensure the total amount of RAM that can be consumed by the IP stack is capped
+ * to a pre-determinable value. */
+#define ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS                60
+
+/* A FreeRTOS queue is used to send events from application tasks to the IP
+ * stack.  ipconfigEVENT_QUEUE_LENGTH sets the maximum number of events that can
+ * be queued for processing at any one time.  The event queue must be a minimum of
+ * 5 greater than the total number of network buffers. */
+#define ipconfigEVENT_QUEUE_LENGTH                            ( ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS + 5 )
+
+/* The address of a socket is the combination of its IP address and its port
+ * number.  FreeRTOS_bind() is used to manually allocate a port number to a socket
+ * (to 'bind' the socket to a port), but manual binding is not normally necessary
+ * for client sockets (those sockets that initiate outgoing connections rather than
+ * wait for incoming connections on a known port number).  If
+ * ipconfigALLOW_SOCKET_SEND_WITHOUT_BIND is set to 1 then calling
+ * FreeRTOS_sendto() on a socket that has not yet been bound will result in the IP
+ * stack automatically binding the socket to a port number from the range
+ * socketAUTO_PORT_ALLOCATION_START_NUMBER to 0xffff.  If
+ * ipconfigALLOW_SOCKET_SEND_WITHOUT_BIND is set to 0 then calling FreeRTOS_sendto()
+ * on a socket that has not yet been bound will result in the send operation being
+ * aborted. */
+#define ipconfigALLOW_SOCKET_SEND_WITHOUT_BIND                1
+
+/* Defines the Time To Live (TTL) values used in outgoing UDP packets. */
+#define ipconfigUDP_TIME_TO_LIVE                              128
+#define ipconfigTCP_TIME_TO_LIVE                              128 /* also defined in FreeRTOSIPConfigDefaults.h */
+
+/* USE_TCP: Use TCP and all its features */
+#define ipconfigUSE_TCP                                       ( 1 )
+
+/* Use the TCP socket wake context with a callback. */
+#define ipconfigSOCKET_HAS_USER_WAKE_CALLBACK_WITH_CONTEXT    ( 1 )
+
+/* USE_WIN: Let TCP use windowing mechanism. */
+#define ipconfigUSE_TCP_WIN                                   ( 1 )
+
+/* The MTU is the maximum number of bytes the payload of a network frame can
+ * contain.  For normal Ethernet V2 frames the maximum MTU is 1500.  Setting a
+ * lower value can save RAM, depending on the buffer management scheme used.  If
+ * ipconfigCAN_FRAGMENT_OUTGOING_PACKETS is 1 then (ipconfigNETWORK_MTU - 28) must
+ * be divisible by 8. */
+#define ipconfigNETWORK_MTU                                   1200
+
+/* Set ipconfigUSE_DNS to 1 to include a basic DNS client/resolver.  DNS is used
+ * through the FreeRTOS_gethostbyname() API function. */
+#define ipconfigUSE_DNS                                       1
+
+/* If ipconfigREPLY_TO_INCOMING_PINGS is set to 1 then the IP stack will
+ * generate replies to incoming ICMP echo (ping) requests. */
+#define ipconfigREPLY_TO_INCOMING_PINGS                       1
+
+/* If ipconfigSUPPORT_OUTGOING_PINGS is set to 1 then the
+ * FreeRTOS_SendPingRequest() API function is available. */
+#define ipconfigSUPPORT_OUTGOING_PINGS                        0
+
+/* If ipconfigSUPPORT_SELECT_FUNCTION is set to 1 then the FreeRTOS_select()
+ * (and associated) API function is available. */
+#define ipconfigSUPPORT_SELECT_FUNCTION                       1
+
+/* If ipconfigFILTER_OUT_NON_ETHERNET_II_FRAMES is set to 1 then Ethernet frames
+ * that are not in Ethernet II format will be dropped.  This option is included for
+ * potential future IP stack developments. */
+#define ipconfigFILTER_OUT_NON_ETHERNET_II_FRAMES             1
+
+/* If ipconfigETHERNET_DRIVER_FILTERS_FRAME_TYPES is set to 1 then it is the
+ * responsibility of the Ethernet interface to filter out packets that are of no
+ * interest.  If the Ethernet interface does not implement this functionality, then
+ * set ipconfigETHERNET_DRIVER_FILTERS_FRAME_TYPES to 0 to have the IP stack
+ * perform the filtering instead (it is much less efficient for the stack to do it
+ * because the packet will already have been passed into the stack).  If the
+ * Ethernet driver does all the necessary filtering in hardware then software
+ * filtering can be removed by using a value other than 1 or 0. */
+#define ipconfigETHERNET_DRIVER_FILTERS_FRAME_TYPES           1
+
+/* The windows simulator cannot really simulate MAC interrupts, and needs to
+ * block occasionally to allow other tasks to run. */
+#define configWINDOWS_MAC_INTERRUPT_SIMULATOR_DELAY           ( 20 / portTICK_PERIOD_MS )
+
+/* Advanced only: in order to access 32-bit fields in the IP packets with
+ * 32-bit memory instructions, all packets will be stored 32-bit-aligned, plus 16-bits.
+ * This has to do with the contents of the IP-packets: all 32-bit fields are
+ * 32-bit-aligned, plus 16-bit(!) */
+#define ipconfigPACKET_FILLER_SIZE                            2
+
+/* Define the size of the pool of TCP window descriptors.  On the average, each
+ * TCP socket will use up to 2 x 6 descriptors, meaning that it can have 2 x 6
+ * outstanding packets (for Rx and Tx).  When using up to 10 TP sockets
+ * simultaneously, one could define TCP_WIN_SEG_COUNT as 120. */
+#define ipconfigTCP_WIN_SEG_COUNT                             240
+
+/* Each TCP socket has a circular buffers for Rx and Tx, which have a fixed
+ * maximum size.  Define the size of Rx buffer for TCP sockets. */
+#define ipconfigTCP_RX_BUFFER_LENGTH                          ( 1000 )
+
+/* Define the size of Tx buffer for TCP sockets. */
+#define ipconfigTCP_TX_BUFFER_LENGTH                          ( 1000 )
+
+/* When using call-back handlers, the driver may check if the handler points to
+ * real program memory (RAM or flash) or just has a random non-zero value. */
+#define ipconfigIS_VALID_PROG_ADDRESS( x )    ( ( x ) != NULL )
+
+/* Include support for TCP hang protection.  All sockets in a connecting or
+ * disconnecting stage will timeout after a period of non-activity. */
+#define ipconfigTCP_HANG_PROTECTION         ( 1 )
+#define ipconfigTCP_HANG_PROTECTION_TIME    ( 30 )
+
+/* Include support for TCP keep-alive messages. */
+#define ipconfigTCP_KEEP_ALIVE              ( 1 )
+#define ipconfigTCP_KEEP_ALIVE_INTERVAL     ( 20 ) /* in seconds */
+
+#define portINLINE                          __inline
+
+#endif /* FREERTOS_IP_CONFIG_H */

--- a/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_multitask/READ_ME_INSTRUCTIONS.url
+++ b/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_multitask/READ_ME_INSTRUCTIONS.url
@@ -1,0 +1,5 @@
+[{000214A0-0000-0000-C000-000000000046}]
+Prop3=19,11
+[InternetShortcut]
+IDList=
+URL=https://www.freertos.org/mqtt_lts/

--- a/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_multitask/WIN32.vcxproj
+++ b/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_multitask/WIN32.vcxproj
@@ -1,0 +1,205 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{C686325E-3261-42F7-AEB1-DDE5280E1CEB}</ProjectGuid>
+    <ProjectName>RTOSDemo</ProjectName>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseOfMfc>false</UseOfMfc>
+    <CharacterSet>MultiByte</CharacterSet>
+    <PlatformToolset>v142</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseOfMfc>false</UseOfMfc>
+    <CharacterSet>MultiByte</CharacterSet>
+    <PlatformToolset>v142</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="$(VCTargetsPath)Microsoft.CPP.UpgradeFromVC60.props" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="$(VCTargetsPath)Microsoft.CPP.UpgradeFromVC60.props" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup>
+    <_ProjectFileVersion>10.0.30319.1</_ProjectFileVersion>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">.\Debug\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">.\Debug\</IntDir>
+    <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</LinkIncremental>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">.\Release\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">.\Release\</IntDir>
+    <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">false</LinkIncremental>
+    <CodeAnalysisRuleSet Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">AllRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Midl>
+      <TypeLibraryName>.\Debug/WIN32.tlb</TypeLibraryName>
+      <HeaderFileName>
+      </HeaderFileName>
+    </Midl>
+    <ClCompile>
+      <Optimization>Disabled</Optimization>
+      <AdditionalIncludeDirectories>..\..\..\..\Source\FreeRTOS-Plus-Trace\Include;..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\include;..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\portable\BufferManagement;..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\portable\Compiler\MSVC;..\..\common\logging-stack;..\common\WinPCap;..\..\..\..\..\FreeRTOS\Source\include;..\..\..\..\..\FreeRTOS\Source\portable\MSVC-MingW;..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\standard\mqtt\include;..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\platform\include;..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\platform\freertos\transport\include;.;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;_WIN32_WINNT=0x0500;WINVER=0x400;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <MinimalRebuild>false</MinimalRebuild>
+      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <PrecompiledHeaderOutputFile>.\Debug/WIN32.pch</PrecompiledHeaderOutputFile>
+      <AssemblerListingLocation>.\Debug/</AssemblerListingLocation>
+      <ObjectFileName>.\Debug/</ObjectFileName>
+      <ProgramDataBaseFileName>.\Debug/</ProgramDataBaseFileName>
+      <WarningLevel>Level4</WarningLevel>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <DisableLanguageExtensions>false</DisableLanguageExtensions>
+      <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
+      <AdditionalOptions>/wd4210 /wd4127 /wd4214 /wd4201 /wd4244  /wd4310 /wd4200 %(AdditionalOptions)</AdditionalOptions>
+      <BrowseInformation>true</BrowseInformation>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <ExceptionHandling>false</ExceptionHandling>
+      <CompileAs>CompileAsC</CompileAs>
+    </ClCompile>
+    <ResourceCompile>
+      <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <Culture>0x0c09</Culture>
+    </ResourceCompile>
+    <Link>
+      <OutputFile>.\Debug/RTOSDemo.exe</OutputFile>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <ProgramDatabaseFile>.\Debug/WIN32.pdb</ProgramDatabaseFile>
+      <SubSystem>Console</SubSystem>
+      <TargetMachine>MachineX86</TargetMachine>
+      <AdditionalDependencies>wpcap.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>..\common\WinPCap</AdditionalLibraryDirectories>
+      <Profile>false</Profile>
+      <ImageHasSafeExceptionHandlers>false</ImageHasSafeExceptionHandlers>
+    </Link>
+    <Bscmake>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <OutputFile>.\Debug/WIN32.bsc</OutputFile>
+    </Bscmake>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Midl>
+      <TypeLibraryName>.\Release/WIN32.tlb</TypeLibraryName>
+      <HeaderFileName>
+      </HeaderFileName>
+    </Midl>
+    <ClCompile>
+      <Optimization>MaxSpeed</Optimization>
+      <InlineFunctionExpansion>OnlyExplicitInline</InlineFunctionExpansion>
+      <PreprocessorDefinitions>_WINSOCKAPI_;WIN32;NDEBUG;_CONSOLE;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <StringPooling>true</StringPooling>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <PrecompiledHeaderOutputFile>.\Release/WIN32.pch</PrecompiledHeaderOutputFile>
+      <AssemblerListingLocation>.\Release/</AssemblerListingLocation>
+      <ObjectFileName>.\Release/</ObjectFileName>
+      <ProgramDataBaseFileName>.\Release/</ProgramDataBaseFileName>
+      <WarningLevel>Level3</WarningLevel>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <AdditionalIncludeDirectories>..\Common\Utils;..\Common\ethernet\lwip-1.4.0\ports\win32\WinPCap;..\Common\ethernet\lwip-1.4.0\src\include\ipv4;..\Common\ethernet\lwip-1.4.0\src\include;..\..\..\Source\include;..\..\..\Source\portable\MSVC-MingW;..\Common\ethernet\lwip-1.4.0\ports\win32\include;..\Common\Include;.\lwIP_Apps;.;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <ResourceCompile>
+      <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <Culture>0x0c09</Culture>
+    </ResourceCompile>
+    <Link>
+      <OutputFile>.\Release/RTOSDemo.exe</OutputFile>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <ProgramDatabaseFile>.\Release/WIN32.pdb</ProgramDatabaseFile>
+      <SubSystem>Console</SubSystem>
+      <TargetMachine>MachineX86</TargetMachine>
+      <AdditionalLibraryDirectories>..\Common\ethernet\lwip-1.4.0\ports\win32\WinPCap</AdditionalLibraryDirectories>
+      <AdditionalDependencies>wpcap.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+    <Bscmake>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <OutputFile>.\Release/WIN32.bsc</OutputFile>
+    </Bscmake>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\..\..\..\FreeRTOS\Source\event_groups.c" />
+    <ClCompile Include="..\..\..\..\..\FreeRTOS\Source\list.c" />
+    <ClCompile Include="..\..\..\..\..\FreeRTOS\Source\portable\MemMang\heap_4.c" />
+    <ClCompile Include="..\..\..\..\..\FreeRTOS\Source\portable\MSVC-MingW\port.c" />
+    <ClCompile Include="..\..\..\..\..\FreeRTOS\Source\queue.c" />
+    <ClCompile Include="..\..\..\..\..\FreeRTOS\Source\stream_buffer.c" />
+    <ClCompile Include="..\..\..\..\..\FreeRTOS\Source\tasks.c" />
+    <ClCompile Include="..\..\..\..\..\FreeRTOS\Source\timers.c" />
+    <ClCompile Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\FreeRTOS_ARP.c" />
+    <ClCompile Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\FreeRTOS_DHCP.c" />
+    <ClCompile Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\FreeRTOS_DNS.c" />
+    <ClCompile Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\FreeRTOS_IP.c" />
+    <ClCompile Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\FreeRTOS_Sockets.c" />
+    <ClCompile Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\FreeRTOS_Stream_Buffer.c" />
+    <ClCompile Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\FreeRTOS_TCP_IP.c" />
+    <ClCompile Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\FreeRTOS_TCP_WIN.c" />
+    <ClCompile Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\FreeRTOS_UDP_IP.c" />
+    <ClCompile Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\portable\BufferManagement\BufferAllocation_2.c" />
+    <ClCompile Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\portable\NetworkInterface\WinPCap\NetworkInterface.c" />
+    <ClCompile Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\platform\freertos\transport\src\plaintext_freertos.c" />
+    <ClCompile Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\standard\mqtt\src\mqtt_lightweight.c" />
+    <ClCompile Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\standard\mqtt\src\mqtt_state.c" />
+    <ClCompile Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\standard\mqtt\src\mqtt.c" />
+    <ClCompile Include="..\common\demo_logging.c" />
+    <ClCompile Include="..\common\main.c" />
+    <ClCompile Include="DemoTasks\MultitaskMQTTExample.c" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\..\..\..\FreeRTOS\Source\include\event_groups.h" />
+    <ClInclude Include="..\..\..\..\..\FreeRTOS\Source\include\FreeRTOS.h" />
+    <ClInclude Include="..\..\..\..\..\FreeRTOS\Source\include\portable.h" />
+    <ClInclude Include="..\..\..\..\..\FreeRTOS\Source\include\projdefs.h" />
+    <ClInclude Include="..\..\..\..\..\FreeRTOS\Source\include\queue.h" />
+    <ClInclude Include="..\..\..\..\..\FreeRTOS\Source\include\semphr.h" />
+    <ClInclude Include="..\..\..\..\..\FreeRTOS\Source\include\task.h" />
+    <ClInclude Include="..\..\..\..\..\FreeRTOS\Source\include\timers.h" />
+    <ClInclude Include="..\..\..\..\..\FreeRTOS\Source\portable\MSVC-MingW\portmacro.h" />
+    <ClInclude Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\include\FreeRTOSIPConfigDefaults.h" />
+    <ClInclude Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\include\FreeRTOS_ARP.h" />
+    <ClInclude Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\include\FreeRTOS_DHCP.h" />
+    <ClInclude Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\include\FreeRTOS_DNS.h" />
+    <ClInclude Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\include\FreeRTOS_IP.h" />
+    <ClInclude Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\include\FreeRTOS_IP_Private.h" />
+    <ClInclude Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\include\FreeRTOS_Sockets.h" />
+    <ClInclude Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\include\FreeRTOS_Stream_Buffer.h" />
+    <ClInclude Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\include\FreeRTOS_TCP_IP.h" />
+    <ClInclude Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\include\FreeRTOS_TCP_WIN.h" />
+    <ClInclude Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\include\FreeRTOS_UDP_IP.h" />
+    <ClInclude Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\include\IPTraceMacroDefaults.h" />
+    <ClInclude Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\include\NetworkBufferManagement.h" />
+    <ClInclude Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\include\NetworkInterface.h" />
+    <ClInclude Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\platform\freertos\transport\include\plaintext_freertos.h" />
+    <ClInclude Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\platform\include\transport_interface.h" />
+    <ClInclude Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\standard\mqtt\include\mqtt_lightweight.h" />
+    <ClInclude Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\standard\mqtt\include\mqtt_state.h" />
+    <ClInclude Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\standard\mqtt\include\mqtt.h" />
+    <ClInclude Include="demo_config.h" />
+    <ClInclude Include="FreeRTOSConfig.h" />
+    <ClInclude Include="FreeRTOSIPConfig.h" />
+    <ClInclude Include="mqtt_config.h" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_multitask/WIN32.vcxproj
+++ b/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_multitask/WIN32.vcxproj
@@ -157,6 +157,7 @@
     <ClCompile Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\FreeRTOS_UDP_IP.c" />
     <ClCompile Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\portable\BufferManagement\BufferAllocation_2.c" />
     <ClCompile Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\portable\NetworkInterface\WinPCap\NetworkInterface.c" />
+    <ClCompile Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\platform\freertos\transport\src\freertos_sockets_wrapper.c" />
     <ClCompile Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\platform\freertos\transport\src\plaintext_freertos.c" />
     <ClCompile Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\standard\mqtt\src\mqtt_lightweight.c" />
     <ClCompile Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\standard\mqtt\src\mqtt_state.c" />
@@ -189,6 +190,7 @@
     <ClInclude Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\include\IPTraceMacroDefaults.h" />
     <ClInclude Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\include\NetworkBufferManagement.h" />
     <ClInclude Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\include\NetworkInterface.h" />
+    <ClInclude Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\platform\freertos\transport\include\freertos_sockets_wrapper.h" />
     <ClInclude Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\platform\freertos\transport\include\plaintext_freertos.h" />
     <ClInclude Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\platform\include\transport_interface.h" />
     <ClInclude Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\standard\mqtt\include\mqtt_lightweight.h" />

--- a/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_multitask/WIN32.vcxproj.filters
+++ b/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_multitask/WIN32.vcxproj.filters
@@ -1,0 +1,217 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="FreeRTOS">
+      <UniqueIdentifier>{af3445a1-4908-4170-89ed-39345d90d30c}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="FreeRTOS\Source">
+      <UniqueIdentifier>{f32be356-4763-4cae-9020-974a2638cb08}</UniqueIdentifier>
+      <Extensions>*.c</Extensions>
+    </Filter>
+    <Filter Include="FreeRTOS\Source\Portable">
+      <UniqueIdentifier>{88f409e6-d396-4ac5-94bd-7a99c914be46}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="FreeRTOS+">
+      <UniqueIdentifier>{e5ad4ec7-23dc-4295-8add-2acaee488f5a}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="FreeRTOS\Source\include">
+      <UniqueIdentifier>{d2dcd641-8d91-492b-852f-5563ffadaec6}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="FreeRTOS+\FreeRTOS+TCP">
+      <UniqueIdentifier>{8672fa26-b119-481f-8b8d-086419c01a3e}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="FreeRTOS+\FreeRTOS+TCP\portable">
+      <UniqueIdentifier>{4570be11-ec96-4b55-ac58-24b50ada980a}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="FreeRTOS+\FreeRTOS+TCP\include">
+      <UniqueIdentifier>{5d93ed51-023a-41ad-9243-8d230165d34b}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="DemoTasks">
+      <UniqueIdentifier>{b71e974a-9f28-4815-972b-d930ba8a34d0}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="FreeRTOS+\FreeRTOS IoT Libraries">
+      <UniqueIdentifier>{60717407-397f-4ea5-8492-3314acdd25f0}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="FreeRTOS+\FreeRTOS IoT Libraries\standard">
+      <UniqueIdentifier>{8a90222f-d723-4b4e-8e6e-c57afaf7fa92}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="FreeRTOS+\FreeRTOS IoT Libraries\standard\mqtt">
+      <UniqueIdentifier>{2d17d5e6-ed70-4e42-9693-f7a63baf4948}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="FreeRTOS+\FreeRTOS IoT Libraries\standard\mqtt\src">
+      <UniqueIdentifier>{7158b0be-01e7-42d1-8d3f-c75118a596a2}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="FreeRTOS+\FreeRTOS IoT Libraries\standard\mqtt\include">
+      <UniqueIdentifier>{6ad56e6d-c330-4830-8f4b-c75b05dfa866}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="FreeRTOS+\FreeRTOS IoT Libraries\platform">
+      <UniqueIdentifier>{84613aa2-91dc-4e1a-a3b3-823b6d7bf0e0}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\..\..\..\FreeRTOS\Source\portable\MSVC-MingW\port.c">
+      <Filter>FreeRTOS\Source\Portable</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\FreeRTOS\Source\timers.c">
+      <Filter>FreeRTOS\Source</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\FreeRTOS\Source\list.c">
+      <Filter>FreeRTOS\Source</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\FreeRTOS\Source\queue.c">
+      <Filter>FreeRTOS\Source</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\FreeRTOS\Source\tasks.c">
+      <Filter>FreeRTOS\Source</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\FreeRTOS_UDP_IP.c">
+      <Filter>FreeRTOS+\FreeRTOS+TCP</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\FreeRTOS_DHCP.c">
+      <Filter>FreeRTOS+\FreeRTOS+TCP</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\FreeRTOS_DNS.c">
+      <Filter>FreeRTOS+\FreeRTOS+TCP</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\FreeRTOS_Sockets.c">
+      <Filter>FreeRTOS+\FreeRTOS+TCP</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\portable\BufferManagement\BufferAllocation_2.c">
+      <Filter>FreeRTOS+\FreeRTOS+TCP\portable</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\portable\NetworkInterface\WinPCap\NetworkInterface.c">
+      <Filter>FreeRTOS+\FreeRTOS+TCP\portable</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\FreeRTOS_ARP.c">
+      <Filter>FreeRTOS+\FreeRTOS+TCP</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\FreeRTOS_IP.c">
+      <Filter>FreeRTOS+\FreeRTOS+TCP</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\FreeRTOS_TCP_IP.c">
+      <Filter>FreeRTOS+\FreeRTOS+TCP</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\FreeRTOS_TCP_WIN.c">
+      <Filter>FreeRTOS+\FreeRTOS+TCP</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\FreeRTOS\Source\event_groups.c">
+      <Filter>FreeRTOS\Source</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\FreeRTOS\Source\portable\MemMang\heap_4.c">
+      <Filter>FreeRTOS\Source\Portable</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\FreeRTOS_Stream_Buffer.c">
+      <Filter>FreeRTOS+\FreeRTOS+TCP</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\FreeRTOS\Source\stream_buffer.c">
+      <Filter>FreeRTOS\Source</Filter>
+    </ClCompile>
+    <ClCompile Include="..\common\demo_logging.c" />
+    <ClCompile Include="..\common\main.c" />
+    <ClCompile Include="DemoTasks\MultitaskMQTTExample.c">
+      <Filter>DemoTasks</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\standard\mqtt\src\mqtt_lightweight.c">
+      <Filter>FreeRTOS+\FreeRTOS IoT Libraries\standard\mqtt\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\standard\mqtt\src\mqtt_state.c">
+      <Filter>FreeRTOS+\FreeRTOS IoT Libraries\standard\mqtt\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\standard\mqtt\src\mqtt.c">
+      <Filter>FreeRTOS+\FreeRTOS IoT Libraries\standard\mqtt\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\platform\freertos\transport\src\plaintext_freertos.c">
+      <Filter>FreeRTOS+\FreeRTOS IoT Libraries\platform</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\include\NetworkInterface.h">
+      <Filter>FreeRTOS+\FreeRTOS+TCP\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\include\FreeRTOS_DNS.h">
+      <Filter>FreeRTOS+\FreeRTOS+TCP\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\include\FreeRTOS_Sockets.h">
+      <Filter>FreeRTOS+\FreeRTOS+TCP\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\include\FreeRTOS_UDP_IP.h">
+      <Filter>FreeRTOS+\FreeRTOS+TCP\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\FreeRTOS\Source\include\timers.h">
+      <Filter>FreeRTOS\Source\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\FreeRTOS\Source\include\event_groups.h">
+      <Filter>FreeRTOS\Source\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\FreeRTOS\Source\include\FreeRTOS.h">
+      <Filter>FreeRTOS\Source\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\FreeRTOS\Source\include\queue.h">
+      <Filter>FreeRTOS\Source\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\FreeRTOS\Source\include\semphr.h">
+      <Filter>FreeRTOS\Source\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\FreeRTOS\Source\include\task.h">
+      <Filter>FreeRTOS\Source\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\FreeRTOS\Source\portable\MSVC-MingW\portmacro.h">
+      <Filter>FreeRTOS\Source\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\include\FreeRTOS_IP_Private.h">
+      <Filter>FreeRTOS+\FreeRTOS+TCP\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\include\NetworkBufferManagement.h">
+      <Filter>FreeRTOS+\FreeRTOS+TCP\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\include\FreeRTOS_ARP.h">
+      <Filter>FreeRTOS+\FreeRTOS+TCP\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\include\FreeRTOS_DHCP.h">
+      <Filter>FreeRTOS+\FreeRTOS+TCP\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\include\FreeRTOS_IP.h">
+      <Filter>FreeRTOS+\FreeRTOS+TCP\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\include\FreeRTOS_TCP_IP.h">
+      <Filter>FreeRTOS+\FreeRTOS+TCP\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\include\FreeRTOS_TCP_WIN.h">
+      <Filter>FreeRTOS+\FreeRTOS+TCP\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\include\FreeRTOSIPConfigDefaults.h">
+      <Filter>FreeRTOS+\FreeRTOS+TCP\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\include\IPTraceMacroDefaults.h">
+      <Filter>FreeRTOS+\FreeRTOS+TCP\include</Filter>
+    </ClInclude>
+    <ClInclude Include="FreeRTOSConfig.h" />
+    <ClInclude Include="FreeRTOSIPConfig.h" />
+    <ClInclude Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\include\FreeRTOS_Stream_Buffer.h">
+      <Filter>FreeRTOS+\FreeRTOS+TCP\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\FreeRTOS\Source\include\portable.h">
+      <Filter>FreeRTOS\Source\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\FreeRTOS\Source\include\projdefs.h">
+      <Filter>FreeRTOS\Source\include</Filter>
+    </ClInclude>
+    <ClInclude Include="demo_config.h" />
+    <ClInclude Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\standard\mqtt\include\mqtt_lightweight.h">
+      <Filter>FreeRTOS+\FreeRTOS IoT Libraries\standard\mqtt\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\standard\mqtt\include\mqtt_state.h">
+      <Filter>FreeRTOS+\FreeRTOS IoT Libraries\standard\mqtt\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\standard\mqtt\include\mqtt.h">
+      <Filter>FreeRTOS+\FreeRTOS IoT Libraries\standard\mqtt\include</Filter>
+    </ClInclude>
+    <ClInclude Include="mqtt_config.h" />
+    <ClInclude Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\platform\freertos\transport\include\plaintext_freertos.h">
+      <Filter>FreeRTOS+\FreeRTOS IoT Libraries\platform</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\platform\include\transport_interface.h">
+      <Filter>FreeRTOS+\FreeRTOS IoT Libraries\platform</Filter>
+    </ClInclude>
+  </ItemGroup>
+</Project>

--- a/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_multitask/demo_config.h
+++ b/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_multitask/demo_config.h
@@ -1,0 +1,125 @@
+/*
+ * FreeRTOS Kernel V10.3.0
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://www.FreeRTOS.org
+ * http://aws.amazon.com/freertos
+ *
+ * 1 tab == 4 spaces!
+ */
+
+#ifndef DEMO_CONFIG_H
+#define DEMO_CONFIG_H
+
+/**************************************************/
+/******* DO NOT CHANGE the following order ********/
+/**************************************************/
+
+/* Include logging header files and define logging macros in the following order:
+ * 1. Include the header file "logging_levels.h".
+ * 2. Define the LIBRARY_LOG_NAME and LIBRARY_LOG_LEVEL macros depending on
+ * the logging configuration for DEMO.
+ * 3. Include the header file "logging_stack.h", if logging is enabled for DEMO.
+ */
+
+#include "logging_levels.h"
+
+/* Logging configuration for the Demo. */
+#ifndef LIBRARY_LOG_NAME
+    #define LIBRARY_LOG_NAME    "MQTTDemo"
+#endif
+
+#ifndef LIBRARY_LOG_LEVEL
+    #define LIBRARY_LOG_LEVEL    LOG_INFO
+#endif
+#include "logging_stack.h"
+
+/************ End of logging configuration ****************/
+
+/**
+ * @brief The MQTT client identifier used in this example.  Each client identifier
+ * must be unique so edit as required to ensure no two clients connecting to the
+ * same broker use the same client identifier.
+ *
+ * #define democonfigCLIENT_IDENTIFIER				"insert here."
+ */
+
+
+/**
+ * @brief MQTT broker end point to connect to.
+ *
+ * @note For running this demo an MQTT broker, which can be run locally on
+ * the same host is recommended. Any MQTT broker, which can be run on a Windows
+ * host can be used for this demo. However, the instructions below are for
+ * setting up a local Mosquitto broker on a Windows host.
+ * 1. Download Mosquitto from https://mosquitto.org/download/
+ * 2. Install Mosquitto as a Windows service by running the installer.
+ * More details about installing as a Windows service can be found at
+ * https://github.com/eclipse/mosquitto/blob/master/readme-windows.txt and
+ * https://github.com/eclipse/mosquitto/blob/master/readme.md
+ * 3. Verify that Mosquitto server is running locally and listening on port
+ * 1883 by following the steps below.
+ *     a. Open Power Shell.
+ *     b. Type in command `netstat -a -p TCP | grep 1883` to check if there
+ *        is an active connection listening on port 1883.
+ *     c. Verify that there is an output as shown below
+ *        `TCP    0.0.0.0:1883           <HOST-NAME>:0       LISTENING`
+ *     d. If there is no output on step c,go through the Mosquitto documentation
+ *        listed above to check if the installation was successful.
+ * 4. Make sure the Mosquitto broker is allowed to communicate through
+ * Windows Firewall. The instructions for allowing an application on Windows 10
+ * Defender Firewall can be found at the link below.
+ * https://support.microsoft.com/en-us/help/4558235/windows-10-allow-an-app-through-microsoft-defender-firewall
+ * After running this MQTT example, consider disabling the Mosquitto broker to
+ * communicate through Windows Firewall for avoiding unwanted network traffic
+ * to your machine.
+ * 5. After verifying that a Mosquitto broker is running successfully, update
+ * the config democonfigMQTT_BROKER_ENDPOINT to the local IP address of the
+ * Windows host machine. Please note that "localhost" or address "127.0.0.1"
+ * will not work as this example is running on a Windows Simulator and not on
+ * Windows host natively. Also note that, if the Windows host is using a
+ * Virtual Private Network(VPN), connection to the Mosquitto broker may not
+ * work.
+ *
+ * As an alternative option, a publicly hosted Mosquitto broker can also be
+ * used as an MQTT broker end point. This can be done by updating the config
+ * democonfigMQTT_BROKER_ENDPOINT to "test.mosquitto.org". However, this is not
+ * recommended due the possible downtimes of the broker as indicated by the
+ * documentation in https://test.mosquitto.org/.
+ */
+#define democonfigMQTT_BROKER_ENDPOINT				"10.0.0.111"
+
+
+/**
+ * @brief The port to use for the demo.
+ *
+ * #define democonfigMQTT_BROKER_PORT					( insert here. )
+ */
+
+
+/**
+ * @brief Set the stack size of the main demo task.
+ *
+ * In the Windows port, this stack only holds a structure. The actual
+ * stack is created by an operating system thread.
+ */
+#define democonfigDEMO_STACKSIZE    configMINIMAL_STACK_SIZE
+
+#endif /* DEMO_CONFIG_H */

--- a/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_multitask/demo_config.h
+++ b/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_multitask/demo_config.h
@@ -103,8 +103,9 @@
  * democonfigMQTT_BROKER_ENDPOINT to "test.mosquitto.org". However, this is not
  * recommended due the possible downtimes of the broker as indicated by the
  * documentation in https://test.mosquitto.org/.
+ *
+ * #define democonfigMQTT_BROKER_ENDPOINT				"localhost"
  */
-#define democonfigMQTT_BROKER_ENDPOINT				"10.0.0.111"
 
 
 /**

--- a/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_multitask/demo_config.h
+++ b/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_multitask/demo_config.h
@@ -58,7 +58,7 @@
  * must be unique so edit as required to ensure no two clients connecting to the
  * same broker use the same client identifier.
  *
- * #define democonfigCLIENT_IDENTIFIER				"insert here."
+ * #define CLIENT_IDENTIFIER				"insert here."
  */
 
 
@@ -91,7 +91,7 @@
  * communicate through Windows Firewall for avoiding unwanted network traffic
  * to your machine.
  * 5. After verifying that a Mosquitto broker is running successfully, update
- * the config democonfigMQTT_BROKER_ENDPOINT to the local IP address of the
+ * the config BROKER_ENDPOINT to the local IP address of the
  * Windows host machine. Please note that "localhost" or address "127.0.0.1"
  * will not work as this example is running on a Windows Simulator and not on
  * Windows host natively. Also note that, if the Windows host is using a
@@ -100,18 +100,18 @@
  *
  * As an alternative option, a publicly hosted Mosquitto broker can also be
  * used as an MQTT broker end point. This can be done by updating the config
- * democonfigMQTT_BROKER_ENDPOINT to "test.mosquitto.org". However, this is not
+ * BROKER_ENDPOINT to "test.mosquitto.org". However, this is not
  * recommended due the possible downtimes of the broker as indicated by the
  * documentation in https://test.mosquitto.org/.
  *
- * #define democonfigMQTT_BROKER_ENDPOINT				"localhost"
+ * #define BROKER_ENDPOINT				"localhost"
  */
 
 
 /**
  * @brief The port to use for the demo.
  *
- * #define democonfigMQTT_BROKER_PORT					( insert here. )
+ * #define BROKER_PORT					( insert here. )
  */
 
 

--- a/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_multitask/demo_config.h
+++ b/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_multitask/demo_config.h
@@ -58,7 +58,7 @@
  * must be unique so edit as required to ensure no two clients connecting to the
  * same broker use the same client identifier.
  *
- * #define CLIENT_IDENTIFIER				"insert here."
+ * #define democonfigCLIENT_IDENTIFIER				"insert here."
  */
 
 
@@ -91,7 +91,7 @@
  * communicate through Windows Firewall for avoiding unwanted network traffic
  * to your machine.
  * 5. After verifying that a Mosquitto broker is running successfully, update
- * the config BROKER_ENDPOINT to the local IP address of the
+ * the config democonfigMQTT_BROKER_ENDPOINT to the local IP address of the
  * Windows host machine. Please note that "localhost" or address "127.0.0.1"
  * will not work as this example is running on a Windows Simulator and not on
  * Windows host natively. Also note that, if the Windows host is using a
@@ -100,18 +100,18 @@
  *
  * As an alternative option, a publicly hosted Mosquitto broker can also be
  * used as an MQTT broker end point. This can be done by updating the config
- * BROKER_ENDPOINT to "test.mosquitto.org". However, this is not
+ * democonfigMQTT_BROKER_ENDPOINT to "test.mosquitto.org". However, this is not
  * recommended due the possible downtimes of the broker as indicated by the
  * documentation in https://test.mosquitto.org/.
  *
- * #define BROKER_ENDPOINT				"localhost"
+ * #define democonfigMQTT_BROKER_ENDPOINT				"insert here."
  */
 
 
 /**
  * @brief The port to use for the demo.
  *
- * #define BROKER_PORT					( insert here. )
+ * #define democonfigMQTT_BROKER_PORT					( insert here. )
  */
 
 

--- a/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_multitask/mqtt_config.h
+++ b/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_multitask/mqtt_config.h
@@ -62,6 +62,6 @@
  * macro sets the limit on how many simultaneous PUBLISH states an MQTT
  * context maintains.
  */
-#define MQTT_STATE_ARRAY_MAX_COUNT    10U
+#define MQTT_STATE_ARRAY_MAX_COUNT    20U
 
 #endif /* ifndef MQTT_CONFIG_H_ */

--- a/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_multitask/mqtt_config.h
+++ b/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_multitask/mqtt_config.h
@@ -1,0 +1,67 @@
+/*
+ * FreeRTOS Kernel V10.3.0
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://www.FreeRTOS.org
+ * http://aws.amazon.com/freertos
+ *
+ * 1 tab == 4 spaces!
+ */
+#ifndef MQTT_CONFIG_H_
+#define MQTT_CONFIG_H_
+
+/**************************************************/
+/******* DO NOT CHANGE the following order ********/
+/**************************************************/
+
+/* Include logging header files and define logging macros in the following order:
+ * 1. Include the header file "logging_levels.h".
+ * 2. Define the LIBRARY_LOG_NAME and LIBRARY_LOG_LEVEL macros depending on
+ * the logging configuration for MQTT.
+ * 3. Include the header file "logging_stack.h", if logging is enabled for MQTT.
+ */
+
+#include "logging_levels.h"
+
+/* Logging configuration for the MQTT library. */
+#ifndef LIBRARY_LOG_NAME
+    #define LIBRARY_LOG_NAME    "MQTT"
+#endif
+
+#ifndef LIBRARY_LOG_LEVEL
+    #define LIBRARY_LOG_LEVEL    LOG_NONE
+#endif
+
+#include "logging_stack.h"
+/************ End of logging configuration ****************/
+
+/**
+ * @brief The maximum number of MQTT PUBLISH messages that may be pending
+ * acknowledgement at any time.
+ *
+ * QoS 1 and 2 MQTT PUBLISHes require acknowledgment from the server before
+ * they can be completed. While they are awaiting the acknowledgment, the
+ * client must maintain information about their state. The value of this
+ * macro sets the limit on how many simultaneous PUBLISH states an MQTT
+ * context maintains.
+ */
+#define MQTT_STATE_ARRAY_MAX_COUNT    10U
+
+#endif /* ifndef MQTT_CONFIG_H_ */

--- a/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_multitask/mqtt_config.h
+++ b/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_multitask/mqtt_config.h
@@ -46,7 +46,7 @@
 #endif
 
 #ifndef LIBRARY_LOG_LEVEL
-    #define LIBRARY_LOG_LEVEL    LOG_NONE
+    #define LIBRARY_LOG_LEVEL    LOG_ERROR
 #endif
 
 #include "logging_stack.h"

--- a/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_multitask/mqtt_multitask_demo.sln
+++ b/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_multitask/mqtt_multitask_demo.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29215.179
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "RTOSDemo", "WIN32.vcxproj", "{C686325E-3261-42F7-AEB1-DDE5280E1CEB}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Win32 = Debug|Win32
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{C686325E-3261-42F7-AEB1-DDE5280E1CEB}.Debug|Win32.ActiveCfg = Debug|Win32
+		{C686325E-3261-42F7-AEB1-DDE5280E1CEB}.Debug|Win32.Build.0 = Debug|Win32
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {150F08BF-9D61-4CC2-8DBF-1335172A1EA4}
+	EndGlobalSection
+	GlobalSection(TestCaseManagementSettings) = postSolution
+		CategoryFile = FreeRTOS_Plus_TCP_Minimal.vsmdi
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
<!--- Title -->

Description
-----------
Add demo for sharing a single MQTT connection between multiple tasks. This demo publishes messages from one task, and receives them on another. It uses a loop in the main task to handle all MQTT API calls, and other tasks can add operations to the main task's queue to be processed.

This is intended to be the initial PR of several. Subsequent PRs will be geared toward adding additional features called out in TODO statements.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
