### PR TITLE
FreeRTOS+TCP /multi /IPv6: FreeRTOS_TCP_WIN

### DIFF
--- a/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/FreeRTOS_TCP_WIN.c
+++ b/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/FreeRTOS_TCP_WIN.c
@@ -46,8 +46,6 @@
 #include "FreeRTOS_Sockets.h"
 #include "FreeRTOS_IP_Private.h"
 
-#include "FreeRTOSIPConfigDefaults.h"
-
 /* Constants used for Smoothed Round Trip Time (SRTT). */
 #define	winSRTT_INCREMENT_NEW 		2
 #define winSRTT_INCREMENT_CURRENT 	6


### PR DESCRIPTION
<!--- Title -->

Description
-----------
The purpose of this PR is to get the sources reviewed. Please do not used them for any project.

FreeRTOS_WIN.c needs no changed for either /multi or /IPv6. I'm adding it for completeness only.
I only removed an #include which was not necessary:

~~~c
#include "FreeRTOSIPConfigDefaults.h"
~~~

Mentioned file has already been included.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.