### PR TITLE
Update plain text transport interface

### DIFF
--- a/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_plain_text/DemoTasks/PlaintextMQTTExample.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_plain_text/DemoTasks/PlaintextMQTTExample.c
@@ -297,7 +297,7 @@ static void prvMQTTDemoTask( void * pvParameters )
     NetworkContext_t xNetworkContext = { 0 };
     MQTTContext_t xMQTTContext;
     MQTTStatus_t xMQTTStatus;
-    BaseType_t xNetworkStatus;
+    PlaintextTransportStatus_t xNetworkStatus;
 
     /* Remove compiler warnings about unused parameters. */
     ( void ) pvParameters;
@@ -317,7 +317,7 @@ static void prvMQTTDemoTask( void * pvParameters )
                                                      democonfigMQTT_BROKER_PORT,
                                                      TRANSPORT_SEND_RECV_TIMEOUT_MS,
                                                      TRANSPORT_SEND_RECV_TIMEOUT_MS );
-        configASSERT( xNetworkStatus == 0 );
+        configASSERT( xNetworkStatus == PLAINTEXT_TRANSPORT_SUCCESS );
 
         /* Sends an MQTT Connect packet over the already connected TCP socket,
          * and waits for connection acknowledgment (CONNACK) packet. */
@@ -381,7 +381,8 @@ static void prvMQTTDemoTask( void * pvParameters )
         MQTT_Disconnect( &xMQTTContext );
 
         /* Close the network connection.  */
-        Plaintext_FreeRTOS_Disconnect( &xNetworkContext );
+        xNetworkStatus = Plaintext_FreeRTOS_Disconnect( &xNetworkContext );
+        configASSERT( xNetworkStatus == PLAINTEXT_TRANSPORT_SUCCESS );
 
         /* Wait for some time between two iterations to ensure that we do not
          * bombard the public test mosquitto broker. */

--- a/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_plain_text/WIN32.vcxproj
+++ b/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_plain_text/WIN32.vcxproj
@@ -157,6 +157,7 @@
     <ClCompile Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\FreeRTOS_UDP_IP.c" />
     <ClCompile Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\portable\BufferManagement\BufferAllocation_2.c" />
     <ClCompile Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\portable\NetworkInterface\WinPCap\NetworkInterface.c" />
+    <ClCompile Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\platform\freertos\transport\src\freertos_sockets_wrapper.c" />
     <ClCompile Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\platform\freertos\transport\src\plaintext_freertos.c" />
     <ClCompile Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\standard\mqtt\src\mqtt_lightweight.c" />
     <ClCompile Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\standard\mqtt\src\mqtt_state.c" />
@@ -189,6 +190,7 @@
     <ClInclude Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\include\IPTraceMacroDefaults.h" />
     <ClInclude Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\include\NetworkBufferManagement.h" />
     <ClInclude Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\include\NetworkInterface.h" />
+    <ClInclude Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\platform\freertos\transport\include\freertos_sockets_wrapper.h" />
     <ClInclude Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\platform\freertos\transport\include\plaintext_freertos.h" />
     <ClInclude Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\platform\include\transport_interface.h" />
     <ClInclude Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\standard\mqtt\include\mqtt_lightweight.h" />

--- a/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_plain_text/WIN32.vcxproj.filters
+++ b/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_plain_text/WIN32.vcxproj.filters
@@ -123,6 +123,9 @@
     <ClCompile Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\platform\freertos\transport\src\plaintext_freertos.c">
       <Filter>FreeRTOS+\FreeRTOS IoT Libraries\platform</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\platform\freertos\transport\src\freertos_sockets_wrapper.c">
+      <Filter>FreeRTOS+\FreeRTOS IoT Libraries\platform</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\include\NetworkInterface.h">
@@ -211,6 +214,9 @@
       <Filter>FreeRTOS+\FreeRTOS IoT Libraries\platform</Filter>
     </ClInclude>
     <ClInclude Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\platform\include\transport_interface.h">
+      <Filter>FreeRTOS+\FreeRTOS IoT Libraries\platform</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\platform\freertos\transport\include\freertos_sockets_wrapper.h">
       <Filter>FreeRTOS+\FreeRTOS IoT Libraries\platform</Filter>
     </ClInclude>
   </ItemGroup>

