### PR TITLE
Add reconnection and resubscribe logic to the MQTT plaintext demo

### DIFF
--- a/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_plain_text/DemoTasks/PlaintextMQTTExample.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_plain_text/DemoTasks/PlaintextMQTTExample.c
@@ -561,7 +561,7 @@ static void prvMQTTSubscribeWithBackoffRetries( MQTTContext_t * pxMQTTContext )
         LogInfo( ( "Attempt to subscribe to the MQTT topic %s.\r\n", mqttexampleTOPIC ) );
         xResult = MQTT_Subscribe( pxMQTTContext,
                                   &xGlobalSubscribeInfo,
-                                  sizeof( MQTTSubscribeInfo_t ),
+                                  sizeof( xGlobalSubscribeInfo ) / sizeof( MQTTSubscribeInfo_t ),
                                   usSubscribePacketIdentifier );
         configASSERT( xResult == MQTTSuccess );
 
@@ -632,8 +632,8 @@ static void prvMQTTUnsubscribeFromTopic( MQTTContext_t * pxMQTTContext )
      * was initialized before sending the SUBSCRIBE packet, there is no need
      * to initialize it again. */
     xResult = MQTT_Unsubscribe( pxMQTTContext,
-                                xGlobalSubscribeInfo,
-                                sizeof( MQTTSubscribeInfo_t ),
+                                &xGlobalSubscribeInfo,
+                                sizeof( xGlobalSubscribeInfo ) / sizeof( MQTTSubscribeInfo_t ),
                                 usUnsubscribePacketIdentifier );
 
     configASSERT( xResult == MQTTSuccess );

--- a/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_plain_text/DemoTasks/PlaintextMQTTExample.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_plain_text/DemoTasks/PlaintextMQTTExample.c
@@ -266,7 +266,7 @@ static void prvMQTTProcessIncomingPublish( MQTTPublishInfo_t * pxPublishInfo );
 static void prvEventCallback( MQTTContext_t * pxMQTTContext,
                               MQTTPacketInfo_t * pxPacketInfo,
                               MQTTDeserializedInfo_t * pxDeserializedInfo );
-
+ 
 /*-----------------------------------------------------------*/
 
 /* @brief Static buffer used to hold MQTT messages being sent and received. */
@@ -653,7 +653,7 @@ static void prvMQTTPublishToTopic( MQTTContext_t * pxMQTTContext )
     /* Some fields not used by this demo so start with everything at 0. */
     ( void ) memset( ( void * ) &xMQTTPublishInfo, 0x00, sizeof( xMQTTPublishInfo ) );
 
-    /* This demo uses QOS0 */
+    /* This demo uses QOS0. */
     xMQTTPublishInfo.qos = MQTTQoS0;
     xMQTTPublishInfo.retain = false;
     xMQTTPublishInfo.pTopicName = mqttexampleTOPIC;
@@ -675,7 +675,9 @@ static void prvMQTTUnsubscribeFromTopic( MQTTContext_t * pxMQTTContext )
     /* Get next unique packet identifier */
     usUnsubscribePacketIdentifier = MQTT_GetPacketId( pxMQTTContext );
 
