### PR TITLE
Connections sharing demo reconnect and TLS

### DIFF
--- a/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_multitask/DemoTasks/MultitaskMQTTExample.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_multitask/DemoTasks/MultitaskMQTTExample.c
@@ -63,9 +63,17 @@
 
 /* MQTT library includes. */
 #include "mqtt.h"
+#include "mqtt_state.h"
+
+/* Retry utilities include. */
+#include "retry_utils.h"
 
 /* Transport interface include. */
-#include "plaintext_freertos.h"
+#if defined( democonfigUSE_TLS ) && ( democonfigUSE_TLS == 1 )
+    #include "tls_freertos.h"
+#else
+    #include "plaintext_freertos.h"
+#endif
 
 /**
  * These configuration settings are required to run the demo.
@@ -84,8 +92,21 @@
  */
     #define democonfigCLIENT_IDENTIFIER    "testClient"__TIME__
 #endif
+
+/* Compile time error for undefined configs. */
 #ifndef democonfigMQTT_BROKER_ENDPOINT
     #error "Please define democonfigMQTT_BROKER_ENDPOINT."
+#endif
+#if defined( democonfigUSE_TLS ) && ( democonfigUSE_TLS == 1 )
+    #ifndef democonfigROOT_CA_PEM
+        #error "Please define Root CA certificate of the MQTT broker(democonfigROOT_CA_PEM) in demo_config.h."
+    #endif
+    #ifndef democonfigCLIENT_CERTIFICATE_PEM
+        #error "Please define client certificate(democonfigCLIENT_CERTIFICATE_PEM) in demo_config.h."
+    #endif
+    #ifndef democonfigCLIENT_PRIVATE_KEY_PEM
+        #error "Please define client private key(democonfigCLIENT_PRIVATE_KEY_PEM) in demo_config.h."
+    #endif
 #endif
 
 /**
@@ -342,10 +363,31 @@ typedef struct publishElement
  * @param[in] pxMQTTContext MQTT context pointer.
  * @param[in] xNetworkContext Network context.
  * @param[in] xCleanSession If a clean session should be established.
+ *
+ * @return `MQTTSuccess` if connection succeeds, else appropriate error code
+ * from MQTT_Connect.
  */
 static MQTTStatus_t prvMQTTConnect( MQTTContext_t * pxMQTTContext,
                                     NetworkContext_t * pxNetworkContext,
                                     bool xCleanSession );
+
+/**
+ * @brief Form a TCP connection to a server.
+ *
+ * @param[in] pxNetworkContext Network context.
+ *
+ * @return `true` if connection succeeds, else `false`.
+ */
+static bool prvConnectNetwork( NetworkContext_t * pxNetworkContext );
+
+/**
+ * @brief Disconnect a TCP connection.
+ *
+ * @param[in] pxNetworkContext Network context.
+ *
+ * @return `true` if disconnect succeeds, else `false`.
+ */
+static bool prvDisconnectNetwork( NetworkContext_t * pxNetworkContext );
 
 /**
  * @brief Initialize context for a command.
@@ -573,6 +615,16 @@ static AckInfo_t pxPendingAcks[ mqttexamplePENDING_ACKS_MAX_SIZE ];
 static SubscriptionElement_t pxSubscriptions[ mqttexampleSUBSCRIPTIONS_MAX_COUNT ];
 
 /**
+ * @brief Array of subscriptions to resubscribe to.
+ */
+static MQTTSubscribeInfo_t pxResendSubscriptions[ mqttexampleSUBSCRIPTIONS_MAX_COUNT ];
+
+/**
+ * @brief Context to use for a resubscription after a reconnect.
+ */
+static CommandContext_t xResubscribeContext;
+
+/**
  * @brief Queue for main task to handle MQTT operations.
  */
 static QueueHandle_t xCommandQueue;