--- a/FreeRTOS-Plus/Source/FreeRTOS-IoT-Libraries-LTS-Beta2/c_sdk/platform/freertos/transport/include/plaintext_freertos.h
+++ b/FreeRTOS-Plus/Source/FreeRTOS-IoT-Libraries-LTS-Beta2/c_sdk/platform/freertos/transport/include/plaintext_freertos.h
@@ -37,18 +37,15 @@
 
 /* Logging configuration for the Sockets. */
 #ifndef LIBRARY_LOG_NAME
-    #define LIBRARY_LOG_NAME     "FreeRTOSTransport"
+    #define LIBRARY_LOG_NAME     "PlaintextTransport"
 #endif
 #ifndef LIBRARY_LOG_LEVEL
-    #define LIBRARY_LOG_LEVEL    LOG_DEBUG
+    #define LIBRARY_LOG_LEVEL    LOG_ERROR
 #endif
 
 #include "logging_stack.h"
 
 /************ End of logging configuration ****************/
-
-/* FreeRTOS+TCP include. */
-#include "FreeRTOS_Sockets.h"
 
 /* Transport interface include. */
 #include "transport_interface.h"
@@ -62,6 +59,16 @@ struct NetworkContext
 };
 
 /**
+ * @brief Plain text transport Connect / Disconnect return status.
+ */
+typedef enum PlaintextTransportStatus
+{
+    PLAINTEXT_TRANSPORT_SUCCESS = 0,       /**< Function successfully completed. */
+    PLAINTEXT_TRANSPORT_INVALID_PARAMETER, /**< At least one parameter was invalid. */
+    PLAINTEXT_TRANSPORT_CONNECT_FAILURE    /**< Initial connection to the server failed. */
+} PlaintextTransportStatus_t;
+
+/**
  * @brief Create a TCP connection with FreeRTOS sockets.
  *
  * @param[out] pNetworkContext Pointer to a network context to contain the
@@ -70,20 +77,23 @@ struct NetworkContext
  * @param[in] port The destination port.
  * @param[in] receiveTimeoutMs Receive socket timeout.
  *
- * @return Non-zero value on error, 0 on success.
+ * @return #PLAINTEXT_TRANSPORT_SUCCESS, #PLAINTEXT_TRANSPORT_INVALID_PARAMETER,
+ * or #PLAINTEXT_TRANSPORT_CONNECT_FAILURE.
  */
-BaseType_t Plaintext_FreeRTOS_Connect( NetworkContext_t * pNetworkContext,
-                                       const char * pHostName,
-                                       uint16_t port,
-                                       uint32_t receiveTimeoutMs,
-                                       uint32_t sendTimeoutMs );
+PlaintextTransportStatus_t Plaintext_FreeRTOS_Connect( NetworkContext_t * pNetworkContext,
+                                                       const char * pHostName,
+                                                       uint16_t port,
+                                                       uint32_t receiveTimeoutMs,
+                                                       uint32_t sendTimeoutMs );
 
 /**
  * @brief Gracefully disconnect an established TCP connection.
  *
  * @param[in] pNetworkContext Network context containing the TCP socket handle.
+ *
+ * @return #PLAINTEXT_TRANSPORT_SUCCESS, or #PLAINTEXT_TRANSPORT_INVALID_PARAMETER.
  */
