### PR TITLE
Fix the Posix port demo libpcap lib linking order issue in static linking for WSL

### DIFF
--- a/FreeRTOS/Demo/Posix_GCC/Makefile
+++ b/FreeRTOS/Demo/Posix_GCC/Makefile
@@ -85,7 +85,7 @@ ${BIN} : $(BUILD_DIR)/$(BIN)
 
 ${BUILD_DIR}/${BIN} : ${OBJ_FILES}
 	-mkdir -p ${@D}
-	$(CC) $(CFLAGS) $(INCLUDE_DIRS) ${LDFLAGS} $^ -o $@
+	$(CC) $^ $(CFLAGS) $(INCLUDE_DIRS) ${LDFLAGS} -o $@
 
 
 -include ${DEP_FILE}


### PR DESCRIPTION
There was a build error on some linux machin that the linker cannot find the funciton symbol defined in pcap.h (from libpcap).
Update the makefile to fix the lib linking order issure in static linking.