@@ -655,8 +707,13 @@ static MQTTStatus_t prvMQTTConnect( MQTTContext_t * pxMQTTContext,
 
     /* Fill in Transport Interface send and receive function pointers. */
     xTransport.pNetworkContext = pxNetworkContext;
-    xTransport.send = Plaintext_FreeRTOS_send;
-    xTransport.recv = Plaintext_FreeRTOS_recv;
+    #if defined( democonfigUSE_TLS ) && ( democonfigUSE_TLS == 1 )
+        xTransport.send = TLS_FreeRTOS_send;
+        xTransport.recv = TLS_FreeRTOS_recv;
+    #else
+        xTransport.send = Plaintext_FreeRTOS_send;
+        xTransport.recv = Plaintext_FreeRTOS_recv;
+    #endif
 
     if( xCleanSession )
     {
@@ -696,7 +753,185 @@ static MQTTStatus_t prvMQTTConnect( MQTTContext_t * pxMQTTContext,
     LogInfo( ( "Session present: %d", xSessionPresent ) );
     configASSERT( xResult == MQTTSuccess );
 
+    /* Resend publishes if session is present. NOTE: It's possible that some
+     * of the operations that were in progress during the network interruption
+     * were subscribes. In that case, we would want to mark those operations
+     * as completing with error and remove them from the list of operations, so
+     * that the calling task can try subscribing again. We do not handle that
+     * case in this demo for simplicity, since only one subscription packet is
+     * sent per iteration of this demo. */
+    if( xSessionPresent )
+    {
+        MQTTStateCursor_t cursor = MQTT_STATE_CURSOR_INITIALIZER;
+        uint16_t packetId = MQTT_PACKET_ID_INVALID;
+        AckInfo_t xFoundAck;
+
+        packetId = MQTT_PublishToResend( &globalMqttContext, &cursor );
+
+        while( packetId != MQTT_PACKET_ID_INVALID )
+        {
+            /* Retrieve the operation but do not remove it from the list. */
+            xFoundAck = prvGetAwaitingOperation( packetId, false );
+
+            if( xFoundAck.usPacketId == packetId )
+            {
+                /* Set the DUP flag. */
+                xFoundAck.xOriginalCommand.pxCmdContext->pxPublishInfo->dup = true;
+                xResult = MQTT_Publish( &globalMqttContext, xFoundAck.xOriginalCommand.pxCmdContext->pxPublishInfo, packetId );
+            }
+
+            packetId = MQTT_PublishToResend( &globalMqttContext, &cursor );
+        }
+    }
+
+    /* If we wanted to resume a session but none existed with the broker, we
+     * should mark all in progress operations as errors so that the tasks that
+     * created them can try again. Also, we will resubscribe to the filters in
+     * the subscription list, so tasks do not unexpectedly lose their subscriptions. */
+    if( !xCleanSession && !xSessionPresent )
+    {
+        int32_t i = 0, j = 0;
+        Command_t xNewCommand;
+        bool xCommandCreated = false;
+        BaseType_t xCommandAdded;
+
+        /* We have a clean session, so clear all operations pending acknowledgments. */
+        for( i = 0; i < mqttexamplePENDING_ACKS_MAX_SIZE; i++ )
+        {
+            if( pxPendingAcks[ i ].usPacketId != MQTT_PACKET_ID_INVALID )
+            {
+                if( pxPendingAcks[ i ].xOriginalCommand.vCallback != NULL )
+                {
+                    /* Bad response to indicate network error. */
+                    pxPendingAcks[ i ].xOriginalCommand.pxCmdContext->xReturnStatus = MQTTBadResponse;
+                    pxPendingAcks[ i ].xOriginalCommand.vCallback( pxPendingAcks[ i ].xOriginalCommand.pxCmdContext );
+                }
+
+                /* Now remove it from the list. */
+                prvGetAwaitingOperation( pxPendingAcks[ i ].usPacketId, true );
+            }
+        }
+
+        /* Populate the array of MQTTSubscribeInfo_t. It's possible there may be
+         * repeated subscriptions in the list. This is fine, since clients
+         * are able to subscribe to a topic with an existing subscription. */
+        for( i = 0; i < mqttexampleSUBSCRIPTIONS_MAX_COUNT; i++ )
+        {
+            if( pxSubscriptions[ i ].usFilterLength != 0 )
+            {
+                pxResendSubscriptions[ j ].pTopicFilter = pxSubscriptions[ i ].pcSubscriptionFilter;
+                pxResendSubscriptions[ j ].topicFilterLength = pxSubscriptions[ i ].usFilterLength;
+                pxResendSubscriptions[ j ].qos = MQTTQoS0;
+                j++;
+            }
+        }
+
+        /* Resubscribe if needed. */
+        if( j > 0 )
+        {
+            prvInitializeCommandContext( &xResubscribeContext );
+            xResubscribeContext.pxSubscribeInfo = pxResendSubscriptions;
+            xResubscribeContext.ulSubscriptionCount = j;
+            /* Set to NULL so existing queues will not be overwritten. */
+            xResubscribeContext.pxResponseQueue = NULL;
+            xResubscribeContext.xTaskToNotify = NULL;
+            xCommandCreated = prvCreateCommand( SUBSCRIBE, &xResubscribeContext, prvCommandCallback, &xNewCommand );
+            /* Send to the front of the queue so we will resubscribe as soon as possible. */
+            xCommandAdded = xQueueSendToFront( xCommandQueue, &xNewCommand, mqttexampleDEMO_TICKS_TO_WAIT );
+            configASSERT( xCommandAdded == pdTRUE );
+        }
+    }
+
     return xResult;
+}
+
+/*-----------------------------------------------------------*/
+
+static bool prvConnectNetwork( NetworkContext_t * pxNetworkContext )
+{
+    bool xConnected = false;
+    RetryUtilsStatus_t xRetryUtilsStatus = RetryUtilsSuccess;
+    RetryUtilsParams_t xReconnectParams;
+
+    #if defined( democonfigUSE_TLS ) && ( democonfigUSE_TLS == 1 )
+        TlsTransportStatus_t xNetworkStatus;
+        NetworkCredentials_t xNetworkCredentials = { 0 };
+
+        /* Set the credentials for establishing a TLS connection. */
+        xNetworkCredentials.pRootCa = ( const unsigned char * ) democonfigROOT_CA_PEM;
+        xNetworkCredentials.rootCaSize = sizeof( democonfigROOT_CA_PEM );
+        xNetworkCredentials.pClientCert = ( const unsigned char * ) democonfigCLIENT_CERTIFICATE_PEM;
+        xNetworkCredentials.clientCertSize = sizeof( democonfigCLIENT_CERTIFICATE_PEM );
+        xNetworkCredentials.pPrivateKey = ( const unsigned char * ) democonfigCLIENT_PRIVATE_KEY_PEM;
+        xNetworkCredentials.privateKeySize = sizeof( democonfigCLIENT_PRIVATE_KEY_PEM );
+    #else  /* if defined( democonfigUSE_TLS ) && ( democonfigUSE_TLS == 1 ) */
+        PlaintextTransportStatus_t xNetworkStatus;
+    #endif /* if defined( democonfigUSE_TLS ) && ( democonfigUSE_TLS == 1 ) */
+
+    /* Initialize reconnect attempts and interval. */
+    xReconnectParams.maxRetryAttempts = MAX_RETRY_ATTEMPTS;
+    RetryUtils_ParamsReset( &xReconnectParams );
+
+    /* Attempt to connect to MQTT broker. If connection fails, retry after a
+     * timeout. Timeout value will exponentially increase until them maximum
+     * number of attempts are reached.
+     */
+    do
+    {
+        /* Establish a TCP connection with the MQTT broker. This example connects to
+         * the MQTT broker as specified in democonfigMQTT_BROKER_ENDPOINT and
+         * democonfigMQTT_BROKER_PORT at the top of this file. */
+        LogInfo( ( "Create a TCP connection to %s:%d.",
+                   democonfigMQTT_BROKER_ENDPOINT,
+                   democonfigMQTT_BROKER_PORT ) );
+
+        #if defined( democonfigUSE_TLS ) && ( democonfigUSE_TLS == 1 )
+            xNetworkStatus = TLS_FreeRTOS_Connect( pxNetworkContext,
+                                                   democonfigMQTT_BROKER_ENDPOINT,
+                                                   democonfigMQTT_BROKER_PORT,
+                                                   &xNetworkCredentials,
+                                                   mqttexampleTRANSPORT_SEND_RECV_TIMEOUT_MS,
+                                                   mqttexampleTRANSPORT_SEND_RECV_TIMEOUT_MS );
+            xConnected = ( xNetworkStatus == TLS_TRANSPORT_SUCCESS );
+        #else
+            xNetworkStatus = Plaintext_FreeRTOS_Connect( pxNetworkContext,
+                                                         democonfigMQTT_BROKER_ENDPOINT,
+                                                         democonfigMQTT_BROKER_PORT,
+                                                         mqttexampleTRANSPORT_SEND_RECV_TIMEOUT_MS,
+                                                         mqttexampleTRANSPORT_SEND_RECV_TIMEOUT_MS );
+            xConnected = ( xNetworkStatus == PLAINTEXT_TRANSPORT_SUCCESS );
+        #endif /* if defined( democonfigUSE_TLS ) && ( democonfigUSE_TLS == 1 ) */
+
+        if( !xConnected )
+        {
+            LogWarn( ( "Connection to the broker failed. Retrying connection with backoff and jitter." ) );
+            xRetryUtilsStatus = RetryUtils_BackoffAndSleep( &xReconnectParams );
+        }
+
+        if( xRetryUtilsStatus == RetryUtilsRetriesExhausted )
+        {
+            LogError( ( "Connection to the broker failed, all attempts exhausted." ) );
+        }
+    } while( ( xConnected != true ) && ( xRetryUtilsStatus == RetryUtilsSuccess ) );
+
+    return xConnected;
+}
+
+/*-----------------------------------------------------------*/
+
+static bool prvDisconnectNetwork( NetworkContext_t * pxNetworkContext )
+{
+    bool xDisconnected = false;
+
+    #if defined( democonfigUSE_TLS ) && ( democonfigUSE_TLS == 1 )
+        TLS_FreeRTOS_Disconnect( pxNetworkContext );
+        xDisconnected = true;
+    #else
+        PlaintextTransportStatus_t xNetworkStatus;
+        xNetworkStatus = Plaintext_FreeRTOS_Disconnect( pxNetworkContext );
+        xDisconnected = ( xNetworkStatus == PLAINTEXT_TRANSPORT_SUCCESS );
+    #endif
+    return xDisconnected;
 }
 
 /*-----------------------------------------------------------*/
@@ -893,7 +1128,7 @@ static MQTTStatus_t prvProcessCommand( Command_t * pxCommand )
 {
     MQTTStatus_t xStatus = MQTTSuccess;
     uint16_t usPacketId = MQTT_PACKET_ID_INVALID;
-    bool xAddAckToList = false, xAckAdded = false;
+    bool xAddAckToList = false, xAckAdded = false, xNetworkResult;
     MQTTPublishInfo_t * pxPublishInfo;
     MQTTSubscribeInfo_t * pxSubscribeInfo;
 
@@ -973,8 +1208,13 @@ static MQTTStatus_t prvProcessCommand( Command_t * pxCommand )
             break;
 
         case CONNECT:
-            /* TODO: Reconnect. */
-            LogInfo( ( "Processed Connect Command" ) );
+            /* Reconnect TCP. */
+            xNetworkResult = prvDisconnectNetwork( globalMqttContext.transportInterface.pNetworkContext );
+            configASSERT( xNetworkResult == true );
+            xNetworkResult = prvConnectNetwork( globalMqttContext.transportInterface.pNetworkContext );
+            configASSERT( xNetworkResult == true );
+            /* MQTT Connect with a persistent session. */
+            xStatus = prvMQTTConnect( &globalMqttContext, globalMqttContext.transportInterface.pNetworkContext, false );
             break;
 
         case TERMINATE:
@@ -1221,9 +1461,17 @@ static void prvCommandLoop()
 
         xStatus = prvProcessCommand( pxCommand );
 
-        /* TODO: After reconnect implemented, add connect operation to front
-         * of queue if status was not successful. */
-        configASSERT( xStatus == MQTTSuccess );
+        /* Add connect operation to front of queue if status was not successful. */
+        if( xStatus != MQTTSuccess )
+        {
+            LogError( ( "MQTT operation failed with status %s",
+                        MQTT_Status_strerror( xStatus ) ) );
+            prvCreateCommand( CONNECT, NULL, NULL, &xNewCommand );
+            xCommandAdded = xQueueSendToFront( xCommandQueue, &xNewCommand, mqttexampleDEMO_TICKS_TO_WAIT );
+            /* Ensure the command was added to the queue. */
+            configASSERT( xCommandAdded == pdTRUE );
+        }
+
         lNumProcessed++;
 
         if( pxCommand->xCommandType == PROCESSLOOP )
@@ -1313,7 +1561,7 @@ void prvPublishTask( void * pvParameters )
 
         while( ( ulNotification & ( 1U << i ) ) != ( 1U << i ) )
         {
-            LogInfo( ( "Waiting for publish %d to complete.", i ) );
+            LogInfo( ( "Waiting for publish %d to complete.", i + 1 ) );
             xTaskNotifyWait( 0, ( 1U << i ), &ulNotification, mqttexampleDEMO_TICKS_TO_WAIT );
         }
 
@@ -1370,14 +1618,14 @@ void prvPublishTask( void * pvParameters )
 
         while( ( ulNotification & ( 1U << i ) ) != ( 1U << i ) )
         {
-            LogInfo( ( "Waiting to free publish context %d.", i ) );
+            LogInfo( ( "Waiting to free publish context %d.", i + 1 ) );
             xTaskNotifyWait( 0, ( 1U << i ), &ulNotification, mqttexampleDEMO_TICKS_TO_WAIT );
         }
 
         vPortFree( pxContexts[ i ] );
         vPortFree( topicBuffers[ i ] );
         vPortFree( payloadBuffers[ i ] );
-        LogInfo( ( "Publish context %d freed.", i ) );
+        LogInfo( ( "Publish context %d freed.", i + 1 ) );
         pxContexts[ i ] = NULL;
     }
 
@@ -1397,7 +1645,7 @@ void prvSubscribeTask( void * pvParameters )
     Command_t xCommand;
     BaseType_t xCommandAdded = pdTRUE;
     MQTTPublishInfo_t * pxReceivedPublish = NULL;
-    static uint16_t usNumReceived = 0;
+    uint16_t usNumReceived = 0;
     uint32_t ulNotification = 0;
     CommandContext_t xContext;
     PublishElement_t xReceivedPublish;
@@ -1499,7 +1747,7 @@ void prvSubscribeTask( void * pvParameters )
 static void prvMQTTDemoTask( void * pvParameters )
 {
     NetworkContext_t xNetworkContext = { 0 };
-    PlaintextTransportStatus_t xNetworkStatus;
+    bool xNetworkStatus;
     BaseType_t xResult;
     uint32_t ulNotification = 0;
     Command_t xCommand;
@@ -1522,6 +1770,24 @@ static void prvMQTTDemoTask( void * pvParameters )
      * synchronization primitives. */
     xDefaultResponseQueue = xPublisherResponseQueue;
 
+    /* Connect to the broker. We connect here with the "clean session" flag set
+     * to true in order to clear any prior state in the broker. We will disconnect
+     * and later form a persistent session, so that it may be resumed if the
+     * network suddenly disconnects. */
+    LogInfo( ( "Creating a TCP connection to %s.\r\n", democonfigMQTT_BROKER_ENDPOINT ) );
+    xNetworkStatus = prvConnectNetwork( &xNetworkContext );
+    configASSERT( xNetworkStatus == true );
+    LogInfo( ( "Clearing broker state." ) );
+    xMQTTStatus = prvMQTTConnect( &globalMqttContext, &xNetworkContext, true );
+    configASSERT( xMQTTStatus == MQTTSuccess );
+
+    /* Disconnect. */
+    xMQTTStatus = MQTT_Disconnect( &globalMqttContext );
+    configASSERT( xMQTTStatus == MQTTSuccess );
+    LogInfo( ( "Disconnecting TCP connection." ) );
+    xNetworkStatus = prvDisconnectNetwork( &xNetworkContext );
+    configASSERT( xNetworkStatus == true );
+
     for( ; ; )
     {
         /* Clear the lists of subscriptions and pending acknowledgments. */
@@ -1534,15 +1800,11 @@ static void prvMQTTDemoTask( void * pvParameters )
         configASSERT( xResult == pdTRUE );
 
         LogInfo( ( "Creating a TCP connection to %s.\r\n", democonfigMQTT_BROKER_ENDPOINT ) );
-
-        /* TODO: Use TLS to connect to the broker. */
-        xNetworkStatus = Plaintext_FreeRTOS_Connect( &xNetworkContext,
-                                                     democonfigMQTT_BROKER_ENDPOINT,
-                                                     democonfigMQTT_BROKER_PORT,
-                                                     mqttexampleTRANSPORT_SEND_RECV_TIMEOUT_MS,
-                                                     mqttexampleTRANSPORT_SEND_RECV_TIMEOUT_MS );
-        configASSERT( xNetworkStatus == PLAINTEXT_TRANSPORT_SUCCESS );
-        xMQTTStatus = prvMQTTConnect( &globalMqttContext, &xNetworkContext, true );
+        /* Connect to the broker. */
+        xNetworkStatus = prvConnectNetwork( &xNetworkContext );
+        configASSERT( xNetworkStatus == true );
+        /* Form an MQTT connection with a persistent session. */
+        xMQTTStatus = prvMQTTConnect( &globalMqttContext, &xNetworkContext, false );
         configASSERT( xMQTTStatus == MQTTSuccess );
         configASSERT( globalMqttContext.connectStatus = MQTTConnected );
 
@@ -1585,8 +1847,8 @@ static void prvMQTTDemoTask( void * pvParameters )
         xQueueReset( xSubscriberResponseQueue );
 
         LogInfo( ( "Disconnecting TCP connection." ) );
-        xNetworkStatus = Plaintext_FreeRTOS_Disconnect( &xNetworkContext );
-        configASSERT( xNetworkStatus == PLAINTEXT_TRANSPORT_SUCCESS );
+        xNetworkStatus = prvDisconnectNetwork( &xNetworkContext );
+        configASSERT( xNetworkStatus == true );
 
         LogInfo( ( "prvMQTTDemoTask() completed an iteration successfully. Total free heap is %u.\r\n", xPortGetFreeHeapSize() ) );
         LogInfo( ( "Demo completed successfully.\r\n" ) );

--- a/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_multitask/DemoTasks/MultitaskMQTTExample.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_multitask/DemoTasks/MultitaskMQTTExample.c
@@ -879,7 +879,7 @@ static bool prvConnectNetwork( NetworkContext_t * pxNetworkContext )
     RetryUtils_ParamsReset( &xReconnectParams );
 
     /* Attempt to connect to MQTT broker. If connection fails, retry after a
-     * timeout. Timeout value will exponentially increase until them maximum
+     * timeout. Timeout value will exponentially increase until the maximum
      * number of attempts are reached.
      */
     do
@@ -916,7 +916,7 @@ static bool prvConnectNetwork( NetworkContext_t * pxNetworkContext )
 
         if( xRetryUtilsStatus == RetryUtilsRetriesExhausted )
         {
-            LogError( ( "Connection to the broker failed, all attempts exhausted." ) );
+            LogError( ( "Connection to the broker failed. All attempts exhausted." ) );
         }
     } while( ( xConnected != true ) && ( xRetryUtilsStatus == RetryUtilsSuccess ) );
 

--- a/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_multitask/DemoTasks/MultitaskMQTTExample.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_multitask/DemoTasks/MultitaskMQTTExample.c
@@ -93,10 +93,12 @@
     #define democonfigCLIENT_IDENTIFIER    "testClient"__TIME__
 #endif
 
-/* Compile time error for undefined configs. */
+/* Compile time error for some undefined configs, and provide default values
+ * for others. */
 #ifndef democonfigMQTT_BROKER_ENDPOINT
     #error "Please define democonfigMQTT_BROKER_ENDPOINT."
 #endif
+
 #if defined( democonfigUSE_TLS ) && ( democonfigUSE_TLS == 1 )
     #ifndef democonfigROOT_CA_PEM
         #error "Please define Root CA certificate of the MQTT broker(democonfigROOT_CA_PEM) in demo_config.h."
@@ -107,15 +109,19 @@
     #ifndef democonfigCLIENT_PRIVATE_KEY_PEM
         #error "Please define client private key(democonfigCLIENT_PRIVATE_KEY_PEM) in demo_config.h."
     #endif
-#endif
+
+    #ifndef democonfigMQTT_BROKER_PORT
+        #define democonfigMQTT_BROKER_PORT    ( 8883 )
+    #endif
+#else /* if defined( democonfigUSE_TLS ) && ( democonfigUSE_TLS == 1 ) */
+    #ifndef democonfigMQTT_BROKER_PORT
+        #define democonfigMQTT_BROKER_PORT    ( 1883 )
+    #endif
+#endif /* if defined( democonfigUSE_TLS ) && ( democonfigUSE_TLS == 1 ) */
 
 /**
- * Provide default values for undefined configuration settings.
+ * @brief The size to use for the network buffer.
  */
-#ifndef democonfigMQTT_BROKER_PORT
-    #define democonfigMQTT_BROKER_PORT    ( 1883 )
-#endif
-
 #ifndef mqttexampleNETWORK_BUFFER_SIZE
     #define mqttexampleNETWORK_BUFFER_SIZE    ( 1024U )
 #endif
@@ -864,7 +870,7 @@ static bool prvConnectNetwork( NetworkContext_t * pxNetworkContext )
         xNetworkCredentials.clientCertSize = sizeof( democonfigCLIENT_CERTIFICATE_PEM );
         xNetworkCredentials.pPrivateKey = ( const unsigned char * ) democonfigCLIENT_PRIVATE_KEY_PEM;
         xNetworkCredentials.privateKeySize = sizeof( democonfigCLIENT_PRIVATE_KEY_PEM );
-    #else  /* if defined( democonfigUSE_TLS ) && ( democonfigUSE_TLS == 1 ) */
+    #else /* if defined( democonfigUSE_TLS ) && ( democonfigUSE_TLS == 1 ) */
         PlaintextTransportStatus_t xNetworkStatus;
     #endif /* if defined( democonfigUSE_TLS ) && ( democonfigUSE_TLS == 1 ) */
 

--- a/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_multitask/FreeRTOSIPConfig.h
+++ b/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_multitask/FreeRTOSIPConfig.h
@@ -89,7 +89,7 @@ extern void vLoggingPrintf( const char * pcFormatString,
  * call to FreeRTOS_gethostbyname() will return immediately, without even creating
  * a socket. */
 #define ipconfigUSE_DNS_CACHE                      ( 1 )
-#define ipconfigDNS_CACHE_NAME_LENGTH              ( 32 )
+#define ipconfigDNS_CACHE_NAME_LENGTH              ( 64 )
 #define ipconfigDNS_CACHE_ENTRIES                  ( 4 )
 #define ipconfigDNS_REQUEST_ATTEMPTS               ( 2 )
 

--- a/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_multitask/WIN32.vcxproj
+++ b/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_multitask/WIN32.vcxproj
@@ -58,8 +58,8 @@
     </Midl>
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>..\..\..\..\Source\FreeRTOS-Plus-Trace\Include;..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\include;..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\portable\BufferManagement;..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\portable\Compiler\MSVC;..\..\common\logging-stack;..\common\WinPCap;..\..\..\..\..\FreeRTOS\Source\include;..\..\..\..\..\FreeRTOS\Source\portable\MSVC-MingW;..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\standard\mqtt\include;..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\platform\include;..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\platform\freertos\transport\include;.;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;_WIN32_WINNT=0x0500;WINVER=0x400;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..\..\..\..\Source\FreeRTOS-Plus-Trace\Include;..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\include;..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\portable\BufferManagement;..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\portable\Compiler\MSVC;..\..\common\logging-stack;..\common\WinPCap;..\..\..\..\..\FreeRTOS\Source\include;..\..\..\..\..\FreeRTOS\Source\portable\MSVC-MingW;..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\standard\mqtt\include;..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\platform\include;..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\platform\freertos\transport\include;..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\platform\freertos\mbedtls;..\..\..\..\Source\mbedtls_utils;..\..\..\..\Source\mbedtls\include;.;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>MBEDTLS_CONFIG_FILE="mbedtls_config.h";WIN32;_DEBUG;_CONSOLE;_WIN32_WINNT=0x0500;WINVER=0x400;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>false</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
@@ -88,7 +88,7 @@
       <ProgramDatabaseFile>.\Debug/WIN32.pdb</ProgramDatabaseFile>
       <SubSystem>Console</SubSystem>
       <TargetMachine>MachineX86</TargetMachine>
-      <AdditionalDependencies>wpcap.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>wpcap.lib;Bcrypt.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>..\common\WinPCap</AdditionalLibraryDirectories>
       <Profile>false</Profile>
       <ImageHasSafeExceptionHandlers>false</ImageHasSafeExceptionHandlers>
@@ -157,11 +157,95 @@
     <ClCompile Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\FreeRTOS_UDP_IP.c" />
     <ClCompile Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\portable\BufferManagement\BufferAllocation_2.c" />
     <ClCompile Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\portable\NetworkInterface\WinPCap\NetworkInterface.c" />
+    <ClCompile Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\platform\freertos\mbedtls\mbedtls_freertos_port.c" />
+    <ClCompile Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\platform\freertos\retry_utils\retry_utils_freertos.c" />
     <ClCompile Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\platform\freertos\transport\src\freertos_sockets_wrapper.c" />
     <ClCompile Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\platform\freertos\transport\src\plaintext_freertos.c" />
+    <ClCompile Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\platform\freertos\transport\src\tls_freertos.c" />
     <ClCompile Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\standard\mqtt\src\mqtt_lightweight.c" />
     <ClCompile Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\standard\mqtt\src\mqtt_state.c" />
     <ClCompile Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\standard\mqtt\src\mqtt.c" />
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\aes.c" />
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\aesni.c" />
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\arc4.c" />
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\aria.c" />
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\asn1parse.c" />
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\asn1write.c" />
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\base64.c" />
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\bignum.c" />
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\blowfish.c" />
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\camellia.c" />
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\ccm.c" />
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\certs.c" />
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\chacha20.c" />
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\chachapoly.c" />
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\cipher.c" />
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\cipher_wrap.c" />
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\cmac.c" />
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\ctr_drbg.c" />
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\debug.c" />
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\des.c" />
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\dhm.c" />
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\ecdh.c" />
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\ecdsa.c" />
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\ecjpake.c" />
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\ecp.c" />
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\ecp_curves.c" />
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\entropy.c" />
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\entropy_poll.c" />
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\error.c" />
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\gcm.c" />
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\havege.c" />
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\hkdf.c" />
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\hmac_drbg.c" />
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\md.c" />
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\md2.c" />
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\md4.c" />
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\md5.c" />
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\md_wrap.c" />
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\memory_buffer_alloc.c" />
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\net_sockets.c" />
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\nist_kw.c" />
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\oid.c" />
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\padlock.c" />
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\pem.c" />
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\pk.c" />
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\pkcs11.c" />
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\pkcs12.c" />
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\pkcs5.c" />
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\pkparse.c" />
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\pkwrite.c" />
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\pk_wrap.c" />
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\platform.c" />
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\platform_util.c" />
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\poly1305.c" />
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\ripemd160.c" />
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\rsa.c" />
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\rsa_internal.c" />
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\sha1.c" />
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\sha256.c" />
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\sha512.c" />
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\ssl_cache.c" />
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\ssl_ciphersuites.c" />
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\ssl_cli.c" />
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\ssl_cookie.c" />
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\ssl_srv.c" />
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\ssl_ticket.c" />
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\ssl_tls.c" />
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\threading.c" />
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\timing.c" />
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\version.c" />
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\version_features.c" />
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\x509.c" />
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\x509write_crt.c" />
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\x509write_csr.c" />
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\x509_create.c" />
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\x509_crl.c" />
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\x509_crt.c" />
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\x509_csr.c" />
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\xtea.c" />
+    <ClCompile Include="..\..\..\..\Source\mbedtls_utils\mbedtls_error.c" />
+    <ClCompile Include="..\..\..\..\Source\mbedtls_utils\mbedtls_utils.c" />
     <ClCompile Include="..\common\demo_logging.c" />
     <ClCompile Include="..\common\main.c" />
     <ClCompile Include="DemoTasks\MultitaskMQTTExample.c" />
@@ -190,15 +274,98 @@
     <ClInclude Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\include\IPTraceMacroDefaults.h" />
     <ClInclude Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\include\NetworkBufferManagement.h" />
     <ClInclude Include="..\..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\include\NetworkInterface.h" />
+    <ClInclude Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\platform\freertos\mbedtls\threading_alt.h" />
     <ClInclude Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\platform\freertos\transport\include\freertos_sockets_wrapper.h" />
     <ClInclude Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\platform\freertos\transport\include\plaintext_freertos.h" />
+    <ClInclude Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\platform\freertos\transport\include\tls_freertos.h" />
+    <ClInclude Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\platform\include\retry_utils.h" />
     <ClInclude Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\platform\include\transport_interface.h" />
     <ClInclude Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\standard\mqtt\include\mqtt_lightweight.h" />
     <ClInclude Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\standard\mqtt\include\mqtt_state.h" />
     <ClInclude Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\standard\mqtt\include\mqtt.h" />
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\aes.h" />
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\aesni.h" />
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\arc4.h" />
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\aria.h" />
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\asn1.h" />
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\asn1write.h" />
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\base64.h" />
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\bignum.h" />
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\blowfish.h" />
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\bn_mul.h" />
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\camellia.h" />
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\ccm.h" />
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\certs.h" />
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\chacha20.h" />
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\chachapoly.h" />
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\check_config.h" />
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\cipher.h" />
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\cipher_internal.h" />
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\cmac.h" />
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\compat-1.3.h" />
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\config.h" />
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\ctr_drbg.h" />
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\debug.h" />
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\des.h" />
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\dhm.h" />
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\ecdh.h" />
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\ecdsa.h" />
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\ecjpake.h" />
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\ecp.h" />
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\ecp_internal.h" />
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\entropy.h" />
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\entropy_poll.h" />
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\error.h" />
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\gcm.h" />
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\havege.h" />
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\hkdf.h" />
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\hmac_drbg.h" />
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\md.h" />
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\md2.h" />
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\md4.h" />
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\md5.h" />
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\md_internal.h" />
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\memory_buffer_alloc.h" />
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\net.h" />
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\net_sockets.h" />
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\nist_kw.h" />
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\oid.h" />
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\padlock.h" />
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\pem.h" />
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\pk.h" />
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\pkcs11.h" />
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\pkcs12.h" />
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\pkcs5.h" />
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\pk_internal.h" />
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\platform.h" />
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\platform_time.h" />
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\platform_util.h" />
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\poly1305.h" />
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\ripemd160.h" />
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\rsa.h" />
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\rsa_internal.h" />
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\sha1.h" />
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\sha256.h" />
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\sha512.h" />
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\ssl.h" />
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\ssl_cache.h" />
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\ssl_ciphersuites.h" />
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\ssl_cookie.h" />
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\ssl_internal.h" />
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\ssl_ticket.h" />
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\threading.h" />
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\timing.h" />
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\version.h" />
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\x509.h" />
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\x509_crl.h" />
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\x509_crt.h" />
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\x509_csr.h" />
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\xtea.h" />
+    <ClInclude Include="..\..\..\..\Source\mbedtls_utils\mbedtls_error.h" />
     <ClInclude Include="demo_config.h" />
     <ClInclude Include="FreeRTOSConfig.h" />
     <ClInclude Include="FreeRTOSIPConfig.h" />
+    <ClInclude Include="mbedtls_config.h" />
     <ClInclude Include="mqtt_config.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_multitask/WIN32.vcxproj.filters
+++ b/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_multitask/WIN32.vcxproj.filters
@@ -47,6 +47,27 @@
     <Filter Include="FreeRTOS+\FreeRTOS IoT Libraries\platform">
       <UniqueIdentifier>{84613aa2-91dc-4e1a-a3b3-823b6d7bf0e0}</UniqueIdentifier>
     </Filter>
+    <Filter Include="FreeRTOS+\mbedtls">
+      <UniqueIdentifier>{f72f1876-a024-463b-84e0-72ce54160ce8}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="FreeRTOS+\mbedtls\include">
+      <UniqueIdentifier>{9624aabd-0464-436c-aec2-add662dabc19}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="FreeRTOS+\mbedtls\library">
+      <UniqueIdentifier>{1fbc269d-4b08-4287-954a-8e0722ef668a}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="FreeRTOS+\mbedtls_utils">
+      <UniqueIdentifier>{83403187-9993-4aaf-bd8b-146cd8020a9c}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="FreeRTOS+\FreeRTOS IoT Libraries\platform\freertos">
+      <UniqueIdentifier>{379e9b0b-ccae-4072-8226-de11c015a5e0}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="FreeRTOS+\FreeRTOS IoT Libraries\platform\freertos\mbedtls">
+      <UniqueIdentifier>{ff1a9e43-547b-4cc6-bb5d-5e1778512bf2}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="FreeRTOS+\FreeRTOS IoT Libraries\platform\freertos\transport">
+      <UniqueIdentifier>{c2722ea4-488d-4bda-9d12-9450d87ab846}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\..\..\..\FreeRTOS\Source\portable\MSVC-MingW\port.c">
@@ -120,8 +141,261 @@
     <ClCompile Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\standard\mqtt\src\mqtt.c">
       <Filter>FreeRTOS+\FreeRTOS IoT Libraries\standard\mqtt\src</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\platform\freertos\transport\src\freertos_sockets_wrapper.c" />
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\aes.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\aesni.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\arc4.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\aria.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\asn1parse.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\asn1write.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\base64.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\bignum.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\blowfish.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\camellia.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\ccm.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\certs.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\chacha20.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\chachapoly.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\cipher.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\cipher_wrap.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\cmac.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\ctr_drbg.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\debug.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\des.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\dhm.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\ecdh.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\ecdsa.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\ecjpake.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\ecp.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\ecp_curves.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\entropy.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\entropy_poll.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\error.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\gcm.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\havege.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\hkdf.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\hmac_drbg.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\md.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\md_wrap.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\md2.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\md4.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\md5.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\memory_buffer_alloc.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\net_sockets.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\nist_kw.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\oid.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\padlock.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\pem.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\pk.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\pk_wrap.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\pkcs5.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\pkcs11.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\pkcs12.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\pkparse.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\pkwrite.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\platform.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\platform_util.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\poly1305.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\ripemd160.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\rsa.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\rsa_internal.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\sha1.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\sha256.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\sha512.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\ssl_cache.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\ssl_ciphersuites.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\ssl_cli.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\ssl_cookie.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\ssl_srv.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\ssl_ticket.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\ssl_tls.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\threading.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\timing.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\version.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\version_features.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\x509.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\x509_create.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\x509_crl.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\x509_crt.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\x509_csr.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\x509write_crt.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\x509write_csr.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\xtea.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls_utils\mbedtls_error.c">
+      <Filter>FreeRTOS+\mbedtls_utils</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls_utils\mbedtls_utils.c">
+      <Filter>FreeRTOS+\mbedtls_utils</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\platform\freertos\mbedtls\mbedtls_freertos_port.c">
+      <Filter>FreeRTOS+\FreeRTOS IoT Libraries\platform\freertos\mbedtls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\platform\freertos\transport\src\tls_freertos.c">
+      <Filter>FreeRTOS+\FreeRTOS IoT Libraries\platform\freertos\transport</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\platform\freertos\transport\src\plaintext_freertos.c">
-      <Filter>FreeRTOS+\FreeRTOS IoT Libraries\platform</Filter>
+      <Filter>FreeRTOS+\FreeRTOS IoT Libraries\platform\freertos\transport</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\platform\freertos\retry_utils\retry_utils_freertos.c">
+      <Filter>FreeRTOS+\FreeRTOS IoT Libraries\platform\freertos</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -207,11 +481,259 @@
       <Filter>FreeRTOS+\FreeRTOS IoT Libraries\standard\mqtt\include</Filter>
     </ClInclude>
     <ClInclude Include="mqtt_config.h" />
-    <ClInclude Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\platform\freertos\transport\include\plaintext_freertos.h">
-      <Filter>FreeRTOS+\FreeRTOS IoT Libraries\platform</Filter>
-    </ClInclude>
     <ClInclude Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\platform\include\transport_interface.h">
       <Filter>FreeRTOS+\FreeRTOS IoT Libraries\platform</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\platform\freertos\transport\include\freertos_sockets_wrapper.h" />
+    <ClInclude Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\platform\include\retry_utils.h">
+      <Filter>FreeRTOS+\FreeRTOS IoT Libraries\platform</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\aes.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\aesni.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\arc4.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\aria.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\asn1.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\asn1write.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\base64.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\bignum.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\blowfish.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\bn_mul.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\camellia.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\ccm.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\certs.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\chacha20.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\chachapoly.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\check_config.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\cipher.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\cipher_internal.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\cmac.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\compat-1.3.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\config.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\ctr_drbg.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\debug.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\des.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\dhm.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\ecdh.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\ecdsa.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\ecjpake.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\ecp.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\ecp_internal.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\entropy.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\entropy_poll.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\error.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\gcm.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\havege.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\hkdf.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\hmac_drbg.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\md.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\md_internal.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\md2.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\md4.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\md5.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\memory_buffer_alloc.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\net.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\net_sockets.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\nist_kw.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\oid.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\padlock.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\pem.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\pk.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\pk_internal.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\pkcs5.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\pkcs11.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\pkcs12.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\platform.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\platform_time.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\platform_util.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\poly1305.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\ripemd160.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\rsa.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\rsa_internal.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\sha1.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\sha256.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\sha512.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\ssl.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\ssl_cache.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\ssl_ciphersuites.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\ssl_cookie.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\ssl_internal.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\ssl_ticket.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\threading.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\timing.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\version.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\x509.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\x509_crl.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\x509_crt.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\x509_csr.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\xtea.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls_utils\mbedtls_error.h">
+      <Filter>FreeRTOS+\mbedtls_utils</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\platform\freertos\mbedtls\threading_alt.h">
+      <Filter>FreeRTOS+\FreeRTOS IoT Libraries\platform\freertos\mbedtls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\platform\freertos\transport\include\tls_freertos.h">
+      <Filter>FreeRTOS+\FreeRTOS IoT Libraries\platform\freertos\transport</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\FreeRTOS-IoT-Libraries-LTS-Beta2\c_sdk\platform\freertos\transport\include\plaintext_freertos.h">
+      <Filter>FreeRTOS+\FreeRTOS IoT Libraries\platform\freertos\transport</Filter>
+    </ClInclude>
+    <ClInclude Include="mbedtls_config.h" />
   </ItemGroup>
 </Project>

--- a/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_multitask/demo_config.h
+++ b/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_multitask/demo_config.h
@@ -63,46 +63,17 @@
 
 
 /**
- * @brief MQTT broker end point to connect to.
+ * @brief Endpoint of the MQTT broker to connect to.
  *
- * @note For running this demo an MQTT broker, which can be run locally on
- * the same host is recommended. Any MQTT broker, which can be run on a Windows
- * host can be used for this demo. However, the instructions below are for
- * setting up a local Mosquitto broker on a Windows host.
- * 1. Download Mosquitto from https://mosquitto.org/download/
- * 2. Install Mosquitto as a Windows service by running the installer.
- * More details about installing as a Windows service can be found at
- * https://github.com/eclipse/mosquitto/blob/master/readme-windows.txt and
- * https://github.com/eclipse/mosquitto/blob/master/readme.md
- * 3. Verify that Mosquitto server is running locally and listening on port
- * 1883 by following the steps below.
- *     a. Open Power Shell.
- *     b. Type in command `netstat -a -p TCP | grep 1883` to check if there
- *        is an active connection listening on port 1883.
- *     c. Verify that there is an output as shown below
- *        `TCP    0.0.0.0:1883           <HOST-NAME>:0       LISTENING`
- *     d. If there is no output on step c,go through the Mosquitto documentation
- *        listed above to check if the installation was successful.
- * 4. Make sure the Mosquitto broker is allowed to communicate through
- * Windows Firewall. The instructions for allowing an application on Windows 10
- * Defender Firewall can be found at the link below.
- * https://support.microsoft.com/en-us/help/4558235/windows-10-allow-an-app-through-microsoft-defender-firewall
- * After running this MQTT example, consider disabling the Mosquitto broker to
- * communicate through Windows Firewall for avoiding unwanted network traffic
- * to your machine.
- * 5. After verifying that a Mosquitto broker is running successfully, update
- * the config democonfigMQTT_BROKER_ENDPOINT to the local IP address of the
- * Windows host machine. Please note that "localhost" or address "127.0.0.1"
- * will not work as this example is running on a Windows Simulator and not on
- * Windows host natively. Also note that, if the Windows host is using a
- * Virtual Private Network(VPN), connection to the Mosquitto broker may not
- * work.
+ * This demo application can be run with any MQTT broker, although it is
+ * recommended to use one that supports mutual authentication. If mutual
+ * authentication is not used, then #democonfigUSE_TLS should be set to 0.
  *
- * As an alternative option, a publicly hosted Mosquitto broker can also be
- * used as an MQTT broker end point. This can be done by updating the config
- * democonfigMQTT_BROKER_ENDPOINT to "test.mosquitto.org". However, this is not
- * recommended due the possible downtimes of the broker as indicated by the
- * documentation in https://test.mosquitto.org/.
+ * For AWS IoT MQTT broker, this is the Thing's REST API Endpoint.
+ *
+ * @note Your AWS IoT Core endpoint can be found in the AWS IoT console under
+ * Settings/Custom Endpoint, or using the describe-endpoint REST API (with
+ * AWS CLI command line tool).
  *
  * #define democonfigMQTT_BROKER_ENDPOINT				"insert here."
  */
@@ -111,8 +82,72 @@
 /**
  * @brief The port to use for the demo.
  *
- * #define democonfigMQTT_BROKER_PORT					( insert here. )
+ * In general, port 8883 is for secured MQTT connections, and port 1883 if not
+ * using TLS.
+ *
+ * @note Port 443 requires use of the ALPN TLS extension with the ALPN protocol
+ * name. When using port 8883, ALPN is not required.
+ *
+ * #define democonfigMQTT_BROKER_PORT    "...insert here..."
  */
+
+/**
+ * @brief Server's root CA certificate.
+ *
+ * For AWS IoT MQTT broker, this certificate is used to identify the AWS IoT
+ * server and is publicly available. Refer to the AWS documentation available
+ * in the link below.
+ * https://docs.aws.amazon.com/iot/latest/developerguide/server-authentication.html#server-authentication-certs
+ *
+ * @note This certificate should be PEM-encoded.
+ *
+ * Must include the PEM header and footer:
+ * "-----BEGIN CERTIFICATE-----\n"\
+ * "...base64 data...\n"\
+ * "-----END CERTIFICATE-----\n"
+ *
+ * #define democonfigROOT_CA_PEM    "...insert here..."
+ */
+
+/**
+ * @brief Client certificate.
+ *
+ * For AWS IoT MQTT broker, refer to the AWS documentation below for details
+ * regarding client authentication.
+ * https://docs.aws.amazon.com/iot/latest/developerguide/client-authentication.html
+ *
+ * @note This certificate should be PEM-encoded.
+ *
+ * Must include the PEM header and footer:
+ * "-----BEGIN CERTIFICATE-----\n"\
+ * "...base64 data...\n"\
+ * "-----END CERTIFICATE-----\n"
+ *
+ * #define democonfigCLIENT_CERTIFICATE_PEM    "...insert here..."
+ */
+
+/**
+ * @brief Client's private key.
+ *
+ * For AWS IoT MQTT broker, refer to the AWS documentation below for details
+ * regarding clientauthentication.
+ * https://docs.aws.amazon.com/iot/latest/developerguide/client-authentication.html
+ *
+ * @note This private key should be PEM-encoded.
+ *
+ * Must include the PEM header and footer:
+ * "-----BEGIN RSA PRIVATE KEY-----\n"\
+ * "...base64 data...\n"\
+ * "-----END RSA PRIVATE KEY-----\n"
+ *
+ * #define democonfigCLIENT_PRIVATE_KEY_PEM    "...insert here..."
+ */
+
+/**
+ * @brief Whether to use mutual authentication. If this macro is not set to 1
+ * or not defined, then plaintext TCP will be used instead of TLS over TCP.
+ */
+#define democonfigUSE_TLS    1
 
 
 /**

--- a/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_multitask/demo_config.h
+++ b/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_multitask/demo_config.h
@@ -88,7 +88,7 @@
  * @note Port 443 requires use of the ALPN TLS extension with the ALPN protocol
  * name. When using port 8883, ALPN is not required.
  *
- * #define democonfigMQTT_BROKER_PORT    "...insert here..."
+ * #define democonfigMQTT_BROKER_PORT    ( insert here. )
  */
 
 /**

--- a/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_multitask/mbedtls_config.h
+++ b/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_multitask/mbedtls_config.h
@@ -1,0 +1,151 @@
+/*
+ *  Copyright (C) 2006-2018, ARM Limited, All Rights Reserved
+ *  SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
+ *
+ *  This file is provided under the Apache License 2.0, or the
+ *  GNU General Public License v2.0 or later.
+ *
+ *  **********
+ *  Apache License 2.0:
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  **********
+ *
+ *  **********
+ *  GNU General Public License v2.0 or later:
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *  **********
+ *
+ *  This repository uses Mbed TLS under Apache 2.0
+ */
+
+/* This file configures mbed TLS for FreeRTOS. */
+
+#ifndef MBEDTLS_CONFIG_H_
+#define MBEDTLS_CONFIG_H_
+
+/* FreeRTOS include. */
+#include "FreeRTOS.h"
+
+/* Generate errors if deprecated functions are used. */
+#define MBEDTLS_DEPRECATED_REMOVED
+
+/* Place AES tables in ROM. */
+#define MBEDTLS_AES_ROM_TABLES
+
+/* Enable the following cipher modes. */
+#define MBEDTLS_CIPHER_MODE_CBC
+#define MBEDTLS_CIPHER_MODE_CFB
+#define MBEDTLS_CIPHER_MODE_CTR
+
+/* Enable the following cipher padding modes. */
+#define MBEDTLS_CIPHER_PADDING_PKCS7
+#define MBEDTLS_CIPHER_PADDING_ONE_AND_ZEROS
+#define MBEDTLS_CIPHER_PADDING_ZEROS_AND_LEN
+#define MBEDTLS_CIPHER_PADDING_ZEROS
+
+/* Cipher suite configuration. */
+#define MBEDTLS_REMOVE_ARC4_CIPHERSUITES
+#define MBEDTLS_ECP_DP_SECP256R1_ENABLED
+#define MBEDTLS_ECP_NIST_OPTIM
+#define MBEDTLS_KEY_EXCHANGE_ECDHE_RSA_ENABLED
+#define MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED
+
+/* Enable all SSL alert messages. */
+#define MBEDTLS_SSL_ALL_ALERT_MESSAGES
+
+/* Enable the following SSL features. */
+#define MBEDTLS_SSL_ENCRYPT_THEN_MAC
+#define MBEDTLS_SSL_EXTENDED_MASTER_SECRET
+#define MBEDTLS_SSL_MAX_FRAGMENT_LENGTH
+#define MBEDTLS_SSL_PROTO_TLS1_2
+#define MBEDTLS_SSL_ALPN
+#define MBEDTLS_SSL_SERVER_NAME_INDICATION
+
+/* Check certificate key usage. */
+#define MBEDTLS_X509_CHECK_KEY_USAGE
+#define MBEDTLS_X509_CHECK_EXTENDED_KEY_USAGE
+
+/* Disable platform entropy functions. */
+#define MBEDTLS_NO_PLATFORM_ENTROPY
+
+/* Enable the following mbed TLS features. */
+#define MBEDTLS_AES_C
+#define MBEDTLS_ASN1_PARSE_C
+#define MBEDTLS_ASN1_WRITE_C
+#define MBEDTLS_BASE64_C
+#define MBEDTLS_BIGNUM_C
+#define MBEDTLS_CIPHER_C
+#define MBEDTLS_CTR_DRBG_C
+#define MBEDTLS_ECDH_C
+#define MBEDTLS_ECDSA_C
+#define MBEDTLS_ECP_C
+#define MBEDTLS_ENTROPY_C
+#define MBEDTLS_GCM_C
+#define MBEDTLS_MD_C
+#define MBEDTLS_OID_C
+#define MBEDTLS_PEM_PARSE_C
+#define MBEDTLS_PK_C
+#define MBEDTLS_PK_PARSE_C
+#define MBEDTLS_PKCS1_V15
+#define MBEDTLS_PLATFORM_C
+#define MBEDTLS_RSA_C
+#define MBEDTLS_SHA1_C
+#define MBEDTLS_SHA256_C
+#define MBEDTLS_SSL_CLI_C
+#define MBEDTLS_SSL_TLS_C
+#define MBEDTLS_THREADING_ALT
+#define MBEDTLS_THREADING_C
+#define MBEDTLS_X509_USE_C
+#define MBEDTLS_X509_CRT_PARSE_C
+
+/* Set the memory allocation functions on FreeRTOS. */
+void * mbedtls_platform_calloc( size_t nmemb,
+                                size_t size );
+void mbedtls_platform_free( void * ptr );
+#define MBEDTLS_PLATFORM_MEMORY
+#define MBEDTLS_PLATFORM_CALLOC_MACRO    mbedtls_platform_calloc
+#define MBEDTLS_PLATFORM_FREE_MACRO      mbedtls_platform_free
+
+/* The network send and receive functions on FreeRTOS. */
+int mbedtls_platform_send( void * ctx,
+                           const unsigned char * buf,
+                           size_t len );
+int mbedtls_platform_recv( void * ctx,
+                           unsigned char * buf,
+                           size_t len );
+
+/* The entropy poll function. */
+int mbedtls_platform_entropy_poll( void * data,
+                                   unsigned char * output,
+                                   size_t len,
+                                   size_t * olen );
+
+#include "mbedtls/check_config.h"
+
+#endif /* ifndef MBEDTLS_CONFIG_H_ */


### PR DESCRIPTION
*Description*:
 - Add reconnect logic to connection sharing demo
   - Demo will try to reconnect to the broker whenever any MQTT call returns an error.
   - Resubscribe to old subscriptions if a persistent session is not granted by the broker.
   - Exponential backoff with jitter for TCP connection.
 - Add mutual auth options for connection to the broker.
   - Instead of replacing the plaintext TCP, I kept both in the demo, and switch between them with a macro. I thought it would make sense to keep the plaintext option here since it is quicker to set up; since this is a demo, a user may want to be able to run this as quickly as possible, and not have to worry about configuring certs.

