### PR TITLE
FreeRTOS+TCP Zynq: check frame type before calculating ICMP checksum (v3)

### DIFF
--- a/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/portable/NetworkInterface/Zynq/NetworkInterface.c
+++ b/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/portable/NetworkInterface/Zynq/NetworkInterface.c
@@ -80,7 +80,7 @@ http://www.freertos.org/FreeRTOS-Plus/FreeRTOS_Plus_TCP/Embedded_Ethernet_Buffer
 	#define iptraceEMAC_TASK_STARTING()    do {} while( ipFALSE_BOOL )
 #endif
 
-/* Default the size of the stack used by the EMAC deferred handler task to twice
+/* Default the size of the stack used by the EMAC deferred handler task to 8 times
 the size of the stack used by the idle task - but allow this to be overridden in
 FreeRTOSConfig.h as configMINIMAL_STACK_SIZE is a user definable constant. */
 #ifndef configEMAC_TASK_STACK_SIZE


### PR DESCRIPTION

<!--- Title -->

Description
-----------
This PR will replace the earlier #177, of which the branch got lost.

The only significant change is in the function `xNetworkInterfaceOutput()`, in which the frame-type is checked before checking the protocol type.

I the current driver, outgoing ARP frames get a size warning. It doesn't cause incorrect behaviour, except for the size warnings in the logging.

Test Steps
-----------
Define `ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM` as `1` and send an outgoing ping. The ARP before the PING may not trigger a size warning, and the ICMP checksum shall be calculated correctly.

Related Issue
-----------
None.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
