### PR TITLE
cbmc: Add patch to remove overflow assert

### DIFF
--- a/FreeRTOS/Test/CBMC/patches/0008-Remove-overflow-assert-from-xQueueGenericCreate.patch
+++ b/FreeRTOS/Test/CBMC/patches/0008-Remove-overflow-assert-from-xQueueGenericCreate.patch
@@ -1,0 +1,20 @@
+diff --git a/FreeRTOS/Source/queue.c b/FreeRTOS/Source/queue.c
+index edd08b26e..259c609f4 100644
+--- a/FreeRTOS/Source/queue.c
++++ b/FreeRTOS/Source/queue.c
+@@ -394,8 +394,13 @@ BaseType_t xQueueGenericReset( QueueHandle_t xQueue,
+          * zero in the case the queue is used as a semaphore. */
+         xQueueSizeInBytes = ( size_t ) ( uxQueueLength * uxItemSize ); /*lint !e961 MISRA exception as the casts are only redundant for some ports. */
+ 
+-        /* Check for multiplication overflow. */
+-        configASSERT( ( uxItemSize == 0 ) || ( uxQueueLength == ( xQueueSizeInBytes / uxItemSize ) ) );
++        /*
++         * Multiplication overflow check is commented out in CBMC test as it involves an
++         * expensive division operation and consumes longer compute time against a wide
++         * range of input combination in CBMC proof.
++         *
++         * configASSERT( ( uxItemSize == 0 ) || ( uxQueueLength == ( xQueueSizeInBytes / uxItemSize ) ) );
++         */
+ 
+         /* Allocate the queue and storage area.  Justification for MISRA
+          * deviation as follows:  pvPortMalloc() always ensures returned memory


### PR DESCRIPTION
Add patch to comment overflow assert in queue proofs

Description
-----------
This is a  patch to comment the [assert check](https://github.com/FreeRTOS/FreeRTOS-Kernel/blob/805b15a0224672bc89b2effffb7ab4c1debc7325/queue.c#L398) for multiplication overflow in `xQueueGenericCreate`. CBMC performs large number of division computations as part of the check, which slows down the proof.  The proof does implicit check for signed and unsigned integer overflows.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