-    /* Send UNSUBSCRIBE packet. */
+    /* Send UNSUBSCRIBE packet. Note that because #pxGlobalSubscriptionList 
+     * was initialized before sending the SUBSCRIBE packet, there is no need
+     * to initialize it again. */
     xResult = MQTT_Unsubscribe( pxMQTTContext,
                                 pxGlobalSubscriptionList,
                                 sizeof( pxGlobalSubscriptionList ) / sizeof( MQTTSubscribeInfo_t ),

--- a/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_plain_text/DemoTasks/PlaintextMQTTExample.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_plain_text/DemoTasks/PlaintextMQTTExample.c
@@ -351,10 +351,10 @@ static void prvMQTTDemoTask( void * pvParameters )
         /****************************** Connect. ******************************/
 
         /* Attempt to connect to the MQTT broker. If connection fails, retry after
-         * a timeout. Timeout value will be exponentially increased till the maximum
-         * attempts are reached or maximum timeout value is reached. The function
-         * returns a failure status if the TCP connection cannot be established to
-         * broker after configured number of attempts. */
+         * a timeout. Timeout value will be exponentially increased until the maximum
+         * number of attempts are reached or the maximum timeout value is reached.
+         * The function returns a failure status if the TCP connection cannot be established
+         * to the broker after the configured number of attempts. */
         xNetworkStatus = prvConnectToServerWithBackoffRetries( &xNetworkContext );
         configASSERT( xNetworkStatus == PLAINTEXT_TRANSPORT_SUCCESS );
 

--- a/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_plain_text/DemoTasks/PlaintextMQTTExample.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_plain_text/DemoTasks/PlaintextMQTTExample.c
@@ -421,7 +421,6 @@ static PlaintextTransportStatus_t prvConnectToServerWithBackoffRetries( NetworkC
     RetryUtilsParams_t xReconnectParams;
 
     /* Initialize reconnect attempts and interval */
-    xReconnectParams.maxRetryAttempts = MAX_RETRY_ATTEMPTS;
     RetryUtils_ParamsReset( &xReconnectParams );
 
     /* Attempt to connect to MQTT broker. If connection fails, retry after
@@ -548,7 +547,6 @@ static void prvMQTTSubscribeWithBackoffRetries( MQTTContext_t * pxMQTTContext )
     xGlobalSubscribeInfo.topicFilterLength = ( uint16_t ) strlen( mqttexampleTOPIC );
 
     /* Initialize retry attempts and interval. */
-    xRetryParams.maxRetryAttempts = MAX_RETRY_ATTEMPTS;
     RetryUtils_ParamsReset( &xRetryParams );
 
     do

--- a/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_plain_text/DemoTasks/PlaintextMQTTExample.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_plain_text/DemoTasks/PlaintextMQTTExample.c
@@ -420,7 +420,7 @@ static PlaintextTransportStatus_t prvConnectToServerWithBackoffRetries( NetworkC
     RetryUtilsStatus_t xRetryUtilsStatus = RetryUtilsSuccess;
     RetryUtilsParams_t xReconnectParams;
 
-    /* Initialize reconnect attempts and interval */
+    /* Initialize reconnect attempts and interval. */
     RetryUtils_ParamsReset( &xReconnectParams );
 
     /* Attempt to connect to MQTT broker. If connection fails, retry after
@@ -481,7 +481,7 @@ static void prvCreateMQTTConnectionWithBroker( MQTTContext_t * pxMQTTContext,
     configASSERT( xResult == MQTTSuccess );
 
     /* Many fields not used in this demo so start with everything at 0. */
-    memset( ( void * ) &xConnectInfo, 0x00, sizeof( xConnectInfo ) );
+    ( void ) memset( ( void * ) &xConnectInfo, 0x00, sizeof( xConnectInfo ) );
 
     /* Start with a clean session i.e. direct the MQTT broker to discard any
      * previous session data. Also, establishing a connection with clean session
@@ -560,7 +560,7 @@ static void prvMQTTSubscribeWithBackoffRetries( MQTTContext_t * pxMQTTContext )
          * messages received from the broker will have QOS0. */
         LogInfo( ( "Attempt to subscribe to the MQTT topic %s.\r\n", mqttexampleTOPIC ) );
         xResult = MQTT_Subscribe( pxMQTTContext,
-                                  xGlobalSubscribeInfo,
+                                  &xGlobalSubscribeInfo,
                                   sizeof( MQTTSubscribeInfo_t ),
                                   usSubscribePacketIdentifier );
         configASSERT( xResult == MQTTSuccess );
@@ -625,7 +625,7 @@ static void prvMQTTUnsubscribeFromTopic( MQTTContext_t * pxMQTTContext )
 {
     MQTTStatus_t xResult;
 
-    /* Get next unique packet identifier */
+    /* Get next unique packet identifier. */
     usUnsubscribePacketIdentifier = MQTT_GetPacketId( pxMQTTContext );
 
     /* Send UNSUBSCRIBE packet. Note that because #xGlobalSubscribeInfo

--- a/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_plain_text/DemoTasks/PlaintextMQTTExample.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_plain_text/DemoTasks/PlaintextMQTTExample.c
@@ -535,7 +535,7 @@ static void prvMQTTSubscribeWithBackoffRetries( MQTTContext_t * pxMQTTContext )
     RetryUtilsParams_t xRetryParams;
 
     /* Some fields not used by this demo so start with everything at 0. */
-    ( void ) memset( ( void * ) xGlobalSubscribeInfo, 0x00, sizeof( MQTTSubscribeInfo_t ) );
+    ( void ) memset( ( void * ) &xGlobalSubscribeInfo, 0x00, sizeof( MQTTSubscribeInfo_t ) );
 
     /* Get a unique packet id. */
     usSubscribePacketIdentifier = MQTT_GetPacketId( pxMQTTContext );

--- a/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_plain_text/DemoTasks/PlaintextMQTTExample.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_plain_text/DemoTasks/PlaintextMQTTExample.c
@@ -325,13 +325,14 @@ static void prvMQTTDemoTask( void * pvParameters )
          * the MQTT broker as specified in democonfigMQTT_BROKER_ENDPOINT and
          * democonfigMQTT_BROKER_PORT at the top of this file. */
         LogInfo( ( "Create a TCP connection to %s.\r\n", democonfigMQTT_BROKER_ENDPOINT ) );
+
         /* Attempt to connect to the MQTT broker. If connection fails, retry after
          * a timeout. Timeout value will be exponentially increased till the maximum
          * attempts are reached or maximum timeout value is reached. The function
          * returns EXIT_FAILURE if the TCP connection cannot be established to
          * broker after configured number of attempts. */
         xNetworkStatus = prvConnectToServerWithBackoffRetries( &xNetworkContext );
-        configASSERT(xNetworkStatus == PLAINTEXT_TRANSPORT_SUCCESS);
+        configASSERT( xNetworkStatus == PLAINTEXT_TRANSPORT_SUCCESS );
 
         /* Sends an MQTT Connect packet over the already connected TCP socket,
          * and waits for connection acknowledgment (CONNACK) packet. */
@@ -408,14 +409,14 @@ static void prvMQTTDemoTask( void * pvParameters )
 }
 /*-----------------------------------------------------------*/
 
-static PlaintextTransportStatus_t prvConnectToServerWithBackoffRetries(NetworkContext_t * pNetworkContext)
+static PlaintextTransportStatus_t prvConnectToServerWithBackoffRetries( NetworkContext_t * pNetworkContext )
 {
     RetryUtilsStatus_t retryUtilsStatus = RetryUtilsSuccess;
     PlaintextTransportStatus_t xNetworkStatus;
     RetryUtilsParams_t reconnectParams;
 
     /* Initialize reconnect attempts and interval */
-    RetryUtils_ParamsReset(&reconnectParams);
+    RetryUtils_ParamsReset( &reconnectParams );
 
     /* Attempt to connect to MQTT broker. If connection fails, retry after
      * a timeout. Timeout value will exponentially increase till maximum
@@ -426,27 +427,27 @@ static PlaintextTransportStatus_t prvConnectToServerWithBackoffRetries(NetworkCo
         /* Establish a TCP connection with the MQTT broker. This example connects
          * to the MQTT broker as specified in BROKER_ENDPOINT and BROKER_PORT
          * at the demo config header. */
-        LogInfo(("Creating a TCP connection to %s:%d.",
-            democonfigMQTT_BROKER_ENDPOINT,
-            democonfigMQTT_BROKER_PORT));
-        xNetworkStatus = Plaintext_FreeRTOS_Connect(pNetworkContext,
-            democonfigMQTT_BROKER_ENDPOINT,
-            democonfigMQTT_BROKER_PORT,
-            TRANSPORT_SEND_RECV_TIMEOUT_MS,
-            TRANSPORT_SEND_RECV_TIMEOUT_MS);
+        LogInfo( ( "Creating a TCP connection to %s:%d.",
+                   democonfigMQTT_BROKER_ENDPOINT,
+                   democonfigMQTT_BROKER_PORT ) );
+        xNetworkStatus = Plaintext_FreeRTOS_Connect( pNetworkContext,
+                                                     democonfigMQTT_BROKER_ENDPOINT,
+                                                     democonfigMQTT_BROKER_PORT,
+                                                     TRANSPORT_SEND_RECV_TIMEOUT_MS,
+                                                     TRANSPORT_SEND_RECV_TIMEOUT_MS );
 
-        if (xNetworkStatus != PLAINTEXT_TRANSPORT_SUCCESS)
+        if( xNetworkStatus != PLAINTEXT_TRANSPORT_SUCCESS )
         {
-            LogWarn(("Connection to the broker failed. Retrying connection with backoff and jitter."));
-            retryUtilsStatus = RetryUtils_BackoffAndSleep(&reconnectParams);
+            LogWarn( ( "Connection to the broker failed. Retrying connection with backoff and jitter." ) );
+            retryUtilsStatus = RetryUtils_BackoffAndSleep( &reconnectParams );
         }
 
-        if (retryUtilsStatus == RetryUtilsRetriesExhausted)
+        if( retryUtilsStatus == RetryUtilsRetriesExhausted )
         {
-            LogError(("Connection to the broker failed, all attempts exhausted."));
-            xNetworkStatus = pdFAIL;
+            LogError( ( "Connection to the broker failed, all attempts exhausted." ) );
+            xNetworkStatus = PLAINTEXT_TRANSPORT_CONNECT_FAILURE;
         }
-    } while ((xNetworkStatus != PLAINTEXT_TRANSPORT_SUCCESS) && (retryUtilsStatus == RetryUtilsSuccess));
+    } while( ( xNetworkStatus != PLAINTEXT_TRANSPORT_SUCCESS ) && ( retryUtilsStatus == RetryUtilsSuccess ) );
 
     return xNetworkStatus;
 }

--- a/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_plain_text/DemoTasks/PlaintextMQTTExample.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_plain_text/DemoTasks/PlaintextMQTTExample.c
@@ -611,7 +611,7 @@ static void prvHandleResubscribe( MQTTContext_t * pxMQTTContext )
         /* Send SUBSCRIBE packet.
          * Note: reusing the value specified in globalSubscribePacketIdentifier is acceptable here
          * because this function is entered only after the receipt of a SUBACK, at which point
-         * its associated packet id is free to use. */
+         * its associated packet id is free to reuse. */
         xResult = MQTT_Subscribe( pxMQTTContext,
                                   pxGlobalSubscriptionList,
                                   sizeof( pxGlobalSubscriptionList ) / sizeof( MQTTSubscribeInfo_t ),

--- a/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_plain_text/DemoTasks/PlaintextMQTTExample.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_plain_text/DemoTasks/PlaintextMQTTExample.c
@@ -183,7 +183,7 @@ static PlaintextTransportStatus_t prvConnectToServerWithBackoffRetries( NetworkC
  * @brief Sends an MQTT Connect packet over the already connected TCP socket.
  *
  * @param pxMQTTContext MQTT context pointer.
- * @param pxNetworkContext network context.
+ * @param pxNetworkContext Network context.
  *
  */
 static void prvCreateMQTTConnectionWithBroker( MQTTContext_t * pxMQTTContext,

--- a/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_plain_text/DemoTasks/PlaintextMQTTExample.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_plain_text/DemoTasks/PlaintextMQTTExample.c
@@ -644,7 +644,6 @@ static void prvMQTTPublishToTopic( MQTTContext_t * pxMQTTContext )
     MQTTStatus_t xResult;
     MQTTPublishInfo_t xMQTTPublishInfo;
 
-
     /***
      * For readability, error handling in this function is restricted to the use of
      * asserts().

--- a/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_plain_text/DemoTasks/PlaintextMQTTExample.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_plain_text/DemoTasks/PlaintextMQTTExample.c
@@ -421,6 +421,7 @@ static PlaintextTransportStatus_t prvConnectToServerWithBackoffRetries( NetworkC
     RetryUtilsParams_t xReconnectParams;
 
     /* Initialize reconnect attempts and interval. */
+    xReconnectParams.maxRetryAttempts = MAX_RETRY_ATTEMPTS;
     RetryUtils_ParamsReset( &xReconnectParams );
 
     /* Attempt to connect to MQTT broker. If connection fails, retry after
@@ -547,6 +548,7 @@ static void prvMQTTSubscribeWithBackoffRetries( MQTTContext_t * pxMQTTContext )
     xGlobalSubscribeInfo.topicFilterLength = ( uint16_t ) strlen( mqttexampleTOPIC );
 
     /* Initialize retry attempts and interval. */
+    xRetryParams.maxRetryAttempts = MAX_RETRY_ATTEMPTS;
     RetryUtils_ParamsReset( &xRetryParams );
 
     do

--- a/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_plain_text/DemoTasks/PlaintextMQTTExample.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_plain_text/DemoTasks/PlaintextMQTTExample.c
@@ -266,7 +266,7 @@ static void prvMQTTProcessIncomingPublish( MQTTPublishInfo_t * pxPublishInfo );
 static void prvEventCallback( MQTTContext_t * pxMQTTContext,
                               MQTTPacketInfo_t * pxPacketInfo,
                               MQTTDeserializedInfo_t * pxDeserializedInfo );
- 
+
 /*-----------------------------------------------------------*/
 
 /* @brief Static buffer used to hold MQTT messages being sent and received. */
@@ -675,7 +675,7 @@ static void prvMQTTUnsubscribeFromTopic( MQTTContext_t * pxMQTTContext )
     /* Get next unique packet identifier */
     usUnsubscribePacketIdentifier = MQTT_GetPacketId( pxMQTTContext );
 
-    /* Send UNSUBSCRIBE packet. Note that because #pxGlobalSubscriptionList 
+    /* Send UNSUBSCRIBE packet. Note that because #pxGlobalSubscriptionList
      * was initialized before sending the SUBSCRIBE packet, there is no need
      * to initialize it again. */
     xResult = MQTT_Unsubscribe( pxMQTTContext,

--- a/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_plain_text/DemoTasks/PlaintextMQTTExample.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_plain_text/DemoTasks/PlaintextMQTTExample.c
@@ -583,8 +583,8 @@ static void prvMQTTSubscribeToTopic( MQTTContext_t * pxMQTTContext )
 static void prvUpdateSubAckStatus( MQTTPacketInfo_t * pxPacketInfo )
 {
     MQTTStatus_t xResult = MQTTSuccess;
-    uint8_t * pPayload = NULL;
-    size_t pSize = 0;
+    uint8_t * pucPayload = NULL;
+    size_t ulSize = 0;
 
     xResult = MQTT_GetSubAckStatusCodes( pxPacketInfo, &pPayload, &pSize );
 

--- a/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_plain_text/DemoTasks/PlaintextMQTTExample.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_plain_text/DemoTasks/PlaintextMQTTExample.c
@@ -321,11 +321,6 @@ static void prvMQTTDemoTask( void * pvParameters )
     {
         /****************************** Connect. ******************************/
 
-        /* Establish a TCP connection with the MQTT broker. This example connects to
-         * the MQTT broker as specified in democonfigMQTT_BROKER_ENDPOINT and
-         * democonfigMQTT_BROKER_PORT at the top of this file. */
-        LogInfo( ( "Create a TCP connection to %s.\r\n", democonfigMQTT_BROKER_ENDPOINT ) );
-
         /* Attempt to connect to the MQTT broker. If connection fails, retry after
          * a timeout. Timeout value will be exponentially increased till the maximum
          * attempts are reached or maximum timeout value is reached. The function
@@ -424,10 +419,10 @@ static PlaintextTransportStatus_t prvConnectToServerWithBackoffRetries( NetworkC
      */
     do
     {
-        /* Establish a TCP connection with the MQTT broker. This example connects
-         * to the MQTT broker as specified in BROKER_ENDPOINT and BROKER_PORT
-         * at the demo config header. */
-        LogInfo( ( "Creating a TCP connection to %s:%d.",
+        /* Establish a TCP connection with the MQTT broker. This example connects to
+         * the MQTT broker as specified in democonfigMQTT_BROKER_ENDPOINT and
+         * democonfigMQTT_BROKER_PORT at the top of this file. */
+        LogInfo( ( "Create a TCP connection to %s:%d.",
                    democonfigMQTT_BROKER_ENDPOINT,
                    democonfigMQTT_BROKER_PORT ) );
         xNetworkStatus = Plaintext_FreeRTOS_Connect( pNetworkContext,

--- a/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_plain_text/WIN32.vcxproj
+++ b/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_plain_text/WIN32.vcxproj
@@ -159,6 +159,7 @@
     <ClCompile Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\portable\NetworkInterface\WinPCap\NetworkInterface.c" />
     <ClCompile Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\platform\freertos\transport\src\freertos_sockets_wrapper.c" />
     <ClCompile Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\platform\freertos\transport\src\plaintext_freertos.c" />
+    <ClCompile Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\platform\freertos\retry_utils\retry_utils_freertos.c" />
     <ClCompile Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\standard\mqtt\src\mqtt_lightweight.c" />
     <ClCompile Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\standard\mqtt\src\mqtt_state.c" />
     <ClCompile Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\standard\mqtt\src\mqtt.c" />
@@ -193,6 +194,7 @@
     <ClInclude Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\platform\freertos\transport\include\freertos_sockets_wrapper.h" />
     <ClInclude Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\platform\freertos\transport\include\plaintext_freertos.h" />
     <ClInclude Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\platform\include\transport_interface.h" />
+    <ClInclude Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\platform\include\retry_utils.h" />
     <ClInclude Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\standard\mqtt\include\mqtt_lightweight.h" />
     <ClInclude Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\standard\mqtt\include\mqtt_state.h" />
     <ClInclude Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\standard\mqtt\include\mqtt.h" />

--- a/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_plain_text/WIN32.vcxproj.filters
+++ b/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_plain_text/WIN32.vcxproj.filters
@@ -126,6 +126,9 @@
     <ClCompile Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\platform\freertos\transport\src\freertos_sockets_wrapper.c">
       <Filter>FreeRTOS+\FreeRTOS IoT Libraries\platform</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\platform\freertos\retry_utils\retry_utils_freertos.c">
+      <Filter>FreeRTOS+\FreeRTOS IoT Libraries\platform</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\include\NetworkInterface.h">
@@ -214,6 +217,9 @@
       <Filter>FreeRTOS+\FreeRTOS IoT Libraries\platform</Filter>
     </ClInclude>
     <ClInclude Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\platform\include\transport_interface.h">
+      <Filter>FreeRTOS+\FreeRTOS IoT Libraries\platform</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\platform\include\retry_utils.h">
       <Filter>FreeRTOS+\FreeRTOS IoT Libraries\platform</Filter>
     </ClInclude>
     <ClInclude Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\platform\freertos\transport\include\freertos_sockets_wrapper.h">

--- a/FreeRTOS-Plus/Source/FreeRTOS-IoT-Libraries-LTS-Beta2/c_sdk/platform/freertos/retry_utils/retry_utils_freertos.c
+++ b/FreeRTOS-Plus/Source/FreeRTOS-IoT-Libraries-LTS-Beta2/c_sdk/platform/freertos/retry_utils/retry_utils_freertos.c
@@ -44,9 +44,9 @@ RetryUtilsStatus_t RetryUtils_BackoffAndSleep( RetryUtilsParams_t * pRetryParams
     RetryUtilsStatus_t status = RetryUtilsRetriesExhausted;
     int32_t backOffDelayMs = 0;
 
-    /* If MAX_RETRY_ATTEMPTS is set to 0, try forever. */
-    if( ( pRetryParams->attemptsDone < MAX_RETRY_ATTEMPTS ) ||
-        ( 0 == MAX_RETRY_ATTEMPTS ) )
+    /* If pRetryParams->maxRetryAttempts is set to 0, try forever. */
+    if( ( pRetryParams->attemptsDone < pRetryParams->maxRetryAttempts ) ||
+        ( 0 == pRetryParams->maxRetryAttempts ) )
     {
         /* Choose a random value for back-off time between 0 and the max jitter value. */
         backOffDelayMs = uxRand() % pRetryParams->nextJitterMax;

--- a/FreeRTOS-Plus/Source/FreeRTOS-IoT-Libraries-LTS-Beta2/c_sdk/platform/freertos/retry_utils/retry_utils_freertos.c
+++ b/FreeRTOS-Plus/Source/FreeRTOS-IoT-Libraries-LTS-Beta2/c_sdk/platform/freertos/retry_utils/retry_utils_freertos.c
@@ -27,26 +27,32 @@
 /* Standard includes. */
 #include <stdint.h>
 
+/* Kernel includes. */
+#include "FreeRTOS.h"
+#include "task.h"
+
 #include "retry_utils.h"
 
 #define _MILLISECONDS_PER_SECOND                    ( 1000U )                                         /**< @brief Milliseconds per second. */
+
+extern UBaseType_t uxRand(void);
 
 /*-----------------------------------------------------------*/
 
 RetryUtilsStatus_t RetryUtils_BackoffAndSleep( RetryUtilsParams_t * pRetryParams )
 {
     RetryUtilsStatus_t status = RetryUtilsRetriesExhausted;
-    int32_t backOffDelay = 0;
+    int32_t backOffDelayMs = 0;
 
     /* If MAX_RETRY_ATTEMPTS is set to 0, try forever. */
     if( ( pRetryParams->attemptsDone < MAX_RETRY_ATTEMPTS ) ||
         ( 0 == MAX_RETRY_ATTEMPTS ) )
     {
         /* Choose a random value for back-off time between 0 and the max jitter value. */
-        backOffDelay = uxRand() % pRetryParams->nextJitterMax;
+        backOffDelayMs = uxRand() % pRetryParams->nextJitterMax;
 
         /*  Wait for backoff time to expire for the next retry. */
-        vTaskDelay(pdMS_TO_TICKS(backOffDelay * _MILLISECONDS_PER_SECOND));
+        vTaskDelay(pdMS_TO_TICKS(backOffDelayMs * _MILLISECONDS_PER_SECOND));
 
         /* Increment backoff counts. */
         pRetryParams->attemptsDone++;

--- a/FreeRTOS-Plus/Source/FreeRTOS-IoT-Libraries-LTS-Beta2/c_sdk/platform/freertos/retry_utils/retry_utils_freertos.c
+++ b/FreeRTOS-Plus/Source/FreeRTOS-IoT-Libraries-LTS-Beta2/c_sdk/platform/freertos/retry_utils/retry_utils_freertos.c
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * @file retry_utils_freertos.c
+ * @brief Utility implementation of backoff logic, used for attempting retries of failed processes.
+ */
+
+/* Standard includes. */
+#include <stdint.h>
+
+#include "retry_utils.h"
+
+#define _MILLISECONDS_PER_SECOND                    ( 1000U )                                         /**< @brief Milliseconds per second. */
+
+/*-----------------------------------------------------------*/
+
+RetryUtilsStatus_t RetryUtils_BackoffAndSleep( RetryUtilsParams_t * pRetryParams )
+{
+    RetryUtilsStatus_t status = RetryUtilsRetriesExhausted;
+    int32_t backOffDelay = 0;
+
+    /* If MAX_RETRY_ATTEMPTS is set to 0, try forever. */
+    if( ( pRetryParams->attemptsDone < MAX_RETRY_ATTEMPTS ) ||
+        ( 0 == MAX_RETRY_ATTEMPTS ) )
+    {
+        /* Choose a random value for back-off time between 0 and the max jitter value. */
+        backOffDelay = uxRand() % pRetryParams->nextJitterMax;
+
+        /*  Wait for backoff time to expire for the next retry. */
+        vTaskDelay(pdMS_TO_TICKS(backOffDelay * _MILLISECONDS_PER_SECOND));
+
+        /* Increment backoff counts. */
+        pRetryParams->attemptsDone++;
+
+        /* Double the max jitter value for the next retry attempt, only
+         * if the new value will be less than the max backoff time value. */
+        if( pRetryParams->nextJitterMax < ( MAX_RETRY_BACKOFF_SECONDS / 2U ) )
+        {
+            pRetryParams->nextJitterMax += pRetryParams->nextJitterMax;
+        }
+        else
+        {
+            pRetryParams->nextJitterMax = MAX_RETRY_BACKOFF_SECONDS;
+        }
+
+        status = RetryUtilsSuccess;
+    }
+    else
+    {
+        /* When max retry attempts are exhausted, let application know by
+         * returning RetryUtilsRetriesExhausted. Application may choose to
+         * restart the retry process after calling RetryUtils_ParamsReset(). */
+        status = RetryUtilsRetriesExhausted;
+        RetryUtils_ParamsReset( pRetryParams );
+    }
+
+    return status;
+}
+
+/*-----------------------------------------------------------*/
+
+void RetryUtils_ParamsReset( RetryUtilsParams_t * pRetryParams )
+{
+    uint32_t jitter = 0;
+
+    /* Reset attempts done to zero so that the next retry cycle can start. */
+    pRetryParams->attemptsDone = 0;
+
+    /* Calculate jitter value using picking a random number. */
+    jitter = ( uxRand() % MAX_JITTER_VALUE_SECONDS );
+
+    /* Reset the backoff value to the initial time out value plus jitter. */
+    pRetryParams->nextJitterMax = INITIAL_RETRY_BACKOFF_SECONDS + jitter;
+}
+
+/*-----------------------------------------------------------*/

--- a/FreeRTOS-Plus/Source/FreeRTOS-IoT-Libraries-LTS-Beta2/c_sdk/platform/freertos/retry_utils/retry_utils_freertos.c
+++ b/FreeRTOS-Plus/Source/FreeRTOS-IoT-Libraries-LTS-Beta2/c_sdk/platform/freertos/retry_utils/retry_utils_freertos.c
@@ -44,9 +44,9 @@ RetryUtilsStatus_t RetryUtils_BackoffAndSleep( RetryUtilsParams_t * pRetryParams
     RetryUtilsStatus_t status = RetryUtilsRetriesExhausted;
     int32_t backOffDelayMs = 0;
 
-    /* If pRetryParams->maxRetryAttempts is set to 0, try forever. */
-    if( ( pRetryParams->attemptsDone < pRetryParams->maxRetryAttempts ) ||
-        ( 0 == pRetryParams->maxRetryAttempts ) )
+    /* If MAX_RETRY_ATTEMPTS is set to 0, try forever. */
+    if( ( pRetryParams->attemptsDone < MAX_RETRY_ATTEMPTS ) ||
+        ( 0 == MAX_RETRY_ATTEMPTS ) )
     {
         /* Choose a random value for back-off time between 0 and the max jitter value. */
         backOffDelayMs = uxRand() % pRetryParams->nextJitterMax;

--- a/FreeRTOS-Plus/Source/FreeRTOS-IoT-Libraries-LTS-Beta2/c_sdk/platform/freertos/retry_utils/retry_utils_freertos.c
+++ b/FreeRTOS-Plus/Source/FreeRTOS-IoT-Libraries-LTS-Beta2/c_sdk/platform/freertos/retry_utils/retry_utils_freertos.c
@@ -33,9 +33,9 @@
 
 #include "retry_utils.h"
 
-#define _MILLISECONDS_PER_SECOND                    ( 1000U )                                         /**< @brief Milliseconds per second. */
+#define _MILLISECONDS_PER_SECOND    ( 1000U )                                                         /**< @brief Milliseconds per second. */
 
-extern UBaseType_t uxRand(void);
+extern UBaseType_t uxRand( void );
 
 /*-----------------------------------------------------------*/
 
@@ -52,7 +52,7 @@ RetryUtilsStatus_t RetryUtils_BackoffAndSleep( RetryUtilsParams_t * pRetryParams
         backOffDelayMs = uxRand() % pRetryParams->nextJitterMax;
 
         /*  Wait for backoff time to expire for the next retry. */
-        vTaskDelay(pdMS_TO_TICKS(backOffDelayMs * _MILLISECONDS_PER_SECOND));
+        vTaskDelay( pdMS_TO_TICKS( backOffDelayMs * _MILLISECONDS_PER_SECOND ) );
 
         /* Increment backoff counts. */
         pRetryParams->attemptsDone++;

--- a/FreeRTOS-Plus/Source/FreeRTOS-IoT-Libraries-LTS-Beta2/c_sdk/platform/include/retry_utils.h
+++ b/FreeRTOS-Plus/Source/FreeRTOS-IoT-Libraries-LTS-Beta2/c_sdk/platform/include/retry_utils.h
@@ -1,0 +1,239 @@
+/*
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * @file retry_utils.h
+ * @brief Declaration of the exponential backoff retry logic utility functions
+ * and constants.
+ */
+
+#ifndef RETRY_UTILS_H_
+#define RETRY_UTILS_H_
+
+/* Standard include. */
+#include <stdint.h>
+
+/**
+ * @page retryutils_page Retry Utilities
+ * @brief An abstraction of utilities for retrying with exponential back off and
+ * jitter.
+ *
+ * @section retryutils_overview Overview
+ * The retry utilities are a set of APIs that aid in retrying with exponential
+ * backoff and jitter. Exponential backoff with jitter is strongly recommended
+ * for retrying failed actions over the network with servers. Please see
+ * https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/ for
+ * more information about the benefits with AWS.
+ *
+ * Exponential backoff with jitter is typically used when retrying a failed
+ * connection to the server. In an environment with poor connectivity, a client
+ * can get disconnected at any time. A backoff strategy helps the client to
+ * conserve battery by not repeatedly attempting reconnections when they are
+ * unlikely to succeed.
+ *
+ * Before retrying the failed communication to the server there is a quiet period.
+ * In this quiet period, the task that is retrying must sleep for some random
+ * amount of seconds between 0 and the lesser of a base value and a predefined
+ * maximum. The base is doubled with each retry attempt until the maximum is
+ * reached.<br>
+ *
+ * > sleep_seconds = random_between( 0, min( 2<sup>attempts_count</sup> * base_seconds, maximum_seconds ) )
+ *
+ * @section retryutils_implementation Implementing Retry Utils
+ *
+ * The functions that must be implemented are:<br>
+ * - @ref RetryUtils_ParamsReset
+ * - @ref RetryUtils_BackoffAndSleep
+ *
+ * The functions are used as shown in the diagram below. This is the exponential
+ * backoff with jitter loop:
+ *
+ * @image html retry_utils_flow.png width=25%
+ *
+ * The following steps give guidance on implementing the Retry Utils. An example
+ * implementation of the Retry Utils for a POSIX platform can be found in file
+ * @ref retry_utils_posix.c.
+ *
+ * -# Implementing @ref RetryUtils_ParamsReset
+ * @snippet this define_retryutils_paramsreset
+ *<br>
+ * This function initializes @ref RetryUtilsParams_t. It is expected to set
+ * @ref RetryUtilsParams_t.attemptsDone to zero. It is also expected to set
+ * @ref RetryUtilsParams_t.nextJitterMax to @ref INITIAL_RETRY_BACKOFF_SECONDS
+ * plus some random amount of seconds, jitter. This jitter is a random number
+ * between 0 and @ref MAX_JITTER_VALUE_SECONDS. This function must be called
+ * before entering the exponential backoff with jitter loop using
+ * @ref RetryUtils_BackoffAndSleep.<br><br>
+ * Please follow the example below to implement your own @ref RetryUtils_ParamsReset.
+ * The lines with FIXME comments should be updated.
+ * @code{c}
+ * void RetryUtils_ParamsReset( RetryUtilsParams_t * pRetryParams )
+ * {
+ *     uint32_t jitter = 0;
+ *
+ *     // Reset attempts done to zero so that the next retry cycle can start.
+ *     pRetryParams->attemptsDone = 0;
+ *
+ *     // Seed pseudo random number generator with the current time. FIXME: Your
+ *     // system may have another method to retrieve the current time to seed the
+ *     // pseudo random number generator.
+ *     srand( time( NULL ) );
+ *
+ *     // Calculate jitter value using picking a random number.
+ *     jitter = ( rand() % MAX_JITTER_VALUE_SECONDS );
+ *
+ *     // Reset the backoff value to the initial time out value plus jitter.
+ *     pRetryParams->nextJitterMax = INITIAL_RETRY_BACKOFF_SECONDS + jitter;
+ * }
+ * @endcode<br>
+ *
+ * -# Implementing @ref RetryUtils_BackoffAndSleep
+ * @snippet this define_retryutils_backoffandsleep
+ * <br>
+ * When this function is invoked, the calling task is expected to sleep a random
+ * number of seconds between 0 and @ref RetryUtilsParams_t.nextJitterMax. After
+ * sleeping this function must double @ref RetryUtilsParams_t.nextJitterMax, but
+ * not exceeding @ref MAX_RETRY_BACKOFF_SECONDS. When @ref MAX_RETRY_ATTEMPTS are
+ * reached this function should return @ref RetryUtilsRetriesExhausted, unless
+ * @ref MAX_RETRY_ATTEMPTS is set to zero.
+ * When @ref RetryUtilsRetriesExhausted is returned the calling application can
+ * stop trying with a failure, or it can call @ref RetryUtils_ParamsReset again
+ * and restart the exponential back off with jitter loop.<br><br>
+ * Please follow the example below to implement your own @ref RetryUtils_BackoffAndSleep.
+ * The lines with FIXME comments should be updated.
+ * @code{c}
+ * RetryUtilsStatus_t RetryUtils_BackoffAndSleep( RetryUtilsParams_t * pRetryParams )
+ * {
+ *     RetryUtilsStatus_t status = RetryUtilsRetriesExhausted;
+ *     // The quiet period delay in seconds.
+ *     int backOffDelay = 0;
+ *
+ *     // If MAX_RETRY_ATTEMPTS is set to 0, try forever.
+ *     if( ( pRetryParams->attemptsDone < MAX_RETRY_ATTEMPTS ) ||
+ *         ( 0 == MAX_RETRY_ATTEMPTS ) )
+ *     {
+ *         // Choose a random value for back-off time between 0 and the max jitter value.
+ *         backOffDelay = rand() % pRetryParams->nextJitterMax;
+ *
+ *         //  Wait for backoff time to expire for the next retry.
+ *         ( void ) myThreadSleepFunction( backOffDelay ); // FIXME: Replace with your system's thread sleep function.
+ *
+ *         // Increment backoff counts.
+ *         pRetryParams->attemptsDone++;
+ *
+ *         // Double the max jitter value for the next retry attempt, only
+ *         // if the new value will be less than the max backoff time value.
+ *         if( pRetryParams->nextJitterMax < ( MAX_RETRY_BACKOFF_SECONDS / 2U ) )
+ *         {
+ *             pRetryParams->nextJitterMax += pRetryParams->nextJitterMax;
+ *         }
+ *         else
+ *         {
+ *             pRetryParams->nextJitterMax = MAX_RETRY_BACKOFF_SECONDS;
+ *         }
+ *
+ *         status = RetryUtilsSuccess;
+ *     }
+ *     else
+ *     {
+ *         // When max retry attempts are exhausted, let application know by
+ *         // returning RetryUtilsRetriesExhausted. Application may choose to
+ *         // restart the retry process after calling RetryUtils_ParamsReset().
+ *         status = RetryUtilsRetriesExhausted;
+ *         RetryUtils_ParamsReset( pRetryParams );
+ *     }
+ *
+ *     return status;
+ * }
+ * @endcode
+ */
+
+/**
+ * @brief Max number of retry attempts. Set this value to 0 if the client must
+ * retry forever.
+ */
+#define MAX_RETRY_ATTEMPTS               4U
+
+/**
+ * @brief Initial fixed backoff value in seconds between two successive
+ * retries. A random jitter value is added to every backoff value.
+ */
+#define INITIAL_RETRY_BACKOFF_SECONDS    1U
+
+/**
+ * @brief Max backoff value in seconds.
+ */
+#define MAX_RETRY_BACKOFF_SECONDS        128U
+
+/**
+ * @brief Max jitter value in seconds.
+ */
+#define MAX_JITTER_VALUE_SECONDS         5U
+
+/**
+ * @brief Status for @ref RetryUtils_BackoffAndSleep.
+ */
+typedef enum RetryUtilsStatus
+{
+    RetryUtilsSuccess = 0,     /**< @brief The function returned successfully after sleeping. */
+    RetryUtilsRetriesExhausted /**< @brief The function exhausted all retry attempts. */
+} RetryUtilsStatus_t;
+
+/**
+ * @brief Represents parameters required for retry logic.
+ */
+typedef struct RetryUtilsParams
+{
+    /**
+     * @brief The cumulative count of backoff delay cycles completed
+     * for retries.
+     */
+    uint32_t attemptsDone;
+
+    /**
+     * @brief The max jitter value for backoff time in retry attempt.
+     */
+    uint32_t nextJitterMax;
+} RetryUtilsParams_t;
+
+
+/**
+ * @brief Resets the retry timeout value and number of attempts.
+ * This function must be called by the application before a new retry attempt.
+ *
+ * @param[in, out] pRetryParams Structure containing attempts done and timeout
+ * value.
+ */
+void RetryUtils_ParamsReset( RetryUtilsParams_t * pRetryParams );
+
+/**
+ * @brief Simple platform specific exponential backoff function. The application
+ * must use this function between retry failures to add exponential delay.
+ * This function will block the calling task for the current timeout value.
+ *
+ * @param[in, out] pRetryParams Structure containing retry parameters.
+ *
+ * @return #RetryUtilsSuccess after a successful sleep, #RetryUtilsRetriesExhausted
+ * when all attempts are exhausted.
+ */
+RetryUtilsStatus_t RetryUtils_BackoffAndSleep( RetryUtilsParams_t * pRetryParams );
+
+#endif /* ifndef RETRY_UTILS_H_ */

--- a/FreeRTOS-Plus/Source/FreeRTOS-IoT-Libraries-LTS-Beta2/c_sdk/platform/include/retry_utils.h
+++ b/FreeRTOS-Plus/Source/FreeRTOS-IoT-Libraries-LTS-Beta2/c_sdk/platform/include/retry_utils.h
@@ -111,9 +111,9 @@
  * When this function is invoked, the calling task is expected to sleep a random
  * number of seconds between 0 and @ref RetryUtilsParams_t.nextJitterMax. After
  * sleeping this function must double @ref RetryUtilsParams_t.nextJitterMax, but
- * not exceeding @ref MAX_RETRY_BACKOFF_SECONDS. When @ref RetryUtilsParams_t.maxRetryAttempts
- * are reached this function should return @ref RetryUtilsRetriesExhausted, unless
- * @ref RetryUtilsParams_t.maxRetryAttempts is set to zero.
+ * not exceeding @ref MAX_RETRY_BACKOFF_SECONDS. When @ref MAX_RETRY_ATTEMPTS are
+ * reached this function should return @ref RetryUtilsRetriesExhausted, unless
+ * @ref MAX_RETRY_ATTEMPTS is set to zero.
  * When @ref RetryUtilsRetriesExhausted is returned the calling application can
  * stop trying with a failure, or it can call @ref RetryUtils_ParamsReset again
  * and restart the exponential back off with jitter loop.<br><br>
@@ -126,9 +126,9 @@
  *     // The quiet period delay in seconds.
  *     int backOffDelay = 0;
  *
- *     // If pRetryParams->maxRetryAttempts is set to 0, try forever.
- *     if( ( pRetryParams->attemptsDone < pRetryParams->maxRetryAttempts ) ||
- *         ( 0 == pRetryParams->maxRetryAttempts ) )
+ *     // If MAX_RETRY_ATTEMPTS is set to 0, try forever.
+ *     if( ( pRetryParams->attemptsDone < MAX_RETRY_ATTEMPTS ) ||
+ *         ( 0 == MAX_RETRY_ATTEMPTS ) )
  *     {
  *         // Choose a random value for back-off time between 0 and the max jitter value.
  *         backOffDelay = rand() % pRetryParams->nextJitterMax;
@@ -202,12 +202,6 @@ typedef enum RetryUtilsStatus
  */
 typedef struct RetryUtilsParams
 {
-    /**
-     * @brief Max number of retry attempts. Set this value to 0 if the client must
-     * retry forever.
-     */
-    uint32_t maxRetryAttempts;
-
     /**
      * @brief The cumulative count of backoff delay cycles completed
      * for retries.

--- a/FreeRTOS-Plus/Source/FreeRTOS-IoT-Libraries-LTS-Beta2/c_sdk/platform/include/retry_utils.h
+++ b/FreeRTOS-Plus/Source/FreeRTOS-IoT-Libraries-LTS-Beta2/c_sdk/platform/include/retry_utils.h
@@ -111,9 +111,9 @@
  * When this function is invoked, the calling task is expected to sleep a random
  * number of seconds between 0 and @ref RetryUtilsParams_t.nextJitterMax. After
  * sleeping this function must double @ref RetryUtilsParams_t.nextJitterMax, but
- * not exceeding @ref MAX_RETRY_BACKOFF_SECONDS. When @ref MAX_RETRY_ATTEMPTS are
- * reached this function should return @ref RetryUtilsRetriesExhausted, unless
- * @ref MAX_RETRY_ATTEMPTS is set to zero.
+ * not exceeding @ref MAX_RETRY_BACKOFF_SECONDS. When @ref RetryUtilsParams_t.maxRetryAttempts
+ * are reached this function should return @ref RetryUtilsRetriesExhausted, unless
+ * @ref RetryUtilsParams_t.maxRetryAttempts is set to zero.
  * When @ref RetryUtilsRetriesExhausted is returned the calling application can
  * stop trying with a failure, or it can call @ref RetryUtils_ParamsReset again
  * and restart the exponential back off with jitter loop.<br><br>
@@ -126,9 +126,9 @@
  *     // The quiet period delay in seconds.
  *     int backOffDelay = 0;
  *
- *     // If MAX_RETRY_ATTEMPTS is set to 0, try forever.
- *     if( ( pRetryParams->attemptsDone < MAX_RETRY_ATTEMPTS ) ||
- *         ( 0 == MAX_RETRY_ATTEMPTS ) )
+ *     // If pRetryParams->maxRetryAttempts is set to 0, try forever.
+ *     if( ( pRetryParams->attemptsDone < pRetryParams->maxRetryAttempts ) ||
+ *         ( 0 == pRetryParams->maxRetryAttempts ) )
  *     {
  *         // Choose a random value for back-off time between 0 and the max jitter value.
  *         backOffDelay = rand() % pRetryParams->nextJitterMax;
@@ -202,6 +202,12 @@ typedef enum RetryUtilsStatus
  */
 typedef struct RetryUtilsParams
 {
+    /**
+     * @brief Max number of retry attempts. Set this value to 0 if the client must
+     * retry forever.
+     */
+    uint32_t maxRetryAttempts;
+
     /**
      * @brief The cumulative count of backoff delay cycles completed
      * for retries.


### PR DESCRIPTION
<!--- Title -->
**Reconnection logic for the MQTT plaintext demo**

Description
-----------
<!--- Describe your changes in detail. -->
This implements retries for FreeRTOS IoT Beta2 libraries, initializing the backoff to some value returned by the PRNG: `uxRand()`. If an attempt (connect or subscribe) fails, `vTaskDelay` is called to make the task sleep for some backoff period that doubles on each retry (but is bounded).

Test Steps
-----------
<!-- Describe the steps to reproduce. -->
Just run the demo as you normally would.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