-void Plaintext_FreeRTOS_Disconnect( const NetworkContext_t * pNetworkContext );
+PlaintextTransportStatus_t Plaintext_FreeRTOS_Disconnect( const NetworkContext_t * pNetworkContext );
 
 /**
  * @brief Receives data from an established TCP connection.

--- a/FreeRTOS-Plus/Source/FreeRTOS-IoT-Libraries-LTS-Beta2/c_sdk/platform/freertos/transport/include/plaintext_freertos.h
+++ b/FreeRTOS-Plus/Source/FreeRTOS-IoT-Libraries-LTS-Beta2/c_sdk/platform/freertos/transport/include/plaintext_freertos.h
@@ -63,9 +63,9 @@ struct NetworkContext
  */
 typedef enum PlaintextTransportStatus
 {
-    PLAINTEXT_TRANSPORT_INVALID_PARAMETER = 0, /**< At least one parameter was invalid. */
     PLAINTEXT_TRANSPORT_SUCCESS = 1,           /**< Function successfully completed. */
-    PLAINTEXT_TRANSPORT_CONNECT_FAILURE        /**< Initial connection to the server failed. */
+    PLAINTEXT_TRANSPORT_INVALID_PARAMETER = 2, /**< At least one parameter was invalid. */
+    PLAINTEXT_TRANSPORT_CONNECT_FAILURE = 3    /**< Initial connection to the server failed. */
 } PlaintextTransportStatus_t;
 
 /**

--- a/FreeRTOS-Plus/Source/FreeRTOS-IoT-Libraries-LTS-Beta2/c_sdk/platform/freertos/transport/include/plaintext_freertos.h
+++ b/FreeRTOS-Plus/Source/FreeRTOS-IoT-Libraries-LTS-Beta2/c_sdk/platform/freertos/transport/include/plaintext_freertos.h
@@ -63,9 +63,9 @@ struct NetworkContext
  */
 typedef enum PlaintextTransportStatus
 {
-    PLAINTEXT_TRANSPORT_SUCCESS = 0,       /**< Function successfully completed. */
-    PLAINTEXT_TRANSPORT_INVALID_PARAMETER, /**< At least one parameter was invalid. */
-    PLAINTEXT_TRANSPORT_CONNECT_FAILURE    /**< Initial connection to the server failed. */
+    PLAINTEXT_TRANSPORT_INVALID_PARAMETER = 0, /**< At least one parameter was invalid. */
+    PLAINTEXT_TRANSPORT_SUCCESS = 1,           /**< Function successfully completed. */
+    PLAINTEXT_TRANSPORT_CONNECT_FAILURE        /**< Initial connection to the server failed. */
 } PlaintextTransportStatus_t;
 
 /**

--- a/FreeRTOS-Plus/Source/FreeRTOS-IoT-Libraries-LTS-Beta2/c_sdk/platform/freertos/transport/src/plaintext_freertos.c
+++ b/FreeRTOS-Plus/Source/FreeRTOS-IoT-Libraries-LTS-Beta2/c_sdk/platform/freertos/transport/src/plaintext_freertos.c
@@ -85,13 +85,15 @@ PlaintextTransportStatus_t Plaintext_FreeRTOS_Disconnect( const NetworkContext_t
         LogError( ( "pNetworkContext cannot be NULL." ) );
         plaintextStatus = PLAINTEXT_TRANSPORT_INVALID_PARAMETER;
     }
+    else if( pNetworkContext->tcpSocket == FREERTOS_INVALID_SOCKET )
+    {
+        LogError( ( "pNetworkContext->tcpSocket cannot be an invalid socket." ) );
+        plaintextStatus = PLAINTEXT_TRANSPORT_INVALID_PARAMETER;
+    }
     else
     {
-        if( pNetworkContext->tcpSocket != FREERTOS_INVALID_SOCKET )
-        {
-            /* Call socket disconnect function to close connection. */
-            Sockets_Disconnect( pNetworkContext->tcpSocket );
-        }
+        /* Call socket disconnect function to close connection. */
+        Sockets_Disconnect( pNetworkContext->tcpSocket );
     }
 
     return plaintextStatus;

--- a/FreeRTOS-Plus/Source/FreeRTOS-IoT-Libraries-LTS-Beta2/c_sdk/platform/freertos/transport/src/plaintext_freertos.c
+++ b/FreeRTOS-Plus/Source/FreeRTOS-IoT-Libraries-LTS-Beta2/c_sdk/platform/freertos/transport/src/plaintext_freertos.c
@@ -31,129 +31,70 @@
 #include "FreeRTOS_IP.h"
 #include "FreeRTOS_Sockets.h"
 
+/* FreeRTOS Socket wrapper include. */
+#include "freertos_sockets_wrapper.h"
+
 /* Transport interface include. */
 #include "plaintext_freertos.h"
 
