### PR TITLE
Add reconnection and resubscribe logic to the MQTT lightweight, keep alive, and mutual auth demo

### DIFF
--- a/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_keep_alive/DemoTasks/KeepAliveMQTTExample.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_keep_alive/DemoTasks/KeepAliveMQTTExample.c
@@ -641,9 +641,10 @@ static void prvUpdateSubAckStatus( MQTTPacketInfo_t * pxPacketInfo )
      * from the event callback and non-NULL parameters. */
     configASSERT( xResult == MQTTSuccess );
 
-    for( ulTopicCount = 0; ulTopicCount < mqttexampleTOPIC_COUNT; ulTopicCount++ )
+    for( ulTopicCount = 0; ulTopicCount < ulSize; ulTopicCount++ )
     {
-        xTopicFilterContext[ ulTopicCount ].xSubAckStatus = pucPayload[ ulTopicCount ];
+        /* Multiply the index by 2 because the status code consists of two bytes. */
+        xTopicFilterContext[ ulTopicCount ].xSubAckStatus = pucPayload[ ulTopicCount * 2 ];
     }
 }
 /*-----------------------------------------------------------*/
@@ -654,7 +655,7 @@ static void prvMQTTSubscribeWithBackoffRetries( MQTTContext_t * pxMQTTContext )
     RetryUtilsStatus_t xRetryUtilsStatus = RetryUtilsSuccess;
     RetryUtilsParams_t xRetryParams;
     MQTTSubscribeInfo_t xMQTTSubscription[ mqttexampleTOPIC_COUNT ];
-    bool xFailedSubscribeToTopic = true;
+    bool xFailedSubscribeToTopic = false;
     uint32_t ulTopicCount = 0U;
 
     /* Some fields not used by this demo so start with everything at 0. */
@@ -716,9 +717,6 @@ static void prvMQTTSubscribeWithBackoffRetries( MQTTContext_t * pxMQTTContext )
                 break;
             }
         }
-
-        /* The broker has successfully acknowledged subscriptions to all topic filters. */
-        xFailedSubscribeToTopic = false;
 
         configASSERT( xRetryUtilsStatus != RetryUtilsRetriesExhausted );
     } while( ( xFailedSubscribeToTopic == true ) && ( xRetryUtilsStatus == RetryUtilsSuccess ) );

