### PR TITLE
Address a few MISRA 2.2 violations in FreeRTOS_IP.c

### DIFF
--- a/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/FreeRTOS_IP.c
+++ b/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/FreeRTOS_IP.c
@@ -2385,8 +2385,8 @@ BaseType_t location = 0;
 	{
 		FreeRTOS_printf( ( "CRC error: %04x location %ld\n", usChecksum, location ) );
 		
-		/* If FreeRTOS_printf is not defined, not using xLocation will be a violation of MISRA
-		 * rule 2.2 as the value assigned to location will not be used. The below statement uses
+		/* If FreeRTOS_printf is not defined, not using 'location' will be a violation of MISRA
+		 * rule 2.2 as the value assigned to 'location' will not be used. The below statement uses
 		 * the variable without modifying the logic of the source. */
 		( void ) location;
 	}

--- a/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/FreeRTOS_IP.c
+++ b/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/FreeRTOS_IP.c
@@ -2096,6 +2096,7 @@ uint8_t ucProtocol;
 		if( xResult != pdPASS )
 		{
 			FreeRTOS_printf( ( "xCheckSizeFields: location %ld\n", xLocation ) );
+			( void ) xLocation;
 		}
 
 		return xResult;
@@ -2370,6 +2371,7 @@ BaseType_t location = 0;
 		( usChecksum == ipINVALID_LENGTH ) )
 	{
 		FreeRTOS_printf( ( "CRC error: %04x location %ld\n", usChecksum, location ) );
+		( void ) location;
 	}
 
 	return usChecksum;

--- a/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/FreeRTOS_IP.c
+++ b/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/FreeRTOS_IP.c
@@ -2105,6 +2105,10 @@ uint8_t ucProtocol;
 		if( xResult != pdPASS )
 		{
 			FreeRTOS_printf( ( "xCheckSizeFields: location %ld\n", xLocation ) );
+			
+			/* If FreeRTOS_printf is not defined, not using xLocation will be a violation of MISRA
+			 * rule 2.2 as the value assigned to xLocation will not be used. The below statement uses
+			 * the variable without modifying the logic of the source. */
 			( void ) xLocation;
 		}
 
@@ -2380,6 +2384,10 @@ BaseType_t location = 0;
 		( usChecksum == ipINVALID_LENGTH ) )
 	{
 		FreeRTOS_printf( ( "CRC error: %04x location %ld\n", usChecksum, location ) );
+		
+		/* If FreeRTOS_printf is not defined, not using xLocation will be a violation of MISRA
+		 * rule 2.2 as the value assigned to xLocation will not be used. The below statement uses
+		 * the variable without modifying the logic of the source. */
 		( void ) location;
 	}
 

--- a/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/FreeRTOS_IP.c
+++ b/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/FreeRTOS_IP.c
@@ -2386,7 +2386,7 @@ BaseType_t location = 0;
 		FreeRTOS_printf( ( "CRC error: %04x location %ld\n", usChecksum, location ) );
 		
 		/* If FreeRTOS_printf is not defined, not using xLocation will be a violation of MISRA
-		 * rule 2.2 as the value assigned to xLocation will not be used. The below statement uses
+		 * rule 2.2 as the value assigned to location will not be used. The below statement uses
 		 * the variable without modifying the logic of the source. */
 		( void ) location;
 	}


### PR DESCRIPTION
Description
-----------
These changes bring in the changes required for addressing some of the MISRA rule 2.2 violations in FreeRTOS_IP.c.
The rule dictates that there shall be no dead code. When `ipconfigPRINTF` is not defined, then the debugging related variables seem to be unused. Use of ( void ) explicitly makes use of these variables while keeping the logic of code unchanged.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
