### PR TITLE
Use chacheable RAM in IAR project for MPU_M7_NUCLEO_H743ZI2 project

### DIFF
--- a/FreeRTOS/Demo/CORTEX_MPU_M7_NUCLEO_H743ZI2_GCC_IAR_Keil/Config/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_MPU_M7_NUCLEO_H743ZI2_GCC_IAR_Keil/Config/FreeRTOSConfig.h
@@ -135,4 +135,9 @@ See http://www.FreeRTOS.org/RTOS-Cortex-M3-M4.html. */
  * configTOTAL_MPU_REGIONS correctly. */
 #define configTOTAL_MPU_REGIONS						16
 
+/* The default TEX,S,C,B setting marks the SRAM as shareable and as a result,
+ * disables cache. Do not mark the SRAM as shareable because caching is being
+ * used. TEX=0, S=0, C=1, B=1. */
+#define configTEX_S_C_B_SRAM						( 0x03UL )
+
 #endif /* FREERTOS_CONFIG_H */

--- a/FreeRTOS/Demo/CORTEX_MPU_M7_NUCLEO_H743ZI2_GCC_IAR_Keil/Projects/IAR/FreeRTOSDemo.ewp
+++ b/FreeRTOS/Demo/CORTEX_MPU_M7_NUCLEO_H743ZI2_GCC_IAR_Keil/Projects/IAR/FreeRTOSDemo.ewp
@@ -782,7 +782,7 @@
                 </option>
                 <option>
                     <name>IlinkIcfFile</name>
-                    <state>$PROJ_DIR$\stm32h743xx_flash.icf</state>
+                    <state>$PROJ_DIR$\stm32h743xx_flash_dtcram.icf</state>
                 </option>
                 <option>
                     <name>IlinkIcfFileSlave</name>

--- a/FreeRTOS/Demo/CORTEX_MPU_M7_NUCLEO_H743ZI2_GCC_IAR_Keil/ST_Code/Core/Src/main.c
+++ b/FreeRTOS/Demo/CORTEX_MPU_M7_NUCLEO_H743ZI2_GCC_IAR_Keil/ST_Code/Core/Src/main.c
@@ -85,11 +85,20 @@ static void MX_USART3_UART_Init(void);
 static void MX_USB_OTG_FS_PCD_Init(void);
 
 /* USER CODE BEGIN PFP */
-
+static void CPU_CACHE_Enable(void);
 /* USER CODE END PFP */
 
 /* Private user code ---------------------------------------------------------*/
 /* USER CODE BEGIN 0 */
+
+static void CPU_CACHE_Enable(void)
+{
+  /* Enable I-Cache */
+  SCB_EnableICache();
+
+  /* Enable D-Cache */
+  SCB_EnableDCache();
+}
 
 /* USER CODE END 0 */
 
@@ -100,7 +109,7 @@ static void MX_USB_OTG_FS_PCD_Init(void);
 int main(void)
 {
   /* USER CODE BEGIN 1 */
-
+  CPU_CACHE_Enable();
   /* USER CODE END 1 */
   
 


### PR DESCRIPTION
Description
-----------

This change updates the IAR project for Nucleo H743ZI2 to use the cacheable DTC RAM and enables L1 cache. In order to ensure the correct functioning of cache, the project sets `configTEX_S_C_B_SRAM` in `FreeRTOSConfig.h` to not mark the RAM as shareable.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