--- a/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_keep_alive/DemoTasks/KeepAliveMQTTExample.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_keep_alive/DemoTasks/KeepAliveMQTTExample.c
@@ -209,8 +209,8 @@ static void prvCreateMQTTConnectionWithBroker( MQTTContext_t * pxMQTTContext,
 
 /**
  * @brief Function to update variable globalSubAckStatus with status
- * information from Subscribe ACK. Called bythe event callback after processing
- * an incoming SUBSCRIBE packet.
+ * information from Subscribe ACK. Called by the event callback after processing
+ * an incoming SUBACK packet.
  *
  * @param Server response to the subscription request.
  */
@@ -682,7 +682,7 @@ static void prvMQTTSubscribeWithBackoffRetries( MQTTContext_t * pxMQTTContext )
         configASSERT( xResult == MQTTSuccess );
 
         /* Check if recent subscription request has been rejected. #xGlobalSubAckStatus is updated
-         * inthe event callback to reflect the status of the SUBACK sent by the broker. It represents
+         * in the event callback to reflect the status of the SUBACK sent by the broker. It represents
          * either the QoS level granted by the server upon subscription, or acknowledgement of
          * server rejection of the subscription request. */
         if( xGlobalSubAckStatus == MQTTSubAckFailure )

--- a/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_keep_alive/DemoTasks/KeepAliveMQTTExample.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_keep_alive/DemoTasks/KeepAliveMQTTExample.c
@@ -415,7 +415,6 @@ static void prvMQTTDemoTask( void * pvParameters )
     MQTTStatus_t xMQTTStatus;
     PlaintextTransportStatus_t xNetworkStatus;
     BaseType_t xTimerStatus;
-    BaseType_t xNetworkStatus;
 
     /* Remove compiler warnings about unused parameters. */
     ( void ) pvParameters;
@@ -680,7 +679,7 @@ static void prvMQTTSubscribeWithBackoffRetries( MQTTContext_t * pxMQTTContext )
          * receiving Publish message before subscribe ack is zero; but application
          * must be ready to receive any packet.  This demo uses the generic packet
          * processing function everywhere to highlight this fact. */
-        xResult = MQTT_ProcessLoop( pxMQTTContext, mqttexamplePROCESS_LOOP_TIMEOUT_MS );
+        xResult = MQTT_ProcessLoop( pxMQTTContext, mqttexampleRECEIVE_LOOP_TIMEOUT_MS );
         configASSERT( xResult == MQTTSuccess );
 
         /* Check if recent subscription request has been rejected. #xGlobalSubAckStatus is updated

--- a/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_keep_alive/DemoTasks/KeepAliveMQTTExample.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_keep_alive/DemoTasks/KeepAliveMQTTExample.c
@@ -22,7 +22,6 @@
  * http://www.FreeRTOS.org
  * http://aws.amazon.com/freertos
  *
- * 1 tab == 4 spaces!
  */
 
 /*
@@ -101,7 +100,7 @@
 /**
  * @brief Timeout for receiving CONNACK packet in milliseconds.
  */
-#define mqttexampleCONNACK_RECV_TIMEOUT_MS          ( 1000U )
+#define mqttexampleCONNACK_RECV_TIMEOUT_MS           ( 1000U )
 
 /**
  * @brief The topic to subscribe and publish to in the example.
@@ -109,28 +108,28 @@
  * The topic name starts with the client identifier to ensure that each demo
  * interacts with a unique topic name.
  */
-#define mqttexampleTOPIC                            democonfigCLIENT_IDENTIFIER "/example/topic"
+#define mqttexampleTOPIC                             democonfigCLIENT_IDENTIFIER "/example/topic"
 
 /**
  * @brief The MQTT message published in this example.
  */
-#define mqttexampleMESSAGE                          "Hello World!"
+#define mqttexampleMESSAGE                           "Hello World!"
 
 /**
  * @brief Dimensions a file scope buffer currently used to send and receive MQTT data
  * from a socket.
  */
-#define mqttexampleSHARED_BUFFER_SIZE               ( 500U )
+#define mqttexampleSHARED_BUFFER_SIZE                ( 500U )
 
 /**
  * @brief Time to wait between each cycle of the demo implemented by prvMQTTDemoTask().
  */
-#define mqttexampleDELAY_BETWEEN_DEMO_ITERATIONS    ( pdMS_TO_TICKS( 5000U ) )
+#define mqttexampleDELAY_BETWEEN_DEMO_ITERATIONS     ( pdMS_TO_TICKS( 5000U ) )
 
 /**
  * @brief Timeout for MQTT_ReceiveLoop in milliseconds.
  */
-#define mqttexampleRECEIVE_LOOP_TIMEOUT_MS          ( 500U )
+#define mqttexampleRECEIVE_LOOP_TIMEOUT_MS           ( 500U )
 
 /**
  * @brief Keep alive time reported to the broker while establishing an MQTT connection.
@@ -140,7 +139,7 @@
  * absence of sending any other Control Packets, the Client MUST send a
  * PINGREQ Packet.
  */
-#define mqttexampleKEEP_ALIVE_TIMEOUT_SECONDS       ( 60U )
+#define mqttexampleKEEP_ALIVE_TIMEOUT_SECONDS        ( 60U )
 
 /**
  * @brief Time to wait before sending ping request to keep MQTT connection alive.
@@ -149,19 +148,19 @@
  * seconds. This is to make sure that a PINGREQ is always sent before the timeout
  * expires in broker.
  */
-#define mqttexampleKEEP_ALIVE_DELAY                 ( pdMS_TO_TICKS( ( ( mqttexampleKEEP_ALIVE_TIMEOUT_SECONDS / 4 ) * 1000 ) ) )
+#define mqttexampleKEEP_ALIVE_DELAY                  ( pdMS_TO_TICKS( ( ( mqttexampleKEEP_ALIVE_TIMEOUT_SECONDS / 4 ) * 1000 ) ) )
 
 /**
  * @brief Delay between MQTT publishes. Note that the receive loop also has a
  * timeout, so the total time between publishes is the sum of the two delays. The
  * keep-alive delay is added here so the keep-alive timer callback executes.
  */
-#define mqttexampleDELAY_BETWEEN_PUBLISHES          ( mqttexampleKEEP_ALIVE_DELAY + pdMS_TO_TICKS( 500U ) )
+#define mqttexampleDELAY_BETWEEN_PUBLISHES           ( mqttexampleKEEP_ALIVE_DELAY + pdMS_TO_TICKS( 500U ) )
 
 /**
  * @brief Transport timeout in milliseconds for transport send and receive.
  */
-#define TRANSPORT_SEND_RECV_TIMEOUT_MS              ( 200U )
+#define mqttexampleTRANSPORT_SEND_RECV_TIMEOUT_MS    ( 200U )
 
 /*-----------------------------------------------------------*/
 
@@ -210,8 +209,8 @@ static void prvCreateMQTTConnectionWithBroker( MQTTContext_t * pxMQTTContext,
 
 /**
  * @brief Function to update variable globalSubAckStatus with status
- * information from Subscribe ACK. Called by eventCallback after processing
- * incoming subscribe echo.
+ * information from Subscribe ACK. Called bythe event callback after processing
+ * an incoming SUBSCRIBE packet.
  *
  * @param Server response to the subscription request.
  */
@@ -542,8 +541,8 @@ static PlaintextTransportStatus_t prvConnectToServerWithBackoffRetries( NetworkC
         xNetworkStatus = Plaintext_FreeRTOS_Connect( pxNetworkContext,
                                                      democonfigMQTT_BROKER_ENDPOINT,
                                                      democonfigMQTT_BROKER_PORT,
-                                                     TRANSPORT_SEND_RECV_TIMEOUT_MS,
-                                                     TRANSPORT_SEND_RECV_TIMEOUT_MS );
+                                                     mqttexampleTRANSPORT_SEND_RECV_TIMEOUT_MS,
+                                                     mqttexampleTRANSPORT_SEND_RECV_TIMEOUT_MS );
 
         if( xNetworkStatus != PLAINTEXT_TRANSPORT_SUCCESS )
         {
@@ -651,8 +650,8 @@ static void prvMQTTSubscribeWithBackoffRetries( MQTTContext_t * pxMQTTContext )
     xGlobalSubscribeInfo.topicFilterLength = ( uint16_t ) strlen( mqttexampleTOPIC );
 
     /* Initialize retry attempts and interval. */
-    xRetryParams.maxRetryAttempts = MAX_RETRY_ATTEMPTS;
     RetryUtils_ParamsReset( &xRetryParams );
+    xRetryParams.maxRetryAttempts = MAX_RETRY_ATTEMPTS;
 
     do
     {
@@ -683,7 +682,7 @@ static void prvMQTTSubscribeWithBackoffRetries( MQTTContext_t * pxMQTTContext )
         configASSERT( xResult == MQTTSuccess );
 
         /* Check if recent subscription request has been rejected. #xGlobalSubAckStatus is updated
-         * in eventCallback to reflect the status of the SUBACK sent by the broker. It represents
+         * inthe event callback to reflect the status of the SUBACK sent by the broker. It represents
          * either the QoS level granted by the server upon subscription, or acknowledgement of
          * server rejection of the subscription request. */
         if( xGlobalSubAckStatus == MQTTSubAckFailure )

--- a/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_keep_alive/DemoTasks/KeepAliveMQTTExample.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_keep_alive/DemoTasks/KeepAliveMQTTExample.c
@@ -517,7 +517,7 @@ static void prvMQTTDemoTask( void * pvParameters )
 }
 /*-----------------------------------------------------------*/
 
-static PlaintextTransportStatus_t prvConnectToServerWithBackoffRetries( NetworkContext_t * pNetworkContext )
+static PlaintextTransportStatus_t prvConnectToServerWithBackoffRetries( NetworkContext_t * pxNetworkContext )
 {
     PlaintextTransportStatus_t xNetworkStatus;
     RetryUtilsStatus_t xRetryUtilsStatus = RetryUtilsSuccess;
@@ -539,7 +539,7 @@ static PlaintextTransportStatus_t prvConnectToServerWithBackoffRetries( NetworkC
         LogInfo( ( "Create a TCP connection to %s:%d.",
                    democonfigMQTT_BROKER_ENDPOINT,
                    democonfigMQTT_BROKER_PORT ) );
-        xNetworkStatus = Plaintext_FreeRTOS_Connect( pNetworkContext,
+        xNetworkStatus = Plaintext_FreeRTOS_Connect( pxNetworkContext,
                                                      democonfigMQTT_BROKER_ENDPOINT,
                                                      democonfigMQTT_BROKER_PORT,
                                                      TRANSPORT_SEND_RECV_TIMEOUT_MS,

--- a/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_keep_alive/DemoTasks/KeepAliveMQTTExample.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_keep_alive/DemoTasks/KeepAliveMQTTExample.c
@@ -514,7 +514,7 @@ static void prvMQTTDemoTask( void * pvParameters )
         xNetworkStatus = Plaintext_FreeRTOS_Disconnect( &xNetworkContext );
         configASSERT( xNetworkStatus == PLAINTEXT_TRANSPORT_SUCCESS );
 
-        /* Reset SUBACK status for each topic iflter after completion of subscription request cycle. */
+        /* Reset SUBACK status for each topic filter after completion of subscription request cycle. */
         for( ulTopicCount = 0; ulTopicCount < mqttexampleTOPIC_COUNT; ulTopicCount++ )
         {
             xTopicFilterContext[ ulTopicCount ].xSubAckStatus = MQTTSubAckFailure;
@@ -643,7 +643,6 @@ static void prvUpdateSubAckStatus( MQTTPacketInfo_t * pxPacketInfo )
 
     for( ulTopicCount = 0; ulTopicCount < ulSize; ulTopicCount++ )
     {
-        /* Multiply the index by 2 because the status code consists of two bytes. */
         xTopicFilterContext[ ulTopicCount ].xSubAckStatus = pucPayload[ ulTopicCount ];
     }
 }

--- a/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_keep_alive/DemoTasks/KeepAliveMQTTExample.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_keep_alive/DemoTasks/KeepAliveMQTTExample.c
@@ -111,6 +111,11 @@
 #define mqttexampleTOPIC                             democonfigCLIENT_IDENTIFIER "/example/topic"
 
 /**
+ * @brief The number of topic filters to subscribe.
+ */
+#define mqttexampleTOPIC_COUNT                       ( 1 )
+
+/**
  * @brief The MQTT message published in this example.
  */
 #define mqttexampleMESSAGE                           "Hello World!"
@@ -334,10 +339,22 @@ static uint16_t usSubscribePacketIdentifier;
 static uint16_t usUnsubscribePacketIdentifier;
 
 /**
- * @brief Status of latest Subscribe ACK;
- * it is updated every time the callback function processes a Subscribe ACK.
+ * @brief A pair containing a topic filter and its SUBACK status.
  */
-static MQTTSubAckStatus_t xGlobalSubAckStatus[ 1 ] = { MQTTSubAckFailure };
+typedef struct topicFilterContext
+{
+    const char * pcTopicFilter;
+    MQTTSubAckStatus_t xSubAckStatus;
+} topicFilterContext_t;
+
+/**
+ * @brief An array containing the context of a SUBACK; the SUBACK status
+ * of a filter is updated when the event callback processes a SUBACK.
+ */
+static topicFilterContext_t xTopicFilterContext[ mqttexampleTOPIC_COUNT ] =
+{
+    { mqttexampleTOPIC, MQTTSubAckFailure }
+};
 
 /**
  * @brief Timer to handle the MQTT keep-alive mechanism.
@@ -401,7 +418,7 @@ void vStartSimpleMQTTDemo( void )
 
 static void prvMQTTDemoTask( void * pvParameters )
 {
-    uint32_t ulPublishCount = 0U;
+    uint32_t ulPublishCount = 0U, ulTopicCount = 0U;
     const uint32_t ulMaxPublishCount = 5UL;
     NetworkContext_t xNetworkContext = { 0 };
     MQTTContext_t xMQTTContext;
@@ -497,8 +514,11 @@ static void prvMQTTDemoTask( void * pvParameters )
         xNetworkStatus = Plaintext_FreeRTOS_Disconnect( &xNetworkContext );
         configASSERT( xNetworkStatus == PLAINTEXT_TRANSPORT_SUCCESS );
 
-        /* Reset global SUBACK status variable after completion of subscription request cycle. */
-        xGlobalSubAckStatus[ 0 ] = MQTTSubAckFailure;
+        /* Reset SUBACK status for each topic iflter after completion of subscription request cycle. */
+        for( ulTopicCount = 0; ulTopicCount < mqttexampleTOPIC_COUNT; ulTopicCount++ )
+        {
+            xTopicFilterContext[ ulTopicCount ].xSubAckStatus = MQTTSubAckFailure;
+        }
 
         /* Wait for some time between two iterations to ensure that we do not
          * bombard the public test mosquitto broker. */
@@ -613,6 +633,7 @@ static void prvUpdateSubAckStatus( MQTTPacketInfo_t * pxPacketInfo )
     MQTTStatus_t xResult = MQTTSuccess;
     uint8_t * pucPayload = NULL;
     size_t ulSize = 0;
+    uint32_t ulTopicCount = 0U;
 
     xResult = MQTT_GetSubAckStatusCodes( pxPacketInfo, &pucPayload, &ulSize );
 
@@ -620,8 +641,10 @@ static void prvUpdateSubAckStatus( MQTTPacketInfo_t * pxPacketInfo )
      * from the event callback and non-NULL parameters. */
     configASSERT( xResult == MQTTSuccess );
 
-    /* Demo only subscribes to one topic, so only one status code is returned. */
-    xGlobalSubAckStatus[ 0 ] = pucPayload[ 0 ];
+    for( ulTopicCount = 0; ulTopicCount < mqttexampleTOPIC_COUNT; ulTopicCount++ )
+    {
+        xTopicFilterContext[ ulTopicCount ].xSubAckStatus = pucPayload[ ulTopicCount ];
+    }
 }
 /*-----------------------------------------------------------*/
 
@@ -630,7 +653,9 @@ static void prvMQTTSubscribeWithBackoffRetries( MQTTContext_t * pxMQTTContext )
     MQTTStatus_t xResult = MQTTSuccess;
     RetryUtilsStatus_t xRetryUtilsStatus = RetryUtilsSuccess;
     RetryUtilsParams_t xRetryParams;
-    MQTTSubscribeInfo_t xMQTTSubscription[ 1 ];
+    MQTTSubscribeInfo_t xMQTTSubscription[ mqttexampleTOPIC_COUNT ];
+    bool xFailedSubscribeToTopic = true;
+    uint32_t ulTopicCount = 0U;
 
     /* Some fields not used by this demo so start with everything at 0. */
     ( void ) memset( ( void * ) &xMQTTSubscription, 0x00, sizeof( xMQTTSubscription ) );
@@ -639,7 +664,7 @@ static void prvMQTTSubscribeWithBackoffRetries( MQTTContext_t * pxMQTTContext )
     usSubscribePacketIdentifier = MQTT_GetPacketId( pxMQTTContext );
 
     /* Subscribe to the mqttexampleTOPIC topic filter. This example subscribes to
-     * only one topic and uses QOS0. */
+     * only one topic and uses QoS0. */
     xMQTTSubscription[ 0 ].qos = MQTTQoS0;
     xMQTTSubscription[ 0 ].pTopicFilter = mqttexampleTOPIC;
     xMQTTSubscription[ 0 ].topicFilterLength = ( uint16_t ) strlen( mqttexampleTOPIC );
@@ -676,19 +701,27 @@ static void prvMQTTSubscribeWithBackoffRetries( MQTTContext_t * pxMQTTContext )
         xResult = MQTT_ProcessLoop( pxMQTTContext, mqttexampleRECEIVE_LOOP_TIMEOUT_MS );
         configASSERT( xResult == MQTTSuccess );
 
-        /* Check if recent subscription request has been rejected. #xGlobalSubAckStatus is updated
+        /* Check if recent subscription request has been rejected. #xTopicFilterContext is updated
          * in the event callback to reflect the status of the SUBACK sent by the broker. It represents
          * either the QoS level granted by the server upon subscription, or acknowledgement of
          * server rejection of the subscription request. */
-        if( xGlobalSubAckStatus[ 0 ] == MQTTSubAckFailure )
+        for( ulTopicCount = 0; ulTopicCount < mqttexampleTOPIC_COUNT; ulTopicCount++ )
         {
-            LogWarn( ( "Server rejected subscription request. Attempting to re-subscribe to topic %s.",
-                       mqttexampleTOPIC ) );
-            xRetryUtilsStatus = RetryUtils_BackoffAndSleep( &xRetryParams );
+            if( xTopicFilterContext[ ulTopicCount ].xSubAckStatus == MQTTSubAckFailure )
+            {
+                LogWarn( ( "Server rejected subscription request. Attempting to re-subscribe to topic %s.",
+                           xTopicFilterContext[ ulTopicCount ].pcTopicFilter ) );
+                xFailedSubscribeToTopic = true;
+                xRetryUtilsStatus = RetryUtils_BackoffAndSleep( &xRetryParams );
+                break;
+            }
         }
 
+        /* The broker has successfully acknowledged subscriptions to all topic filters. */
+        xFailedSubscribeToTopic = false;
+
         configASSERT( xRetryUtilsStatus != RetryUtilsRetriesExhausted );
-    } while( ( xGlobalSubAckStatus[ 0 ] == MQTTSubAckFailure ) && ( xRetryUtilsStatus == RetryUtilsSuccess ) );
+    } while( ( xFailedSubscribeToTopic == true ) && ( xRetryUtilsStatus == RetryUtilsSuccess ) );
 }
 /*-----------------------------------------------------------*/
 
@@ -727,7 +760,7 @@ static void prvMQTTPublishToTopic( MQTTContext_t * pxMQTTContext )
 static void prvMQTTUnsubscribeFromTopic( MQTTContext_t * pxMQTTContext )
 {
     MQTTStatus_t xResult;
-    MQTTSubscribeInfo_t xMQTTSubscription[ 1 ];
+    MQTTSubscribeInfo_t xMQTTSubscription[ mqttexampleTOPIC_COUNT ];
 
     /* Some fields not used by this demo so start with everything at 0. */
     ( void ) memset( ( void * ) &xMQTTSubscription, 0x00, sizeof( xMQTTSubscription ) );
@@ -736,7 +769,7 @@ static void prvMQTTUnsubscribeFromTopic( MQTTContext_t * pxMQTTContext )
     usSubscribePacketIdentifier = MQTT_GetPacketId( pxMQTTContext );
 
     /* Subscribe to the mqttexampleTOPIC topic filter. This example subscribes to
-     * only one topic and uses QOS0. */
+     * only one topic and uses QoS0. */
     xMQTTSubscription[ 0 ].qos = MQTTQoS0;
     xMQTTSubscription[ 0 ].pTopicFilter = mqttexampleTOPIC;
     xMQTTSubscription[ 0 ].topicFilterLength = ( uint16_t ) strlen( mqttexampleTOPIC );
@@ -757,6 +790,8 @@ static void prvMQTTUnsubscribeFromTopic( MQTTContext_t * pxMQTTContext )
 static void prvMQTTProcessResponse( MQTTPacketInfo_t * pxIncomingPacket,
                                     uint16_t usPacketId )
 {
+    uint32_t ulTopicCount = 0U;
+
     switch( pxIncomingPacket->type )
     {
         case MQTT_PACKET_TYPE_SUBACK:
@@ -764,14 +799,17 @@ static void prvMQTTProcessResponse( MQTTPacketInfo_t * pxIncomingPacket,
             /* A SUBACK from the broker, containing the server response to our subscription request, has been received.
              * It contains the status code indicating server approval/rejection for the subscription to the single topic
              * requested. The SUBACK will be parsed to obtain the status code, and this status code will be stored in global
-             * variable #xGlobalSubAckStatus. */
+             * variable #xTopicFilterContext. */
             prvUpdateSubAckStatus( pxIncomingPacket );
 
-            if( xGlobalSubAckStatus[ 0 ] != MQTTSubAckFailure )
+            for( ulTopicCount = 0; ulTopicCount < mqttexampleTOPIC_COUNT; ulTopicCount++ )
             {
-                LogInfo( ( "Subscribed to the topic %s with maximum QoS %u.\r\n",
-                           mqttexampleTOPIC,
-                           xGlobalSubAckStatus[ 0 ] ) );
+                if( xTopicFilterContext[ ulTopicCount ].xSubAckStatus != MQTTSubAckFailure )
+                {
+                    LogInfo( ( "Subscribed to the topic %s with maximum QoS %u.\r\n",
+                               xTopicFilterContext[ ulTopicCount ].pcTopicFilter,
+                               xTopicFilterContext[ ulTopicCount ].xSubAckStatus ) );
+                }
             }
 
             /* Make sure ACK packet identifier matches with Request packet identifier. */

--- a/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_keep_alive/DemoTasks/KeepAliveMQTTExample.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_keep_alive/DemoTasks/KeepAliveMQTTExample.c
@@ -523,8 +523,8 @@ static PlaintextTransportStatus_t prvConnectToServerWithBackoffRetries( NetworkC
     RetryUtilsParams_t xReconnectParams;
 
     /* Initialize reconnect attempts and interval. */
-    xReconnectParams.maxRetryAttempts = MAX_RETRY_ATTEMPTS;
     RetryUtils_ParamsReset( &xReconnectParams );
+    xReconnectParams.maxRetryAttempts = MAX_RETRY_ATTEMPTS;
 
     /* Attempt to connect to MQTT broker. If connection fails, retry after
      * a timeout. Timeout value will exponentially increase till maximum

--- a/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_keep_alive/DemoTasks/KeepAliveMQTTExample.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_keep_alive/DemoTasks/KeepAliveMQTTExample.c
@@ -644,7 +644,7 @@ static void prvUpdateSubAckStatus( MQTTPacketInfo_t * pxPacketInfo )
     for( ulTopicCount = 0; ulTopicCount < ulSize; ulTopicCount++ )
     {
         /* Multiply the index by 2 because the status code consists of two bytes. */
-        xTopicFilterContext[ ulTopicCount ].xSubAckStatus = pucPayload[ ulTopicCount * 2 ];
+        xTopicFilterContext[ ulTopicCount ].xSubAckStatus = pucPayload[ ulTopicCount ];
     }
 }
 /*-----------------------------------------------------------*/

--- a/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_keep_alive/WIN32.vcxproj
+++ b/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_keep_alive/WIN32.vcxproj
@@ -157,6 +157,7 @@
     <ClCompile Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\FreeRTOS_UDP_IP.c" />
     <ClCompile Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\portable\BufferManagement\BufferAllocation_2.c" />
     <ClCompile Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\portable\NetworkInterface\WinPCap\NetworkInterface.c" />
+    <ClCompile Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\platform\freertos\transport\src\freertos_sockets_wrapper.c" />
     <ClCompile Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\platform\freertos\transport\src\plaintext_freertos.c" />
     <ClCompile Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\platform\freertos\retry_utils\retry_utils_freertos.c" />
     <ClCompile Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\standard\mqtt\src\mqtt_lightweight.c" />

--- a/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_keep_alive/WIN32.vcxproj
+++ b/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_keep_alive/WIN32.vcxproj
@@ -158,6 +158,7 @@
     <ClCompile Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\portable\BufferManagement\BufferAllocation_2.c" />
     <ClCompile Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\portable\NetworkInterface\WinPCap\NetworkInterface.c" />
     <ClCompile Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\platform\freertos\transport\src\plaintext_freertos.c" />
+    <ClCompile Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\platform\freertos\retry_utils\retry_utils_freertos.c" />
     <ClCompile Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\standard\mqtt\src\mqtt_lightweight.c" />
     <ClCompile Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\standard\mqtt\src\mqtt_state.c" />
     <ClCompile Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\standard\mqtt\src\mqtt.c" />
@@ -191,6 +192,7 @@
     <ClInclude Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\include\NetworkInterface.h" />
     <ClInclude Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\platform\freertos\transport\include\plaintext_freertos.h" />
     <ClInclude Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\platform\include\transport_interface.h" />
+    <ClInclude Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\platform\include\retry_utils.h" />
     <ClInclude Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\standard\mqtt\include\mqtt_lightweight.h" />
     <ClInclude Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\standard\mqtt\include\mqtt_state.h" />
     <ClInclude Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\standard\mqtt\include\mqtt.h" />

--- a/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_keep_alive/WIN32.vcxproj.filters
+++ b/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_keep_alive/WIN32.vcxproj.filters
@@ -123,6 +123,9 @@
     <ClCompile Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\platform\freertos\transport\src\plaintext_freertos.c">
       <Filter>FreeRTOS+\FreeRTOS IoT Libraries\platform</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\platform\freertos\retry_utils\retry_utils_freertos.c">
+      <Filter>FreeRTOS+\FreeRTOS IoT Libraries\platform</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\include\NetworkInterface.h">
@@ -211,6 +214,9 @@
       <Filter>FreeRTOS+\FreeRTOS IoT Libraries\platform</Filter>
     </ClInclude>
     <ClInclude Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\platform\include\transport_interface.h">
+      <Filter>FreeRTOS+\FreeRTOS IoT Libraries\platform</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\platform\include\retry_utils.h">
       <Filter>FreeRTOS+\FreeRTOS IoT Libraries\platform</Filter>
     </ClInclude>
   </ItemGroup>

--- a/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_light_weight/DemoTasks/LightWeightMQTTExample.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_light_weight/DemoTasks/LightWeightMQTTExample.c
@@ -867,6 +867,7 @@ static void prvMQTTUpdateSubAckStatus( MQTTPacketInfo_t * pxPacketInfo )
 {
     uint8_t * pucPayload = NULL;
     uint32_t ulTopicCount = 0U;
+    size_t ulSize = 0U;
 
     /* Check if the pxPacketInfo contains a valid SUBACK packet. */
     configASSERT( pxPacketInfo != NULL );
@@ -875,8 +876,9 @@ static void prvMQTTUpdateSubAckStatus( MQTTPacketInfo_t * pxPacketInfo )
     configASSERT( pxPacketInfo->remainingLength >= 3U );
 
     pucPayload = pxPacketInfo->pRemainingData + ( ( uint16_t ) sizeof( uint16_t ) );
+    ulSize = pxPacketInfo->remainingLength - sizeof( uint16_t );
 
-    for( ulTopicCount = 0; ulTopicCount < mqttexampleTOPIC_COUNT; ulTopicCount++ )
+    for( ulTopicCount = 0; ulTopicCount < ulSize; ulTopicCount++ )
     {
         /* 0x80 denotes that the broker rejected subscription to a topic filter.
          * Multiply the index by 2 because the status code consists of two bytes. */

--- a/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_light_weight/DemoTasks/LightWeightMQTTExample.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_light_weight/DemoTasks/LightWeightMQTTExample.c
@@ -882,7 +882,7 @@ static void prvMQTTUpdateSubAckStatus( MQTTPacketInfo_t * pxPacketInfo )
     {
         /* 0x80 denotes that the broker rejected subscription to a topic filter.
          * Multiply the index by 2 because the status code consists of two bytes. */
-        if( pucPayload[ ulTopicCount * 2 ] & 0x80 )
+        if( pucPayload[ ulTopicCount ] == 0x80 )
         {
             xTopicFilterContext[ ulTopicCount ].xSubAckSuccess = false;
         }

--- a/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_light_weight/DemoTasks/LightWeightMQTTExample.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_light_weight/DemoTasks/LightWeightMQTTExample.c
@@ -621,8 +621,8 @@ static Socket_t prvConnectToServerWithBackoffRetries()
     RetryUtilsParams_t xReconnectParams;
 
     /* Initialize reconnect attempts and interval. */
-    xReconnectParams.maxRetryAttempts = MAX_RETRY_ATTEMPTS;
     RetryUtils_ParamsReset( &xReconnectParams );
+    xReconnectParams.maxRetryAttempts = MAX_RETRY_ATTEMPTS;
 
     /* Attempt to connect to MQTT broker. If connection fails, retry after
      * a timeout. Timeout value will exponentially increase till maximum

--- a/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_light_weight/DemoTasks/LightWeightMQTTExample.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_light_weight/DemoTasks/LightWeightMQTTExample.c
@@ -22,7 +22,6 @@
  * http://www.FreeRTOS.org
  * http://aws.amazon.com/freertos
  *
- * 1 tab == 4 spaces!
  */
 
 /*
@@ -105,23 +104,23 @@
  * The topic name starts with the client identifier to ensure that each demo
  * interacts with a unique topic name.
  */
-#define mqttexampleTOPIC                            democonfigCLIENT_IDENTIFIER "/example/topic"
+#define mqttexampleTOPIC                             democonfigCLIENT_IDENTIFIER "/example/topic"
 
 /**
  * @brief The MQTT message published in this example.
  */
-#define mqttexampleMESSAGE                          "Hello Light Weight MQTT World!"
+#define mqttexampleMESSAGE                           "Hello Light Weight MQTT World!"
 
 /**
  * @brief Dimensions a file scope buffer currently used to send and receive MQTT data
  * from a socket.
  */
-#define mqttexampleSHARED_BUFFER_SIZE               ( 500U )
+#define mqttexampleSHARED_BUFFER_SIZE                ( 500U )
 
 /**
  * @brief Time to wait between each cycle of the demo implemented by prvMQTTDemoTask().
  */
-#define mqttexampleDELAY_BETWEEN_DEMO_ITERATIONS    ( pdMS_TO_TICKS( 5000U ) )
+#define mqttexampleDELAY_BETWEEN_DEMO_ITERATIONS     ( pdMS_TO_TICKS( 5000U ) )
 
 /**
  * @brief Keep alive time reported to the broker while establishing an MQTT connection.
@@ -131,7 +130,7 @@
  * absence of sending any other Control Packets, the Client MUST send a
  * PINGREQ Packet.
  */
-#define mqttexampleKEEP_ALIVE_TIMEOUT_SECONDS       ( 10U )
+#define mqttexampleKEEP_ALIVE_TIMEOUT_SECONDS        ( 10U )
 
 /**
  * @brief Time to wait before sending ping request to keep MQTT connection alive.
@@ -140,23 +139,23 @@
  * seconds. This is to make sure that a PINGREQ is always sent before the timeout
  * expires in broker.
  */
-#define mqttexampleKEEP_ALIVE_DELAY                 ( pdMS_TO_TICKS( ( ( mqttexampleKEEP_ALIVE_TIMEOUT_SECONDS / 4 ) * 1000 ) ) )
+#define mqttexampleKEEP_ALIVE_DELAY                  ( pdMS_TO_TICKS( ( ( mqttexampleKEEP_ALIVE_TIMEOUT_SECONDS / 4 ) * 1000 ) ) )
 
 /**
  * @brief Number of times a attempt a network receive when it fails due to timeout.
  */
-#define mqttexampleMAX_RECV_ATTEMPTS                ( 10U )
+#define mqttexampleMAX_RECV_ATTEMPTS                 ( 10U )
 
 /**
  * @brief Maximum number of times to call FreeRTOS_recv when initiating a
  * graceful socket shutdown.
  */
-#define mqttexampleMAX_SOCKET_SHUTDOWN_LOOPS        ( 3 )
+#define mqttexampleMAX_SOCKET_SHUTDOWN_LOOPS         ( 3 )
 
 /**
  * @brief Transport timeout in milliseconds for transport send and receive.
  */
-#define TRANSPORT_SEND_RECV_TIMEOUT_MS              ( 200U )
+#define mqttexampleTRANSPORT_SEND_RECV_TIMEOUT_MS    ( 200U )
 /*-----------------------------------------------------------*/
 
 /**
@@ -564,7 +563,7 @@ static Socket_t prvCreateTCPConnectionToBroker( void )
 
             if( FreeRTOS_connect( xMQTTSocket, &xBrokerAddress, sizeof( xBrokerAddress ) ) == 0 )
             {
-                xTransportTimeout = pdMS_TO_TICKS( TRANSPORT_SEND_RECV_TIMEOUT_MS );
+                xTransportTimeout = pdMS_TO_TICKS( mqttexampleTRANSPORT_SEND_RECV_TIMEOUT_MS );
 
                 /* Set socket receive timeout.
                  * Setting the receive block time cannot fail. */
@@ -730,7 +729,7 @@ static void prvCreateMQTTConnectionWithBroker( Socket_t xMQTTSocket )
 
     do
     {
-        /* Since TCP socket has timeout, retry until the data is available */
+        /* Since TCP socket has timeout, retry until the data is available. */
         xResult = MQTT_GetIncomingPacketTypeAndLength( prvTransportRecv,
                                                        &xNetworkContext,
                                                        &xIncomingPacket );
@@ -821,8 +820,8 @@ static void prvMQTTSubscribeWithBackoffRetries( Socket_t xMQTTSocket )
     RetryUtilsParams_t xRetryParams;
 
     /* Initialize retry attempts and interval. */
-    xRetryParams.maxRetryAttempts = MAX_RETRY_ATTEMPTS;
     RetryUtils_ParamsReset( &xRetryParams );
+    xRetryParams.maxRetryAttempts = MAX_RETRY_ATTEMPTS;
 
     do
     {
@@ -834,7 +833,6 @@ static void prvMQTTSubscribeWithBackoffRetries( Socket_t xMQTTSocket )
          * from the broker. This demo uses QOS0 in Subscribe, therefore, the Publish
          * messages received from the broker will have QOS0. */
         LogInfo( ( "Attempt to subscribe to the MQTT topic %s.\r\n", mqttexampleTOPIC ) );
-        vTaskDelay( pdMS_TO_TICKS( 3000 ) );
         prvMQTTSubscribeToTopic( xMQTTSocket );
 
         LogInfo( ( "SUBSCRIBE sent for topic %s to broker.\n\n", mqttexampleTOPIC ) );
@@ -849,7 +847,7 @@ static void prvMQTTSubscribeWithBackoffRetries( Socket_t xMQTTSocket )
         prvMQTTProcessIncomingPacket( xMQTTSocket );
 
         /* Check if recent subscription request has been rejected. #xGlobalSubAckStatus is updated
-         * in eventCallback to reflect the status of the SUBACK sent by the broker. It represents
+         * inthe event callback to reflect the status of the SUBACK sent by the broker. It represents
          * either the QoS level granted by the server upon subscription, or acknowledgement of
          * server rejection of the subscription request. */
         if( xGlobalSubAckStatus == false )
@@ -1012,7 +1010,7 @@ static void prvMQTTProcessResponse( MQTTPacketInfo_t * pxIncomingPacket,
         case MQTT_PACKET_TYPE_SUBACK:
 
             /* Check if recent subscription request has been accepted. xGlobalSubAckStatus is updated
-            * in mqttProcessIncomingPacket to reflect the status of the SUBACK sent by the broker. */
+             * in #prvMQTTProcessIncomingPacket to reflect the status of the SUBACK sent by the broker. */
             if( xGlobalSubAckStatus == true )
             {
                 LogInfo( ( "Subscribed to the topic %s.\r\n", democonfigMQTT_BROKER_ENDPOINT ) );
@@ -1094,7 +1092,6 @@ static void prvMQTTProcessIncomingPacket( Socket_t xMQTTSocket )
     /* Determine incoming packet type and remaining length. */
     xNetworkContext.xTcpSocket = xMQTTSocket;
 
-    /* Since TCP socket has timeout, retry until the data is available */
     xResult = MQTT_GetIncomingPacketTypeAndLength( prvTransportRecv,
                                                    &xNetworkContext,
                                                    &xIncomingPacket );
@@ -1140,6 +1137,9 @@ static void prvMQTTProcessIncomingPacket( Socket_t xMQTTSocket )
             if( xIncomingPacket.type == MQTT_PACKET_TYPE_SUBACK )
             {
                 xGlobalSubAckStatus = ( xResult == MQTTSuccess );
+
+                /* #MQTTServerRefused is returned when the broker refuses the client
+                 * to subscribe a specific topic filter. */
                 configASSERT( xResult == MQTTSuccess || xResult == MQTTServerRefused );
             }
             else

--- a/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_light_weight/WIN32.vcxproj
+++ b/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_light_weight/WIN32.vcxproj
@@ -13,7 +13,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{C686325E-3261-42F7-AEB1-DDE5280E1CEB}</ProjectGuid>
     <ProjectName>RTOSDemo</ProjectName>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
@@ -26,7 +26,7 @@
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
@@ -157,6 +157,7 @@
     <ClCompile Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\FreeRTOS_UDP_IP.c" />
     <ClCompile Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\portable\BufferManagement\BufferAllocation_2.c" />
     <ClCompile Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\portable\NetworkInterface\WinPCap\NetworkInterface.c" />
+    <ClCompile Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\platform\freertos\retry_utils\retry_utils_freertos.c" />
     <ClCompile Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\standard\mqtt\src\mqtt_lightweight.c" />
     <ClCompile Include="..\common\demo_logging.c" />
     <ClCompile Include="..\common\main.c" />

--- a/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_light_weight/WIN32.vcxproj.filters
+++ b/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_light_weight/WIN32.vcxproj.filters
@@ -44,6 +44,9 @@
     <Filter Include="FreeRTOS+\FreeRTOS IoT Libraries\standard\mqtt\include">
       <UniqueIdentifier>{6ad56e6d-c330-4830-8f4b-c75b05dfa866}</UniqueIdentifier>
     </Filter>
+    <Filter Include="FreeRTOS+\FreeRTOS IoT Libraries\platform">
+      <UniqueIdentifier>{84613aa2-91dc-4e1a-a3b3-823b6d7bf0e0}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\..\..\..\FreeRTOS\Source\portable\MSVC-MingW\port.c">
@@ -110,6 +113,9 @@
     </ClCompile>
     <ClCompile Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\standard\mqtt\src\mqtt_lightweight.c">
       <Filter>FreeRTOS+\FreeRTOS IoT Libraries\standard\mqtt\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\platform\freertos\retry_utils\retry_utils_freertos.c">
+      <Filter>FreeRTOS+\FreeRTOS IoT Libraries\platform</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_mutual_auth/DemoTasks/MutualAuthMQTTExample.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_mutual_auth/DemoTasks/MutualAuthMQTTExample.c
@@ -461,7 +461,7 @@ static void prvMQTTDemoTask( void * pvParameters )
         /* Close the network connection.  */
         TLS_FreeRTOS_Disconnect( &xNetworkContext );
 
-        /* Reset SUBACK status for each topic iflter after completion of subscription request cycle. */
+        /* Reset SUBACK status for each topic filter after completion of subscription request cycle. */
         for( ulTopicCount = 0; ulTopicCount < mqttexampleTOPIC_COUNT; ulTopicCount++ )
         {
             xTopicFilterContext[ ulTopicCount ].xSubAckStatus = MQTTSubAckFailure;
@@ -603,7 +603,6 @@ static void prvUpdateSubAckStatus( MQTTPacketInfo_t * pxPacketInfo )
 
     for( ulTopicCount = 0; ulTopicCount < ulSize; ulTopicCount++ )
     {
-        /* Multiply the index by 2 because the status code consists of two bytes. */
         xTopicFilterContext[ ulTopicCount ].xSubAckStatus = pucPayload[ ulTopicCount ];
     }
 }

--- a/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_mutual_auth/DemoTasks/MutualAuthMQTTExample.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_mutual_auth/DemoTasks/MutualAuthMQTTExample.c
@@ -21,6 +21,8 @@
  *
  * http://www.FreeRTOS.org
  * http://aws.amazon.com/freertos
+ *
+ * 1 tab == 4 spaces!
  */
 
 /*
@@ -52,6 +54,9 @@
 
 /* MQTT library includes. */
 #include "mqtt.h"
+
+/* Retry utilities include. */
+#include "retry_utils.h"
 
 /* Transport interface implementation include header for TLS. */
 #include "tls_freertos.h"
@@ -175,6 +180,20 @@
 static void prvMQTTDemoTask( void * pvParameters );
 
 /**
+ * @brief Connect to MQTT broker with reconnection retries.
+ *
+ * If connection fails, retry is attempted after a timeout.
+ * Timeout value will exponentially increase until maximum
+ * timeout value is reached or the number of attempts are exhausted.
+ *
+ * @param[out] pxNetworkContext The output parameter to return the created network context.
+ *
+ * @return The status of the final connection attempt.
+ */
+static TlsTransportStatus_t prvConnectToServerWithBackoffRetries( NetworkCredentials_t * pxNetworkCredentials,
+                                                                  NetworkContext_t * pNetworkContext )
+
+/**
  * @brief Sends an MQTT Connect packet over the already connected TLS over TCP connection.
  *
  * @param[in, out] pxMQTTContext MQTT context pointer.
@@ -184,12 +203,22 @@ static void prvCreateMQTTConnectionWithBroker( MQTTContext_t * pxMQTTContext,
                                                NetworkContext_t * pxNetworkContext );
 
 /**
+ * @brief Function to update variable globalSubAckStatus with status
+ * information from Subscribe ACK. Called by eventCallback after processing
+ * incoming subscribe echo.
+ *
+ * @param[in] Server response to the subscription request.
+ */
+static void prvUpdateSubAckStatus( MQTTPacketInfo_t * pxPacketInfo );
+
+/**
  * @brief Subscribes to the topic as specified in mqttexampleTOPIC at the top of
- * this file.
+ * this file. In the case of a Subscribe ACK failure, then subscription is
+ * retried using an exponential backoff strategy with jitter.
  *
  * @param[in] pxMQTTContext MQTT context pointer.
  */
-static void prvMQTTSubscribeToTopic( MQTTContext_t * pxMQTTContext );
+static void prvMQTTSubscribeWithBackoffRetries( MQTTContext_t * pxMQTTContext );
 
 /**
  * @brief Publishes a message mqttexampleMESSAGE on mqttexampleTOPIC topic.
@@ -245,16 +274,6 @@ static void prvEventCallback( MQTTContext_t * pxMQTTContext,
                               MQTTPacketInfo_t * pxPacketInfo,
                               MQTTDeserializedInfo_t * pxDeserializedInfo );
 
-/**
- * @brief TLS connect to endpoint democonfigMQTT_BROKER_ENDPOINT.
- *
- * @param[in] pxNetworkCredentials Network credentials to establish a TLS connection
- * with democonfigMQTT_BROKER_ENDPOINT.
- * @param[in] pxNetworkCredentials Network context.
- */
-static void prvTLSConnect( NetworkCredentials_t * pxNetworkCredentials,
-                           NetworkContext_t * pxNetworkContext );
-
 /*-----------------------------------------------------------*/
 
 /* @brief Static buffer used to hold MQTT messages being sent and received. */
@@ -286,6 +305,19 @@ static uint16_t usSubscribePacketIdentifier;
  * request.
  */
 static uint16_t usUnsubscribePacketIdentifier;
+
+/**
+ * @brief Status of latest Subscribe ACK;
+ * it is updated every time the callback function processes a Subscribe ACK.
+ */
+static MQTTSubAckStatus_t xGlobalSubAckStatus = MQTTSubAckFailure;
+
+/**
+ * @brief Topic to subscribe.
+ * Used to re-subscribe to topics that failed initial subscription attempts.
+ */
+static MQTTSubscribeInfo_t xGlobalSubscribeInfo;
+
 
 /** @brief Static buffer used to hold MQTT messages being sent and received. */
 static MQTTFixedBuffer_t xBuffer =
@@ -348,13 +380,16 @@ static void prvMQTTDemoTask( void * pvParameters )
     {
         /****************************** Connect. ******************************/
 
-        /* Establish a TLS connection with the MQTT broker. This example connects to
-         * the MQTT broker as specified by democonfigMQTT_BROKER_ENDPOINT and
-         * democonfigMQTT_BROKER_PORT in the demo_config.h file. */
+        /* Attempt to establish TLS session with MQTT broker. If connection fails,
+         * retry after a timeout. Timeout value will be exponentially increased until
+         * the maximum number of attempts are reached or the maximum timeout value is reached.
+         * The function returns a failure status if the TCP connection cannot be established
+         * to the broker after the configured number of attempts. */
         LogInfo( ( "Creating a TLS connection to %s:%u.\r\n",
                    democonfigMQTT_BROKER_ENDPOINT,
                    democonfigMQTT_BROKER_PORT ) );
-        prvTLSConnect( &xNetworkCredentials, &xNetworkContext );
+        xNetworkStatus = prvConnectToServerWithBackoffRetries( &xNetworkContext );
+        configASSERT( xNetworkStatus == TLS_TRANSPORT_SUCCESS );
 
         /* Sends an MQTT Connect packet over the already established TLS connection,
          * and waits for connection acknowledgment (CONNACK) packet. */
@@ -363,17 +398,10 @@ static void prvMQTTDemoTask( void * pvParameters )
 
         /**************************** Subscribe. ******************************/
 
-        /* The client is now connected to the broker. Subscribe to the topic
-         * as specified in mqttexampleTOPIC at the top of this file by sending a
-         * subscribe packet then waiting for a subscribe acknowledgment (SUBACK).
-         * The function #prvMQTTSubscribeToTopic will not wait to receive a SUBACK,
-         * but the function #MQTT_ProcessLoop will attempt to receive the SUBACK
-         * from network and if a SUBACK is received, application will be notified
-         * through the callback registered (#prvEventCallback for this application).
-         * This demo uses QoS1 in Subscribe, therefore, the Publish messages
-         * received from the broker will have QoS1. */
-        LogInfo( ( "Attempt to subscribe to the MQTT topic %s.\r\n", mqttexampleTOPIC ) );
-        prvMQTTSubscribeToTopic( &xMQTTContext );
+        /* If server rejected the subscription request, attempt to resubscribe to topic.
+         * Attempts are made according to the exponential backoff retry strategy
+         * implemented in retryUtils. */
+        prvMQTTSubscribeWithBackoffRetries( &xMQTTContext );
 
         /* Process incoming packet from the broker. After sending the subscribe, the
          * client may receive a publish before it receives a subscribe ack. Therefore,
@@ -422,6 +450,9 @@ static void prvMQTTDemoTask( void * pvParameters )
         /* Close the network connection.  */
         TLS_FreeRTOS_Disconnect( &xNetworkContext );
 
+        /* Reset global SUBACK status variable after completion of subscription request cycle. */
+        xGlobalSubAckStatus = MQTTSubAckFailure;
+
         /* Wait for some time between two iterations to ensure that we do not
          * the broker. */
         LogInfo( ( "prvMQTTDemoTask() completed an iteration successfully. Total free heap is %u.\r\n", xPortGetFreeHeapSize() ) );
@@ -432,10 +463,12 @@ static void prvMQTTDemoTask( void * pvParameters )
 }
 /*-----------------------------------------------------------*/
 
-static void prvTLSConnect( NetworkCredentials_t * pxNetworkCredentials,
-                           NetworkContext_t * pxNetworkContext )
+static TlsTransportStatus_t prvConnectToServerWithBackoffRetries( NetworkCredentials_t * pxNetworkCredentials,
+                                                                  NetworkContext_t * pNetworkContext )
 {
-    BaseType_t xNetworkStatus;
+    TlsTransportStatus_t xNetworkStatus;
+    RetryUtilsStatus_t xRetryUtilsStatus = RetryUtilsSuccess;
+    RetryUtilsParams_t xReconnectParams;
 
     /* Set the credentials for establishing a TLS connection. */
     pxNetworkCredentials->pRootCa = ( const unsigned char * ) democonfigROOT_CA_PEM;
@@ -445,19 +478,47 @@ static void prvTLSConnect( NetworkCredentials_t * pxNetworkCredentials,
     pxNetworkCredentials->pPrivateKey = ( const unsigned char * ) democonfigCLIENT_PRIVATE_KEY_PEM;
     pxNetworkCredentials->privateKeySize = sizeof( democonfigCLIENT_PRIVATE_KEY_PEM );
 
-    /* Attempt to create a mutually authenticated TLS connection. */
-    xNetworkStatus = TLS_FreeRTOS_Connect( pxNetworkContext,
-                                           democonfigMQTT_BROKER_ENDPOINT,
-                                           democonfigMQTT_BROKER_PORT,
-                                           pxNetworkCredentials,
-                                           mqttexampleTRANSPORT_SEND_RECV_TIMEOUT_MS,
-                                           mqttexampleTRANSPORT_SEND_RECV_TIMEOUT_MS );
-    configASSERT( xNetworkStatus == TLS_TRANSPORT_SUCCESS );
-    LogInfo( ( "A mutually authenticated TLS connection established with %s:%u.\r\n",
-               democonfigMQTT_BROKER_ENDPOINT,
-               democonfigMQTT_BROKER_PORT ) );
+    /* Initialize reconnect attempts and interval. */
+    xReconnectParams.maxRetryAttempts = MAX_RETRY_ATTEMPTS;
+    RetryUtils_ParamsReset( &xReconnectParams );
+
+    /* Attempt to connect to MQTT broker. If connection fails, retry after
+     * a timeout. Timeout value will exponentially increase till maximum
+     * attempts are reached.
+     */
+    do
+    {
+        /* Establish a TCP connection with the MQTT broker. This example connects to
+         * the MQTT broker as specified in democonfigMQTT_BROKER_ENDPOINT and
+         * democonfigMQTT_BROKER_PORT at the top of this file. */
+        LogInfo( ( "Create a TCP connection to %s:%d.",
+                   democonfigMQTT_BROKER_ENDPOINT,
+                   democonfigMQTT_BROKER_PORT ) );
+        /* Attempt to create a mutually authenticated TLS connection. */
+        xNetworkStatus = TLS_FreeRTOS_Connect( pxNetworkContext,
+                                               democonfigMQTT_BROKER_ENDPOINT,
+                                               democonfigMQTT_BROKER_PORT,
+                                               pxNetworkCredentials,
+                                               mqttexampleTRANSPORT_SEND_RECV_TIMEOUT_MS,
+                                               mqttexampleTRANSPORT_SEND_RECV_TIMEOUT_MS );
+
+        if( xNetworkStatus != TLS_TRANSPORT_SUCCESS )
+        {
+            LogWarn( ( "Connection to the broker failed. Retrying connection with backoff and jitter." ) );
+            xRetryUtilsStatus = RetryUtils_BackoffAndSleep( &xReconnectParams );
+        }
+
+        if( xRetryUtilsStatus == RetryUtilsRetriesExhausted )
+        {
+            LogError( ( "Connection to the broker failed, all attempts exhausted." ) );
+            xNetworkStatus = TLS_TRANSPORT_CONNECT_FAILURE;
+        }
+    } while( ( xNetworkStatus != TLS_TRANSPORT_SUCCESS ) && ( xRetryUtilsStatus == RetryUtilsSuccess ) );
+
+    return xNetworkStatus;
 }
 /*-----------------------------------------------------------*/
+
 static void prvCreateMQTTConnectionWithBroker( MQTTContext_t * pxMQTTContext,
                                                NetworkContext_t * pxNetworkContext )
 {
@@ -481,7 +542,7 @@ static void prvCreateMQTTConnectionWithBroker( MQTTContext_t * pxMQTTContext,
     configASSERT( xResult == MQTTSuccess );
 
     /* Some fields are not used in this demo so start with everything at 0. */
-    memset( ( void * ) &xConnectInfo, 0x00, sizeof( xConnectInfo ) );
+    ( void ) memset( ( void * ) &xConnectInfo, 0x00, sizeof( xConnectInfo ) );
 
     /* Start with a clean session i.e. direct the MQTT broker to discard any
      * previous session data. Also, establishing a connection with clean session
@@ -513,35 +574,69 @@ static void prvCreateMQTTConnectionWithBroker( MQTTContext_t * pxMQTTContext,
 }
 /*-----------------------------------------------------------*/
 
-static void prvMQTTSubscribeToTopic( MQTTContext_t * pxMQTTContext )
+static void prvMQTTSubscribeWithBackoffRetries( MQTTContext_t * pxMQTTContext )
 {
-    MQTTStatus_t xResult;
-    MQTTSubscribeInfo_t xMQTTSubscription[ 1 ];
+    MQTTStatus_t xResult = MQTTSuccess;
+    RetryUtilsStatus_t xRetryUtilsStatus = RetryUtilsSuccess;
+    RetryUtilsParams_t xRetryParams;
 
-    /***
-     * For readability, error handling in this function is restricted to the use of
-     * asserts().
-     ***/
-
-    /* Some fields are not used by this demo so start with everything at 0. */
-    ( void ) memset( ( void * ) &xMQTTSubscription, 0x00, sizeof( xMQTTSubscription ) );
-
-    /* Subscribe to the mqttexampleTOPIC topic filter. This example subscribes to
-     * only one topic and uses QoS1. */
-    xMQTTSubscription[ 0 ].qos = MQTTQoS1;
-    xMQTTSubscription[ 0 ].pTopicFilter = mqttexampleTOPIC;
-    xMQTTSubscription[ 0 ].topicFilterLength = ( uint16_t ) strlen( mqttexampleTOPIC );
+    /* Some fields not used by this demo so start with everything at 0. */
+    ( void ) memset( ( void * ) &xGlobalSubscribeInfo, 0x00, sizeof( MQTTSubscribeInfo_t ) );
 
     /* Get a unique packet id. */
     usSubscribePacketIdentifier = MQTT_GetPacketId( pxMQTTContext );
 
-    /* Send SUBSCRIBE packet. */
-    xResult = MQTT_Subscribe( pxMQTTContext,
-                              xMQTTSubscription,
-                              sizeof( xMQTTSubscription ) / sizeof( MQTTSubscribeInfo_t ),
-                              usSubscribePacketIdentifier );
+    /* Subscribe to the mqttexampleTOPIC topic filter. This example subscribes to
+     * only one topic and uses QOS0. */
+    xGlobalSubscribeInfo.qos = MQTTQoS0;
+    xGlobalSubscribeInfo.pTopicFilter = mqttexampleTOPIC;
+    xGlobalSubscribeInfo.topicFilterLength = ( uint16_t ) strlen( mqttexampleTOPIC );
 
-    configASSERT( xResult == MQTTSuccess );
+    /* Initialize retry attempts and interval. */
+    xRetryParams.maxRetryAttempts = MAX_RETRY_ATTEMPTS;
+    RetryUtils_ParamsReset( &xRetryParams );
+
+    do
+    {
+        /* The client is now connected to the broker. Subscribe to the topic
+         * as specified in mqttexampleTOPIC at the top of this file by sending a
+         * subscribe packet then waiting for a subscribe acknowledgment (SUBACK).
+         * This client will then publish to the same topic it subscribed to, so it
+         * will expect all the messages it sends to the broker to be sent back to it
+         * from the broker. This demo uses QOS0 in Subscribe, therefore, the Publish
+         * messages received from the broker will have QOS0. */
+        LogInfo( ( "Attempt to subscribe to the MQTT topic %s.\r\n", mqttexampleTOPIC ) );
+        xResult = MQTT_Subscribe( pxMQTTContext,
+                                  &xGlobalSubscribeInfo,
+                                  sizeof( xGlobalSubscribeInfo ) / sizeof( MQTTSubscribeInfo_t ),
+                                  usSubscribePacketIdentifier );
+        configASSERT( xResult == MQTTSuccess );
+
+        LogInfo( ( "SUBSCRIBE sent for topic %s to broker.\n\n", mqttexampleTOPIC ) );
+
+        /* Process incoming packet from the broker. After sending the subscribe, the
+         * client may receive a publish before it receives a subscribe ack. Therefore,
+         * call generic incoming packet processing function. Since this demo is
+         * subscribing to the topic to which no one is publishing, probability of
+         * receiving Publish message before subscribe ack is zero; but application
+         * must be ready to receive any packet.  This demo uses the generic packet
+         * processing function everywhere to highlight this fact. */
+        xResult = MQTT_ProcessLoop( pxMQTTContext, mqttexamplePROCESS_LOOP_TIMEOUT_MS );
+        configASSERT( xResult == MQTTSuccess );
+
+        /* Check if recent subscription request has been rejected. #xGlobalSubAckStatus is updated
+         * in eventCallback to reflect the status of the SUBACK sent by the broker. It represents
+         * either the QoS level granted by the server upon subscription, or acknowledgement of
+         * server rejection of the subscription request. */
+        if( xGlobalSubAckStatus == MQTTSubAckFailure )
+        {
+            LogWarn( ( "Server rejected subscription request. Attempting to re-subscribe to topic %s.",
+                       mqttexampleTOPIC ) );
+            xRetryUtilsStatus = RetryUtils_BackoffAndSleep( &xRetryParams );
+        }
+
+        configASSERT( xRetryUtilsStatus != RetryUtilsRetriesExhausted );
+    } while( ( xGlobalSubAckStatus == MQTTSubAckFailure ) && ( xRetryUtilsStatus == RetryUtilsSuccess ) );
 }
 /*-----------------------------------------------------------*/
 
@@ -549,7 +644,6 @@ static void prvMQTTPublishToTopic( MQTTContext_t * pxMQTTContext )
 {
     MQTTStatus_t xResult;
     MQTTPublishInfo_t xMQTTPublishInfo;
-
 
     /***
      * For readability, error handling in this function is restricted to the use of
@@ -559,7 +653,7 @@ static void prvMQTTPublishToTopic( MQTTContext_t * pxMQTTContext )
     /* Some fields are not used by this demo so start with everything at 0. */
     ( void ) memset( ( void * ) &xMQTTPublishInfo, 0x00, sizeof( xMQTTPublishInfo ) );
 
-    /* This demo uses QoS1 */
+    /* This demo uses QoS1. */
     xMQTTPublishInfo.qos = MQTTQoS1;
     xMQTTPublishInfo.retain = false;
     xMQTTPublishInfo.pTopicName = mqttexampleTOPIC;
@@ -580,24 +674,16 @@ static void prvMQTTPublishToTopic( MQTTContext_t * pxMQTTContext )
 static void prvMQTTUnsubscribeFromTopic( MQTTContext_t * pxMQTTContext )
 {
     MQTTStatus_t xResult;
-    MQTTSubscribeInfo_t xMQTTSubscription[ 1 ];
 
-    /* Some fields are not used by this demo so start with everything at 0. */
-    memset( ( void * ) &xMQTTSubscription, 0x00, sizeof( xMQTTSubscription ) );
-
-    /* Unsubscribe to the mqttexampleTOPIC topic filter. */
-    xMQTTSubscription[ 0 ].pTopicFilter = mqttexampleTOPIC;
-    xMQTTSubscription[ 0 ].topicFilterLength = ( uint16_t ) strlen( mqttexampleTOPIC );
-
-    /* Get next unique packet identifier */
+    /* Get next unique packet identifier. */
     usUnsubscribePacketIdentifier = MQTT_GetPacketId( pxMQTTContext );
-    /* Make sure the packet id obtained is valid. */
-    configASSERT( usUnsubscribePacketIdentifier != 0 );
 
-    /* Send UNSUBSCRIBE packet. */
+    /* Send UNSUBSCRIBE packet. Note that because #xGlobalSubscribeInfo
+     * was initialized before sending the SUBSCRIBE packet, there is no need
+     * to initialize it again. */
     xResult = MQTT_Unsubscribe( pxMQTTContext,
-                                xMQTTSubscription,
-                                sizeof( xMQTTSubscription ) / sizeof( MQTTSubscribeInfo_t ),
+                                &xGlobalSubscribeInfo,
+                                sizeof( xGlobalSubscribeInfo ) / sizeof( MQTTSubscribeInfo_t ),
                                 usUnsubscribePacketIdentifier );
 
     configASSERT( xResult == MQTTSuccess );
@@ -616,7 +702,20 @@ static void prvMQTTProcessResponse( MQTTPacketInfo_t * pxIncomingPacket,
             break;
 
         case MQTT_PACKET_TYPE_SUBACK:
-            LogInfo( ( "Subscribed to the topic %s.\r\n", mqttexampleTOPIC ) );
+
+            /* A SUBACK from the broker, containing the server response to our subscription request, has been received.
+             * It contains the status code indicating server approval/rejection for the subscription to the single topic
+             * requested. The SUBACK will be parsed to obtain the status code, and this status code will be stored in global
+             * variable globalSubAckStatus. */
+            prvUpdateSubAckStatus( pxIncomingPacket );
+
+            if( xGlobalSubAckStatus != MQTTSubAckFailure )
+            {
+                LogInfo( ( "Subscribed to the topic %s with maximum QoS %u.\r\n",
+                           mqttexampleTOPIC,
+                           xGlobalSubAckStatus ) );
+            }
+
             /* Make sure ACK packet identifier matches with Request packet identifier. */
             configASSERT( usSubscribePacketIdentifier == usPacketId );
             break;

--- a/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_mutual_auth/DemoTasks/MutualAuthMQTTExample.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_mutual_auth/DemoTasks/MutualAuthMQTTExample.c
@@ -604,7 +604,7 @@ static void prvUpdateSubAckStatus( MQTTPacketInfo_t * pxPacketInfo )
     for( ulTopicCount = 0; ulTopicCount < ulSize; ulTopicCount++ )
     {
         /* Multiply the index by 2 because the status code consists of two bytes. */
-        xTopicFilterContext[ ulTopicCount ].xSubAckStatus = pucPayload[ ulTopicCount * 2 ];
+        xTopicFilterContext[ ulTopicCount ].xSubAckStatus = pucPayload[ ulTopicCount ];
     }
 }
 /*-----------------------------------------------------------*/

--- a/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_mutual_auth/DemoTasks/MutualAuthMQTTExample.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_mutual_auth/DemoTasks/MutualAuthMQTTExample.c
@@ -386,9 +386,6 @@ static void prvMQTTDemoTask( void * pvParameters )
          * the maximum number of attempts are reached or the maximum timeout value is reached.
          * The function returns a failure status if the TCP connection cannot be established
          * to the broker after the configured number of attempts. */
-        LogInfo( ( "Creating a TLS connection to %s:%u.\r\n",
-                   democonfigMQTT_BROKER_ENDPOINT,
-                   democonfigMQTT_BROKER_PORT ) );
         xNetworkStatus = prvConnectToServerWithBackoffRetries( &xNetworkCredentials,
                                                                &xNetworkContext );
         configASSERT( xNetworkStatus == TLS_TRANSPORT_SUCCESS );
@@ -490,10 +487,10 @@ static TlsTransportStatus_t prvConnectToServerWithBackoffRetries( NetworkCredent
      */
     do
     {
-        /* Establish a TCP connection with the MQTT broker. This example connects to
+        /* Establish a TLS session with the MQTT broker. This example connects to
          * the MQTT broker as specified in democonfigMQTT_BROKER_ENDPOINT and
          * democonfigMQTT_BROKER_PORT at the top of this file. */
-        LogInfo( ( "Create a TCP connection to %s:%d.",
+        LogInfo( ( "Creating a TLS connection to %s:%u.\r\n",
                    democonfigMQTT_BROKER_ENDPOINT,
                    democonfigMQTT_BROKER_PORT ) );
         /* Attempt to create a mutually authenticated TLS connection. */

--- a/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_mutual_auth/DemoTasks/MutualAuthMQTTExample.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_mutual_auth/DemoTasks/MutualAuthMQTTExample.c
@@ -22,7 +22,6 @@
  * http://www.FreeRTOS.org
  * http://aws.amazon.com/freertos
  *
- * 1 tab == 4 spaces!
  */
 
 /*
@@ -204,8 +203,8 @@ static void prvCreateMQTTConnectionWithBroker( MQTTContext_t * pxMQTTContext,
 
 /**
  * @brief Function to update variable globalSubAckStatus with status
- * information from Subscribe ACK. Called by eventCallback after processing
- * incoming subscribe echo.
+ * information from Subscribe ACK. Called bythe event callback after processing
+ * an incoming SUBSCRIBE packet.
  *
  * @param[in] Server response to the subscription request.
  */
@@ -609,8 +608,8 @@ static void prvMQTTSubscribeWithBackoffRetries( MQTTContext_t * pxMQTTContext )
     xGlobalSubscribeInfo.topicFilterLength = ( uint16_t ) strlen( mqttexampleTOPIC );
 
     /* Initialize retry attempts and interval. */
-    xRetryParams.maxRetryAttempts = MAX_RETRY_ATTEMPTS;
     RetryUtils_ParamsReset( &xRetryParams );
+    xRetryParams.maxRetryAttempts = MAX_RETRY_ATTEMPTS;
 
     do
     {
@@ -641,7 +640,7 @@ static void prvMQTTSubscribeWithBackoffRetries( MQTTContext_t * pxMQTTContext )
         configASSERT( xResult == MQTTSuccess );
 
         /* Check if recent subscription request has been rejected. #xGlobalSubAckStatus is updated
-         * in eventCallback to reflect the status of the SUBACK sent by the broker. It represents
+         * inthe event callback to reflect the status of the SUBACK sent by the broker. It represents
          * either the QoS level granted by the server upon subscription, or acknowledgement of
          * server rejection of the subscription request. */
         if( xGlobalSubAckStatus == MQTTSubAckFailure )

--- a/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_mutual_auth/DemoTasks/MutualAuthMQTTExample.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_mutual_auth/DemoTasks/MutualAuthMQTTExample.c
@@ -203,8 +203,8 @@ static void prvCreateMQTTConnectionWithBroker( MQTTContext_t * pxMQTTContext,
 
 /**
  * @brief Function to update variable globalSubAckStatus with status
- * information from Subscribe ACK. Called bythe event callback after processing
- * an incoming SUBSCRIBE packet.
+ * information from Subscribe ACK. Called by the event callback after processing
+ * an incoming SUBACK packet.
  *
  * @param[in] Server response to the subscription request.
  */
@@ -640,7 +640,7 @@ static void prvMQTTSubscribeWithBackoffRetries( MQTTContext_t * pxMQTTContext )
         configASSERT( xResult == MQTTSuccess );
 
         /* Check if recent subscription request has been rejected. #xGlobalSubAckStatus is updated
-         * inthe event callback to reflect the status of the SUBACK sent by the broker. It represents
+         * in the event callback to reflect the status of the SUBACK sent by the broker. It represents
          * either the QoS level granted by the server upon subscription, or acknowledgement of
          * server rejection of the subscription request. */
         if( xGlobalSubAckStatus == MQTTSubAckFailure )

--- a/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_mutual_auth/DemoTasks/MutualAuthMQTTExample.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_mutual_auth/DemoTasks/MutualAuthMQTTExample.c
@@ -202,7 +202,7 @@ static void prvCreateMQTTConnectionWithBroker( MQTTContext_t * pxMQTTContext,
                                                NetworkContext_t * pxNetworkContext );
 
 /**
- * @brief Function to update variable globalSubAckStatus with status
+ * @brief Function to update variable #xGlobalSubAckStatus with status
  * information from Subscribe ACK. Called by the event callback after processing
  * an incoming SUBACK packet.
  *
@@ -309,13 +309,7 @@ static uint16_t usUnsubscribePacketIdentifier;
  * @brief Status of latest Subscribe ACK;
  * it is updated every time the callback function processes a Subscribe ACK.
  */
-static MQTTSubAckStatus_t xGlobalSubAckStatus = MQTTSubAckFailure;
-
-/**
- * @brief Topic to subscribe.
- * Used to re-subscribe to topics that failed initial subscription attempts.
- */
-static MQTTSubscribeInfo_t xGlobalSubscribeInfo;
+static MQTTSubAckStatus_t xGlobalSubAckStatus[ 1 ] = { MQTTSubAckFailure };
 
 
 /** @brief Static buffer used to hold MQTT messages being sent and received. */
@@ -449,7 +443,7 @@ static void prvMQTTDemoTask( void * pvParameters )
         TLS_FreeRTOS_Disconnect( &xNetworkContext );
 
         /* Reset global SUBACK status variable after completion of subscription request cycle. */
-        xGlobalSubAckStatus = MQTTSubAckFailure;
+        xGlobalSubAckStatus[ 0 ] = MQTTSubAckFailure;
 
         /* Wait for some time between two iterations to ensure that we do not
          * the broker. */
@@ -585,7 +579,7 @@ static void prvUpdateSubAckStatus( MQTTPacketInfo_t * pxPacketInfo )
     configASSERT( xResult == MQTTSuccess );
 
     /* Demo only subscribes to one topic, so only one status code is returned. */
-    xGlobalSubAckStatus = pucPayload[ 0 ];
+    xGlobalSubAckStatus[ 0 ] = pucPayload[ 0 ];
 }
 /*-----------------------------------------------------------*/
 
@@ -594,18 +588,19 @@ static void prvMQTTSubscribeWithBackoffRetries( MQTTContext_t * pxMQTTContext )
     MQTTStatus_t xResult = MQTTSuccess;
     RetryUtilsStatus_t xRetryUtilsStatus = RetryUtilsSuccess;
     RetryUtilsParams_t xRetryParams;
+    MQTTSubscribeInfo_t xMQTTSubscription[ 1 ];
 
     /* Some fields not used by this demo so start with everything at 0. */
-    ( void ) memset( ( void * ) &xGlobalSubscribeInfo, 0x00, sizeof( MQTTSubscribeInfo_t ) );
+    ( void ) memset( ( void * ) &xMQTTSubscription, 0x00, sizeof( xMQTTSubscription ) );
 
     /* Get a unique packet id. */
     usSubscribePacketIdentifier = MQTT_GetPacketId( pxMQTTContext );
 
     /* Subscribe to the mqttexampleTOPIC topic filter. This example subscribes to
      * only one topic and uses QOS0. */
-    xGlobalSubscribeInfo.qos = MQTTQoS0;
-    xGlobalSubscribeInfo.pTopicFilter = mqttexampleTOPIC;
-    xGlobalSubscribeInfo.topicFilterLength = ( uint16_t ) strlen( mqttexampleTOPIC );
+    xMQTTSubscription[ 0 ].qos = MQTTQoS0;
+    xMQTTSubscription[ 0 ].pTopicFilter = mqttexampleTOPIC;
+    xMQTTSubscription[ 0 ].topicFilterLength = ( uint16_t ) strlen( mqttexampleTOPIC );
 
     /* Initialize retry attempts and interval. */
     RetryUtils_ParamsReset( &xRetryParams );
@@ -622,8 +617,8 @@ static void prvMQTTSubscribeWithBackoffRetries( MQTTContext_t * pxMQTTContext )
          * messages received from the broker will have QOS0. */
         LogInfo( ( "Attempt to subscribe to the MQTT topic %s.\r\n", mqttexampleTOPIC ) );
         xResult = MQTT_Subscribe( pxMQTTContext,
-                                  &xGlobalSubscribeInfo,
-                                  sizeof( xGlobalSubscribeInfo ) / sizeof( MQTTSubscribeInfo_t ),
+                                  xMQTTSubscription,
+                                  sizeof( xMQTTSubscription ) / sizeof( MQTTSubscribeInfo_t ),
                                   usSubscribePacketIdentifier );
         configASSERT( xResult == MQTTSuccess );
 
@@ -643,7 +638,7 @@ static void prvMQTTSubscribeWithBackoffRetries( MQTTContext_t * pxMQTTContext )
          * in the event callback to reflect the status of the SUBACK sent by the broker. It represents
          * either the QoS level granted by the server upon subscription, or acknowledgement of
          * server rejection of the subscription request. */
-        if( xGlobalSubAckStatus == MQTTSubAckFailure )
+        if( xGlobalSubAckStatus[ 0 ] == MQTTSubAckFailure )
         {
             LogWarn( ( "Server rejected subscription request. Attempting to re-subscribe to topic %s.",
                        mqttexampleTOPIC ) );
@@ -651,7 +646,7 @@ static void prvMQTTSubscribeWithBackoffRetries( MQTTContext_t * pxMQTTContext )
         }
 
         configASSERT( xRetryUtilsStatus != RetryUtilsRetriesExhausted );
-    } while( ( xGlobalSubAckStatus == MQTTSubAckFailure ) && ( xRetryUtilsStatus == RetryUtilsSuccess ) );
+    } while( ( xGlobalSubAckStatus[ 0 ] == MQTTSubAckFailure ) && ( xRetryUtilsStatus == RetryUtilsSuccess ) );
 }
 /*-----------------------------------------------------------*/
 
@@ -689,16 +684,27 @@ static void prvMQTTPublishToTopic( MQTTContext_t * pxMQTTContext )
 static void prvMQTTUnsubscribeFromTopic( MQTTContext_t * pxMQTTContext )
 {
     MQTTStatus_t xResult;
+    MQTTSubscribeInfo_t xMQTTSubscription[ 1 ];
+
+    /* Some fields not used by this demo so start with everything at 0. */
+    ( void ) memset( ( void * ) &xMQTTSubscription, 0x00, sizeof( xMQTTSubscription ) );
+
+    /* Get a unique packet id. */
+    usSubscribePacketIdentifier = MQTT_GetPacketId( pxMQTTContext );
+
+    /* Subscribe to the mqttexampleTOPIC topic filter. This example subscribes to
+     * only one topic and uses QOS0. */
+    xMQTTSubscription[ 0 ].qos = MQTTQoS0;
+    xMQTTSubscription[ 0 ].pTopicFilter = mqttexampleTOPIC;
+    xMQTTSubscription[ 0 ].topicFilterLength = ( uint16_t ) strlen( mqttexampleTOPIC );
 
     /* Get next unique packet identifier. */
     usUnsubscribePacketIdentifier = MQTT_GetPacketId( pxMQTTContext );
 
-    /* Send UNSUBSCRIBE packet. Note that because #xGlobalSubscribeInfo
-     * was initialized before sending the SUBSCRIBE packet, there is no need
-     * to initialize it again. */
+    /* Send UNSUBSCRIBE packet. */
     xResult = MQTT_Unsubscribe( pxMQTTContext,
-                                &xGlobalSubscribeInfo,
-                                sizeof( xGlobalSubscribeInfo ) / sizeof( MQTTSubscribeInfo_t ),
+                                xMQTTSubscription,
+                                sizeof( xMQTTSubscription ) / sizeof( MQTTSubscribeInfo_t ),
                                 usUnsubscribePacketIdentifier );
 
     configASSERT( xResult == MQTTSuccess );
@@ -721,14 +727,14 @@ static void prvMQTTProcessResponse( MQTTPacketInfo_t * pxIncomingPacket,
             /* A SUBACK from the broker, containing the server response to our subscription request, has been received.
              * It contains the status code indicating server approval/rejection for the subscription to the single topic
              * requested. The SUBACK will be parsed to obtain the status code, and this status code will be stored in global
-             * variable globalSubAckStatus. */
+             * variable #xGlobalSubAckStatus. */
             prvUpdateSubAckStatus( pxIncomingPacket );
 
-            if( xGlobalSubAckStatus != MQTTSubAckFailure )
+            if( xGlobalSubAckStatus[ 0 ] != MQTTSubAckFailure )
             {
                 LogInfo( ( "Subscribed to the topic %s with maximum QoS %u.\r\n",
                            mqttexampleTOPIC,
-                           xGlobalSubAckStatus ) );
+                           xGlobalSubAckStatus[ 0 ] ) );
             }
 
             /* Make sure ACK packet identifier matches with Request packet identifier. */

--- a/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_mutual_auth/DemoTasks/MutualAuthMQTTExample.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_mutual_auth/DemoTasks/MutualAuthMQTTExample.c
@@ -477,8 +477,8 @@ static TlsTransportStatus_t prvConnectToServerWithBackoffRetries( NetworkCredent
     pxNetworkCredentials->privateKeySize = sizeof( democonfigCLIENT_PRIVATE_KEY_PEM );
 
     /* Initialize reconnect attempts and interval. */
-    xReconnectParams.maxRetryAttempts = MAX_RETRY_ATTEMPTS;
     RetryUtils_ParamsReset( &xReconnectParams );
+    xReconnectParams.maxRetryAttempts = MAX_RETRY_ATTEMPTS;
 
     /* Attempt to connect to MQTT broker. If connection fails, retry after
      * a timeout. Timeout value will exponentially increase till maximum

--- a/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_mutual_auth/DemoTasks/MutualAuthMQTTExample.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_mutual_auth/DemoTasks/MutualAuthMQTTExample.c
@@ -601,9 +601,10 @@ static void prvUpdateSubAckStatus( MQTTPacketInfo_t * pxPacketInfo )
      * from the event callback and non-NULL parameters. */
     configASSERT( xResult == MQTTSuccess );
 
-    for( ulTopicCount = 0; ulTopicCount < mqttexampleTOPIC_COUNT; ulTopicCount++ )
+    for( ulTopicCount = 0; ulTopicCount < ulSize; ulTopicCount++ )
     {
-        xTopicFilterContext[ ulTopicCount ].xSubAckStatus = pucPayload[ ulTopicCount ];
+        /* Multiply the index by 2 because the status code consists of two bytes. */
+        xTopicFilterContext[ ulTopicCount ].xSubAckStatus = pucPayload[ ulTopicCount * 2 ];
     }
 }
 /*-----------------------------------------------------------*/
@@ -614,7 +615,7 @@ static void prvMQTTSubscribeWithBackoffRetries( MQTTContext_t * pxMQTTContext )
     RetryUtilsStatus_t xRetryUtilsStatus = RetryUtilsSuccess;
     RetryUtilsParams_t xRetryParams;
     MQTTSubscribeInfo_t xMQTTSubscription[ mqttexampleTOPIC_COUNT ];
-    bool xFailedSubscribeToTopic = true;
+    bool xFailedSubscribeToTopic = false;
     uint32_t ulTopicCount = 0U;
 
     /* Some fields not used by this demo so start with everything at 0. */
@@ -676,9 +677,6 @@ static void prvMQTTSubscribeWithBackoffRetries( MQTTContext_t * pxMQTTContext )
                 break;
             }
         }
-
-        /* The broker has successfully acknowledged subscriptions to all topic filters. */
-        xFailedSubscribeToTopic = false;
 
         configASSERT( xRetryUtilsStatus != RetryUtilsRetriesExhausted );
     } while( ( xFailedSubscribeToTopic == true ) && ( xRetryUtilsStatus == RetryUtilsSuccess ) );

--- a/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_mutual_auth/WIN32.vcxproj
+++ b/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_mutual_auth/WIN32.vcxproj
@@ -13,7 +13,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{C686325E-3261-42F7-AEB1-DDE5280E1CEB}</ProjectGuid>
     <ProjectName>RTOSDemo</ProjectName>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
@@ -26,7 +26,7 @@
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
@@ -160,6 +160,7 @@
     <ClCompile Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\platform\freertos\mbedtls\mbedtls_freertos_port.c" />
     <ClCompile Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\platform\freertos\transport\src\freertos_sockets_wrapper.c" />
     <ClCompile Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\platform\freertos\transport\src\tls_freertos.c" />
+    <ClCompile Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\platform\freertos\retry_utils\retry_utils_freertos.c" />
     <ClCompile Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\standard\mqtt\src\mqtt_lightweight.c" />
     <ClCompile Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\standard\mqtt\src\mqtt_state.c" />
     <ClCompile Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\standard\mqtt\src\mqtt.c" />
@@ -513,6 +514,7 @@
     <ClInclude Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\platform\freertos\transport\include\freertos_sockets_wrapper.h" />
     <ClInclude Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\platform\freertos\transport\include\tls_freertos.h" />
     <ClInclude Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\platform\include\transport_interface.h" />
+    <ClInclude Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\platform\include\retry_utils.h" />
     <ClInclude Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\standard\mqtt\include\mqtt_lightweight.h" />
     <ClInclude Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\standard\mqtt\include\mqtt_state.h" />
     <ClInclude Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\standard\mqtt\include\mqtt.h" />

--- a/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_mutual_auth/WIN32.vcxproj.filters
+++ b/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_mutual_auth/WIN32.vcxproj.filters
@@ -399,6 +399,9 @@
     <ClCompile Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\platform\freertos\transport\src\freertos_sockets_wrapper.c">
       <Filter>FreeRTOS+\FreeRTOS IoT Libraries\platform\freertos\transport\src</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\platform\freertos\retry_utils\retry_utils_freertos.c">
+      <Filter>FreeRTOS+\FreeRTOS IoT Libraries\platform</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\include\NetworkInterface.h">
@@ -484,6 +487,9 @@
     </ClInclude>
     <ClInclude Include="mqtt_config.h" />
     <ClInclude Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\platform\include\transport_interface.h">
+      <Filter>FreeRTOS+\FreeRTOS IoT Libraries\platform</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\platform\include\retry_utils.h">
       <Filter>FreeRTOS+\FreeRTOS IoT Libraries\platform</Filter>
     </ClInclude>
     <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\aes.h">

--- a/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_plain_text/DemoTasks/PlaintextMQTTExample.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_plain_text/DemoTasks/PlaintextMQTTExample.c
@@ -543,7 +543,7 @@ static void prvUpdateSubAckStatus( MQTTPacketInfo_t * pxPacketInfo )
     for( ulTopicCount = 0; ulTopicCount < ulSize; ulTopicCount++ )
     {
         /* Multiply the index by 2 because the status code consists of two bytes. */
-        xTopicFilterContext[ ulTopicCount ].xSubAckStatus = pucPayload[ ulTopicCount * 2 ];
+        xTopicFilterContext[ ulTopicCount ].xSubAckStatus = pucPayload[ ulTopicCount ];
     }
 }
 /*-----------------------------------------------------------*/

--- a/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_plain_text/DemoTasks/PlaintextMQTTExample.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_plain_text/DemoTasks/PlaintextMQTTExample.c
@@ -111,6 +111,11 @@
 #define mqttexampleTOPIC                             democonfigCLIENT_IDENTIFIER "/example/topic"
 
 /**
+ * @brief The number of topic filters to subscribe to.
+ */
+#define mqttexampleTOPIC_COUNT                       ( 1 )
+
+/**
  * @brief The MQTT message published in this example.
  */
 #define mqttexampleMESSAGE                           "Hello World!"
@@ -189,7 +194,7 @@ static void prvCreateMQTTConnectionWithBroker( MQTTContext_t * pxMQTTContext,
                                                NetworkContext_t * pxNetworkContext );
 
 /**
- * @brief Function to update variable #xGlobalSubAckStatus with status
+ * @brief Function to update variable #xTopicFilterContext with status
  * information from Subscribe ACK. Called by the event callback after processing
  * an incoming SUBACK packet.
  *
@@ -288,10 +293,22 @@ static uint16_t usSubscribePacketIdentifier;
 static uint16_t usUnsubscribePacketIdentifier;
 
 /**
- * @brief Status of latest Subscribe ACK;
- * it is updated every time the callback function processes a Subscribe ACK.
+ * @brief A pair containing a topic filter and its SUBACK status.
  */
-static MQTTSubAckStatus_t xGlobalSubAckStatus[ 1 ] = { MQTTSubAckFailure };
+typedef struct topicFilterContext
+{
+    const char * pcTopicFilter;
+    MQTTSubAckStatus_t xSubAckStatus;
+} topicFilterContext_t;
+
+/**
+ * @brief An array containing the context of a SUBACK; the SUBACK status
+ * of a filter is updated when the event callback processes a SUBACK.
+ */
+static topicFilterContext_t xTopicFilterContext[ mqttexampleTOPIC_COUNT ] =
+{
+    { mqttexampleTOPIC, MQTTSubAckFailure }
+};
 
 
 /** @brief Static buffer used to hold MQTT messages being sent and received. */
@@ -322,7 +339,7 @@ void vStartSimpleMQTTDemo( void )
 
 static void prvMQTTDemoTask( void * pvParameters )
 {
-    uint32_t ulPublishCount = 0U;
+    uint32_t ulPublishCount = 0U, ulTopicCount = 0U;
     const uint32_t ulMaxPublishCount = 5UL;
     NetworkContext_t xNetworkContext = { 0 };
     MQTTContext_t xMQTTContext;
@@ -396,8 +413,11 @@ static void prvMQTTDemoTask( void * pvParameters )
         xNetworkStatus = Plaintext_FreeRTOS_Disconnect( &xNetworkContext );
         configASSERT( xNetworkStatus == PLAINTEXT_TRANSPORT_SUCCESS );
 
-        /* Reset global SUBACK status variable after completion of subscription request cycle. */
-        xGlobalSubAckStatus[ 0 ] = MQTTSubAckFailure;
+        /* Reset SUBACK status for each topic iflter after completion of subscription request cycle. */
+        for( ulTopicCount = 0; ulTopicCount < mqttexampleTOPIC_COUNT; ulTopicCount++ )
+        {
+            xTopicFilterContext[ ulTopicCount ].xSubAckStatus = MQTTSubAckFailure;
+        }
 
         /* Wait for some time between two iterations to ensure that we do not
          * bombard the public test mosquitto broker. */
@@ -512,6 +532,7 @@ static void prvUpdateSubAckStatus( MQTTPacketInfo_t * pxPacketInfo )
     MQTTStatus_t xResult = MQTTSuccess;
     uint8_t * pucPayload = NULL;
     size_t ulSize = 0;
+    uint32_t ulTopicCount = 0U;
 
     xResult = MQTT_GetSubAckStatusCodes( pxPacketInfo, &pucPayload, &ulSize );
 
@@ -520,7 +541,10 @@ static void prvUpdateSubAckStatus( MQTTPacketInfo_t * pxPacketInfo )
     configASSERT( xResult == MQTTSuccess );
 
     /* Demo only subscribes to one topic, so only one status code is returned. */
-    xGlobalSubAckStatus[ 0 ] = pucPayload[ 0 ];
+    for( ulTopicCount = 0; ulTopicCount < mqttexampleTOPIC_COUNT; ulTopicCount++ )
+    {
+        xTopicFilterContext[ ulTopicCount ].xSubAckStatus = pucPayload[ ulTopicCount ];
+    }
 }
 /*-----------------------------------------------------------*/
 
@@ -529,7 +553,9 @@ static void prvMQTTSubscribeWithBackoffRetries( MQTTContext_t * pxMQTTContext )
     MQTTStatus_t xResult = MQTTSuccess;
     RetryUtilsStatus_t xRetryUtilsStatus = RetryUtilsSuccess;
     RetryUtilsParams_t xRetryParams;
-    MQTTSubscribeInfo_t xMQTTSubscription[ 1 ];
+    MQTTSubscribeInfo_t xMQTTSubscription[ mqttexampleTOPIC_COUNT ];
+    bool xFailedSubscribeToTopic = true;
+    uint32_t ulTopicCount = 0U;
 
     /* Some fields not used by this demo so start with everything at 0. */
     ( void ) memset( ( void * ) &xMQTTSubscription, 0x00, sizeof( xMQTTSubscription ) );
@@ -575,19 +601,27 @@ static void prvMQTTSubscribeWithBackoffRetries( MQTTContext_t * pxMQTTContext )
         xResult = MQTT_ProcessLoop( pxMQTTContext, mqttexamplePROCESS_LOOP_TIMEOUT_MS );
         configASSERT( xResult == MQTTSuccess );
 
-        /* Check if recent subscription request has been rejected. #xGlobalSubAckStatus is updated
+        /* Check if recent subscription request has been rejected. #xTopicFilterContext is updated
          * in the event callback to reflect the status of the SUBACK sent by the broker. It represents
          * either the QoS level granted by the server upon subscription, or acknowledgement of
          * server rejection of the subscription request. */
-        if( xGlobalSubAckStatus[ 0 ] == MQTTSubAckFailure )
+        for( ulTopicCount = 0; ulTopicCount < mqttexampleTOPIC_COUNT; ulTopicCount++ )
         {
-            LogWarn( ( "Server rejected subscription request. Attempting to re-subscribe to topic %s.",
-                       mqttexampleTOPIC ) );
-            xRetryUtilsStatus = RetryUtils_BackoffAndSleep( &xRetryParams );
+            if( xTopicFilterContext[ ulTopicCount ].xSubAckStatus == MQTTSubAckFailure )
+            {
+                LogWarn( ( "Server rejected subscription request. Attempting to re-subscribe to topic %s.",
+                           xTopicFilterContext[ ulTopicCount ].pcTopicFilter ) );
+                xFailedSubscribeToTopic = true;
+                xRetryUtilsStatus = RetryUtils_BackoffAndSleep( &xRetryParams );
+                break;
+            }
         }
 
+        /* The broker has successfully acknowledged subscriptions to all topic filters. */
+        xFailedSubscribeToTopic = false;
+
         configASSERT( xRetryUtilsStatus != RetryUtilsRetriesExhausted );
-    } while( ( xGlobalSubAckStatus[ 0 ] == MQTTSubAckFailure ) && ( xRetryUtilsStatus == RetryUtilsSuccess ) );
+    } while( ( xFailedSubscribeToTopic == true ) && ( xRetryUtilsStatus == RetryUtilsSuccess ) );
 }
 /*-----------------------------------------------------------*/
 
@@ -622,7 +656,7 @@ static void prvMQTTPublishToTopic( MQTTContext_t * pxMQTTContext )
 static void prvMQTTUnsubscribeFromTopic( MQTTContext_t * pxMQTTContext )
 {
     MQTTStatus_t xResult;
-    MQTTSubscribeInfo_t xMQTTSubscription[ 1 ];
+    MQTTSubscribeInfo_t xMQTTSubscription[ mqttexampleTOPIC_COUNT ];
 
     /* Some fields not used by this demo so start with everything at 0. */
     ( void ) memset( ( void * ) &xMQTTSubscription, 0x00, sizeof( xMQTTSubscription ) );
@@ -652,6 +686,8 @@ static void prvMQTTUnsubscribeFromTopic( MQTTContext_t * pxMQTTContext )
 static void prvMQTTProcessResponse( MQTTPacketInfo_t * pxIncomingPacket,
                                     uint16_t usPacketId )
 {
+    uint32_t ulTopicCount = 0U;
+
     switch( pxIncomingPacket->type )
     {
         case MQTT_PACKET_TYPE_SUBACK:
@@ -659,14 +695,17 @@ static void prvMQTTProcessResponse( MQTTPacketInfo_t * pxIncomingPacket,
             /* A SUBACK from the broker, containing the server response to our subscription request, has been received.
              * It contains the status code indicating server approval/rejection for the subscription to the single topic
              * requested. The SUBACK will be parsed to obtain the status code, and this status code will be stored in global
-             * variable #xGlobalSubAckStatus. */
+             * variable #xTopicFilterContext. */
             prvUpdateSubAckStatus( pxIncomingPacket );
 
-            if( xGlobalSubAckStatus[ 0 ] != MQTTSubAckFailure )
+            for( ulTopicCount = 0; ulTopicCount < mqttexampleTOPIC_COUNT; ulTopicCount++ )
             {
-                LogInfo( ( "Subscribed to the topic %s with maximum QoS %u.\r\n",
-                           mqttexampleTOPIC,
-                           xGlobalSubAckStatus[ 0 ] ) );
+                if( xTopicFilterContext[ ulTopicCount ].xSubAckStatus != MQTTSubAckFailure )
+                {
+                    LogInfo( ( "Subscribed to the topic %s with maximum QoS %u.\r\n",
+                               xTopicFilterContext[ ulTopicCount ].pcTopicFilter,
+                               xTopicFilterContext[ ulTopicCount ].xSubAckStatus ) );
+                }
             }
 
             /* Make sure ACK packet identifier matches with Request packet identifier. */

--- a/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_plain_text/DemoTasks/PlaintextMQTTExample.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_plain_text/DemoTasks/PlaintextMQTTExample.c
@@ -416,7 +416,7 @@ static void prvMQTTDemoTask( void * pvParameters )
 }
 /*-----------------------------------------------------------*/
 
-static PlaintextTransportStatus_t prvConnectToServerWithBackoffRetries( NetworkContext_t * pNetworkContext )
+static PlaintextTransportStatus_t prvConnectToServerWithBackoffRetries( NetworkContext_t * pxNetworkContext )
 {
     PlaintextTransportStatus_t xNetworkStatus;
     RetryUtilsStatus_t xRetryUtilsStatus = RetryUtilsSuccess;
@@ -438,7 +438,7 @@ static PlaintextTransportStatus_t prvConnectToServerWithBackoffRetries( NetworkC
         LogInfo( ( "Create a TCP connection to %s:%d.",
                    democonfigMQTT_BROKER_ENDPOINT,
                    democonfigMQTT_BROKER_PORT ) );
-        xNetworkStatus = Plaintext_FreeRTOS_Connect( pNetworkContext,
+        xNetworkStatus = Plaintext_FreeRTOS_Connect( pxNetworkContext,
                                                      democonfigMQTT_BROKER_ENDPOINT,
                                                      democonfigMQTT_BROKER_PORT,
                                                      TRANSPORT_SEND_RECV_TIMEOUT_MS,

--- a/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_plain_text/DemoTasks/PlaintextMQTTExample.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_plain_text/DemoTasks/PlaintextMQTTExample.c
@@ -111,7 +111,7 @@
 #define mqttexampleTOPIC                             democonfigCLIENT_IDENTIFIER "/example/topic"
 
 /**
- * @brief The number of topic filters to subscribe to.
+ * @brief The number of topic filters to subscribe.
  */
 #define mqttexampleTOPIC_COUNT                       ( 1 )
 
@@ -376,7 +376,7 @@ static void prvMQTTDemoTask( void * pvParameters )
         prvMQTTSubscribeWithBackoffRetries( &xMQTTContext );
 
         /**************************** Publish and Keep Alive Loop. ******************************/
-        /* Publish messages with QOS0, send and process Keep alive messages. */
+        /* Publish messages with QoS0, send and process Keep alive messages. */
         for( ulPublishCount = 0; ulPublishCount < ulMaxPublishCount; ulPublishCount++ )
         {
             LogInfo( ( "Publish to the MQTT topic %s.\r\n", mqttexampleTOPIC ) );
@@ -540,7 +540,6 @@ static void prvUpdateSubAckStatus( MQTTPacketInfo_t * pxPacketInfo )
      * from the event callback and non-NULL parameters. */
     configASSERT( xResult == MQTTSuccess );
 
-    /* Demo only subscribes to one topic, so only one status code is returned. */
     for( ulTopicCount = 0; ulTopicCount < mqttexampleTOPIC_COUNT; ulTopicCount++ )
     {
         xTopicFilterContext[ ulTopicCount ].xSubAckStatus = pucPayload[ ulTopicCount ];
@@ -635,7 +634,7 @@ static void prvMQTTPublishToTopic( MQTTContext_t * pxMQTTContext )
      * asserts().
      ***/
 
-    /* Some fields not used by this demo so start with everything at 0. */
+    /* Some fields are not used by this demo so start with everything at 0. */
     ( void ) memset( ( void * ) &xMQTTPublishInfo, 0x00, sizeof( xMQTTPublishInfo ) );
 
     /* This demo uses QoS0. */

--- a/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_plain_text/DemoTasks/PlaintextMQTTExample.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_plain_text/DemoTasks/PlaintextMQTTExample.c
@@ -208,7 +208,7 @@ static void prvUpdateSubAckStatus( MQTTPacketInfo_t * pxPacketInfo );
 static void prvMQTTSubscribeWithBackoffRetries( MQTTContext_t * pxMQTTContext );
 
 /**
- * @brief  Publishes a message mqttexampleMESSAGE on mqttexampleTOPIC topic.
+ * @brief Publishes a message mqttexampleMESSAGE on mqttexampleTOPIC topic.
  *
  * @param pxMQTTContext MQTT context pointer.
  */

--- a/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_plain_text/DemoTasks/PlaintextMQTTExample.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_plain_text/DemoTasks/PlaintextMQTTExample.c
@@ -422,8 +422,8 @@ static PlaintextTransportStatus_t prvConnectToServerWithBackoffRetries( NetworkC
     RetryUtilsParams_t xReconnectParams;
 
     /* Initialize reconnect attempts and interval. */
-    xReconnectParams.maxRetryAttempts = MAX_RETRY_ATTEMPTS;
     RetryUtils_ParamsReset( &xReconnectParams );
+    xReconnectParams.maxRetryAttempts = MAX_RETRY_ATTEMPTS;
 
     /* Attempt to connect to MQTT broker. If connection fails, retry after
      * a timeout. Timeout value will exponentially increase till maximum

--- a/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_plain_text/DemoTasks/PlaintextMQTTExample.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_plain_text/DemoTasks/PlaintextMQTTExample.c
@@ -189,7 +189,7 @@ static void prvCreateMQTTConnectionWithBroker( MQTTContext_t * pxMQTTContext,
                                                NetworkContext_t * pxNetworkContext );
 
 /**
- * @brief Function to update variable globalSubAckStatus with status
+ * @brief Function to update variable #xGlobalSubAckStatus with status
  * information from Subscribe ACK. Called by the event callback after processing
  * an incoming SUBACK packet.
  *
@@ -291,13 +291,7 @@ static uint16_t usUnsubscribePacketIdentifier;
  * @brief Status of latest Subscribe ACK;
  * it is updated every time the callback function processes a Subscribe ACK.
  */
-static MQTTSubAckStatus_t xGlobalSubAckStatus = MQTTSubAckFailure;
-
-/**
- * @brief Topic to subscribe.
- * Used to re-subscribe to topics that failed initial subscription attempts.
- */
-static MQTTSubscribeInfo_t xGlobalSubscribeInfo;
+static MQTTSubAckStatus_t xGlobalSubAckStatus[ 1 ] = { MQTTSubAckFailure };
 
 
 /** @brief Static buffer used to hold MQTT messages being sent and received. */
@@ -403,7 +397,7 @@ static void prvMQTTDemoTask( void * pvParameters )
         configASSERT( xNetworkStatus == PLAINTEXT_TRANSPORT_SUCCESS );
 
         /* Reset global SUBACK status variable after completion of subscription request cycle. */
-        xGlobalSubAckStatus = MQTTSubAckFailure;
+        xGlobalSubAckStatus[ 0 ] = MQTTSubAckFailure;
 
         /* Wait for some time between two iterations to ensure that we do not
          * bombard the public test mosquitto broker. */
@@ -526,7 +520,7 @@ static void prvUpdateSubAckStatus( MQTTPacketInfo_t * pxPacketInfo )
     configASSERT( xResult == MQTTSuccess );
 
     /* Demo only subscribes to one topic, so only one status code is returned. */
-    xGlobalSubAckStatus = pucPayload[ 0 ];
+    xGlobalSubAckStatus[ 0 ] = pucPayload[ 0 ];
 }
 /*-----------------------------------------------------------*/
 
@@ -535,18 +529,19 @@ static void prvMQTTSubscribeWithBackoffRetries( MQTTContext_t * pxMQTTContext )
     MQTTStatus_t xResult = MQTTSuccess;
     RetryUtilsStatus_t xRetryUtilsStatus = RetryUtilsSuccess;
     RetryUtilsParams_t xRetryParams;
+    MQTTSubscribeInfo_t xMQTTSubscription[ 1 ];
 
     /* Some fields not used by this demo so start with everything at 0. */
-    ( void ) memset( ( void * ) &xGlobalSubscribeInfo, 0x00, sizeof( MQTTSubscribeInfo_t ) );
+    ( void ) memset( ( void * ) &xMQTTSubscription, 0x00, sizeof( xMQTTSubscription ) );
 
     /* Get a unique packet id. */
     usSubscribePacketIdentifier = MQTT_GetPacketId( pxMQTTContext );
 
     /* Subscribe to the mqttexampleTOPIC topic filter. This example subscribes to
-     * only one topic and uses QOS0. */
-    xGlobalSubscribeInfo.qos = MQTTQoS0;
-    xGlobalSubscribeInfo.pTopicFilter = mqttexampleTOPIC;
-    xGlobalSubscribeInfo.topicFilterLength = ( uint16_t ) strlen( mqttexampleTOPIC );
+     * only one topic and uses QoS0. */
+    xMQTTSubscription[ 0 ].qos = MQTTQoS0;
+    xMQTTSubscription[ 0 ].pTopicFilter = mqttexampleTOPIC;
+    xMQTTSubscription[ 0 ].topicFilterLength = ( uint16_t ) strlen( mqttexampleTOPIC );
 
     /* Initialize retry attempts and interval. */
     RetryUtils_ParamsReset( &xRetryParams );
@@ -563,8 +558,8 @@ static void prvMQTTSubscribeWithBackoffRetries( MQTTContext_t * pxMQTTContext )
          * messages received from the broker will have QOS0. */
         LogInfo( ( "Attempt to subscribe to the MQTT topic %s.\r\n", mqttexampleTOPIC ) );
         xResult = MQTT_Subscribe( pxMQTTContext,
-                                  &xGlobalSubscribeInfo,
-                                  sizeof( xGlobalSubscribeInfo ) / sizeof( MQTTSubscribeInfo_t ),
+                                  xMQTTSubscription,
+                                  sizeof( xMQTTSubscription ) / sizeof( MQTTSubscribeInfo_t ),
                                   usSubscribePacketIdentifier );
         configASSERT( xResult == MQTTSuccess );
 
@@ -584,7 +579,7 @@ static void prvMQTTSubscribeWithBackoffRetries( MQTTContext_t * pxMQTTContext )
          * in the event callback to reflect the status of the SUBACK sent by the broker. It represents
          * either the QoS level granted by the server upon subscription, or acknowledgement of
          * server rejection of the subscription request. */
-        if( xGlobalSubAckStatus == MQTTSubAckFailure )
+        if( xGlobalSubAckStatus[ 0 ] == MQTTSubAckFailure )
         {
             LogWarn( ( "Server rejected subscription request. Attempting to re-subscribe to topic %s.",
                        mqttexampleTOPIC ) );
@@ -592,7 +587,7 @@ static void prvMQTTSubscribeWithBackoffRetries( MQTTContext_t * pxMQTTContext )
         }
 
         configASSERT( xRetryUtilsStatus != RetryUtilsRetriesExhausted );
-    } while( ( xGlobalSubAckStatus == MQTTSubAckFailure ) && ( xRetryUtilsStatus == RetryUtilsSuccess ) );
+    } while( ( xGlobalSubAckStatus[ 0 ] == MQTTSubAckFailure ) && ( xRetryUtilsStatus == RetryUtilsSuccess ) );
 }
 /*-----------------------------------------------------------*/
 
@@ -609,7 +604,7 @@ static void prvMQTTPublishToTopic( MQTTContext_t * pxMQTTContext )
     /* Some fields not used by this demo so start with everything at 0. */
     ( void ) memset( ( void * ) &xMQTTPublishInfo, 0x00, sizeof( xMQTTPublishInfo ) );
 
-    /* This demo uses QOS0. */
+    /* This demo uses QoS0. */
     xMQTTPublishInfo.qos = MQTTQoS0;
     xMQTTPublishInfo.retain = false;
     xMQTTPublishInfo.pTopicName = mqttexampleTOPIC;
@@ -627,16 +622,27 @@ static void prvMQTTPublishToTopic( MQTTContext_t * pxMQTTContext )
 static void prvMQTTUnsubscribeFromTopic( MQTTContext_t * pxMQTTContext )
 {
     MQTTStatus_t xResult;
+    MQTTSubscribeInfo_t xMQTTSubscription[ 1 ];
+
+    /* Some fields not used by this demo so start with everything at 0. */
+    ( void ) memset( ( void * ) &xMQTTSubscription, 0x00, sizeof( xMQTTSubscription ) );
+
+    /* Get a unique packet id. */
+    usSubscribePacketIdentifier = MQTT_GetPacketId( pxMQTTContext );
+
+    /* Subscribe to the mqttexampleTOPIC topic filter. This example subscribes to
+     * only one topic and uses QoS0. */
+    xMQTTSubscription[ 0 ].qos = MQTTQoS0;
+    xMQTTSubscription[ 0 ].pTopicFilter = mqttexampleTOPIC;
+    xMQTTSubscription[ 0 ].topicFilterLength = ( uint16_t ) strlen( mqttexampleTOPIC );
 
     /* Get next unique packet identifier. */
     usUnsubscribePacketIdentifier = MQTT_GetPacketId( pxMQTTContext );
 
-    /* Send UNSUBSCRIBE packet. Note that because #xGlobalSubscribeInfo
-     * was initialized before sending the SUBSCRIBE packet, there is no need
-     * to initialize it again. */
+    /* Send UNSUBSCRIBE packet. */
     xResult = MQTT_Unsubscribe( pxMQTTContext,
-                                &xGlobalSubscribeInfo,
-                                sizeof( xGlobalSubscribeInfo ) / sizeof( MQTTSubscribeInfo_t ),
+                                xMQTTSubscription,
+                                sizeof( xMQTTSubscription ) / sizeof( MQTTSubscribeInfo_t ),
                                 usUnsubscribePacketIdentifier );
 
     configASSERT( xResult == MQTTSuccess );
@@ -653,14 +659,14 @@ static void prvMQTTProcessResponse( MQTTPacketInfo_t * pxIncomingPacket,
             /* A SUBACK from the broker, containing the server response to our subscription request, has been received.
              * It contains the status code indicating server approval/rejection for the subscription to the single topic
              * requested. The SUBACK will be parsed to obtain the status code, and this status code will be stored in global
-             * variable globalSubAckStatus. */
+             * variable #xGlobalSubAckStatus. */
             prvUpdateSubAckStatus( pxIncomingPacket );
 
-            if( xGlobalSubAckStatus != MQTTSubAckFailure )
+            if( xGlobalSubAckStatus[ 0 ] != MQTTSubAckFailure )
             {
                 LogInfo( ( "Subscribed to the topic %s with maximum QoS %u.\r\n",
                            mqttexampleTOPIC,
-                           xGlobalSubAckStatus ) );
+                           xGlobalSubAckStatus[ 0 ] ) );
             }
 
             /* Make sure ACK packet identifier matches with Request packet identifier. */

--- a/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_plain_text/DemoTasks/PlaintextMQTTExample.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_plain_text/DemoTasks/PlaintextMQTTExample.c
@@ -540,9 +540,10 @@ static void prvUpdateSubAckStatus( MQTTPacketInfo_t * pxPacketInfo )
      * from the event callback and non-NULL parameters. */
     configASSERT( xResult == MQTTSuccess );
 
-    for( ulTopicCount = 0; ulTopicCount < mqttexampleTOPIC_COUNT; ulTopicCount++ )
+    for( ulTopicCount = 0; ulTopicCount < ulSize; ulTopicCount++ )
     {
-        xTopicFilterContext[ ulTopicCount ].xSubAckStatus = pucPayload[ ulTopicCount ];
+        /* Multiply the index by 2 because the status code consists of two bytes. */
+        xTopicFilterContext[ ulTopicCount ].xSubAckStatus = pucPayload[ ulTopicCount * 2 ];
     }
 }
 /*-----------------------------------------------------------*/
@@ -553,7 +554,7 @@ static void prvMQTTSubscribeWithBackoffRetries( MQTTContext_t * pxMQTTContext )
     RetryUtilsStatus_t xRetryUtilsStatus = RetryUtilsSuccess;
     RetryUtilsParams_t xRetryParams;
     MQTTSubscribeInfo_t xMQTTSubscription[ mqttexampleTOPIC_COUNT ];
-    bool xFailedSubscribeToTopic = true;
+    bool xFailedSubscribeToTopic = false;
     uint32_t ulTopicCount = 0U;
 
     /* Some fields not used by this demo so start with everything at 0. */
@@ -615,9 +616,6 @@ static void prvMQTTSubscribeWithBackoffRetries( MQTTContext_t * pxMQTTContext )
                 break;
             }
         }
-
-        /* The broker has successfully acknowledged subscriptions to all topic filters. */
-        xFailedSubscribeToTopic = false;
 
         configASSERT( xRetryUtilsStatus != RetryUtilsRetriesExhausted );
     } while( ( xFailedSubscribeToTopic == true ) && ( xRetryUtilsStatus == RetryUtilsSuccess ) );

--- a/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_plain_text/DemoTasks/PlaintextMQTTExample.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_plain_text/DemoTasks/PlaintextMQTTExample.c
@@ -262,7 +262,9 @@ static void prvEventCallback( MQTTContext_t * pxMQTTContext,
 
 /*-----------------------------------------------------------*/
 
-/* @brief Static buffer used to hold MQTT messages being sent and received. */
+/**
+ * @brief Static buffer used to hold MQTT messages being sent and received.
+ */
 static uint8_t ucSharedBuffer[ mqttexampleSHARED_BUFFER_SIZE ];
 
 /**
@@ -293,7 +295,7 @@ static uint16_t usUnsubscribePacketIdentifier;
 static MQTTSubAckStatus_t xGlobalSubAckStatus = MQTTSubAckFailure;
 
 /**
- * @brief Array to keep subscription topics.
+ * @brief Topic to subscribe.
  * Used to re-subscribe to topics that failed initial subscription attempts.
  */
 static MQTTSubscribeInfo_t xGlobalSubscribeInfo;

--- a/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_plain_text/DemoTasks/PlaintextMQTTExample.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_plain_text/DemoTasks/PlaintextMQTTExample.c
@@ -22,7 +22,6 @@
  * http://www.FreeRTOS.org
  * http://aws.amazon.com/freertos
  *
- * 1 tab == 4 spaces!
  */
 
 /*
@@ -101,7 +100,7 @@
 /**
  * @brief Timeout for receiving CONNACK packet in milliseconds.
  */
-#define mqttexampleCONNACK_RECV_TIMEOUT_MS          ( 1000U )
+#define mqttexampleCONNACK_RECV_TIMEOUT_MS           ( 1000U )
 
 /**
  * @brief The topic to subscribe and publish to in the example.
@@ -109,28 +108,28 @@
  * The topic name starts with the client identifier to ensure that each demo
  * interacts with a unique topic name.
  */
-#define mqttexampleTOPIC                            democonfigCLIENT_IDENTIFIER "/example/topic"
+#define mqttexampleTOPIC                             democonfigCLIENT_IDENTIFIER "/example/topic"
 
 /**
  * @brief The MQTT message published in this example.
  */
-#define mqttexampleMESSAGE                          "Hello World!"
+#define mqttexampleMESSAGE                           "Hello World!"
 
 /**
  * @brief Dimensions a file scope buffer currently used to send and receive MQTT data
  * from a socket.
  */
-#define mqttexampleSHARED_BUFFER_SIZE               ( 500U )
+#define mqttexampleSHARED_BUFFER_SIZE                ( 500U )
 
 /**
  * @brief Time to wait between each cycle of the demo implemented by prvMQTTDemoTask().
  */
-#define mqttexampleDELAY_BETWEEN_DEMO_ITERATIONS    ( pdMS_TO_TICKS( 5000U ) )
+#define mqttexampleDELAY_BETWEEN_DEMO_ITERATIONS     ( pdMS_TO_TICKS( 5000U ) )
 
 /**
  * @brief Timeout for MQTT_ProcessLoop in milliseconds.
  */
-#define mqttexamplePROCESS_LOOP_TIMEOUT_MS          ( 500U )
+#define mqttexamplePROCESS_LOOP_TIMEOUT_MS           ( 500U )
 
 /**
  * @brief Keep alive time reported to the broker while establishing an MQTT connection.
@@ -140,21 +139,21 @@
  * absence of sending any other Control Packets, the Client MUST send a
  * PINGREQ Packet.
  */
-#define mqttexampleKEEP_ALIVE_TIMEOUT_SECONDS       ( 60U )
+#define mqttexampleKEEP_ALIVE_TIMEOUT_SECONDS        ( 60U )
 
 /**
  * @brief Delay between MQTT publishes. Note that the process loop also has a
  * timeout, so the total time between publishes is the sum of the two delays.
  */
-#define mqttexampleDELAY_BETWEEN_PUBLISHES          ( pdMS_TO_TICKS( 500U ) )
+#define mqttexampleDELAY_BETWEEN_PUBLISHES           ( pdMS_TO_TICKS( 500U ) )
 
 /**
  * @brief Transport timeout in milliseconds for transport send and receive.
  */
-#define TRANSPORT_SEND_RECV_TIMEOUT_MS              ( 200U )
+#define mqttexampleTRANSPORT_SEND_RECV_TIMEOUT_MS    ( 200U )
 
-#define _MILLISECONDS_PER_SECOND                    ( 1000U )                                         /**< @brief Milliseconds per second. */
-#define _MILLISECONDS_PER_TICK                      ( _MILLISECONDS_PER_SECOND / configTICK_RATE_HZ ) /**< Milliseconds per FreeRTOS tick. */
+#define _MILLISECONDS_PER_SECOND                     ( 1000U )                                         /**< @brief Milliseconds per second. */
+#define _MILLISECONDS_PER_TICK                       ( _MILLISECONDS_PER_SECOND / configTICK_RATE_HZ ) /**< Milliseconds per FreeRTOS tick. */
 
 /*-----------------------------------------------------------*/
 
@@ -191,8 +190,8 @@ static void prvCreateMQTTConnectionWithBroker( MQTTContext_t * pxMQTTContext,
 
 /**
  * @brief Function to update variable globalSubAckStatus with status
- * information from Subscribe ACK. Called by eventCallback after processing
- * incoming subscribe echo.
+ * information from Subscribe ACK. Called bythe event callback after processing
+ * an incoming SUBSCRIBE packet.
  *
  * @param Server response to the subscription request.
  */
@@ -441,8 +440,8 @@ static PlaintextTransportStatus_t prvConnectToServerWithBackoffRetries( NetworkC
         xNetworkStatus = Plaintext_FreeRTOS_Connect( pxNetworkContext,
                                                      democonfigMQTT_BROKER_ENDPOINT,
                                                      democonfigMQTT_BROKER_PORT,
-                                                     TRANSPORT_SEND_RECV_TIMEOUT_MS,
-                                                     TRANSPORT_SEND_RECV_TIMEOUT_MS );
+                                                     mqttexampleTRANSPORT_SEND_RECV_TIMEOUT_MS,
+                                                     mqttexampleTRANSPORT_SEND_RECV_TIMEOUT_MS );
 
         if( xNetworkStatus != PLAINTEXT_TRANSPORT_SUCCESS )
         {
@@ -550,8 +549,8 @@ static void prvMQTTSubscribeWithBackoffRetries( MQTTContext_t * pxMQTTContext )
     xGlobalSubscribeInfo.topicFilterLength = ( uint16_t ) strlen( mqttexampleTOPIC );
 
     /* Initialize retry attempts and interval. */
-    xRetryParams.maxRetryAttempts = MAX_RETRY_ATTEMPTS;
     RetryUtils_ParamsReset( &xRetryParams );
+    xRetryParams.maxRetryAttempts = MAX_RETRY_ATTEMPTS;
 
     do
     {
@@ -582,7 +581,7 @@ static void prvMQTTSubscribeWithBackoffRetries( MQTTContext_t * pxMQTTContext )
         configASSERT( xResult == MQTTSuccess );
 
         /* Check if recent subscription request has been rejected. #xGlobalSubAckStatus is updated
-         * in eventCallback to reflect the status of the SUBACK sent by the broker. It represents
+         * inthe event callback to reflect the status of the SUBACK sent by the broker. It represents
          * either the QoS level granted by the server upon subscription, or acknowledgement of
          * server rejection of the subscription request. */
         if( xGlobalSubAckStatus == MQTTSubAckFailure )

--- a/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_plain_text/DemoTasks/PlaintextMQTTExample.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_plain_text/DemoTasks/PlaintextMQTTExample.c
@@ -190,8 +190,8 @@ static void prvCreateMQTTConnectionWithBroker( MQTTContext_t * pxMQTTContext,
 
 /**
  * @brief Function to update variable globalSubAckStatus with status
- * information from Subscribe ACK. Called bythe event callback after processing
- * an incoming SUBSCRIBE packet.
+ * information from Subscribe ACK. Called by the event callback after processing
+ * an incoming SUBACK packet.
  *
  * @param Server response to the subscription request.
  */
@@ -581,7 +581,7 @@ static void prvMQTTSubscribeWithBackoffRetries( MQTTContext_t * pxMQTTContext )
         configASSERT( xResult == MQTTSuccess );
 
         /* Check if recent subscription request has been rejected. #xGlobalSubAckStatus is updated
-         * inthe event callback to reflect the status of the SUBACK sent by the broker. It represents
+         * in the event callback to reflect the status of the SUBACK sent by the broker. It represents
          * either the QoS level granted by the server upon subscription, or acknowledgement of
          * server rejection of the subscription request. */
         if( xGlobalSubAckStatus == MQTTSubAckFailure )

--- a/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_plain_text/DemoTasks/PlaintextMQTTExample.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_plain_text/DemoTasks/PlaintextMQTTExample.c
@@ -413,7 +413,7 @@ static void prvMQTTDemoTask( void * pvParameters )
         xNetworkStatus = Plaintext_FreeRTOS_Disconnect( &xNetworkContext );
         configASSERT( xNetworkStatus == PLAINTEXT_TRANSPORT_SUCCESS );
 
-        /* Reset SUBACK status for each topic iflter after completion of subscription request cycle. */
+        /* Reset SUBACK status for each topic filter after completion of subscription request cycle. */
         for( ulTopicCount = 0; ulTopicCount < mqttexampleTOPIC_COUNT; ulTopicCount++ )
         {
             xTopicFilterContext[ ulTopicCount ].xSubAckStatus = MQTTSubAckFailure;
@@ -542,7 +542,6 @@ static void prvUpdateSubAckStatus( MQTTPacketInfo_t * pxPacketInfo )
 
     for( ulTopicCount = 0; ulTopicCount < ulSize; ulTopicCount++ )
     {
-        /* Multiply the index by 2 because the status code consists of two bytes. */
         xTopicFilterContext[ ulTopicCount ].xSubAckStatus = pucPayload[ ulTopicCount ];
     }
 }


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->
This PR simply follows changes from PR #271. It implements retries for all MQTT demos. If an attempt (connect or subscribe) fails, vTaskDelay is called to make the task sleep for some backoff period that doubles on each retry (but is bounded).

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
