### PR TITLE
Add 20Mhz support by overwriting MCLKCTRLB default register value 0x1…

### DIFF
--- a/FreeRTOS/Demo/AVR_ATMega4809_Atmel_Studio/RTOSDemo/clk_config.h
+++ b/FreeRTOS/Demo/AVR_ATMega4809_Atmel_Studio/RTOSDemo/clk_config.h
@@ -6,7 +6,10 @@
 
 #if ( configCPU_CLOCK_HZ == 20000000 )
 
-    #define CLK_init()  _PROTECTED_WRITE(CLKCTRL.MCLKCTRLA, CLKCTRL_CLKSEL_OSC20M_gc);
+    #define CLK_init()  { \
+                        _PROTECTED_WRITE(CLKCTRL.MCLKCTRLA, CLKCTRL_CLKSEL_OSC20M_gc); \
+                        _PROTECTED_WRITE(CLKCTRL.MCLKCTRLB, 0); \
+                        }
 
 #elif ( configCPU_CLOCK_HZ == 10000000 )
 

--- a/FreeRTOS/Demo/AVR_ATMega4809_IAR/clk_config.h
+++ b/FreeRTOS/Demo/AVR_ATMega4809_IAR/clk_config.h
@@ -6,7 +6,10 @@
 
 #if ( configCPU_CLOCK_HZ == 20000000 )
 
-    #define CLK_init()  ccp_write_io((void *)&(CLKCTRL.MCLKCTRLA), CLKCTRL_CLKSEL_OSC20M_gc);
+    #define CLK_init()  { \
+                        _PROTECTED_WRITE(CLKCTRL.MCLKCTRLA, CLKCTRL_CLKSEL_OSC20M_gc); \
+                        _PROTECTED_WRITE(CLKCTRL.MCLKCTRLB, 0); \
+                        }
 
 #elif ( configCPU_CLOCK_HZ == 10000000 )
 

--- a/FreeRTOS/Demo/AVR_ATMega4809_MPLAB.X/clk_config.h
+++ b/FreeRTOS/Demo/AVR_ATMega4809_MPLAB.X/clk_config.h
@@ -6,7 +6,10 @@
 
 #if ( configCPU_CLOCK_HZ == 20000000 )
 
-    #define CLK_init()  _PROTECTED_WRITE(CLKCTRL.MCLKCTRLA, CLKCTRL_CLKSEL_OSC20M_gc);
+    #define CLK_init()  { \
+                        _PROTECTED_WRITE(CLKCTRL.MCLKCTRLA, CLKCTRL_CLKSEL_OSC20M_gc); \
+                        _PROTECTED_WRITE(CLKCTRL.MCLKCTRLB, 0); \
+                        }
 
 #elif ( configCPU_CLOCK_HZ == 10000000 )
 


### PR DESCRIPTION
To run the Atmega4809 demo on 20Mhz the CLK_init() has to overwrite the default MCLKCTRLB register value 0x11 to 0
Otherwise a clock divide by 6 is still active.

Related Issue
-----------
#288 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