-/* Maximum number of times to call FreeRTOS_recv when initiating a graceful shutdown. */
-#ifndef TRANSPORT_FREERTOS_SHUTDOWN_LOOPS
-    #define TRANSPORT_FREERTOS_SHUTDOWN_LOOPS    ( 3 )
-#endif
-
-/* A negative error code indicating a network failure. */
-#define TRANSPORT_FREERTOS_NETWORK_ERROR    ( -1 )
-
-BaseType_t Plaintext_FreeRTOS_Connect( NetworkContext_t * pNetworkContext,
-                                       const char * pHostName,
-                                       uint16_t port,
-                                       uint32_t receiveTimeoutMs,
-                                       uint32_t sendTimeoutMs )
+PlaintextTransportStatus_t Plaintext_FreeRTOS_Connect( NetworkContext_t * pNetworkContext,
+                                                       const char * pHostName,
+                                                       uint16_t port,
+                                                       uint32_t receiveTimeoutMs,
+                                                       uint32_t sendTimeoutMs )
 {
-    Socket_t tcpSocket = FREERTOS_INVALID_SOCKET;
+    PlaintextTransportStatus_t plaintextStatus = PLAINTEXT_TRANSPORT_SUCCESS;
     BaseType_t socketStatus = 0;
-    struct freertos_sockaddr serverAddress = { 0 };
-    TickType_t transportTimeout = 0;
 
-    /* Create a new TCP socket. */
-    tcpSocket = FreeRTOS_socket( FREERTOS_AF_INET, FREERTOS_SOCK_STREAM, FREERTOS_IPPROTO_TCP );
-
-    if( tcpSocket == FREERTOS_INVALID_SOCKET )
+    if( ( pNetworkContext == NULL ) || ( pHostName == NULL ) )
     {
-        LogError( ( "Failed to create new socket." ) );
-        socketStatus = TRANSPORT_FREERTOS_NETWORK_ERROR;
+        LogError( ( "Invalid input parameter(s): Arguments cannot be NULL. pNetworkContext=%p, "
+                    "pHostName=%p.",
+                    pNetworkContext,
+                    pHostName ) );
+        plaintextStatus = PLAINTEXT_TRANSPORT_INVALID_PARAMETER;
     }
     else
     {
-        LogDebug( ( "Created new TCP socket." ) );
+        /* Establish a TCP connection with the server. */
+        socketStatus = Sockets_Connect( &( pNetworkContext->tcpSocket ),
+                                        pHostName,
+                                        port,
+                                        receiveTimeoutMs,
+                                        sendTimeoutMs );
 
-        /* Connection parameters. */
-        serverAddress.sin_family = FREERTOS_AF_INET;
-        serverAddress.sin_port = FreeRTOS_htons( port );
-        serverAddress.sin_addr = FreeRTOS_gethostbyname( pHostName );
-        serverAddress.sin_len = ( uint8_t ) sizeof( serverAddress );
-
-        /* Check for errors from DNS lookup. */
-        if( serverAddress.sin_addr == 0 )
-        {
-            LogError( ( "Failed to resolve %s.", pHostName ) );
-            socketStatus = TRANSPORT_FREERTOS_NETWORK_ERROR;
-        }
-    }
-
-    if( socketStatus == 0 )
-    {
-        /* Establish connection. */
-        LogDebug( ( "Creating TCP Connection to %s.", pHostName ) );
-        socketStatus = FreeRTOS_connect( tcpSocket, &serverAddress, sizeof( serverAddress ) );
-
+        /* A non zero status is an error. */
         if( socketStatus != 0 )
         {
-            LogError( ( "Failed to establish TCP Connection: ReturnCode=%d.", socketStatus ) );
+            LogError( ( "Failed to connect to %s with error %d.",
+                        pHostName,
+                        socketStatus ) );
+            plaintextStatus = PLAINTEXT_TRANSPORT_CONNECT_FAILURE;
         }
     }
 
-    if( socketStatus == 0 )
-    {
-        /* Set socket receive timeout. */
-        transportTimeout = pdMS_TO_TICKS( receiveTimeoutMs );
-        /* Setting the receive block time cannot fail. */
-        ( void ) FreeRTOS_setsockopt( tcpSocket,
-                                      0,
-                                      FREERTOS_SO_RCVTIMEO,
-                                      &transportTimeout,
-                                      sizeof( TickType_t ) );
+    return plaintextStatus;
+}
 
-        /* Set socket send timeout. */
-        transportTimeout = pdMS_TO_TICKS( sendTimeoutMs );
-        /* Setting the send block time cannot fail. */
-        ( void ) FreeRTOS_setsockopt( tcpSocket,
-                                      0,
-                                      FREERTOS_SO_SNDTIMEO,
-                                      &transportTimeout,
-                                      sizeof( TickType_t ) );
-    }
+PlaintextTransportStatus_t Plaintext_FreeRTOS_Disconnect( const NetworkContext_t * pNetworkContext )
+{
+    PlaintextTransportStatus_t plaintextStatus = PLAINTEXT_TRANSPORT_SUCCESS;
 
-    /* Clean up on failure. */
-    if( socketStatus != 0 )
+    if( pNetworkContext == NULL )
     {
-        if( tcpSocket != FREERTOS_INVALID_SOCKET )
-        {
-            FreeRTOS_closesocket( tcpSocket );
-        }
+        LogError( ( "pNetworkContext cannot be NULL." ) );
+        plaintextStatus = PLAINTEXT_TRANSPORT_INVALID_PARAMETER;
     }
     else
     {
-        /* Set the socket. */
-        pNetworkContext->tcpSocket = tcpSocket;
-        LogDebug( ( "TCP Connection to %s established.", pHostName ) );
-    }
-
-    return socketStatus;
-}
-
-void Plaintext_FreeRTOS_Disconnect( const NetworkContext_t * pNetworkContext )
-{
-    BaseType_t waitForShutdownLoopCount = 0;
-    uint8_t pDummyBuffer[ 2 ];
-
-    if( pNetworkContext->tcpSocket != FREERTOS_INVALID_SOCKET )
-    {
-        /* Initiate graceful shutdown. */
-        ( void ) FreeRTOS_shutdown( pNetworkContext->tcpSocket, FREERTOS_SHUT_RDWR );
-
-        /* Wait for the socket to disconnect gracefully (indicated by FreeRTOS_recv()
-         * returning a FREERTOS_EINVAL error) before closing the socket. */
-        while( FreeRTOS_recv( pNetworkContext->tcpSocket, pDummyBuffer, sizeof( pDummyBuffer ), 0 ) >= 0 )
+        if( pNetworkContext->tcpSocket != FREERTOS_INVALID_SOCKET )
         {
-            /* We don't need to delay since FreeRTOS_recv should already have a timeout. */
-
-            if( ++waitForShutdownLoopCount >= TRANSPORT_FREERTOS_SHUTDOWN_LOOPS )
-            {
-                break;
-            }
+            /* Call socket disconnect function to close connection. */
+            Sockets_Disconnect( pNetworkContext->tcpSocket );
         }
-
-        ( void ) FreeRTOS_closesocket( pNetworkContext->tcpSocket );
     }
+
+    return plaintextStatus;
 }
 
 int32_t Plaintext_FreeRTOS_recv( NetworkContext_t * pNetworkContext,


### PR DESCRIPTION
Update plain text transport interface to use the common socket wrapper functions.

Description
-----------
A wrapper for Socket connect and disconnect using FreeRTOS+TCP is present [here](https://github.com/FreeRTOS/FreeRTOS/blob/lts-development/FreeRTOS-Plus/Source/FreeRTOS-IoT-Libraries-LTS-Beta2/c_sdk/platform/freertos/transport/src/freertos_sockets_wrapper.c). This wrapped code can be used by [tls transport implementation](https://github.com/FreeRTOS/FreeRTOS/blob/lts-development/FreeRTOS-Plus/Source/FreeRTOS-IoT-Libraries-LTS-Beta2/c_sdk/platform/freertos/transport/src/tls_freertos.c#L454) and [plain text transport implementation](https://github.com/FreeRTOS/FreeRTOS/blob/lts-development/FreeRTOS-Plus/Source/FreeRTOS-IoT-Libraries-LTS-Beta2/c_sdk/platform/freertos/transport/src/plaintext_freertos.c#L51-#L128).

This change is updating the plain text transport implementation to use the wrapper functions.

Test Steps
-----------
Ran the plain text demo successfully.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
