### PR TITLE
Fix warnings after moving callback prototypes

### DIFF
--- a/FreeRTOS/Demo/AVR_ATMega4809_Atmel_Studio/RTOSDemo/main.c
+++ b/FreeRTOS/Demo/AVR_ATMega4809_Atmel_Studio/RTOSDemo/main.c
@@ -51,7 +51,7 @@ int main( void )
 #elif ( mainSELECTED_APPLICATION == 2 )
     main_full();
 #endif
-    
+
     return 0;
 }
 
@@ -78,7 +78,7 @@ This is usefull in application development, for debugging.  To use this
 hook, uncomment it, and set configCHECK_FOR_STACK_OVERFLOW to 1 in
 "FreeRTOSConfig.h" header file. */
 
-// void vApplicationStackOverflowHook(TaskHandle_t *pxTask, signed char *pcTaskName )
+// void vApplicationStackOverflowHook(TaskHandle_t *pxTask, char *pcTaskName )
 // {
 //     for( ;; );
 // }

--- a/FreeRTOS/Demo/AVR_ATMega4809_IAR/main.c
+++ b/FreeRTOS/Demo/AVR_ATMega4809_IAR/main.c
@@ -43,7 +43,7 @@ extern void init_full( void );
 int main( void )
 {
     prvSetupHardware();
-    
+
 #if ( mainSELECTED_APPLICATION == 0 )
     main_blinky();
 #elif ( mainSELECTED_APPLICATION == 1 )
@@ -51,7 +51,7 @@ int main( void )
 #elif ( mainSELECTED_APPLICATION == 2 )
     main_full();
 #endif
-    
+
     return 0;
 }
 
@@ -78,7 +78,7 @@ This is usefull in application development, for debugging.  To use this
 hook, uncomment it, and set configCHECK_FOR_STACK_OVERFLOW to 1 in
 "FreeRTOSConfig.h" header file. */
 
-// void vApplicationStackOverflowHook(TaskHandle_t *pxTask, signed char *pcTaskName )
+// void vApplicationStackOverflowHook(TaskHandle_t *pxTask, char *pcTaskName )
 // {
 //     for( ;; );
 // }

--- a/FreeRTOS/Demo/AVR_ATMega4809_MPLAB.X/main.c
+++ b/FreeRTOS/Demo/AVR_ATMega4809_MPLAB.X/main.c
@@ -51,7 +51,7 @@ int main( void )
 #elif ( mainSELECTED_APPLICATION == 2 )
     main_full();
 #endif
-    
+
     return 0;
 }
 
@@ -78,7 +78,7 @@ This is usefull in application development, for debugging.  To use this
 hook, uncomment it, and set configCHECK_FOR_STACK_OVERFLOW to 1 in
 "FreeRTOSConfig.h" header file. */
 
-// void vApplicationStackOverflowHook(TaskHandle_t *pxTask, signed char *pcTaskName )
+// void vApplicationStackOverflowHook(TaskHandle_t *pxTask, char *pcTaskName )
 // {
 //     for( ;; );
 // }

--- a/FreeRTOS/Demo/AVR_ATmega328PB_Xplained_mini_GCC/RTOSDemo/main.c
+++ b/FreeRTOS/Demo/AVR_ATmega328PB_Xplained_mini_GCC/RTOSDemo/main.c
@@ -59,10 +59,10 @@ int main(void)
 	/* Initializes MCU, drivers and middleware.
 	This is generated from Atmel START project. */
 	atmel_start_init();
-	
+
 	/* Standard register test. */
 	vStartRegTestTasks();
-	
+
 	/* Optionally enable below tests. This port only has 2KB RAM. */
 	vStartIntegerMathTasks( tskIDLE_PRIORITY );
 	vStartPolledQueueTasks( mainQUEUE_POLL_PRIORITY );
@@ -102,7 +102,7 @@ BaseType_t xFirstTimeCheck = pdTRUE;
 		{
 			uxErrorHasOccurred |= ( 0x01U << 2);
 		}
-		
+
 		/* When check task runs before any other tasks, all above checks shall fail.
 		To avoid false alarm, clear errors upon first entry. */
 		if ( xFirstTimeCheck == pdTRUE )
@@ -110,7 +110,7 @@ BaseType_t xFirstTimeCheck = pdTRUE;
 			uxErrorHasOccurred = 0;
 			xFirstTimeCheck = pdFALSE;
 		}
-		
+
 		/* Could set break point at below line to verify uxErrorHasOccurred. */
 		vTaskDelay( mainCHECK_PERIOD );
 	}
@@ -126,7 +126,7 @@ static void vBlinkOnboardUserLED( void *pvParameters )
 	for( ;; )
 	{
 		vParTestToggleLED( 0 );
-		
+
 		vTaskDelay( mainBLINK_LED_OK_HALF_PERIOD );
 	}
 
@@ -141,9 +141,9 @@ void vApplicationIdleHook( void )
 
 /*-----------------------------------------------------------*/
 
-void vApplicationStackOverflowHook( TaskHandle_t xTask, signed char *pcTaskName )
+void vApplicationStackOverflowHook( TaskHandle_t xTask, char *pcTaskName )
 {
-	/* When stack overflow happens, trap instead of attempting to recover. 
+	/* When stack overflow happens, trap instead of attempting to recover.
 	Read input arguments to learn about the offending task. */
 	for( ;; )
 	{

--- a/FreeRTOS/Demo/AVR_Dx_Atmel_Studio/RTOSDemo/main.c
+++ b/FreeRTOS/Demo/AVR_Dx_Atmel_Studio/RTOSDemo/main.c
@@ -51,7 +51,7 @@ int main( void )
 #elif ( mainSELECTED_APPLICATION == 2 )
     main_full();
 #endif
-    
+
     return 0;
 }
 
@@ -78,7 +78,7 @@ This is usefull in application development, for debugging.  To use this
 hook, uncomment it, and set configCHECK_FOR_STACK_OVERFLOW to 1 in
 "FreeRTOSConfig.h" header file. */
 
-// void vApplicationStackOverflowHook(TaskHandle_t *pxTask, signed char *pcTaskName )
+// void vApplicationStackOverflowHook(TaskHandle_t *pxTask, char *pcTaskName )
 // {
 //     for( ;; );
 // }

--- a/FreeRTOS/Demo/AVR_Dx_IAR/main.c
+++ b/FreeRTOS/Demo/AVR_Dx_IAR/main.c
@@ -43,7 +43,7 @@ extern void init_full( void );
 int main( void )
 {
     prvSetupHardware();
-    
+
 #if ( mainSELECTED_APPLICATION == 0 )
     main_blinky();
 #elif ( mainSELECTED_APPLICATION == 1 )
@@ -51,7 +51,7 @@ int main( void )
 #elif ( mainSELECTED_APPLICATION == 2 )
     main_full();
 #endif
-    
+
     return 0;
 }
 
@@ -78,7 +78,7 @@ This is usefull in application development, for debugging.  To use this
 hook, uncomment it, and set configCHECK_FOR_STACK_OVERFLOW to 1 in
 "FreeRTOSConfig.h" header file. */
 
-// void vApplicationStackOverflowHook(TaskHandle_t *pxTask, signed char *pcTaskName )
+// void vApplicationStackOverflowHook(TaskHandle_t *pxTask, char *pcTaskName )
 // {
 //     for( ;; );
 // }

--- a/FreeRTOS/Demo/AVR_Dx_MPLAB.X/main.c
+++ b/FreeRTOS/Demo/AVR_Dx_MPLAB.X/main.c
@@ -78,7 +78,7 @@ This is usefull in application development, for debugging.  To use this
 hook, uncomment it, and set configCHECK_FOR_STACK_OVERFLOW to 1 in
 "FreeRTOSConfig.h" header file. */
 
-// void vApplicationStackOverflowHook(TaskHandle_t *pxTask, signed char *pcTaskName )
+// void vApplicationStackOverflowHook(TaskHandle_t *pxTask, char *pcTaskName )
 // {
 //     for( ;; );
 // }

--- a/FreeRTOS/Demo/CORTEX_LM3S6965_GCC_QEMU/.settings/language.settings.xml
+++ b/FreeRTOS/Demo/CORTEX_LM3S6965_GCC_QEMU/.settings/language.settings.xml
@@ -5,7 +5,7 @@
 			<provider copy-of="extension" id="org.eclipse.cdt.ui.UserLanguageSettingsProvider"/>
 			<provider-reference id="org.eclipse.cdt.core.ReferencedProjectsLanguageSettingsProvider" ref="shared-provider"/>
 			<provider-reference id="org.eclipse.cdt.managedbuilder.core.MBSLanguageSettingsProvider" ref="shared-provider"/>
-			<provider class="org.eclipse.cdt.managedbuilder.language.settings.providers.GCCBuiltinSpecsDetector" console="false" env-hash="-920242998058162869" id="ilg.gnuarmeclipse.managedbuild.cross.GCCBuiltinSpecsDetector" keep-relative-paths="false" name="CDT ARM Cross GCC Built-in Compiler Settings " parameter="${COMMAND} ${FLAGS} ${cross_toolchain_flags} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
+			<provider class="org.eclipse.cdt.managedbuilder.language.settings.providers.GCCBuiltinSpecsDetector" console="false" env-hash="1283716845372686666" id="ilg.gnuarmeclipse.managedbuild.cross.GCCBuiltinSpecsDetector" keep-relative-paths="false" name="CDT ARM Cross GCC Built-in Compiler Settings " parameter="${COMMAND} ${FLAGS} ${cross_toolchain_flags} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
 				<language-scope id="org.eclipse.cdt.core.gcc"/>
 				<language-scope id="org.eclipse.cdt.core.g++"/>
 			</provider>

--- a/FreeRTOS/Demo/CORTEX_LM3S6965_GCC_QEMU/main.c
+++ b/FreeRTOS/Demo/CORTEX_LM3S6965_GCC_QEMU/main.c
@@ -158,7 +158,7 @@ extern void vSetupHighFrequencyTimer( void );
 /*
  * Hook functions that can get called by the kernel.
  */
-void vApplicationStackOverflowHook( TaskHandle_t *pxTask, signed char *pcTaskName );
+void vApplicationStackOverflowHook( TaskHandle_t pxTask, char *pcTaskName );
 void vApplicationTickHook( void );
 
 /*
@@ -379,8 +379,8 @@ void ( *vOLEDClear )( void ) = NULL;
 }
 /*-----------------------------------------------------------*/
 
-volatile signed char *pcOverflowedTask = NULL; /* Prevent task name being optimised away. */
-void vApplicationStackOverflowHook( TaskHandle_t *pxTask, signed char *pcTaskName )
+volatile char *pcOverflowedTask = NULL; /* Prevent task name being optimised away. */
+void vApplicationStackOverflowHook( TaskHandle_t pxTask, char *pcTaskName )
 {
 	( void ) pxTask;
 	pcOverflowedTask = pcTaskName;

--- a/FreeRTOS/Demo/CORTEX_LM3Sxxxx_IAR_Keil/main.c
+++ b/FreeRTOS/Demo/CORTEX_LM3Sxxxx_IAR_Keil/main.c
@@ -185,7 +185,7 @@ extern void vSetupHighFrequencyTimer( void );
 /*
  * Hook functions that can get called by the kernel.
  */
-void vApplicationStackOverflowHook( TaskHandle_t *pxTask, signed char *pcTaskName );
+void vApplicationStackOverflowHook( TaskHandle_t pxTask, char *pcTaskName );
 void vApplicationTickHook( void );
 
 static void prvPrintString( const char * pcString );
@@ -453,8 +453,8 @@ void ( *vOLEDClear )( void ) = NULL;
 }
 /*-----------------------------------------------------------*/
 
-volatile signed char *pcOverflowedTask = NULL;
-void vApplicationStackOverflowHook( TaskHandle_t *pxTask, signed char *pcTaskName )
+volatile char *pcOverflowedTask = NULL;
+void vApplicationStackOverflowHook( TaskHandle_t pxTask, char *pcTaskName )
 {
 	( void ) pxTask;
 	pcOverflowedTask = pcTaskName;

--- a/FreeRTOS/Demo/CORTEX_MPU_M23_Nuvoton_NuMaker_PFM_M2351_IAR_GCC/Projects/IAR/NonSecure/main_ns.c
+++ b/FreeRTOS/Demo/CORTEX_MPU_M23_Nuvoton_NuMaker_PFM_M2351_IAR_GCC/Projects/IAR/NonSecure/main_ns.c
@@ -88,7 +88,7 @@ static void prvCreateTasks( void )
 /*-----------------------------------------------------------*/
 
 /* Stack overflow hook. */
-void vApplicationStackOverflowHook( TaskHandle_t xTask, signed char *pcTaskName )
+void vApplicationStackOverflowHook( TaskHandle_t xTask, char *pcTaskName )
 {
 	/* Force an assert. */
 	configASSERT( pcTaskName == 0 );

--- a/FreeRTOS/Demo/CORTEX_MPU_M23_Nuvoton_NuMaker_PFM_M2351_IAR_GCC/Projects/Keil/NonSecure/main_ns.c
+++ b/FreeRTOS/Demo/CORTEX_MPU_M23_Nuvoton_NuMaker_PFM_M2351_IAR_GCC/Projects/Keil/NonSecure/main_ns.c
@@ -131,7 +131,7 @@ static void prvCreateTasks( void )
 /*-----------------------------------------------------------*/
 
 /* Stack overflow hook. */
-void vApplicationStackOverflowHook( TaskHandle_t xTask, signed char *pcTaskName )
+void vApplicationStackOverflowHook( TaskHandle_t xTask, char *pcTaskName )
 {
 	/* Force an assert. */
 	configASSERT( pcTaskName == 0 );

--- a/FreeRTOS/Demo/CORTEX_MPU_M33F_NXP_LPC55S69_MCUXpresso/Projects/MCUXpresso/NonSecure/main_ns.c
+++ b/FreeRTOS/Demo/CORTEX_MPU_M33F_NXP_LPC55S69_MCUXpresso/Projects/MCUXpresso/NonSecure/main_ns.c
@@ -101,7 +101,7 @@ void SystemInit( void )
 /*-----------------------------------------------------------*/
 
 /* Stack overflow hook. */
-void vApplicationStackOverflowHook( TaskHandle_t xTask, signed char *pcTaskName )
+void vApplicationStackOverflowHook( TaskHandle_t xTask, char *pcTaskName )
 {
 	/* Force an assert. */
 	configASSERT( pcTaskName == 0 );

--- a/FreeRTOS/Demo/CORTEX_MPU_M33F_Simulator_Keil_GCC/NonSecure/main_ns.c
+++ b/FreeRTOS/Demo/CORTEX_MPU_M33F_Simulator_Keil_GCC/NonSecure/main_ns.c
@@ -126,7 +126,7 @@ static void prvCreateTasks( void )
 /*-----------------------------------------------------------*/
 
 /* Stack overflow hook. */
-void vApplicationStackOverflowHook( TaskHandle_t xTask, signed char *pcTaskName )
+void vApplicationStackOverflowHook( TaskHandle_t xTask, char *pcTaskName )
 {
 	/* Force an assert. */
 	configASSERT( pcTaskName == 0 );

--- a/FreeRTOS/Demo/ColdFire_MCF52221_CodeWarrior/sources/main.c
+++ b/FreeRTOS/Demo/ColdFire_MCF52221_CodeWarrior/sources/main.c
@@ -238,7 +238,7 @@ void prvSetupHardware( void )
 }
 /*-----------------------------------------------------------*/
 
-void vApplicationStackOverflowHook( TaskHandle_t *pxTask, signed char *pcTaskName )
+void vApplicationStackOverflowHook( TaskHandle_t pxTask, char *pcTaskName )
 {
 	/* This will get called if a stack overflow is detected during the context
 	switch.  Set configCHECK_FOR_STACK_OVERFLOWS to 2 to also check for stack

--- a/FreeRTOS/Demo/ColdFire_MCF52233_Eclipse/RTOSDemo/main.c
+++ b/FreeRTOS/Demo/ColdFire_MCF52233_Eclipse/RTOSDemo/main.c
@@ -285,7 +285,7 @@ static const unsigned long _cfm[6] = {
 }
 /*-----------------------------------------------------------*/
 
-void vApplicationStackOverflowHook( xTaskHandle *pxTask, signed char *pcTaskName )
+void vApplicationStackOverflowHook( xTaskHandle pxTask, char *pcTaskName )
 {
 	/* This will get called if a stack overflow is detected during the context
 	switch.  Set configCHECK_FOR_STACK_OVERFLOWS to 2 to also check for stack

--- a/FreeRTOS/Demo/ColdFire_MCF52259_CodeWarrior/main.c
+++ b/FreeRTOS/Demo/ColdFire_MCF52259_CodeWarrior/main.c
@@ -253,7 +253,7 @@ void prvSetupHardware( void )
 }
 /*-----------------------------------------------------------*/
 
-void vApplicationStackOverflowHook( TaskHandle_t *pxTask, signed char *pcTaskName )
+void vApplicationStackOverflowHook( TaskHandle_t pxTask, char *pcTaskName )
 {
 	/* This will get called if a stack overflow is detected during the context
 	switch.  Set configCHECK_FOR_STACK_OVERFLOWS to 2 to also check for stack

--- a/FreeRTOS/Demo/NEC_78K0R_IAR/main.c
+++ b/FreeRTOS/Demo/NEC_78K0R_IAR/main.c
@@ -150,11 +150,11 @@ short main( void )
 
 	/* Create the RegTest tasks as described at the top of this file. */
 	xTaskCreate( vRegTest1, "Reg1", configMINIMAL_STACK_SIZE, NULL, 0, NULL );
-	xTaskCreate( vRegTest2, "Reg2", configMINIMAL_STACK_SIZE, NULL, 0, NULL );	
-	
+	xTaskCreate( vRegTest2, "Reg2", configMINIMAL_STACK_SIZE, NULL, 0, NULL );
+
 	/* Create the button push task as described at the top of this file. */
-	xTaskCreate( vButtonTask, "Button", configMINIMAL_STACK_SIZE, NULL, mainBUTTON_PRIORITY, NULL );		
-	
+	xTaskCreate( vButtonTask, "Button", configMINIMAL_STACK_SIZE, NULL, mainBUTTON_PRIORITY, NULL );
+
 	/* Create the 'check' task as described at the top of this file. */
 	xTaskCreate( vErrorChecks, "Check", configMINIMAL_STACK_SIZE, ( void* )mainCHECK_PARAMETER_VALUE, mainCHECK_TASK_PRIORITY, NULL );
 
@@ -167,7 +167,7 @@ short main( void )
 		vCreateBlockTimeTasks();
 	}
 	#endif
-	
+
 	/* Finally start the scheduler running. */
 	vTaskStartScheduler();
 
@@ -218,24 +218,24 @@ TickType_t xToggleRate = mainNO_ERROR_TOGGLE_PERIOD, xLastWakeTime;
 			{
 				xToggleRate = mainERROR_TOGGLE_PERIOD;
 			}
-		
+
 			if( xAreSemaphoreTasksStillRunning() != pdTRUE)
 			{
 				xToggleRate = mainERROR_TOGGLE_PERIOD;
 			}
-			
+
 			if( xAreGenericQueueTasksStillRunning() != pdTRUE )
 			{
 				xToggleRate = mainERROR_TOGGLE_PERIOD;
-			}	
-		
+			}
+
 			if( xAreBlockTimeTestTasksStillRunning() != pdTRUE )
 			{
 				xToggleRate = mainERROR_TOGGLE_PERIOD;
-			}			
+			}
 		}
 		#endif
-		
+
 		/* Toggle the LED.  The toggle rate will depend on whether or not an
 		error has been found in any tasks. */
 		mainLED_0 = !mainLED_0;
@@ -281,24 +281,24 @@ unsigned char ucResetFlag = RESF;
 		   X1  and X2  pin in crystal resonator mode
 		   High speed oszillation frequency 10MHz < fMX <= 20MHz */
 		CMC   = 0x41;
-		
+
 		/* Set oscillation stabilization time. */
 		OSTS  = 0x07;
-		
+
 		/* Set speed mode: fMX > 10MHz for Flash memory high speed operation. */
 		OSMC  = 0x01;
-		
+
 		/* Start up X1 oscillator operation
 		   Internal high-speed oscillator operating. */
 		MSTOP = 0;
-		
+
 		/* Check oscillation stabilization time status. */
 		while(OSTC < 0x07)
 		{
 			/* Wait until X1 clock stabilization time. */
 			portNOP();
 		}
-		
+
 		/* Switch CPU clock to X1 oscillator. */
 		MCM0 = 1;
 		while(MCS != 1)
@@ -309,10 +309,10 @@ unsigned char ucResetFlag = RESF;
 
 		/* Stop the internal high-speed oscillator operation. */
 		HIOSTOP = 1;
-		
+
 		/* Stop the XT1 oscillator operation. */
 		XTSTOP  = 1;
-		
+
 		/* Operating frequency f = fx
 		   Change clock generator setting, if necessary. */
 		CKC &= 0xF8;
@@ -320,31 +320,31 @@ unsigned char ucResetFlag = RESF;
 		/* From here onwards the X1 oscillator is supplied to the CPU. */
 	}
 	#endif
-	
+
 	/* LED port initialization - set port register. */
 	P7  = 0x80;
-	
+
 	/* Set port mode register. */
 	PM7 = 0x3F;
-	
+
 	/* Switch pin initialization - enable pull-up resistor. */
 	PU12_bit.no0  = 1;
 
 	/* INTP0 is used by the button on the target board. */
-	
+
 	/* INTP0 disable. */
-	PMK0 = 1;			
-	
+	PMK0 = 1;
+
 	/* INTP0 IF clear. */
-	PIF0 = 0;			
+	PIF0 = 0;
 	EGN0_bit.no0  = 1;
-	
+
 	/* INTP0 priority low. */
 	PPR10 = 0;
 	PPR00 = 1;
-	
+
 	/* Enable ext. INTP0 interrupt */
-	PMK0  = 0;	
+	PMK0  = 0;
 
 	return pdTRUE;
 }
@@ -362,8 +362,11 @@ void vRegTestError( void )
 }
 /*-----------------------------------------------------------*/
 
-void vApplicationStackOverflowHook( void )
+void vApplicationStackOverflowHook( TaskHandle_t xTask, char *pcTaskName )
 {
+	( void ) xTask;
+	( void ) pcTaskName;
+
 	/* This will get called if an overflow is detected in the stack of a task.
 	Inspect pxCurrentTCB to see which was the offending task. */
 	for( ;; );

--- a/FreeRTOS/Demo/NEC_V850ES_IAR/main.c
+++ b/FreeRTOS/Demo/NEC_V850ES_IAR/main.c
@@ -124,7 +124,7 @@ void main( void )
 	vStartSemaphoreTasks( mainSEM_TEST_PRIORITY );
 	vStartGenericQueueTasks( mainGEN_QUEUE_TASK_PRIORITY );
 	vStartQueuePeekTasks();
-	
+
 	/* Create the check task as described at the top of this file. */
 	xTaskCreate( prvCheckTask, "Check", configMINIMAL_STACK_SIZE, mainCHECK_PARAMETER, mainCHECK_TASK_PRIORITY, NULL );
 
@@ -135,22 +135,22 @@ void main( void )
 	#ifdef __IAR_V850ES_Fx3__
 	{
 		/* The extra IO required for the com test and led flashing tasks is only
-		available on the application board, not the target boards. */	
+		available on the application board, not the target boards. */
 		vAltStartComTestTasks( mainCOMTEST_PRIORITY, mainBAUD_RATE, mainCOMTEST_LED );
 		vStartLEDFlashTasks( mainFLASH_PRIORITY );
-		
+
 		/* The Fx3 also has enough RAM to run loads more tasks. */
 		vStartRecursiveMutexTasks();
 		vStartBlockingQueueTasks( mainBLOCK_Q_PRIORITY );
-		vStartPolledQueueTasks( mainQUEUE_POLL_PRIORITY );				
+		vStartPolledQueueTasks( mainQUEUE_POLL_PRIORITY );
 	}
-	#endif	
-	
+	#endif
+
 	/* The suicide tasks must be created last as they need to know how many
 	tasks were running prior to their creation in order to ascertain whether
 	or not the correct/expected number of tasks are running at any given time. */
     vCreateSuicidalTasks( mainCREATOR_TASK_PRIORITY );
-	
+
 	/* Start the scheduler. */
 	vTaskStartScheduler();
 
@@ -170,23 +170,23 @@ unsigned portBASE_TYPE uxLEDToUse = 0;
 	{
 		xDelayPeriod = mainERROR_DELAY;
 	}
-	
+
 	/* Initialise xLastWakeTime before it is used.  After this point it is not
 	written to directly. */
 	xLastWakeTime = xTaskGetTickCount();
-	
+
 	/* Cycle for ever, delaying then checking all the other tasks are still
 	operating without error. */
 	for( ;; )
 	{
 		/* Wait until it is time to check all the other tasks again. */
 		vTaskDelayUntil( &xLastWakeTime, xDelayPeriod );
-		
+
 		if( lRegTestStatus != pdPASS )
 		{
 			xDelayPeriod = mainERROR_DELAY;
 		}
-		
+
 		if( xAreGenericQueueTasksStillRunning() != pdTRUE )
 		{
 			xDelayPeriod = mainERROR_DELAY;
@@ -207,14 +207,14 @@ unsigned portBASE_TYPE uxLEDToUse = 0;
 	    	xDelayPeriod = mainERROR_DELAY;
 	    }
 
-		/* The Fx3 runs more tasks, so more checks are performed. */		
+		/* The Fx3 runs more tasks, so more checks are performed. */
 		#ifdef __IAR_V850ES_Fx3__
 		{
 			if( xAreComTestTasksStillRunning() != pdTRUE )
 			{
 				xDelayPeriod = mainERROR_DELAY;
 			}
-			
+
 			if( xArePollingQueuesStillRunning() != pdTRUE )
 			{
 				xDelayPeriod = mainERROR_DELAY;
@@ -224,12 +224,12 @@ unsigned portBASE_TYPE uxLEDToUse = 0;
 			{
 				xDelayPeriod = mainERROR_DELAY;
 			}
-			
+
 			if( xAreRecursiveMutexTasksStillRunning() != pdTRUE )
 			{
 				xDelayPeriod = mainERROR_DELAY;
-			}		
-			
+			}
+
 			/* The application board has more LEDs and uses the flash tasks
 			so the check task instead uses LED3 as LED3 is still spare. */
 			uxLEDToUse = 3;
@@ -252,8 +252,11 @@ static void prvSetupHardware( void )
 }
 /*-----------------------------------------------------------*/
 
-void vApplicationStackOverflowHook( void )
+void vApplicationStackOverflowHook( TaskHandle_t xTask, char *pcTaskName )
 {
+	( void ) xTask;
+	( void ) pcTaskName;
+
 	/* This will be called if a task overflows its stack.  pxCurrentTCB
 	can be inspected to see which is the offending task. */
 	for( ;; );
@@ -265,7 +268,7 @@ void vRegTestFailed( void )
 	/* Called by the RegTest tasks if an error is found.  lRegTestStatus is
 	inspected by the check task. */
 	lRegTestStatus = pdFAIL;
-	
+
 	/* Do not return from here as the reg test tasks clobber all registers so
 	function calls may not function correctly. */
 	for( ;; );

--- a/FreeRTOS/Demo/NiosII_CycloneIII_DBC3C40_GCC/RTOSDemo/main.c
+++ b/FreeRTOS/Demo/NiosII_CycloneIII_DBC3C40_GCC/RTOSDemo/main.c
@@ -31,13 +31,13 @@
  * defined and/or created within this file:
  *
  * "Check" task -  This only executes every five seconds but has the highest
- * priority so is guaranteed to get processor time.  Its main function is to 
+ * priority so is guaranteed to get processor time.  Its main function is to
  * check that all the standard demo tasks are still operational.  The check
  * task will write an error message to the console should an error be detected
  * within any of the demo tasks.  The check task also toggles the LED defined
  * by mainCHECK_LED every 5 seconds while the system is error free, with the
  * toggle rate increasing to every 500ms should an error occur.
- * 
+ *
  * "Reg test" tasks - These fill the registers with known values, then check
  * that each register still contains its expected value.  Each task uses
  * different values.  The tasks run with very low priority so get preempted very
@@ -92,7 +92,7 @@ error has been detected. */
 /* The LED toggled by the Check task. */
 #define mainCHECK_LED       ( 7 )
 
-/* The first LED used by the ComTest tasks.  One LED toggles each time a 
+/* The first LED used by the ComTest tasks.  One LED toggles each time a
 character is transmitted, and one each time a character is received and
 verified as being the expected character. */
 #define mainCOMTEST_LED     ( 4 )
@@ -125,7 +125,7 @@ static void prvSetupHardware( void );
 
 /*
  * Execute all of the check functions to ensure the tests haven't failed.
- */ 
+ */
 static void prvCheckTask( void *pvParameters );
 
 /*
@@ -149,7 +149,7 @@ int main( void )
 {
     /* Configure any hardware required for this demo. */
 	prvSetupHardware();
-    
+
 	/* Create all the other standard demo tasks.  These serve no purpose other
     than to test the port and demonstrate the use of the FreeRTOS API. */
 	vStartLEDFlashTasks( tskIDLE_PRIORITY );
@@ -164,10 +164,10 @@ int main( void )
 	vStartCountingSemaphoreTasks();
 	vStartRecursiveMutexTasks();
     vAltStartComTestTasks( mainCOM_TEST_PRIORITY, 0, mainCOMTEST_LED );
-    
+
 	/* prvCheckTask uses sprintf so requires more stack. */
 	xTaskCreate( prvCheckTask, "Check", configMINIMAL_STACK_SIZE, NULL, mainCHECK_TASK_PRIORITY, NULL );
-    
+
     /* The RegTest tasks as described at the top of this file. */
     xTaskCreate( prvFirstRegTestTask, "Rreg1", configMINIMAL_STACK_SIZE, mainREG_TEST_1_PARAMETER, mainREG_TEST_PRIORITY, NULL );
     xTaskCreate( prvSecondRegTestTask, "Rreg2", configMINIMAL_STACK_SIZE, mainREG_TEST_2_PARAMETER, mainREG_TEST_PRIORITY, NULL );
@@ -178,7 +178,7 @@ int main( void )
 
     /* Finally start the scheduler. */
 	vTaskStartScheduler();
-    
+
 	/* Will only reach here if there is insufficient heap available to start
 	the scheduler. */
 	for( ;; );
@@ -192,8 +192,11 @@ static void prvSetupHardware( void )
 }
 /*-----------------------------------------------------------*/
 
-void vApplicationStackOverflowHook( void )
+void vApplicationStackOverflowHook( TaskHandle_t xTask, char *pcTaskName )
 {
+	( void ) xTask;
+	( void ) pcTaskName;
+
 	/* Look at pxCurrentTCB to see which task overflowed its stack. */
 	for( ;; )
     {
@@ -204,7 +207,7 @@ void vApplicationStackOverflowHook( void )
 
 void _general_exception_handler( unsigned long ulCause, unsigned long ulStatus )
 {
-	/* This overrides the definition provided by the kernel.  Other exceptions 
+	/* This overrides the definition provided by the kernel.  Other exceptions
 	should be handled here. */
 	for( ;; )
     {
@@ -227,8 +230,8 @@ const char * pcMessage;
 	{
 		/* Wait until it is time to run the tests again. */
 		vTaskDelayUntil( &xLastExecutionTime, ulTicksToWait );
-		
-		/* Have any of the standard demo tasks detected an error in their 
+
+		/* Have any of the standard demo tasks detected an error in their
 		operation? */
 		if( xAreIntegerMathsTaskStillRunning() != pdTRUE )
 		{
@@ -300,7 +303,7 @@ const char * pcMessage;
         else if( ulLastRegTest2 == ulRegTest2Counter )
         {
             /* ulRegTest2Counter is no longer being incremented, indicating
-            that an error has been discovered in prvSecondRegTestTask(). */            
+            that an error has been discovered in prvSecondRegTestTask(). */
             ulTicksToWait = mainERROR_PERIOD;
             pcMessage = "Error: Reg Test2.\n";
         }
@@ -308,19 +311,19 @@ const char * pcMessage;
 		{
 			pcMessage = NULL;
 		}
-        
+
         /* Remember the counter values this time around so a counter failing
         to be incremented correctly can be spotted. */
         ulLastRegTest1 = ulRegTest1Counter;
         ulLastRegTest2 = ulRegTest2Counter;
-        
-        /* Print out an error message if there is one.  Mutual exclusion is 
+
+        /* Print out an error message if there is one.  Mutual exclusion is
         not used as this is the only task accessing stdout. */
         if( pcMessage != NULL )
         {
             printf( pcMessage );
         }
-        
+
         /* Provide visual feedback of the system status.  If the LED is toggled
         every 5 seconds then no errors have been found.  If the LED is toggled
         every 500ms then at least one error has been found. */
@@ -334,17 +337,17 @@ static void prvFirstRegTestTask( void *pvParameters )
     /* Check the parameters are passed in as expected. */
     if( pvParameters != mainREG_TEST_1_PARAMETER )
     {
-        /* Don't execute any further so an error is recognised by the check 
+        /* Don't execute any further so an error is recognised by the check
         task. */
         vTaskDelete( NULL );
     }
-    
+
     /* Fill registers with known values, then check that each register still
     contains its expected value.  An incorrect value is indicative of an error
-    in the context switching process. 
-    
+    in the context switching process.
+
     If no errors are found ulRegTest1Counter is incremented.  The check task
-    will recognise an error if ulRegTest1Counter stops being incremented. 
+    will recognise an error if ulRegTest1Counter stops being incremented.
     This task also performs a manual yield in the middle of its execution, just
     to increase the test coverage. */
     asm volatile (
@@ -438,15 +441,15 @@ static void prvSecondRegTestTask( void *pvParameters )
     /* Check the parameters are passed in as expected. */
     if( pvParameters != mainREG_TEST_2_PARAMETER )
     {
-        /* Don't execute any further so an error is recognised by the check 
+        /* Don't execute any further so an error is recognised by the check
         task. */
         vTaskDelete( NULL );
     }
-    
+
     /* Fill registers with known values, then check that each register still
     contains its expected value.  An incorrect value is indicative of an error
-    in the context switching process. 
-    
+    in the context switching process.
+
     If no errors are found ulRegTest2Counter is incremented.  The check task
     will recognise an error if ulRegTest2Counter stops being incremented. */
     asm volatile (

--- a/FreeRTOS/Demo/PPC440_DP_FPU_Xilinx_Virtex5_GCC/RTOSDemo/main.c
+++ b/FreeRTOS/Demo/PPC440_DP_FPU_Xilinx_Virtex5_GCC/RTOSDemo/main.c
@@ -653,8 +653,8 @@ static void prvRegTestTask2( void *pvParameters )
 /* This hook function will get called if there is a suspected stack overflow.
 An overflow can cause the task name to be corrupted, in which case the task
 handle needs to be used to determine the offending task. */
-void vApplicationStackOverflowHook( TaskHandle_t xTask, signed char *pcTaskName );
-void vApplicationStackOverflowHook( TaskHandle_t xTask, signed char *pcTaskName )
+void vApplicationStackOverflowHook( TaskHandle_t xTask, char *pcTaskName );
+void vApplicationStackOverflowHook( TaskHandle_t xTask, char *pcTaskName )
 {
 /* To prevent the optimiser removing the variables. */
 volatile TaskHandle_t xTaskIn = xTask;

--- a/FreeRTOS/Demo/PPC440_SP_FPU_Xilinx_Virtex5_GCC/RTOSDemo/main.c
+++ b/FreeRTOS/Demo/PPC440_SP_FPU_Xilinx_Virtex5_GCC/RTOSDemo/main.c
@@ -653,8 +653,8 @@ static void prvRegTestTask2( void *pvParameters )
 /* This hook function will get called if there is a suspected stack overflow.
 An overflow can cause the task name to be corrupted, in which case the task
 handle needs to be used to determine the offending task. */
-void vApplicationStackOverflowHook( TaskHandle_t xTask, signed char *pcTaskName );
-void vApplicationStackOverflowHook( TaskHandle_t xTask, signed char *pcTaskName )
+void vApplicationStackOverflowHook( TaskHandle_t xTask, char *pcTaskName );
+void vApplicationStackOverflowHook( TaskHandle_t xTask, char *pcTaskName )
 {
 /* To prevent the optimiser removing the variables. */
 volatile TaskHandle_t xTaskIn = xTask;

--- a/FreeRTOS/Demo/PPC440_Xilinx_Virtex5_GCC/RTOSDemo/main.c
+++ b/FreeRTOS/Demo/PPC440_Xilinx_Virtex5_GCC/RTOSDemo/main.c
@@ -659,8 +659,8 @@ static void prvRegTestTask2( void *pvParameters )
 /* This hook function will get called if there is a suspected stack overflow.
 An overflow can cause the task name to be corrupted, in which case the task
 handle needs to be used to determine the offending task. */
-void vApplicationStackOverflowHook( TaskHandle_t xTask, signed char *pcTaskName );
-void vApplicationStackOverflowHook( TaskHandle_t xTask, signed char *pcTaskName )
+void vApplicationStackOverflowHook( TaskHandle_t xTask, char *pcTaskName );
+void vApplicationStackOverflowHook( TaskHandle_t xTask, char *pcTaskName )
 {
 /* To prevent the optimiser removing the variables. */
 volatile TaskHandle_t xTaskIn = xTask;


### PR DESCRIPTION
Recently the prototypes for the application hook functions were
moved out of the kernel .c files and into the .h files.  That
changes results in compile time warnings for projects that provide
hook functions with a slightly different prototype - in particular
where signed char * is used in place of just char * as an older
FreeRTOS coding convention required chars to be explicitly qualified
as signed or unsigned.

This PR fixes the warnings by ensuring the signature of
implemented hook functions matches the signature of the prototypes.

