### PR TITLE
Add MQTT Server Auth (Basic TLS) demo

### DIFF
--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Basic_TLS/DemoTasks/BasicTLSMQTTExample.c
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Basic_TLS/DemoTasks/BasicTLSMQTTExample.c
@@ -489,7 +489,7 @@ static TlsTransportStatus_t prvConnectToServerWithBackoffRetries( NetworkCredent
     /* When using a local Mosquitto server setup, SNI needs to be disabled for
      * an MQTT broker that only has an IP address but no hostname. However,
      * SNI should be enabled whenever possible. */
-    pxNetworkCredentials->disableSni = true;
+    pxNetworkCredentials->disableSni = pdTRUE;
     /* Initialize reconnect attempts and interval. */
     RetryUtils_ParamsReset( &xReconnectParams );
     xReconnectParams.maxRetryAttempts = MAX_RETRY_ATTEMPTS;

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Basic_TLS/DemoTasks/BasicTLSMQTTExample.c
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Basic_TLS/DemoTasks/BasicTLSMQTTExample.c
@@ -485,6 +485,8 @@ static TlsTransportStatus_t prvConnectToServerWithBackoffRetries( NetworkCredent
     /* Set the credentials for establishing a TLS connection. */
     pxNetworkCredentials->pRootCa = ( const unsigned char * ) democonfigROOT_CA_PEM;
     pxNetworkCredentials->rootCaSize = sizeof( democonfigROOT_CA_PEM );
+    /* Disable SNI when using a local server. */
+    pxNetworkCredentials->disableSni = true;
     /* Initialize reconnect attempts and interval. */
     RetryUtils_ParamsReset( &xReconnectParams );
     xReconnectParams.maxRetryAttempts = MAX_RETRY_ATTEMPTS;

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Basic_TLS/DemoTasks/BasicTLSMQTTExample.c
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Basic_TLS/DemoTasks/BasicTLSMQTTExample.c
@@ -1,0 +1,877 @@
+/*
+ * FreeRTOS Kernel V10.3.0
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://www.FreeRTOS.org
+ * http://aws.amazon.com/freertos
+ *
+ */
+
+/*
+ * Demo for showing the use of the MQTT API using a server-authenticated
+ * network connection.
+ *
+ * The example shown below uses MQTT APIs to create MQTT messages and send them
+ * over the server-authenticated network connection established with the
+ * MQTT broker. This example is single-threaded and uses statically allocated
+ * memory. It uses QoS2 for sending and receiving messages from the broker.
+ *
+ * A server-authenticated TLS connection is used to connect to the MQTT message
+ * broker in this example. Define democonfigMQTT_BROKER_ENDPOINT and
+ * democonfigROOT_CA_PEM in demo_config.h to establish a server-authenticated
+ * connection.
+ */
+
+/* Standard includes. */
+#include <string.h>
+#include <stdio.h>
+
+/* Kernel includes. */
+#include "FreeRTOS.h"
+#include "task.h"
+
+/* Demo Specific configs. */
+#include "demo_config.h"
+
+/* MQTT library includes. */
+#include "core_mqtt.h"
+
+/* Retry utilities include. */
+#include "retry_utils.h"
+
+/* Transport interface implementation include header for TLS. */
+#include "tls_freertos.h"
+
+/*-----------------------------------------------------------*/
+
+/* Compile time error for undefined configs. */
+#ifndef democonfigMQTT_BROKER_ENDPOINT
+    #error "Define the config democonfigMQTT_BROKER_ENDPOINT by following the instructions in file demo_config.h."
+#endif
+#ifndef democonfigROOT_CA_PEM
+    #error "Please define Root CA certificate of the MQTT broker(democonfigROOT_CA_PEM) in demo_config.h."
+#endif
+
+/*-----------------------------------------------------------*/
+
+/* Default values for configs. */
+#ifndef democonfigCLIENT_IDENTIFIER
+
+/**
+ * @brief The MQTT client identifier used in this example.  Each client identifier
+ * must be unique so edit as required to ensure no two clients connecting to the
+ * same broker use the same client identifier.
+ *
+ * @note Appending __TIME__ to the client id string will help to create a unique
+ * client id every time an application binary is built. Only a single instance of
+ * this application's compiled binary may be used at a time, since the client ID
+ * will always be the same.
+ */
+    #define democonfigCLIENT_IDENTIFIER    "testClient"__TIME__
+#endif
+
+#ifndef democonfigMQTT_BROKER_PORT
+
+/**
+ * @brief The port to use for the demo.
+ */
+    #define democonfigMQTT_BROKER_PORT    ( 8883 )
+#endif
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Timeout for receiving CONNACK packet in milliseconds.
+ */
+#define mqttexampleCONNACK_RECV_TIMEOUT_MS                ( 1000U )
+
+/**
+ * @brief The topic to subscribe and publish to in the example.
+ *
+ * The topic name starts with the client identifier to ensure that each demo
+ * interacts with a unique topic name.
+ */
+#define mqttexampleTOPIC                                  democonfigCLIENT_IDENTIFIER "/example/topic"
+
+/**
+ * @brief The number of topic filters to subscribe.
+ */
+#define mqttexampleTOPIC_COUNT                            ( 1 )
+
+/**
+ * @brief The MQTT message published in this example.
+ */
+#define mqttexampleMESSAGE                                "Hello World!"
+
+/**
+ * @brief Time in ticks to wait between each cycle of the demo implemented
+ * by prvMQTTDemoTask().
+ */
+#define mqttexampleDELAY_BETWEEN_DEMO_ITERATIONS_TICKS    ( pdMS_TO_TICKS( 5000U ) )
+
+/**
+ * @brief Timeout for MQTT_ProcessLoop in milliseconds.
+ */
+#define mqttexamplePROCESS_LOOP_TIMEOUT_MS                ( 500U )
+
+/**
+ * @brief The keep-alive timeout period reported to the broker while establishing
+ * an MQTT connection.
+ *
+ * It is the responsibility of the client to ensure that the interval between
+ * control packets being sent does not exceed this keep-alive value. In the
+ * absence of sending any other control packets, the client MUST send a
+ * PINGREQ packet.
+ */
+#define mqttexampleKEEP_ALIVE_TIMEOUT_SECONDS             ( 60U )
+
+/**
+ * @brief Delay (in ticks) between consecutive cycles of MQTT publish operations in a
+ * demo iteration.
+ *
+ * Note that the process loop also has a timeout, so the total time between
+ * publishes is the sum of the two delays.
+ */
+#define mqttexampleDELAY_BETWEEN_PUBLISHES_TICKS          ( pdMS_TO_TICKS( 2000U ) )
+
+/**
+ * @brief Transport timeout in milliseconds for transport send and receive.
+ */
+#define mqttexampleTRANSPORT_SEND_RECV_TIMEOUT_MS         ( 200U )
+
+/**
+ * @brief Milliseconds per second.
+ */
+#define _MILLISECONDS_PER_SECOND                          ( 1000U )
+
+/**
+ * @brief Milliseconds per FreeRTOS tick.
+ */
+#define _MILLISECONDS_PER_TICK                            ( _MILLISECONDS_PER_SECOND / configTICK_RATE_HZ )
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief The task used to demonstrate the MQTT API.
+ *
+ * @param[in] pvParameters Parameters as passed at the time of task creation. Not
+ * used in this example.
+ */
+static void prvMQTTDemoTask( void * pvParameters );
+
+/**
+ * @brief Connect to MQTT broker with reconnection retries.
+ *
+ * If connection fails, retry is attempted after a timeout.
+ * Timeout value will exponentially increase until the maximum
+ * timeout value is reached or the number of attempts are exhausted.
+ *
+ * @param[out] pxNetworkContext The output parameter to return the created network context.
+ *
+ * @return The status of the final connection attempt.
+ */
+static TlsTransportStatus_t prvConnectToServerWithBackoffRetries( NetworkCredentials_t * pxNetworkCredentials,
+                                                                  NetworkContext_t * pNetworkContext );
+
+/**
+ * @brief Sends an MQTT Connect packet over the already connected TLS over TCP connection.
+ *
+ * @param[in, out] pxMQTTContext MQTT context pointer.
+ * @param[in] xNetworkContext network context.
+ */
+static void prvCreateMQTTConnectionWithBroker( MQTTContext_t * pxMQTTContext,
+                                               NetworkContext_t * pxNetworkContext );
+
+/**
+ * @brief Function to update variable #xTopicFilterContext with status
+ * information from Subscribe ACK. Called by the event callback after processing
+ * an incoming SUBACK packet.
+ *
+ * @param[in] Server response to the subscription request.
+ */
+static void prvUpdateSubAckStatus( MQTTPacketInfo_t * pxPacketInfo );
+
+/**
+ * @brief Subscribes to the topic as specified in mqttexampleTOPIC at the top of
+ * this file. In the case of a Subscribe ACK failure, then subscription is
+ * retried using an exponential backoff strategy with jitter.
+ *
+ * @param[in] pxMQTTContext MQTT context pointer.
+ */
+static void prvMQTTSubscribeWithBackoffRetries( MQTTContext_t * pxMQTTContext );
+
+/**
+ * @brief Publishes a message mqttexampleMESSAGE on mqttexampleTOPIC topic.
+ *
+ * @param[in] pxMQTTContext MQTT context pointer.
+ */
+static void prvMQTTPublishToTopic( MQTTContext_t * pxMQTTContext );
+
+/**
+ * @brief Unsubscribes from the previously subscribed topic as specified
+ * in mqttexampleTOPIC.
+ *
+ * @param[in] pxMQTTContext MQTT context pointer.
+ */
+static void prvMQTTUnsubscribeFromTopic( MQTTContext_t * pxMQTTContext );
+
+/**
+ * @brief The timer query function provided to the MQTT context.
+ *
+ * @return Time in milliseconds.
+ */
+static uint32_t prvGetTimeMs( void );
+
+/**
+ * @brief Process a response or ack to an MQTT request (PING, PUBLISH,
+ * SUBSCRIBE or UNSUBSCRIBE). This function processes PINGRESP, PUBACK,
+ * PUBREC, PUBREL, PUBCOMP, SUBACK, and UNSUBACK.
+ *
+ * @param[in] pxIncomingPacket is a pointer to structure containing deserialized
+ * MQTT response.
+ * @param[in] usPacketId is the packet identifier from the ack received.
+ */
+static void prvMQTTProcessResponse( MQTTPacketInfo_t * pxIncomingPacket,
+                                    uint16_t usPacketId );
+
+/**
+ * @brief Process incoming Publish message.
+ *
+ * @param[in] pxPublishInfo is a pointer to structure containing deserialized
+ * Publish message.
+ */
+static void prvMQTTProcessIncomingPublish( MQTTPublishInfo_t * pxPublishInfo );
+
+/**
+ * @brief The application callback function for getting the incoming publishes,
+ * incoming acks, and ping responses reported from the MQTT library.
+ *
+ * @param[in] pxMQTTContext MQTT context pointer.
+ * @param[in] pxPacketInfo Packet Info pointer for the incoming packet.
+ * @param[in] pxDeserializedInfo Deserialized information from the incoming packet.
+ */
+static void prvEventCallback( MQTTContext_t * pxMQTTContext,
+                              MQTTPacketInfo_t * pxPacketInfo,
+                              MQTTDeserializedInfo_t * pxDeserializedInfo );
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Static buffer used to hold MQTT messages being sent and received.
+ */
+static uint8_t ucSharedBuffer[ democonfigNETWORK_BUFFER_SIZE ];
+
+/**
+ * @brief Global entry time into the application to use as a reference timestamp
+ * in the #prvGetTimeMs function. #prvGetTimeMs will always return the difference
+ * between the current time and the global entry time. This will reduce the chances
+ * of overflow for the 32 bit unsigned integer used for holding the timestamp.
+ */
+static uint32_t ulGlobalEntryTimeMs;
+
+/**
+ * @brief Packet Identifier generated when Publish request was sent to the broker;
+ * it is used to match received Publish ACK to the transmitted Publish packet.
+ */
+static uint16_t usPublishPacketIdentifier;
+
+/**
+ * @brief Packet Identifier generated when Subscribe request was sent to the broker;
+ * it is used to match received Subscribe ACK to the transmitted Subscribe packet.
+ */
+static uint16_t usSubscribePacketIdentifier;
+
+/**
+ * @brief Packet Identifier generated when Unsubscribe request was sent to the broker;
+ * it is used to match received Unsubscribe response to the transmitted Unsubscribe
+ * request.
+ */
+static uint16_t usUnsubscribePacketIdentifier;
+
+/**
+ * @brief A pair containing a topic filter and its SUBACK status.
+ */
+typedef struct topicFilterContext
+{
+    const char * pcTopicFilter;
+    MQTTSubAckStatus_t xSubAckStatus;
+} topicFilterContext_t;
+
+/**
+ * @brief An array containing the context of a SUBACK; the SUBACK status
+ * of a filter is updated when the event callback processes a SUBACK.
+ */
+static topicFilterContext_t xTopicFilterContext[ mqttexampleTOPIC_COUNT ] =
+{
+    { mqttexampleTOPIC, MQTTSubAckFailure }
+};
+
+
+/** @brief Static buffer used to hold MQTT messages being sent and received. */
+static MQTTFixedBuffer_t xBuffer =
+{
+    ucSharedBuffer,
+    democonfigNETWORK_BUFFER_SIZE
+};
+
+/*-----------------------------------------------------------*/
+
+/*
+ * @brief Create the task that demonstrates the MQTT API Demo over a
+ * server-authenticated network connection with MQTT broker.
+ */
+void vStartSimpleMQTTDemo( void )
+{
+    /* This example uses a single application task, which in turn is used to
+     * connect, subscribe, publish, unsubscribe, and disconnect from the MQTT
+     * broker. */
+    xTaskCreate( prvMQTTDemoTask,          /* Function that implements the task. */
+                 "MQTTDemo",               /* Text name for the task - only used for debugging. */
+                 democonfigDEMO_STACKSIZE, /* Size of stack (in words, not bytes) to allocate for the task. */
+                 NULL,                     /* Task parameter - not used in this case. */
+                 tskIDLE_PRIORITY,         /* Task priority, must be between 0 and configMAX_PRIORITIES - 1. */
+                 NULL );                   /* Used to pass out a handle to the created task - not used in this case. */
+}
+/*-----------------------------------------------------------*/
+
+/*
+ * @brief The Example shown below uses MQTT APIs to create MQTT messages and
+ * send them over the server-authenticated network connection established with the
+ * MQTT broker. This example is single-threaded and uses statically allocated
+ * memory. It uses QoS2 for sending and receiving messages from the broker.
+ *
+ * This MQTT client subscribes to the topic as specified in mqttexampleTOPIC at the
+ * top of this file by sending a subscribe packet and waiting for a subscribe
+ * acknowledgment (SUBACK) from the broker. The client will then publish to the
+ * same topic it subscribed to, therefore expecting that all outgoing messages will be
+ * sent back from the broker.
+ */
+static void prvMQTTDemoTask( void * pvParameters )
+{
+    uint32_t ulPublishCount = 0U, ulTopicCount = 0U;
+    const uint32_t ulMaxPublishCount = 5UL;
+    NetworkContext_t xNetworkContext = { 0 };
+    NetworkCredentials_t xNetworkCredentials = { 0 };
+    MQTTContext_t xMQTTContext = { 0 };
+    MQTTStatus_t xMQTTStatus;
+    TlsTransportStatus_t xNetworkStatus;
+
+    /* Remove compiler warnings about unused parameters. */
+    ( void ) pvParameters;
+
+    /* Set the entry time of the demo application. This entry time will be used
+     * to calculate relative time elapsed in the execution of the demo application,
+     * by the timer utility function that is provided to the MQTT library.
+     */
+    ulGlobalEntryTimeMs = prvGetTimeMs();
+
+    for( ; ; )
+    {
+        /****************************** Connect. ******************************/
+
+        /* Attempt to establish a TLS connection with the MQTT broker. This example
+         * connects to the MQTT broker specified in democonfigMQTT_BROKER_ENDPOINT, using
+         * the port number specified in democonfigMQTT_BROKER_PORT (these macros are defined
+         * in file demo_config.h). If the connection fails, attempt to re-connect after a timeout.
+         * The timeout value will be exponentially increased until either the maximum timeout value
+         * is reached, or the maximum number of attempts are exhausted. The function returns a failure status
+         * if the TCP connection cannot be established with the broker after a configured number
+         * of attempts. */
+        xNetworkStatus = prvConnectToServerWithBackoffRetries( &xNetworkCredentials,
+                                                               &xNetworkContext );
+        configASSERT( xNetworkStatus == TLS_TRANSPORT_SUCCESS );
+
+        /* Send an MQTT CONNECT packet over the established TLS connection,
+         * and wait for the connection acknowledgment (CONNACK) packet. */
+        LogInfo( ( "Creating an MQTT connection to %s.\r\n", democonfigMQTT_BROKER_ENDPOINT ) );
+        prvCreateMQTTConnectionWithBroker( &xMQTTContext, &xNetworkContext );
+
+        /**************************** Subscribe. ******************************/
+
+        /* If the server rejected the subscription request, attempt to resubscribe to the
+         * topic. Attempts are made according to the exponential backoff retry strategy
+         * implemented in retryUtils. */
+        prvMQTTSubscribeWithBackoffRetries( &xMQTTContext );
+
+        /* Process incoming packet from the broker. After sending a subscribe packet, the
+         * client may receive a publish before it receives a subscribe ack. Therefore,
+         * call the generic incoming packet processing function. Since this demo is
+         * subscribing to a topic to which no one is publishing, the probability of
+         * receiving a publish message before a subscribe ack is zero. Regardless, the
+         * application must be prepared to receive any packet. This demo uses the generic packet
+         * processing function everywhere to highlight this fact. */
+        xMQTTStatus = MQTT_ProcessLoop( &xMQTTContext, mqttexamplePROCESS_LOOP_TIMEOUT_MS );
+        configASSERT( xMQTTStatus == MQTTSuccess );
+
+        /**************************** Publish and Keep-Alive Loop. ******************************/
+        /* Publish messages with QoS2, and send and process keep-alive messages. */
+        for( ulPublishCount = 0; ulPublishCount < ulMaxPublishCount; ulPublishCount++ )
+        {
+            LogInfo( ( "Publish to the MQTT topic %s.\r\n", mqttexampleTOPIC ) );
+            prvMQTTPublishToTopic( &xMQTTContext );
+
+            /* Process incoming publish echo. Since the application subscribed and published
+             * to the same topic, the broker will send the incoming publish message back
+             * to the application. */
+            LogInfo( ( "Attempt to receive publish message from broker.\r\n" ) );
+            xMQTTStatus = MQTT_ProcessLoop( &xMQTTContext, mqttexamplePROCESS_LOOP_TIMEOUT_MS );
+            configASSERT( xMQTTStatus == MQTTSuccess );
+
+            /* Leave connection idle for some time. */
+            LogInfo( ( "Keeping Connection Idle...\r\n\r\n" ) );
+            vTaskDelay( mqttexampleDELAY_BETWEEN_PUBLISHES_TICKS );
+        }
+
+        /************************ Unsubscribe from the topic. **************************/
+        LogInfo( ( "Unsubscribe from the MQTT topic %s.\r\n", mqttexampleTOPIC ) );
+        prvMQTTUnsubscribeFromTopic( &xMQTTContext );
+
+        /* Process incoming UNSUBACK packet from the broker. */
+        xMQTTStatus = MQTT_ProcessLoop( &xMQTTContext, mqttexamplePROCESS_LOOP_TIMEOUT_MS );
+        configASSERT( xMQTTStatus == MQTTSuccess );
+
+        /**************************** Disconnect. ******************************/
+
+        /* Send an MQTT DISCONNECT packet over the already-connected TLS over TCP connection.
+         * There is no corresponding response expected from the broker. After sending the
+         * disconnect request, the client must close the network connection. */
+        LogInfo( ( "Disconnecting the MQTT connection with %s.\r\n", democonfigMQTT_BROKER_ENDPOINT ) );
+        xMQTTStatus = MQTT_Disconnect( &xMQTTContext );
+        configASSERT( xMQTTStatus == MQTTSuccess );
+
+        /* Close the network connection.  */
+        TLS_FreeRTOS_Disconnect( &xNetworkContext );
+
+        /* Reset SUBACK status for each topic filter after completion of the subscription request cycle. */
+        for( ulTopicCount = 0; ulTopicCount < mqttexampleTOPIC_COUNT; ulTopicCount++ )
+        {
+            xTopicFilterContext[ ulTopicCount ].xSubAckStatus = MQTTSubAckFailure;
+        }
+
+        /* Wait for some time between two iterations to ensure that we do not
+         * bombard the broker. */
+        LogInfo( ( "prvMQTTDemoTask() completed an iteration successfully. Total free heap is %u.\r\n", xPortGetFreeHeapSize() ) );
+        LogInfo( ( "Demo completed successfully.\r\n" ) );
+        LogInfo( ( "Short delay before starting the next iteration.... \r\n\r\n" ) );
+        vTaskDelay( mqttexampleDELAY_BETWEEN_DEMO_ITERATIONS_TICKS );
+    }
+}
+/*-----------------------------------------------------------*/
+
+static TlsTransportStatus_t prvConnectToServerWithBackoffRetries( NetworkCredentials_t * pxNetworkCredentials,
+                                                                  NetworkContext_t * pxNetworkContext )
+{
+    TlsTransportStatus_t xNetworkStatus;
+    RetryUtilsStatus_t xRetryUtilsStatus = RetryUtilsSuccess;
+    RetryUtilsParams_t xReconnectParams;
+
+    /* Set the credentials for establishing a TLS connection. */
+    pxNetworkCredentials->pRootCa = ( const unsigned char * ) democonfigROOT_CA_PEM;
+    pxNetworkCredentials->rootCaSize = sizeof( democonfigROOT_CA_PEM );
+    /* Initialize reconnect attempts and interval. */
+    RetryUtils_ParamsReset( &xReconnectParams );
+    xReconnectParams.maxRetryAttempts = MAX_RETRY_ATTEMPTS;
+
+    /* Attempt to connect to the MQTT broker. If connection fails, retry after
+     * a timeout. Timeout value will exponentially increase until maximum
+     * attempts are reached.
+     */
+    do
+    {
+        /* Establish a TLS session with the MQTT broker. This example connects to
+         * the MQTT broker as specified in democonfigMQTT_BROKER_ENDPOINT and
+         * democonfigMQTT_BROKER_PORT at the top of this file. */
+        LogInfo( ( "Creating a TLS connection to %s:%u.\r\n",
+                   democonfigMQTT_BROKER_ENDPOINT,
+                   democonfigMQTT_BROKER_PORT ) );
+        /* Attempt to create a server-authenticated TLS connection. */
+        xNetworkStatus = TLS_FreeRTOS_Connect( pxNetworkContext,
+                                               democonfigMQTT_BROKER_ENDPOINT,
+                                               democonfigMQTT_BROKER_PORT,
+                                               pxNetworkCredentials,
+                                               mqttexampleTRANSPORT_SEND_RECV_TIMEOUT_MS,
+                                               mqttexampleTRANSPORT_SEND_RECV_TIMEOUT_MS );
+
+        if( xNetworkStatus != TLS_TRANSPORT_SUCCESS )
+        {
+            LogWarn( ( "Connection to the broker failed. Retrying connection with backoff and jitter." ) );
+            xRetryUtilsStatus = RetryUtils_BackoffAndSleep( &xReconnectParams );
+        }
+
+        if( xRetryUtilsStatus == RetryUtilsRetriesExhausted )
+        {
+            LogError( ( "Connection to the broker failed, all attempts exhausted." ) );
+            xNetworkStatus = TLS_TRANSPORT_CONNECT_FAILURE;
+        }
+    } while( ( xNetworkStatus != TLS_TRANSPORT_SUCCESS ) && ( xRetryUtilsStatus == RetryUtilsSuccess ) );
+
+    return xNetworkStatus;
+}
+/*-----------------------------------------------------------*/
+
+static void prvCreateMQTTConnectionWithBroker( MQTTContext_t * pxMQTTContext,
+                                               NetworkContext_t * pxNetworkContext )
+{
+    MQTTStatus_t xResult;
+    MQTTConnectInfo_t xConnectInfo;
+    bool xSessionPresent;
+    TransportInterface_t xTransport;
+
+    /***
+     * For readability, error handling in this function is restricted to the use of
+     * asserts().
+     ***/
+
+    /* Fill in Transport Interface send and receive function pointers. */
+    xTransport.pNetworkContext = pxNetworkContext;
+    xTransport.send = TLS_FreeRTOS_send;
+    xTransport.recv = TLS_FreeRTOS_recv;
+
+    /* Initialize MQTT library. */
+    xResult = MQTT_Init( pxMQTTContext, &xTransport, prvGetTimeMs, prvEventCallback, &xBuffer );
+    configASSERT( xResult == MQTTSuccess );
+
+    /* Some fields are not used in this demo so start with everything at 0. */
+    memset( ( void * ) &xConnectInfo, 0x00, sizeof( xConnectInfo ) );
+
+    /* Start with a clean session i.e. direct the MQTT broker to discard any
+     * previous session data. Also, establishing a connection with clean session
+     * will ensure that the broker does not store any data when this client
+     * gets disconnected. */
+    xConnectInfo.cleanSession = true;
+
+    /* The client identifier is used to uniquely identify this MQTT client to
+     * the MQTT broker. In a production device the identifier can be something
+     * unique, such as a device serial number. */
+    xConnectInfo.pClientIdentifier = democonfigCLIENT_IDENTIFIER;
+    xConnectInfo.clientIdentifierLength = ( uint16_t ) strlen( democonfigCLIENT_IDENTIFIER );
+
+    /* Set MQTT keep-alive period. If the application does not send packets at an interval less than
+     * the keep-alive period, the MQTT library will send PINGREQ packets. */
+    xConnectInfo.keepAliveSeconds = mqttexampleKEEP_ALIVE_TIMEOUT_SECONDS;
+
+    /* Send MQTT CONNECT packet to broker. LWT is not used in this demo, so it
+     * is passed as NULL. */
+    xResult = MQTT_Connect( pxMQTTContext,
+                            &xConnectInfo,
+                            NULL,
+                            mqttexampleCONNACK_RECV_TIMEOUT_MS,
+                            &xSessionPresent );
+    configASSERT( xResult == MQTTSuccess );
+
+    /* Successfully established and MQTT connection with the broker. */
+    LogInfo( ( "An MQTT connection is established with %s.", democonfigMQTT_BROKER_ENDPOINT ) );
+}
+/*-----------------------------------------------------------*/
+
+static void prvUpdateSubAckStatus( MQTTPacketInfo_t * pxPacketInfo )
+{
+    MQTTStatus_t xResult = MQTTSuccess;
+    uint8_t * pucPayload = NULL;
+    size_t ulSize = 0;
+    uint32_t ulTopicCount = 0U;
+
+    xResult = MQTT_GetSubAckStatusCodes( pxPacketInfo, &pucPayload, &ulSize );
+
+    /* MQTT_GetSubAckStatusCodes always returns success if called with packet info
+     * from the event callback and non-NULL parameters. */
+    configASSERT( xResult == MQTTSuccess );
+
+    for( ulTopicCount = 0; ulTopicCount < ulSize; ulTopicCount++ )
+    {
+        xTopicFilterContext[ ulTopicCount ].xSubAckStatus = pucPayload[ ulTopicCount ];
+    }
+}
+/*-----------------------------------------------------------*/
+
+static void prvMQTTSubscribeWithBackoffRetries( MQTTContext_t * pxMQTTContext )
+{
+    MQTTStatus_t xResult = MQTTSuccess;
+    RetryUtilsStatus_t xRetryUtilsStatus = RetryUtilsSuccess;
+    RetryUtilsParams_t xRetryParams;
+    MQTTSubscribeInfo_t xMQTTSubscription[ mqttexampleTOPIC_COUNT ];
+    bool xFailedSubscribeToTopic = false;
+    uint32_t ulTopicCount = 0U;
+
+    /* Some fields not used by this demo so start with everything at 0. */
+    ( void ) memset( ( void * ) &xMQTTSubscription, 0x00, sizeof( xMQTTSubscription ) );
+
+    /* Get a unique packet id. */
+    usSubscribePacketIdentifier = MQTT_GetPacketId( pxMQTTContext );
+
+    /* Subscribe to the mqttexampleTOPIC topic filter. This example subscribes to
+     * only one topic and uses QoS2. */
+    xMQTTSubscription[ 0 ].qos = MQTTQoS2;
+    xMQTTSubscription[ 0 ].pTopicFilter = mqttexampleTOPIC;
+    xMQTTSubscription[ 0 ].topicFilterLength = ( uint16_t ) strlen( mqttexampleTOPIC );
+
+    /* Initialize retry attempts and interval. */
+    RetryUtils_ParamsReset( &xRetryParams );
+    xRetryParams.maxRetryAttempts = MAX_RETRY_ATTEMPTS;
+
+    do
+    {
+        /* The client is now connected to the broker. Subscribe to the topic
+         * as specified in mqttexampleTOPIC at the top of this file by sending a
+         * subscribe packet then waiting for a subscribe acknowledgment (SUBACK).
+         * This client will then publish to the same topic it subscribed to, so it
+         * will expect all the messages it sends to the broker to be sent back to it
+         * from the broker. This demo uses QOS2 in Subscribe, therefore, the Publish
+         * messages received from the broker will have QOS2. */
+        LogInfo( ( "Attempt to subscribe to the MQTT topic %s.\r\n", mqttexampleTOPIC ) );
+        xResult = MQTT_Subscribe( pxMQTTContext,
+                                  xMQTTSubscription,
+                                  sizeof( xMQTTSubscription ) / sizeof( MQTTSubscribeInfo_t ),
+                                  usSubscribePacketIdentifier );
+        configASSERT( xResult == MQTTSuccess );
+
+        LogInfo( ( "SUBSCRIBE sent for topic %s to broker.\n\n", mqttexampleTOPIC ) );
+
+        /* Process incoming packet from the broker. After sending the subscribe, the
+         * client may receive a publish before it receives a subscribe ack. Therefore,
+         * call generic incoming packet processing function. Since this demo is
+         * subscribing to the topic to which no one is publishing, probability of
+         * receiving Publish message before subscribe ack is zero; but application
+         * must be ready to receive any packet.  This demo uses the generic packet
+         * processing function everywhere to highlight this fact. */
+        xResult = MQTT_ProcessLoop( pxMQTTContext, mqttexamplePROCESS_LOOP_TIMEOUT_MS );
+        configASSERT( xResult == MQTTSuccess );
+
+        /* Check if recent subscription request has been rejected. #xTopicFilterContext is updated
+         * in the event callback to reflect the status of the SUBACK sent by the broker. It represents
+         * either the QoS level granted by the server upon subscription, or acknowledgement of
+         * server rejection of the subscription request. */
+        for( ulTopicCount = 0; ulTopicCount < mqttexampleTOPIC_COUNT; ulTopicCount++ )
+        {
+            if( xTopicFilterContext[ ulTopicCount ].xSubAckStatus == MQTTSubAckFailure )
+            {
+                LogWarn( ( "Server rejected subscription request. Attempting to re-subscribe to topic %s.",
+                           xTopicFilterContext[ ulTopicCount ].pcTopicFilter ) );
+                xFailedSubscribeToTopic = true;
+                xRetryUtilsStatus = RetryUtils_BackoffAndSleep( &xRetryParams );
+                break;
+            }
+        }
+
+        configASSERT( xRetryUtilsStatus != RetryUtilsRetriesExhausted );
+    } while( ( xFailedSubscribeToTopic == true ) && ( xRetryUtilsStatus == RetryUtilsSuccess ) );
+}
+/*-----------------------------------------------------------*/
+
+static void prvMQTTPublishToTopic( MQTTContext_t * pxMQTTContext )
+{
+    MQTTStatus_t xResult;
+    MQTTPublishInfo_t xMQTTPublishInfo;
+
+    /***
+     * For readability, error handling in this function is restricted to the use of
+     * asserts().
+     ***/
+
+    /* Some fields are not used by this demo so start with everything at 0. */
+    ( void ) memset( ( void * ) &xMQTTPublishInfo, 0x00, sizeof( xMQTTPublishInfo ) );
+
+    /* This demo uses QoS2 */
+    xMQTTPublishInfo.qos = MQTTQoS2;
+    xMQTTPublishInfo.retain = false;
+    xMQTTPublishInfo.pTopicName = mqttexampleTOPIC;
+    xMQTTPublishInfo.topicNameLength = ( uint16_t ) strlen( mqttexampleTOPIC );
+    xMQTTPublishInfo.pPayload = mqttexampleMESSAGE;
+    xMQTTPublishInfo.payloadLength = strlen( mqttexampleMESSAGE );
+
+    /* Get a unique packet id. */
+    usPublishPacketIdentifier = MQTT_GetPacketId( pxMQTTContext );
+
+    /* Send PUBLISH packet. */
+    xResult = MQTT_Publish( pxMQTTContext, &xMQTTPublishInfo, usPublishPacketIdentifier );
+
+    configASSERT( xResult == MQTTSuccess );
+}
+/*-----------------------------------------------------------*/
+
+static void prvMQTTUnsubscribeFromTopic( MQTTContext_t * pxMQTTContext )
+{
+    MQTTStatus_t xResult;
+    MQTTSubscribeInfo_t xMQTTSubscription[ mqttexampleTOPIC_COUNT ];
+
+    /* Some fields are not used by this demo so start with everything at 0. */
+    memset( ( void * ) &xMQTTSubscription, 0x00, sizeof( xMQTTSubscription ) );
+
+    /* Unsubscribe from the mqttexampleTOPIC topic filter. */
+    xMQTTSubscription[ 0 ].qos = MQTTQoS2;
+    xMQTTSubscription[ 0 ].pTopicFilter = mqttexampleTOPIC;
+    xMQTTSubscription[ 0 ].topicFilterLength = ( uint16_t ) strlen( mqttexampleTOPIC );
+
+    /* Get next unique packet identifier. */
+    usUnsubscribePacketIdentifier = MQTT_GetPacketId( pxMQTTContext );
+    /* Make sure the packet id obtained is valid. */
+    configASSERT( usUnsubscribePacketIdentifier != 0 );
+
+    /* Send UNSUBSCRIBE packet. */
+    xResult = MQTT_Unsubscribe( pxMQTTContext,
+                                xMQTTSubscription,
+                                sizeof( xMQTTSubscription ) / sizeof( MQTTSubscribeInfo_t ),
+                                usUnsubscribePacketIdentifier );
+
+    configASSERT( xResult == MQTTSuccess );
+}
+/*-----------------------------------------------------------*/
+
+static void prvMQTTProcessResponse( MQTTPacketInfo_t * pxIncomingPacket,
+                                    uint16_t usPacketId )
+{
+    uint32_t ulTopicCount = 0U;
+
+    switch( pxIncomingPacket->type )
+    {
+        case MQTT_PACKET_TYPE_PUBACK:
+            LogInfo( ( "PUBACK received for packet Id %u.\r\n", usPacketId ) );
+            break;
+
+        case MQTT_PACKET_TYPE_SUBACK:
+
+            /* A SUBACK from the broker, containing the server response to our subscription request, has been received.
+             * It contains the status code indicating server approval/rejection for the subscription to the single topic
+             * requested. The SUBACK will be parsed to obtain the status code, and this status code will be stored in global
+             * variable #xTopicFilterContext. */
+            prvUpdateSubAckStatus( pxIncomingPacket );
+
+            for( ulTopicCount = 0; ulTopicCount < mqttexampleTOPIC_COUNT; ulTopicCount++ )
+            {
+                if( xTopicFilterContext[ ulTopicCount ].xSubAckStatus != MQTTSubAckFailure )
+                {
+                    LogInfo( ( "Subscribed to the topic %s with maximum QoS %u.\r\n",
+                               xTopicFilterContext[ ulTopicCount ].pcTopicFilter,
+                               xTopicFilterContext[ ulTopicCount ].xSubAckStatus ) );
+                }
+            }
+
+            /* Make sure ACK packet identifier matches with Request packet identifier. */
+            configASSERT( usSubscribePacketIdentifier == usPacketId );
+            break;
+
+        case MQTT_PACKET_TYPE_UNSUBACK:
+            LogInfo( ( "Unsubscribed from the topic %s.\r\n", mqttexampleTOPIC ) );
+            /* Make sure ACK packet identifier matches with Request packet identifier. */
+            configASSERT( usUnsubscribePacketIdentifier == usPacketId );
+            break;
+
+        case MQTT_PACKET_TYPE_PINGRESP:
+            LogInfo( ( "Ping Response successfully received.\r\n" ) );
+            break;
+
+        case MQTT_PACKET_TYPE_PUBREC:
+            LogInfo( ( "PUBREC received for packet id %u.\n\n",
+                       usPacketId ) );
+            break;
+
+        case MQTT_PACKET_TYPE_PUBREL:
+
+            /* Nothing to be done from application as library handles
+             * PUBREL. */
+            LogInfo( ( "PUBREL received for packet id %u.\n\n",
+                       usPacketId ) );
+            break;
+
+        case MQTT_PACKET_TYPE_PUBCOMP:
+
+            /* Nothing to be done from application as library handles
+             * PUBCOMP. */
+            LogInfo( ( "PUBCOMP received for packet id %u.\n\n",
+                       usPacketId ) );
+            break;
+
+        /* Any other packet type is invalid. */
+        default:
+            LogWarn( ( "prvMQTTProcessResponse() called with unknown packet type:(%02X).\r\n",
+                       pxIncomingPacket->type ) );
+    }
+}
+
+/*-----------------------------------------------------------*/
+
+static void prvMQTTProcessIncomingPublish( MQTTPublishInfo_t * pxPublishInfo )
+{
+    configASSERT( pxPublishInfo != NULL );
+
+    /* Process incoming Publish. */
+    LogInfo( ( "Incoming QoS : %d\n", pxPublishInfo->qos ) );
+
+    /* Verify the received publish is for the we have subscribed to. */
+    if( ( pxPublishInfo->topicNameLength == strlen( mqttexampleTOPIC ) ) &&
+        ( 0 == strncmp( mqttexampleTOPIC, pxPublishInfo->pTopicName, pxPublishInfo->topicNameLength ) ) )
+    {
+        LogInfo( ( "\r\nIncoming Publish Topic Name: %.*s matches subscribed topic.\r\n"
+                   "Incoming Publish Message : %.*s\r\n",
+                   pxPublishInfo->topicNameLength,
+                   pxPublishInfo->pTopicName,
+                   pxPublishInfo->payloadLength,
+                   pxPublishInfo->pPayload ) );
+    }
+    else
+    {
+        LogInfo( ( "Incoming Publish Topic Name: %.*s does not match subscribed topic.\r\n",
+                   pxPublishInfo->topicNameLength,
+                   pxPublishInfo->pTopicName ) );
+    }
+}
+
+/*-----------------------------------------------------------*/
+
+static void prvEventCallback( MQTTContext_t * pxMQTTContext,
+                              MQTTPacketInfo_t * pxPacketInfo,
+                              MQTTDeserializedInfo_t * pxDeserializedInfo )
+{
+    /* The MQTT context is not used in this function. */
+    ( void ) pxMQTTContext;
+
+    if( ( pxPacketInfo->type & 0xF0U ) == MQTT_PACKET_TYPE_PUBLISH )
+    {
+        LogInfo( ( "PUBLISH received for packet id %u.\n\n",
+                   pxDeserializedInfo->packetIdentifier ) );
+        prvMQTTProcessIncomingPublish( pxDeserializedInfo->pPublishInfo );
+    }
+    else
+    {
+        prvMQTTProcessResponse( pxPacketInfo, pxDeserializedInfo->packetIdentifier );
+    }
+}
+
+/*-----------------------------------------------------------*/
+
+static uint32_t prvGetTimeMs( void )
+{
+    TickType_t xTickCount = 0;
+    uint32_t ulTimeMs = 0UL;
+
+    /* Get the current tick count. */
+    xTickCount = xTaskGetTickCount();
+
+    /* Convert the ticks to milliseconds. */
+    ulTimeMs = ( uint32_t ) xTickCount * _MILLISECONDS_PER_TICK;
+
+    /* Reduce ulGlobalEntryTimeMs from obtained time so as to always return the
+     * elapsed time in the application. */
+    ulTimeMs = ( uint32_t ) ( ulTimeMs - ulGlobalEntryTimeMs );
+
+    return ulTimeMs;
+}
+
+/*-----------------------------------------------------------*/

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Basic_TLS/DemoTasks/BasicTLSMQTTExample.c
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Basic_TLS/DemoTasks/BasicTLSMQTTExample.c
@@ -159,12 +159,12 @@
 /**
  * @brief Milliseconds per second.
  */
-#define _MILLISECONDS_PER_SECOND                          ( 1000U )
+#define MILLISECONDS_PER_SECOND                           ( 1000U )
 
 /**
  * @brief Milliseconds per FreeRTOS tick.
  */
-#define _MILLISECONDS_PER_TICK                            ( _MILLISECONDS_PER_SECOND / configTICK_RATE_HZ )
+#define MILLISECONDS_PER_TICK                             ( MILLISECONDS_PER_SECOND / configTICK_RATE_HZ )
 
 /*-----------------------------------------------------------*/
 
@@ -485,7 +485,10 @@ static TlsTransportStatus_t prvConnectToServerWithBackoffRetries( NetworkCredent
     /* Set the credentials for establishing a TLS connection. */
     pxNetworkCredentials->pRootCa = ( const unsigned char * ) democonfigROOT_CA_PEM;
     pxNetworkCredentials->rootCaSize = sizeof( democonfigROOT_CA_PEM );
-    /* Disable SNI when using a local server. */
+
+    /* When using a local Mosquitto server setup, SNI needs to be disabled for
+     * an MQTT broker that only has an IP address but no hostname. However,
+     * SNI should be enabled whenever possible. */
     pxNetworkCredentials->disableSni = true;
     /* Initialize reconnect attempts and interval. */
     RetryUtils_ParamsReset( &xReconnectParams );
@@ -551,7 +554,7 @@ static void prvCreateMQTTConnectionWithBroker( MQTTContext_t * pxMQTTContext,
     configASSERT( xResult == MQTTSuccess );
 
     /* Some fields are not used in this demo so start with everything at 0. */
-    memset( ( void * ) &xConnectInfo, 0x00, sizeof( xConnectInfo ) );
+    ( void ) memset( ( void * ) &xConnectInfo, 0x00, sizeof( xConnectInfo ) );
 
     /* Start with a clean session i.e. direct the MQTT broker to discard any
      * previous session data. Also, establishing a connection with clean session
@@ -867,7 +870,7 @@ static uint32_t prvGetTimeMs( void )
     xTickCount = xTaskGetTickCount();
 
     /* Convert the ticks to milliseconds. */
-    ulTimeMs = ( uint32_t ) xTickCount * _MILLISECONDS_PER_TICK;
+    ulTimeMs = ( uint32_t ) xTickCount * MILLISECONDS_PER_TICK;
 
     /* Reduce ulGlobalEntryTimeMs from obtained time so as to always return the
      * elapsed time in the application. */

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Basic_TLS/FreeRTOSConfig.h
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Basic_TLS/FreeRTOSConfig.h
@@ -1,0 +1,214 @@
+/*
+ * FreeRTOS Kernel V10.3.0
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://www.FreeRTOS.org
+ * http://aws.amazon.com/freertos
+ */
+
+#ifndef FREERTOS_CONFIG_H
+#define FREERTOS_CONFIG_H
+
+/*-----------------------------------------------------------
+* Application specific definitions.
+*
+* These definitions should be adjusted for your particular hardware and
+* application requirements.
+*
+* THESE PARAMETERS ARE DESCRIBED WITHIN THE 'CONFIGURATION' SECTION OF THE
+* FreeRTOS API DOCUMENTATION AVAILABLE ON THE FreeRTOS.org WEB SITE.
+* http://www.freertos.org/a00110.html
+*
+* The bottom of this file contains some constants specific to running the UDP
+* stack in this demo.  Constants specific to FreeRTOS+TCP itself (rather than
+* the demo) are contained in FreeRTOSIPConfig.h.
+*----------------------------------------------------------*/
+#define configUSE_PREEMPTION                       1
+#define configUSE_PORT_OPTIMISED_TASK_SELECTION    1
+#define configMAX_PRIORITIES                       ( 7 )
+#define configTICK_RATE_HZ                         ( 1000 )                  /* In this non-real time simulated environment the tick frequency has to be at least a multiple of the Win32 tick frequency, and therefore very slow. */
+#define configMINIMAL_STACK_SIZE                   ( ( unsigned short ) 60 ) /* In this simulated case, the stack only has to hold one small structure as the real stack is part of the Win32 thread. */
+#define configTOTAL_HEAP_SIZE                      ( ( size_t ) ( 2048U * 1024U ) )
+#define configMAX_TASK_NAME_LEN                    ( 15 )
+#define configUSE_TRACE_FACILITY                   0
+#define configUSE_16_BIT_TICKS                     0
+#define configIDLE_SHOULD_YIELD                    1
+#define configUSE_CO_ROUTINES                      0
+#define configUSE_MUTEXES                          1
+#define configUSE_RECURSIVE_MUTEXES                1
+#define configQUEUE_REGISTRY_SIZE                  0
+#define configUSE_APPLICATION_TASK_TAG             0
+#define configUSE_COUNTING_SEMAPHORES              1
+#define configUSE_ALTERNATIVE_API                  0
+#define configNUM_THREAD_LOCAL_STORAGE_POINTERS    0
+#define configENABLE_BACKWARD_COMPATIBILITY        1
+#define configSUPPORT_STATIC_ALLOCATION            1
+
+/* Hook function related definitions. */
+#define configUSE_TICK_HOOK                        0
+#define configUSE_IDLE_HOOK                        0
+#define configUSE_MALLOC_FAILED_HOOK               0
+#define configCHECK_FOR_STACK_OVERFLOW             0 /* Not applicable to the Win32 port. */
+
+/* Software timer related definitions. */
+#define configUSE_TIMERS                           1
+#define configTIMER_TASK_PRIORITY                  ( configMAX_PRIORITIES - 1 )
+#define configTIMER_QUEUE_LENGTH                   5
+#define configTIMER_TASK_STACK_DEPTH               ( configMINIMAL_STACK_SIZE * 2 )
+
+/* Event group related definitions. */
+#define configUSE_EVENT_GROUPS                     1
+
+/* Run time stats gathering configuration options. */
+#define configGENERATE_RUN_TIME_STATS              0
+
+/* Co-routine definitions. */
+#define configUSE_CO_ROUTINES                      0
+#define configMAX_CO_ROUTINE_PRIORITIES            ( 2 )
+
+/* Set the following definitions to 1 to include the API function, or zero
+ * to exclude the API function. */
+#define INCLUDE_vTaskPrioritySet                   1
+#define INCLUDE_uxTaskPriorityGet                  1
+#define INCLUDE_vTaskDelete                        1
+#define INCLUDE_vTaskCleanUpResources              0
+#define INCLUDE_vTaskSuspend                       1
+#define INCLUDE_vTaskDelayUntil                    1
+#define INCLUDE_vTaskDelay                         1
+#define INCLUDE_uxTaskGetStackHighWaterMark        1
+#define INCLUDE_xTaskGetSchedulerState             1
+#define INCLUDE_xTimerGetTimerTaskHandle           0
+#define INCLUDE_xTaskGetIdleTaskHandle             0
+#define INCLUDE_xQueueGetMutexHolder               1
+#define INCLUDE_eTaskGetState                      1
+#define INCLUDE_xEventGroupSetBitsFromISR          1
+#define INCLUDE_xTimerPendFunctionCall             1
+#define INCLUDE_pcTaskGetTaskName                  1
+
+/* This demo makes use of one or more example stats formatting functions.  These
+ * format the raw data provided by the uxTaskGetSystemState() function in to human
+ * readable ASCII form.  See the notes in the implementation of vTaskList() within
+ * FreeRTOS/Source/tasks.c for limitations.  configUSE_STATS_FORMATTING_FUNCTIONS
+ * is set to 2 so the formatting functions are included without the stdio.h being
+ * included in tasks.c.  That is because this project defines its own sprintf()
+ * functions. */
+#define configUSE_STATS_FORMATTING_FUNCTIONS       1
+
+/* Assert call defined for debug builds. */
+#ifdef _DEBUG
+    extern void vAssertCalled( const char * pcFile,
+                               uint32_t ulLine );
+    #define configASSERT( x )    if( ( x ) == 0 ) vAssertCalled( __FILE__, __LINE__ )
+#endif /* _DEBUG */
+
+
+
+/* Application specific definitions follow. **********************************/
+
+/* Only used when running in the FreeRTOS Windows simulator.  Defines the
+ * priority of the task used to simulate Ethernet interrupts. */
+#define configMAC_ISR_SIMULATOR_PRIORITY          ( configMAX_PRIORITIES - 1 )
+
+/* This demo creates a virtual network connection by accessing the raw Ethernet
+ * or WiFi data to and from a real network connection.  Many computers have more
+ * than one real network port, and configNETWORK_INTERFACE_TO_USE is used to tell
+ * the demo which real port should be used to create the virtual port.  The ports
+ * available are displayed on the console when the application is executed.  For
+ * example, on my development laptop setting configNETWORK_INTERFACE_TO_USE to 4
+ * results in the wired network being used, while setting
+ * configNETWORK_INTERFACE_TO_USE to 2 results in the wireless network being
+ * used. */
+#define configNETWORK_INTERFACE_TO_USE            1L
+
+/* The address to which logging is sent should UDP logging be enabled. */
+#define configUDP_LOGGING_ADDR0                   192
+#define configUDP_LOGGING_ADDR1                   168
+#define configUDP_LOGGING_ADDR2                   0
+#define configUDP_LOGGING_ADDR3                   11
+
+/* Default MAC address configuration.  The demo creates a virtual network
+ * connection that uses this MAC address by accessing the raw Ethernet/WiFi data
+ * to and from a real network connection on the host PC.  See the
+ * configNETWORK_INTERFACE_TO_USE definition above for information on how to
+ * configure the real network connection to use. */
+#define configMAC_ADDR0                           0x00
+#define configMAC_ADDR1                           0x11
+#define configMAC_ADDR2                           0x11
+#define configMAC_ADDR3                           0x11
+#define configMAC_ADDR4                           0x11
+#define configMAC_ADDR5                           0x41
+
+/* Default IP address configuration.  Used in ipconfigUSE_DNS is set to 0, or
+ * ipconfigUSE_DNS is set to 1 but a DNS server cannot be contacted. */
+#define configIP_ADDR0                            10
+#define configIP_ADDR1                            10
+#define configIP_ADDR2                            10
+#define configIP_ADDR3                            200
+
+/* Default gateway IP address configuration.  Used in ipconfigUSE_DNS is set to
+ * 0, or ipconfigUSE_DNS is set to 1 but a DNS server cannot be contacted. */
+#define configGATEWAY_ADDR0                       10
+#define configGATEWAY_ADDR1                       10
+#define configGATEWAY_ADDR2                       10
+#define configGATEWAY_ADDR3                       1
+
+/* Default DNS server configuration.  OpenDNS addresses are 208.67.222.222 and
+ * 208.67.220.220.  Used in ipconfigUSE_DNS is set to 0, or ipconfigUSE_DNS is set
+ * to 1 but a DNS server cannot be contacted.*/
+#define configDNS_SERVER_ADDR0                    208
+#define configDNS_SERVER_ADDR1                    67
+#define configDNS_SERVER_ADDR2                    222
+#define configDNS_SERVER_ADDR3                    222
+
+/* Default netmask configuration.  Used in ipconfigUSE_DNS is set to 0, or
+ * ipconfigUSE_DNS is set to 1 but a DNS server cannot be contacted. */
+#define configNET_MASK0                           255
+#define configNET_MASK1                           0
+#define configNET_MASK2                           0
+#define configNET_MASK3                           0
+
+/* The UDP port to which print messages are sent. */
+#define configPRINT_PORT                          ( 15000 )
+
+/* Task pool definitions for the demos of IoT Libraries. */
+#define configTASKPOOL_ENABLE_ASSERTS             1
+#define configTASKPOOL_NUMBER_OF_WORKERS          1
+#define configTASKPOOL_WORKER_PRIORITY            tskIDLE_PRIORITY
+#define configTASKPOOL_WORKER_STACK_SIZE_BYTES    2048
+
+#if ( defined( _MSC_VER ) && ( _MSC_VER <= 1600 ) && !defined( snprintf ) )
+    /* Map to Windows names. */
+    #define snprintf     _snprintf
+    #define vsnprintf    _vsnprintf
+#endif
+
+/* Visual studio does not have an implementation of strcasecmp(). */
+#define strcasecmp     _stricmp
+#define strncasecmp    _strnicmp
+#define strcmpi        _strcmpi
+
+/* Prototype for the function used to print out.  In this case it prints to the
+ * console before the network is connected then a UDP port after the network has
+ * connected. */
+extern void vLoggingPrintf( const char * pcFormatString,
+                            ... );
+#define configPRINTF( X )    vLoggingPrintf X
+
+#endif /* FREERTOS_CONFIG_H */

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Basic_TLS/FreeRTOSIPConfig.h
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Basic_TLS/FreeRTOSIPConfig.h
@@ -1,0 +1,309 @@
+/*
+ * FreeRTOS Kernel V10.3.0
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://www.FreeRTOS.org
+ * http://aws.amazon.com/freertos
+ */
+
+
+/*****************************************************************************
+*
+* See the following URL for configuration information.
+* http://www.freertos.org/FreeRTOS-Plus/FreeRTOS_Plus_TCP/TCP_IP_Configuration.html
+*
+*****************************************************************************/
+
+#ifndef FREERTOS_IP_CONFIG_H
+#define FREERTOS_IP_CONFIG_H
+
+/* Prototype for the function used to print out.  In this case it prints to the
+ * console before the network is connected then a UDP port after the network has
+ * connected. */
+extern void vLoggingPrintf( const char * pcFormatString,
+                            ... );
+
+/* Set to 1 to print out debug messages.  If ipconfigHAS_DEBUG_PRINTF is set to
+ * 1 then FreeRTOS_debug_printf should be defined to the function used to print
+ * out the debugging messages. */
+#define ipconfigHAS_DEBUG_PRINTF    0
+#if ( ipconfigHAS_DEBUG_PRINTF == 1 )
+    #define FreeRTOS_debug_printf( X )    vLoggingPrintf X
+#endif
+
+/* Set to 1 to print out non debugging messages, for example the output of the
+ * FreeRTOS_netstat() command, and ping replies.  If ipconfigHAS_PRINTF is set to 1
+ * then FreeRTOS_printf should be set to the function used to print out the
+ * messages. */
+#define ipconfigHAS_PRINTF    1
+#if ( ipconfigHAS_PRINTF == 1 )
+    #define FreeRTOS_printf( X )    vLoggingPrintf X
+#endif
+
+/* Define the byte order of the target MCU (the MCU FreeRTOS+TCP is executing
+ * on).  Valid options are pdFREERTOS_BIG_ENDIAN and pdFREERTOS_LITTLE_ENDIAN. */
+#define ipconfigBYTE_ORDER                         pdFREERTOS_LITTLE_ENDIAN
+
+/* If the network card/driver includes checksum offloading (IP/TCP/UDP checksums)
+ * then set ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM to 1 to prevent the software
+ * stack repeating the checksum calculations. */
+#define ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM     1
+
+/* Several API's will block until the result is known, or the action has been
+ * performed, for example FreeRTOS_send() and FreeRTOS_recv().  The timeouts can be
+ * set per socket, using setsockopt().  If not set, the times below will be
+ * used as defaults. */
+#define ipconfigSOCK_DEFAULT_RECEIVE_BLOCK_TIME    ( 2000 )
+#define ipconfigSOCK_DEFAULT_SEND_BLOCK_TIME       ( 5000 )
+
+/* Include support for LLMNR: Link-local Multicast Name Resolution
+ * (non-Microsoft) */
+#define ipconfigUSE_LLMNR                          ( 0 )
+
+/* Include support for NBNS: NetBIOS Name Service (Microsoft) */
+#define ipconfigUSE_NBNS                           ( 0 )
+
+/* Include support for DNS caching.  For TCP, having a small DNS cache is very
+ * useful.  When a cache is present, ipconfigDNS_REQUEST_ATTEMPTS can be kept low
+ * and also DNS may use small timeouts.  If a DNS reply comes in after the DNS
+ * socket has been destroyed, the result will be stored into the cache.  The next
+ * call to FreeRTOS_gethostbyname() will return immediately, without even creating
+ * a socket. */
+#define ipconfigUSE_DNS_CACHE                      ( 1 )
+#define ipconfigDNS_CACHE_NAME_LENGTH              ( 64 )
+#define ipconfigDNS_CACHE_ENTRIES                  ( 4 )
+#define ipconfigDNS_REQUEST_ATTEMPTS               ( 2 )
+
+/* The IP stack executes it its own task (although any application task can make
+ * use of its services through the published sockets API). ipconfigUDP_TASK_PRIORITY
+ * sets the priority of the task that executes the IP stack.  The priority is a
+ * standard FreeRTOS task priority so can take any value from 0 (the lowest
+ * priority) to (configMAX_PRIORITIES - 1) (the highest priority).
+ * configMAX_PRIORITIES is a standard FreeRTOS configuration parameter defined in
+ * FreeRTOSConfig.h, not FreeRTOSIPConfig.h. Consideration needs to be given as to
+ * the priority assigned to the task executing the IP stack relative to the
+ * priority assigned to tasks that use the IP stack. */
+#define ipconfigIP_TASK_PRIORITY                   ( configMAX_PRIORITIES - 2 )
+
+/* The size, in words (not bytes), of the stack allocated to the FreeRTOS+TCP
+ * task.  This setting is less important when the FreeRTOS Win32 simulator is used
+ * as the Win32 simulator only stores a fixed amount of information on the task
+ * stack.  FreeRTOS includes optional stack overflow detection, see:
+ * http://www.freertos.org/Stacks-and-stack-overflow-checking.html */
+#define ipconfigIP_TASK_STACK_SIZE_WORDS           ( configMINIMAL_STACK_SIZE * 5 )
+
+/* ipconfigRAND32() is called by the IP stack to generate random numbers for
+ * things such as a DHCP transaction number or initial sequence number.  Random
+ * number generation is performed via this macro to allow applications to use their
+ * own random number generation method.  For example, it might be possible to
+ * generate a random number by sampling noise on an analogue input. */
+extern UBaseType_t uxRand();
+#define ipconfigRAND32()    uxRand()
+
+/* If ipconfigUSE_NETWORK_EVENT_HOOK is set to 1 then FreeRTOS+TCP will call the
+ * network event hook at the appropriate times.  If ipconfigUSE_NETWORK_EVENT_HOOK
+ * is not set to 1 then the network event hook will never be called.  See
+ * http://www.FreeRTOS.org/FreeRTOS-Plus/FreeRTOS_Plus_UDP/API/vApplicationIPNetworkEventHook.shtml
+ */
+#define ipconfigUSE_NETWORK_EVENT_HOOK                        1
+
+/* Sockets have a send block time attribute.  If FreeRTOS_sendto() is called but
+ * a network buffer cannot be obtained then the calling task is held in the Blocked
+ * state (so other tasks can continue to executed) until either a network buffer
+ * becomes available or the send block time expires.  If the send block time expires
+ * then the send operation is aborted.  The maximum allowable send block time is
+ * capped to the value set by ipconfigMAX_SEND_BLOCK_TIME_TICKS.  Capping the
+ * maximum allowable send block time prevents prevents a deadlock occurring when
+ * all the network buffers are in use and the tasks that process (and subsequently
+ * free) the network buffers are themselves blocked waiting for a network buffer.
+ * ipconfigMAX_SEND_BLOCK_TIME_TICKS is specified in RTOS ticks.  A time in
+ * milliseconds can be converted to a time in ticks by dividing the time in
+ * milliseconds by portTICK_PERIOD_MS. */
+#define ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS                 ( 5000 / portTICK_PERIOD_MS )
+
+/* If ipconfigUSE_DHCP is 1 then FreeRTOS+TCP will attempt to retrieve an IP
+ * address, netmask, DNS server address and gateway address from a DHCP server.  If
+ * ipconfigUSE_DHCP is 0 then FreeRTOS+TCP will use a static IP address.  The
+ * stack will revert to using the static IP address even when ipconfigUSE_DHCP is
+ * set to 1 if a valid configuration cannot be obtained from a DHCP server for any
+ * reason.  The static configuration used is that passed into the stack by the
+ * FreeRTOS_IPInit() function call. */
+#define ipconfigUSE_DHCP                                      1
+
+/* When ipconfigUSE_DHCP is set to 1, DHCP requests will be sent out at
+ * increasing time intervals until either a reply is received from a DHCP server
+ * and accepted, or the interval between transmissions reaches
+ * ipconfigMAXIMUM_DISCOVER_TX_PERIOD.  The IP stack will revert to using the
+ * static IP address passed as a parameter to FreeRTOS_IPInit() if the
+ * re-transmission time interval reaches ipconfigMAXIMUM_DISCOVER_TX_PERIOD without
+ * a DHCP reply being received. */
+#define ipconfigMAXIMUM_DISCOVER_TX_PERIOD                    ( 120000 / portTICK_PERIOD_MS )
+
+/* The ARP cache is a table that maps IP addresses to MAC addresses.  The IP
+ * stack can only send a UDP message to a remove IP address if it knowns the MAC
+ * address associated with the IP address, or the MAC address of the router used to
+ * contact the remote IP address.  When a UDP message is received from a remote IP
+ * address the MAC address and IP address are added to the ARP cache.  When a UDP
+ * message is sent to a remote IP address that does not already appear in the ARP
+ * cache then the UDP message is replaced by a ARP message that solicits the
+ * required MAC address information.  ipconfigARP_CACHE_ENTRIES defines the maximum
+ * number of entries that can exist in the ARP table at any one time. */
+#define ipconfigARP_CACHE_ENTRIES                             6
+
+/* ARP requests that do not result in an ARP response will be re-transmitted a
+ * maximum of ipconfigMAX_ARP_RETRANSMISSIONS times before the ARP request is
+ * aborted. */
+#define ipconfigMAX_ARP_RETRANSMISSIONS                       ( 5 )
+
+/* ipconfigMAX_ARP_AGE defines the maximum time between an entry in the ARP
+ * table being created or refreshed and the entry being removed because it is stale.
+ * New ARP requests are sent for ARP cache entries that are nearing their maximum
+ * age.  ipconfigMAX_ARP_AGE is specified in tens of seconds, so a value of 150 is
+ * equal to 1500 seconds (or 25 minutes). */
+#define ipconfigMAX_ARP_AGE                                   150
+
+/* Implementing FreeRTOS_inet_addr() necessitates the use of string handling
+ * routines, which are relatively large.  To save code space the full
+ * FreeRTOS_inet_addr() implementation is made optional, and a smaller and faster
+ * alternative called FreeRTOS_inet_addr_quick() is provided.  FreeRTOS_inet_addr()
+ * takes an IP in decimal dot format (for example, "192.168.0.1") as its parameter.
+ * FreeRTOS_inet_addr_quick() takes an IP address as four separate numerical octets
+ * (for example, 192, 168, 0, 1) as its parameters.  If
+ * ipconfigINCLUDE_FULL_INET_ADDR is set to 1 then both FreeRTOS_inet_addr() and
+ * FreeRTOS_indet_addr_quick() are available.  If ipconfigINCLUDE_FULL_INET_ADDR is
+ * not set to 1 then only FreeRTOS_indet_addr_quick() is available. */
+#define ipconfigINCLUDE_FULL_INET_ADDR                        1
+
+/* ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS defines the total number of network buffer that
+ * are available to the IP stack.  The total number of network buffers is limited
+ * to ensure the total amount of RAM that can be consumed by the IP stack is capped
+ * to a pre-determinable value. */
+#define ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS                60
+
+/* A FreeRTOS queue is used to send events from application tasks to the IP
+ * stack.  ipconfigEVENT_QUEUE_LENGTH sets the maximum number of events that can
+ * be queued for processing at any one time.  The event queue must be a minimum of
+ * 5 greater than the total number of network buffers. */
+#define ipconfigEVENT_QUEUE_LENGTH                            ( ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS + 5 )
+
+/* The address of a socket is the combination of its IP address and its port
+ * number.  FreeRTOS_bind() is used to manually allocate a port number to a socket
+ * (to 'bind' the socket to a port), but manual binding is not normally necessary
+ * for client sockets (those sockets that initiate outgoing connections rather than
+ * wait for incoming connections on a known port number).  If
+ * ipconfigALLOW_SOCKET_SEND_WITHOUT_BIND is set to 1 then calling
+ * FreeRTOS_sendto() on a socket that has not yet been bound will result in the IP
+ * stack automatically binding the socket to a port number from the range
+ * socketAUTO_PORT_ALLOCATION_START_NUMBER to 0xffff.  If
+ * ipconfigALLOW_SOCKET_SEND_WITHOUT_BIND is set to 0 then calling FreeRTOS_sendto()
+ * on a socket that has not yet been bound will result in the send operation being
+ * aborted. */
+#define ipconfigALLOW_SOCKET_SEND_WITHOUT_BIND                1
+
+/* Defines the Time To Live (TTL) values used in outgoing UDP packets. */
+#define ipconfigUDP_TIME_TO_LIVE                              128
+#define ipconfigTCP_TIME_TO_LIVE                              128 /* also defined in FreeRTOSIPConfigDefaults.h */
+
+/* USE_TCP: Use TCP and all its features */
+#define ipconfigUSE_TCP                                       ( 1 )
+
+/* Use the TCP socket wake context with a callback. */
+#define ipconfigSOCKET_HAS_USER_WAKE_CALLBACK_WITH_CONTEXT    ( 1 )
+
+/* USE_WIN: Let TCP use windowing mechanism. */
+#define ipconfigUSE_TCP_WIN                                   ( 1 )
+
+/* The MTU is the maximum number of bytes the payload of a network frame can
+ * contain.  For normal Ethernet V2 frames the maximum MTU is 1500.  Setting a
+ * lower value can save RAM, depending on the buffer management scheme used.  If
+ * ipconfigCAN_FRAGMENT_OUTGOING_PACKETS is 1 then (ipconfigNETWORK_MTU - 28) must
+ * be divisible by 8. */
+#define ipconfigNETWORK_MTU                                   1200
+
+/* Set ipconfigUSE_DNS to 1 to include a basic DNS client/resolver.  DNS is used
+ * through the FreeRTOS_gethostbyname() API function. */
+#define ipconfigUSE_DNS                                       1
+
+/* If ipconfigREPLY_TO_INCOMING_PINGS is set to 1 then the IP stack will
+ * generate replies to incoming ICMP echo (ping) requests. */
+#define ipconfigREPLY_TO_INCOMING_PINGS                       1
+
+/* If ipconfigSUPPORT_OUTGOING_PINGS is set to 1 then the
+ * FreeRTOS_SendPingRequest() API function is available. */
+#define ipconfigSUPPORT_OUTGOING_PINGS                        0
+
+/* If ipconfigSUPPORT_SELECT_FUNCTION is set to 1 then the FreeRTOS_select()
+ * (and associated) API function is available. */
+#define ipconfigSUPPORT_SELECT_FUNCTION                       1
+
+/* If ipconfigFILTER_OUT_NON_ETHERNET_II_FRAMES is set to 1 then Ethernet frames
+ * that are not in Ethernet II format will be dropped.  This option is included for
+ * potential future IP stack developments. */
+#define ipconfigFILTER_OUT_NON_ETHERNET_II_FRAMES             1
+
+/* If ipconfigETHERNET_DRIVER_FILTERS_FRAME_TYPES is set to 1 then it is the
+ * responsibility of the Ethernet interface to filter out packets that are of no
+ * interest.  If the Ethernet interface does not implement this functionality, then
+ * set ipconfigETHERNET_DRIVER_FILTERS_FRAME_TYPES to 0 to have the IP stack
+ * perform the filtering instead (it is much less efficient for the stack to do it
+ * because the packet will already have been passed into the stack).  If the
+ * Ethernet driver does all the necessary filtering in hardware then software
+ * filtering can be removed by using a value other than 1 or 0. */
+#define ipconfigETHERNET_DRIVER_FILTERS_FRAME_TYPES           1
+
+/* The windows simulator cannot really simulate MAC interrupts, and needs to
+ * block occasionally to allow other tasks to run. */
+#define configWINDOWS_MAC_INTERRUPT_SIMULATOR_DELAY           ( 20 / portTICK_PERIOD_MS )
+
+/* Advanced only: in order to access 32-bit fields in the IP packets with
+ * 32-bit memory instructions, all packets will be stored 32-bit-aligned, plus 16-bits.
+ * This has to do with the contents of the IP-packets: all 32-bit fields are
+ * 32-bit-aligned, plus 16-bit(!) */
+#define ipconfigPACKET_FILLER_SIZE                            2
+
+/* Define the size of the pool of TCP window descriptors.  On the average, each
+ * TCP socket will use up to 2 x 6 descriptors, meaning that it can have 2 x 6
+ * outstanding packets (for Rx and Tx).  When using up to 10 TP sockets
+ * simultaneously, one could define TCP_WIN_SEG_COUNT as 120. */
+#define ipconfigTCP_WIN_SEG_COUNT                             240
+
+/* Each TCP socket has a circular buffers for Rx and Tx, which have a fixed
+ * maximum size.  Define the size of Rx buffer for TCP sockets. */
+#define ipconfigTCP_RX_BUFFER_LENGTH                          ( 1000 )
+
+/* Define the size of Tx buffer for TCP sockets. */
+#define ipconfigTCP_TX_BUFFER_LENGTH                          ( 1000 )
+
+/* When using call-back handlers, the driver may check if the handler points to
+ * real program memory (RAM or flash) or just has a random non-zero value. */
+#define ipconfigIS_VALID_PROG_ADDRESS( x )    ( ( x ) != NULL )
+
+/* Include support for TCP hang protection.  All sockets in a connecting or
+ * disconnecting stage will timeout after a period of non-activity. */
+#define ipconfigTCP_HANG_PROTECTION         ( 1 )
+#define ipconfigTCP_HANG_PROTECTION_TIME    ( 30 )
+
+/* Include support for TCP keep-alive messages. */
+#define ipconfigTCP_KEEP_ALIVE              ( 1 )
+#define ipconfigTCP_KEEP_ALIVE_INTERVAL     ( 20 ) /* in seconds */
+
+#define portINLINE                          __inline
+
+#endif /* FREERTOS_IP_CONFIG_H */

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Basic_TLS/READ_ME_INSTRUCTIONS.url
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Basic_TLS/READ_ME_INSTRUCTIONS.url
@@ -1,0 +1,5 @@
+[{000214A0-0000-0000-C000-000000000046}]
+Prop3=19,11
+[InternetShortcut]
+IDList=
+URL=https://www.freertos.org/mqtt_lts/

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Basic_TLS/WIN32.vcxproj
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Basic_TLS/WIN32.vcxproj
@@ -1,0 +1,614 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{C686325E-3261-42F7-AEB1-DDE5280E1CEB}</ProjectGuid>
+    <ProjectName>RTOSDemo</ProjectName>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseOfMfc>false</UseOfMfc>
+    <CharacterSet>MultiByte</CharacterSet>
+    <PlatformToolset>v142</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseOfMfc>false</UseOfMfc>
+    <CharacterSet>MultiByte</CharacterSet>
+    <PlatformToolset>v142</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="$(VCTargetsPath)Microsoft.CPP.UpgradeFromVC60.props" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="$(VCTargetsPath)Microsoft.CPP.UpgradeFromVC60.props" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup>
+    <_ProjectFileVersion>10.0.30319.1</_ProjectFileVersion>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">.\Debug\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">.\Debug\</IntDir>
+    <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</LinkIncremental>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">.\Release\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">.\Release\</IntDir>
+    <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">false</LinkIncremental>
+    <CodeAnalysisRuleSet Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">AllRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Midl>
+      <TypeLibraryName>.\Debug/WIN32.tlb</TypeLibraryName>
+      <HeaderFileName>
+      </HeaderFileName>
+    </Midl>
+    <ClCompile>
+      <Optimization>Disabled</Optimization>
+      <AdditionalIncludeDirectories>..\..\..\..\Source\FreeRTOS-Plus-Trace\Include;..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\include;..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\portable\BufferManagement;..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\portable\Compiler\MSVC;..\..\Common\Logging;..\common\WinPCap;..\..\..\..\FreeRTOS\Source\include;..\..\..\..\FreeRTOS\Source\portable\MSVC-MingW;..\..\..\Source\Application-Protocols\coreMQTT\source\include;..\..\..\Source\Application-Protocols\platform\include;..\..\..\Source\Application-Protocols\platform\freertos\transport\include;..\..\..\Source\Application-Protocols\platform\freertos\mbedtls;..\..\..\..\Source\mbedtls_utils;..\..\..\ThirdParty\mbedtls\include;.;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>MBEDTLS_CONFIG_FILE="mbedtls_config.h";WIN32;_DEBUG;_CONSOLE;_WIN32_WINNT=0x0500;WINVER=0x400;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <MinimalRebuild>false</MinimalRebuild>
+      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <PrecompiledHeaderOutputFile>.\Debug/WIN32.pch</PrecompiledHeaderOutputFile>
+      <AssemblerListingLocation>.\Debug/</AssemblerListingLocation>
+      <ObjectFileName>.\Debug/</ObjectFileName>
+      <ProgramDataBaseFileName>.\Debug/</ProgramDataBaseFileName>
+      <WarningLevel>Level4</WarningLevel>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <DisableLanguageExtensions>false</DisableLanguageExtensions>
+      <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
+      <AdditionalOptions>/wd4210 /wd4127 /wd4214 /wd4201 /wd4244  /wd4310 /wd4200 %(AdditionalOptions)</AdditionalOptions>
+      <BrowseInformation>true</BrowseInformation>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <ExceptionHandling>false</ExceptionHandling>
+      <CompileAs>CompileAsC</CompileAs>
+    </ClCompile>
+    <ResourceCompile>
+      <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <Culture>0x0c09</Culture>
+    </ResourceCompile>
+    <Link>
+      <OutputFile>.\Debug/RTOSDemo.exe</OutputFile>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <ProgramDatabaseFile>.\Debug/WIN32.pdb</ProgramDatabaseFile>
+      <SubSystem>Console</SubSystem>
+      <TargetMachine>MachineX86</TargetMachine>
+      <AdditionalDependencies>wpcap.lib;Bcrypt.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>..\Common\WinPCap</AdditionalLibraryDirectories>
+      <Profile>false</Profile>
+      <ImageHasSafeExceptionHandlers>false</ImageHasSafeExceptionHandlers>
+    </Link>
+    <Bscmake>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <OutputFile>.\Debug/WIN32.bsc</OutputFile>
+    </Bscmake>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Midl>
+      <TypeLibraryName>.\Release/WIN32.tlb</TypeLibraryName>
+      <HeaderFileName>
+      </HeaderFileName>
+    </Midl>
+    <ClCompile>
+      <Optimization>MaxSpeed</Optimization>
+      <InlineFunctionExpansion>OnlyExplicitInline</InlineFunctionExpansion>
+      <PreprocessorDefinitions>_WINSOCKAPI_;WIN32;NDEBUG;_CONSOLE;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <StringPooling>true</StringPooling>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <PrecompiledHeaderOutputFile>.\Release/WIN32.pch</PrecompiledHeaderOutputFile>
+      <AssemblerListingLocation>.\Release/</AssemblerListingLocation>
+      <ObjectFileName>.\Release/</ObjectFileName>
+      <ProgramDataBaseFileName>.\Release/</ProgramDataBaseFileName>
+      <WarningLevel>Level3</WarningLevel>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <AdditionalIncludeDirectories>..\Common\Utils;..\Common\ethernet\lwip-1.4.0\ports\win32\WinPCap;..\Common\ethernet\lwip-1.4.0\src\include\ipv4;..\Common\ethernet\lwip-1.4.0\src\include;..\..\..\Source\include;..\..\..\Source\portable\MSVC-MingW;..\Common\ethernet\lwip-1.4.0\ports\win32\include;..\Common\Include;.\lwIP_Apps;.;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <ResourceCompile>
+      <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <Culture>0x0c09</Culture>
+    </ResourceCompile>
+    <Link>
+      <OutputFile>.\Release/RTOSDemo.exe</OutputFile>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <ProgramDatabaseFile>.\Release/WIN32.pdb</ProgramDatabaseFile>
+      <SubSystem>Console</SubSystem>
+      <TargetMachine>MachineX86</TargetMachine>
+      <AdditionalLibraryDirectories>..\Common\ethernet\lwip-1.4.0\ports\win32\WinPCap</AdditionalLibraryDirectories>
+      <AdditionalDependencies>wpcap.lib;Bcrypt.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+    <Bscmake>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <OutputFile>.\Release/WIN32.bsc</OutputFile>
+    </Bscmake>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\..\..\FreeRTOS\Source\event_groups.c" />
+    <ClCompile Include="..\..\..\..\FreeRTOS\Source\list.c" />
+    <ClCompile Include="..\..\..\..\FreeRTOS\Source\portable\MemMang\heap_4.c" />
+    <ClCompile Include="..\..\..\..\FreeRTOS\Source\portable\MSVC-MingW\port.c" />
+    <ClCompile Include="..\..\..\..\FreeRTOS\Source\queue.c" />
+    <ClCompile Include="..\..\..\..\FreeRTOS\Source\stream_buffer.c" />
+    <ClCompile Include="..\..\..\..\FreeRTOS\Source\tasks.c" />
+    <ClCompile Include="..\..\..\..\FreeRTOS\Source\timers.c" />
+    <ClCompile Include="..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\FreeRTOS_ARP.c" />
+    <ClCompile Include="..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\FreeRTOS_DHCP.c" />
+    <ClCompile Include="..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\FreeRTOS_DNS.c" />
+    <ClCompile Include="..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\FreeRTOS_IP.c" />
+    <ClCompile Include="..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\FreeRTOS_Sockets.c" />
+    <ClCompile Include="..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\FreeRTOS_Stream_Buffer.c" />
+    <ClCompile Include="..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\FreeRTOS_TCP_IP.c" />
+    <ClCompile Include="..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\FreeRTOS_TCP_WIN.c" />
+    <ClCompile Include="..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\FreeRTOS_UDP_IP.c" />
+    <ClCompile Include="..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\portable\BufferManagement\BufferAllocation_2.c" />
+    <ClCompile Include="..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\portable\NetworkInterface\WinPCap\NetworkInterface.c" />
+    <ClCompile Include="..\..\..\Source\Application-Protocols\platform\freertos\mbedtls\mbedtls_freertos_port.c" />
+    <ClCompile Include="..\..\..\Source\Application-Protocols\platform\freertos\mbedtls\mbedtls_error.c" />
+    <ClCompile Include="..\..\..\Source\Application-Protocols\platform\freertos\retry_utils\retry_utils_freertos.c" />
+    <ClCompile Include="..\..\..\Source\Application-Protocols\platform\freertos\transport\src\freertos_sockets_wrapper.c" />
+    <ClCompile Include="..\..\..\Source\Application-Protocols\platform\freertos\transport\src\tls_freertos.c" />
+    <ClCompile Include="..\..\..\Source\Application-Protocols\coreMQTT\source\core_mqtt_serializer.c" />
+    <ClCompile Include="..\..\..\Source\Application-Protocols\coreMQTT\source\core_mqtt_state.c" />
+    <ClCompile Include="..\..\..\Source\Application-Protocols\coreMQTT\source\core_mqtt.c" />
+    <ClCompile Include="..\..\..\ThirdParty\mbedtls\library\aes.c">
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">TurnOffAllWarnings</WarningLevel>
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">TurnOffAllWarnings</WarningLevel>
+    </ClCompile>
+    <ClCompile Include="..\..\..\ThirdParty\mbedtls\library\aesni.c">
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">TurnOffAllWarnings</WarningLevel>
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">TurnOffAllWarnings</WarningLevel>
+    </ClCompile>
+    <ClCompile Include="..\..\..\ThirdParty\mbedtls\library\arc4.c">
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">TurnOffAllWarnings</WarningLevel>
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">TurnOffAllWarnings</WarningLevel>
+    </ClCompile>
+    <ClCompile Include="..\..\..\ThirdParty\mbedtls\library\aria.c">
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">TurnOffAllWarnings</WarningLevel>
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">TurnOffAllWarnings</WarningLevel>
+    </ClCompile>
+    <ClCompile Include="..\..\..\ThirdParty\mbedtls\library\asn1parse.c">
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">TurnOffAllWarnings</WarningLevel>
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">TurnOffAllWarnings</WarningLevel>
+    </ClCompile>
+    <ClCompile Include="..\..\..\ThirdParty\mbedtls\library\asn1write.c">
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">TurnOffAllWarnings</WarningLevel>
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">TurnOffAllWarnings</WarningLevel>
+    </ClCompile>
+    <ClCompile Include="..\..\..\ThirdParty\mbedtls\library\base64.c">
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">TurnOffAllWarnings</WarningLevel>
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">TurnOffAllWarnings</WarningLevel>
+    </ClCompile>
+    <ClCompile Include="..\..\..\ThirdParty\mbedtls\library\bignum.c">
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">TurnOffAllWarnings</WarningLevel>
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">TurnOffAllWarnings</WarningLevel>
+    </ClCompile>
+    <ClCompile Include="..\..\..\ThirdParty\mbedtls\library\blowfish.c">
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">TurnOffAllWarnings</WarningLevel>
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">TurnOffAllWarnings</WarningLevel>
+    </ClCompile>
+    <ClCompile Include="..\..\..\ThirdParty\mbedtls\library\camellia.c">
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">TurnOffAllWarnings</WarningLevel>
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">TurnOffAllWarnings</WarningLevel>
+    </ClCompile>
+    <ClCompile Include="..\..\..\ThirdParty\mbedtls\library\ccm.c">
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">TurnOffAllWarnings</WarningLevel>
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">TurnOffAllWarnings</WarningLevel>
+    </ClCompile>
+    <ClCompile Include="..\..\..\ThirdParty\mbedtls\library\certs.c">
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">TurnOffAllWarnings</WarningLevel>
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">TurnOffAllWarnings</WarningLevel>
+    </ClCompile>
+    <ClCompile Include="..\..\..\ThirdParty\mbedtls\library\chacha20.c">
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">TurnOffAllWarnings</WarningLevel>
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">TurnOffAllWarnings</WarningLevel>
+    </ClCompile>
+    <ClCompile Include="..\..\..\ThirdParty\mbedtls\library\chachapoly.c">
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">TurnOffAllWarnings</WarningLevel>
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">TurnOffAllWarnings</WarningLevel>
+    </ClCompile>
+    <ClCompile Include="..\..\..\ThirdParty\mbedtls\library\cipher.c">
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">TurnOffAllWarnings</WarningLevel>
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">TurnOffAllWarnings</WarningLevel>
+    </ClCompile>
+    <ClCompile Include="..\..\..\ThirdParty\mbedtls\library\cipher_wrap.c">
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">TurnOffAllWarnings</WarningLevel>
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">TurnOffAllWarnings</WarningLevel>
+    </ClCompile>
+    <ClCompile Include="..\..\..\ThirdParty\mbedtls\library\cmac.c">
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">TurnOffAllWarnings</WarningLevel>
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">TurnOffAllWarnings</WarningLevel>
+    </ClCompile>
+    <ClCompile Include="..\..\..\ThirdParty\mbedtls\library\ctr_drbg.c">
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">TurnOffAllWarnings</WarningLevel>
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">TurnOffAllWarnings</WarningLevel>
+    </ClCompile>
+    <ClCompile Include="..\..\..\ThirdParty\mbedtls\library\debug.c">
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">TurnOffAllWarnings</WarningLevel>
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">TurnOffAllWarnings</WarningLevel>
+    </ClCompile>
+    <ClCompile Include="..\..\..\ThirdParty\mbedtls\library\des.c">
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">TurnOffAllWarnings</WarningLevel>
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">TurnOffAllWarnings</WarningLevel>
+    </ClCompile>
+    <ClCompile Include="..\..\..\ThirdParty\mbedtls\library\dhm.c">
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">TurnOffAllWarnings</WarningLevel>
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">TurnOffAllWarnings</WarningLevel>
+    </ClCompile>
+    <ClCompile Include="..\..\..\ThirdParty\mbedtls\library\ecdh.c">
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">TurnOffAllWarnings</WarningLevel>
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">TurnOffAllWarnings</WarningLevel>
+    </ClCompile>
+    <ClCompile Include="..\..\..\ThirdParty\mbedtls\library\ecdsa.c">
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">TurnOffAllWarnings</WarningLevel>
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">TurnOffAllWarnings</WarningLevel>
+    </ClCompile>
+    <ClCompile Include="..\..\..\ThirdParty\mbedtls\library\ecjpake.c">
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">TurnOffAllWarnings</WarningLevel>
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">TurnOffAllWarnings</WarningLevel>
+    </ClCompile>
+    <ClCompile Include="..\..\..\ThirdParty\mbedtls\library\ecp.c">
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">TurnOffAllWarnings</WarningLevel>
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">TurnOffAllWarnings</WarningLevel>
+    </ClCompile>
+    <ClCompile Include="..\..\..\ThirdParty\mbedtls\library\ecp_curves.c">
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">TurnOffAllWarnings</WarningLevel>
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">TurnOffAllWarnings</WarningLevel>
+    </ClCompile>
+    <ClCompile Include="..\..\..\ThirdParty\mbedtls\library\entropy.c">
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">TurnOffAllWarnings</WarningLevel>
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">TurnOffAllWarnings</WarningLevel>
+    </ClCompile>
+    <ClCompile Include="..\..\..\ThirdParty\mbedtls\library\entropy_poll.c">
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">TurnOffAllWarnings</WarningLevel>
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">TurnOffAllWarnings</WarningLevel>
+    </ClCompile>
+    <ClCompile Include="..\..\..\ThirdParty\mbedtls\library\error.c">
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">TurnOffAllWarnings</WarningLevel>
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">TurnOffAllWarnings</WarningLevel>
+    </ClCompile>
+    <ClCompile Include="..\..\..\ThirdParty\mbedtls\library\gcm.c">
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">TurnOffAllWarnings</WarningLevel>
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">TurnOffAllWarnings</WarningLevel>
+    </ClCompile>
+    <ClCompile Include="..\..\..\ThirdParty\mbedtls\library\havege.c">
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">TurnOffAllWarnings</WarningLevel>
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">TurnOffAllWarnings</WarningLevel>
+    </ClCompile>
+    <ClCompile Include="..\..\..\ThirdParty\mbedtls\library\hkdf.c">
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">TurnOffAllWarnings</WarningLevel>
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">TurnOffAllWarnings</WarningLevel>
+    </ClCompile>
+    <ClCompile Include="..\..\..\ThirdParty\mbedtls\library\hmac_drbg.c">
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">TurnOffAllWarnings</WarningLevel>
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">TurnOffAllWarnings</WarningLevel>
+    </ClCompile>
+    <ClCompile Include="..\..\..\ThirdParty\mbedtls\library\md.c">
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">TurnOffAllWarnings</WarningLevel>
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">TurnOffAllWarnings</WarningLevel>
+    </ClCompile>
+    <ClCompile Include="..\..\..\ThirdParty\mbedtls\library\md2.c">
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">TurnOffAllWarnings</WarningLevel>
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">TurnOffAllWarnings</WarningLevel>
+    </ClCompile>
+    <ClCompile Include="..\..\..\ThirdParty\mbedtls\library\md4.c">
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">TurnOffAllWarnings</WarningLevel>
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">TurnOffAllWarnings</WarningLevel>
+    </ClCompile>
+    <ClCompile Include="..\..\..\ThirdParty\mbedtls\library\md5.c">
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">TurnOffAllWarnings</WarningLevel>
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">TurnOffAllWarnings</WarningLevel>
+    </ClCompile>
+    <ClCompile Include="..\..\..\ThirdParty\mbedtls\library\memory_buffer_alloc.c">
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">TurnOffAllWarnings</WarningLevel>
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">TurnOffAllWarnings</WarningLevel>
+    </ClCompile>
+    <ClCompile Include="..\..\..\ThirdParty\mbedtls\library\net_sockets.c">
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">TurnOffAllWarnings</WarningLevel>
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">TurnOffAllWarnings</WarningLevel>
+    </ClCompile>
+    <ClCompile Include="..\..\..\ThirdParty\mbedtls\library\nist_kw.c">
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">TurnOffAllWarnings</WarningLevel>
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">TurnOffAllWarnings</WarningLevel>
+    </ClCompile>
+    <ClCompile Include="..\..\..\ThirdParty\mbedtls\library\oid.c">
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">TurnOffAllWarnings</WarningLevel>
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">TurnOffAllWarnings</WarningLevel>
+    </ClCompile>
+    <ClCompile Include="..\..\..\ThirdParty\mbedtls\library\padlock.c">
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">TurnOffAllWarnings</WarningLevel>
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">TurnOffAllWarnings</WarningLevel>
+    </ClCompile>
+    <ClCompile Include="..\..\..\ThirdParty\mbedtls\library\pem.c">
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">TurnOffAllWarnings</WarningLevel>
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">TurnOffAllWarnings</WarningLevel>
+    </ClCompile>
+    <ClCompile Include="..\..\..\ThirdParty\mbedtls\library\pk.c">
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">TurnOffAllWarnings</WarningLevel>
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">TurnOffAllWarnings</WarningLevel>
+    </ClCompile>
+    <ClCompile Include="..\..\..\ThirdParty\mbedtls\library\pkcs11.c">
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">TurnOffAllWarnings</WarningLevel>
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">TurnOffAllWarnings</WarningLevel>
+    </ClCompile>
+    <ClCompile Include="..\..\..\ThirdParty\mbedtls\library\pkcs12.c">
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">TurnOffAllWarnings</WarningLevel>
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">TurnOffAllWarnings</WarningLevel>
+    </ClCompile>
+    <ClCompile Include="..\..\..\ThirdParty\mbedtls\library\pkcs5.c">
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">TurnOffAllWarnings</WarningLevel>
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">TurnOffAllWarnings</WarningLevel>
+    </ClCompile>
+    <ClCompile Include="..\..\..\ThirdParty\mbedtls\library\pkparse.c">
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">TurnOffAllWarnings</WarningLevel>
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">TurnOffAllWarnings</WarningLevel>
+    </ClCompile>
+    <ClCompile Include="..\..\..\ThirdParty\mbedtls\library\pkwrite.c">
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">TurnOffAllWarnings</WarningLevel>
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">TurnOffAllWarnings</WarningLevel>
+    </ClCompile>
+    <ClCompile Include="..\..\..\ThirdParty\mbedtls\library\pk_wrap.c">
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">TurnOffAllWarnings</WarningLevel>
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">TurnOffAllWarnings</WarningLevel>
+    </ClCompile>
+    <ClCompile Include="..\..\..\ThirdParty\mbedtls\library\platform.c">
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">TurnOffAllWarnings</WarningLevel>
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">TurnOffAllWarnings</WarningLevel>
+    </ClCompile>
+    <ClCompile Include="..\..\..\ThirdParty\mbedtls\library\platform_util.c">
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">TurnOffAllWarnings</WarningLevel>
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">TurnOffAllWarnings</WarningLevel>
+    </ClCompile>
+    <ClCompile Include="..\..\..\ThirdParty\mbedtls\library\poly1305.c">
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">TurnOffAllWarnings</WarningLevel>
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">TurnOffAllWarnings</WarningLevel>
+    </ClCompile>
+    <ClCompile Include="..\..\..\ThirdParty\mbedtls\library\ripemd160.c">
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">TurnOffAllWarnings</WarningLevel>
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">TurnOffAllWarnings</WarningLevel>
+    </ClCompile>
+    <ClCompile Include="..\..\..\ThirdParty\mbedtls\library\rsa.c">
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">TurnOffAllWarnings</WarningLevel>
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">TurnOffAllWarnings</WarningLevel>
+    </ClCompile>
+    <ClCompile Include="..\..\..\ThirdParty\mbedtls\library\rsa_internal.c">
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">TurnOffAllWarnings</WarningLevel>
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">TurnOffAllWarnings</WarningLevel>
+    </ClCompile>
+    <ClCompile Include="..\..\..\ThirdParty\mbedtls\library\sha1.c">
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">TurnOffAllWarnings</WarningLevel>
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">TurnOffAllWarnings</WarningLevel>
+    </ClCompile>
+    <ClCompile Include="..\..\..\ThirdParty\mbedtls\library\sha256.c">
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">TurnOffAllWarnings</WarningLevel>
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">TurnOffAllWarnings</WarningLevel>
+    </ClCompile>
+    <ClCompile Include="..\..\..\ThirdParty\mbedtls\library\sha512.c">
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">TurnOffAllWarnings</WarningLevel>
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">TurnOffAllWarnings</WarningLevel>
+    </ClCompile>
+    <ClCompile Include="..\..\..\ThirdParty\mbedtls\library\ssl_cache.c">
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">TurnOffAllWarnings</WarningLevel>
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">TurnOffAllWarnings</WarningLevel>
+    </ClCompile>
+    <ClCompile Include="..\..\..\ThirdParty\mbedtls\library\ssl_ciphersuites.c">
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">TurnOffAllWarnings</WarningLevel>
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">TurnOffAllWarnings</WarningLevel>
+    </ClCompile>
+    <ClCompile Include="..\..\..\ThirdParty\mbedtls\library\ssl_cli.c">
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">TurnOffAllWarnings</WarningLevel>
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">TurnOffAllWarnings</WarningLevel>
+    </ClCompile>
+    <ClCompile Include="..\..\..\ThirdParty\mbedtls\library\ssl_cookie.c">
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">TurnOffAllWarnings</WarningLevel>
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">TurnOffAllWarnings</WarningLevel>
+    </ClCompile>
+    <ClCompile Include="..\..\..\ThirdParty\mbedtls\library\ssl_msg.c">
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">TurnOffAllWarnings</WarningLevel>
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">TurnOffAllWarnings</WarningLevel>
+    </ClCompile>
+    <ClCompile Include="..\..\..\ThirdParty\mbedtls\library\ssl_srv.c">
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">TurnOffAllWarnings</WarningLevel>
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">TurnOffAllWarnings</WarningLevel>
+    </ClCompile>
+    <ClCompile Include="..\..\..\ThirdParty\mbedtls\library\ssl_ticket.c">
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">TurnOffAllWarnings</WarningLevel>
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">TurnOffAllWarnings</WarningLevel>
+    </ClCompile>
+    <ClCompile Include="..\..\..\ThirdParty\mbedtls\library\ssl_tls.c">
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">TurnOffAllWarnings</WarningLevel>
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">TurnOffAllWarnings</WarningLevel>
+    </ClCompile>
+    <ClCompile Include="..\..\..\ThirdParty\mbedtls\library\ssl_tls13_keys.c">
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">TurnOffAllWarnings</WarningLevel>
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">TurnOffAllWarnings</WarningLevel>
+    </ClCompile>
+    <ClCompile Include="..\..\..\ThirdParty\mbedtls\library\threading.c">
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">TurnOffAllWarnings</WarningLevel>
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">TurnOffAllWarnings</WarningLevel>
+    </ClCompile>
+    <ClCompile Include="..\..\..\ThirdParty\mbedtls\library\timing.c">
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">TurnOffAllWarnings</WarningLevel>
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">TurnOffAllWarnings</WarningLevel>
+    </ClCompile>
+    <ClCompile Include="..\..\..\ThirdParty\mbedtls\library\version.c">
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">TurnOffAllWarnings</WarningLevel>
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">TurnOffAllWarnings</WarningLevel>
+    </ClCompile>
+    <ClCompile Include="..\..\..\ThirdParty\mbedtls\library\version_features.c">
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">TurnOffAllWarnings</WarningLevel>
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">TurnOffAllWarnings</WarningLevel>
+    </ClCompile>
+    <ClCompile Include="..\..\..\ThirdParty\mbedtls\library\x509.c">
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">TurnOffAllWarnings</WarningLevel>
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">TurnOffAllWarnings</WarningLevel>
+    </ClCompile>
+    <ClCompile Include="..\..\..\ThirdParty\mbedtls\library\x509write_crt.c">
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">TurnOffAllWarnings</WarningLevel>
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">TurnOffAllWarnings</WarningLevel>
+    </ClCompile>
+    <ClCompile Include="..\..\..\ThirdParty\mbedtls\library\x509write_csr.c">
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">TurnOffAllWarnings</WarningLevel>
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">TurnOffAllWarnings</WarningLevel>
+    </ClCompile>
+    <ClCompile Include="..\..\..\ThirdParty\mbedtls\library\x509_create.c">
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">TurnOffAllWarnings</WarningLevel>
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">TurnOffAllWarnings</WarningLevel>
+    </ClCompile>
+    <ClCompile Include="..\..\..\ThirdParty\mbedtls\library\x509_crl.c">
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">TurnOffAllWarnings</WarningLevel>
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">TurnOffAllWarnings</WarningLevel>
+    </ClCompile>
+    <ClCompile Include="..\..\..\ThirdParty\mbedtls\library\x509_crt.c">
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">TurnOffAllWarnings</WarningLevel>
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">TurnOffAllWarnings</WarningLevel>
+    </ClCompile>
+    <ClCompile Include="..\..\..\ThirdParty\mbedtls\library\x509_csr.c">
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">TurnOffAllWarnings</WarningLevel>
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">TurnOffAllWarnings</WarningLevel>
+    </ClCompile>
+    <ClCompile Include="..\..\..\ThirdParty\mbedtls\library\xtea.c">
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">TurnOffAllWarnings</WarningLevel>
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">TurnOffAllWarnings</WarningLevel>
+    </ClCompile>
+    <ClCompile Include="..\Common\demo_logging.c" />
+    <ClCompile Include="..\Common\main.c" />
+    <ClCompile Include="DemoTasks\BasicTLSMQTTExample.c" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\..\..\FreeRTOS\Source\include\event_groups.h" />
+    <ClInclude Include="..\..\..\..\FreeRTOS\Source\include\FreeRTOS.h" />
+    <ClInclude Include="..\..\..\..\FreeRTOS\Source\include\portable.h" />
+    <ClInclude Include="..\..\..\..\FreeRTOS\Source\include\projdefs.h" />
+    <ClInclude Include="..\..\..\..\FreeRTOS\Source\include\queue.h" />
+    <ClInclude Include="..\..\..\..\FreeRTOS\Source\include\semphr.h" />
+    <ClInclude Include="..\..\..\..\FreeRTOS\Source\include\task.h" />
+    <ClInclude Include="..\..\..\..\FreeRTOS\Source\include\timers.h" />
+    <ClInclude Include="..\..\..\..\FreeRTOS\Source\portable\MSVC-MingW\portmacro.h" />
+    <ClInclude Include="..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\include\FreeRTOSIPConfigDefaults.h" />
+    <ClInclude Include="..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\include\FreeRTOS_ARP.h" />
+    <ClInclude Include="..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\include\FreeRTOS_DHCP.h" />
+    <ClInclude Include="..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\include\FreeRTOS_DNS.h" />
+    <ClInclude Include="..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\include\FreeRTOS_IP.h" />
+    <ClInclude Include="..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\include\FreeRTOS_IP_Private.h" />
+    <ClInclude Include="..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\include\FreeRTOS_Sockets.h" />
+    <ClInclude Include="..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\include\FreeRTOS_Stream_Buffer.h" />
+    <ClInclude Include="..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\include\FreeRTOS_TCP_IP.h" />
+    <ClInclude Include="..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\include\FreeRTOS_TCP_WIN.h" />
+    <ClInclude Include="..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\include\FreeRTOS_UDP_IP.h" />
+    <ClInclude Include="..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\include\IPTraceMacroDefaults.h" />
+    <ClInclude Include="..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\include\NetworkBufferManagement.h" />
+    <ClInclude Include="..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\include\NetworkInterface.h" />
+    <ClInclude Include="..\..\..\Source\Application-Protocols\platform\freertos\mbedtls\mbedtls_error.h" />
+    <ClInclude Include="..\..\..\Source\Application-Protocols\platform\freertos\mbedtls\threading_alt.h" />
+    <ClInclude Include="..\..\..\Source\Application-Protocols\platform\freertos\transport\include\freertos_sockets_wrapper.h" />
+    <ClInclude Include="..\..\..\Source\Application-Protocols\platform\freertos\transport\include\tls_freertos.h" />
+    <ClInclude Include="..\..\..\Source\Application-Protocols\platform\include\retry_utils.h" />
+    <ClInclude Include="..\..\..\Source\Application-Protocols\platform\include\transport_interface.h" />
+    <ClInclude Include="..\..\..\Source\Application-Protocols\coreMQTT\source\include\core_mqtt_serializer.h" />
+    <ClInclude Include="..\..\..\Source\Application-Protocols\coreMQTT\source\include\core_mqtt_state.h" />
+    <ClInclude Include="..\..\..\Source\Application-Protocols\coreMQTT\source\include\core_mqtt.h" />
+    <ClInclude Include="..\..\..\ThirdParty\mbedtls\include\mbedtls\aes.h" />
+    <ClInclude Include="..\..\..\ThirdParty\mbedtls\include\mbedtls\aesni.h" />
+    <ClInclude Include="..\..\..\ThirdParty\mbedtls\include\mbedtls\arc4.h" />
+    <ClInclude Include="..\..\..\ThirdParty\mbedtls\include\mbedtls\aria.h" />
+    <ClInclude Include="..\..\..\ThirdParty\mbedtls\include\mbedtls\asn1.h" />
+    <ClInclude Include="..\..\..\ThirdParty\mbedtls\include\mbedtls\asn1write.h" />
+    <ClInclude Include="..\..\..\ThirdParty\mbedtls\include\mbedtls\base64.h" />
+    <ClInclude Include="..\..\..\ThirdParty\mbedtls\include\mbedtls\bignum.h" />
+    <ClInclude Include="..\..\..\ThirdParty\mbedtls\include\mbedtls\blowfish.h" />
+    <ClInclude Include="..\..\..\ThirdParty\mbedtls\include\mbedtls\bn_mul.h" />
+    <ClInclude Include="..\..\..\ThirdParty\mbedtls\include\mbedtls\camellia.h" />
+    <ClInclude Include="..\..\..\ThirdParty\mbedtls\include\mbedtls\ccm.h" />
+    <ClInclude Include="..\..\..\ThirdParty\mbedtls\include\mbedtls\certs.h" />
+    <ClInclude Include="..\..\..\ThirdParty\mbedtls\include\mbedtls\chacha20.h" />
+    <ClInclude Include="..\..\..\ThirdParty\mbedtls\include\mbedtls\chachapoly.h" />
+    <ClInclude Include="..\..\..\ThirdParty\mbedtls\include\mbedtls\check_config.h" />
+    <ClInclude Include="..\..\..\ThirdParty\mbedtls\include\mbedtls\cipher.h" />
+    <ClInclude Include="..\..\..\ThirdParty\mbedtls\include\mbedtls\cipher_internal.h" />
+    <ClInclude Include="..\..\..\ThirdParty\mbedtls\include\mbedtls\cmac.h" />
+    <ClInclude Include="..\..\..\ThirdParty\mbedtls\include\mbedtls\compat-1.3.h" />
+    <ClInclude Include="..\..\..\ThirdParty\mbedtls\include\mbedtls\config.h" />
+    <ClInclude Include="..\..\..\ThirdParty\mbedtls\include\mbedtls\ctr_drbg.h" />
+    <ClInclude Include="..\..\..\ThirdParty\mbedtls\include\mbedtls\debug.h" />
+    <ClInclude Include="..\..\..\ThirdParty\mbedtls\include\mbedtls\des.h" />
+    <ClInclude Include="..\..\..\ThirdParty\mbedtls\include\mbedtls\dhm.h" />
+    <ClInclude Include="..\..\..\ThirdParty\mbedtls\include\mbedtls\ecdh.h" />
+    <ClInclude Include="..\..\..\ThirdParty\mbedtls\include\mbedtls\ecdsa.h" />
+    <ClInclude Include="..\..\..\ThirdParty\mbedtls\include\mbedtls\ecjpake.h" />
+    <ClInclude Include="..\..\..\ThirdParty\mbedtls\include\mbedtls\ecp.h" />
+    <ClInclude Include="..\..\..\ThirdParty\mbedtls\include\mbedtls\ecp_internal.h" />
+    <ClInclude Include="..\..\..\ThirdParty\mbedtls\include\mbedtls\entropy.h" />
+    <ClInclude Include="..\..\..\ThirdParty\mbedtls\include\mbedtls\entropy_poll.h" />
+    <ClInclude Include="..\..\..\ThirdParty\mbedtls\include\mbedtls\error.h" />
+    <ClInclude Include="..\..\..\ThirdParty\mbedtls\include\mbedtls\gcm.h" />
+    <ClInclude Include="..\..\..\ThirdParty\mbedtls\include\mbedtls\havege.h" />
+    <ClInclude Include="..\..\..\ThirdParty\mbedtls\include\mbedtls\hkdf.h" />
+    <ClInclude Include="..\..\..\ThirdParty\mbedtls\include\mbedtls\hmac_drbg.h" />
+    <ClInclude Include="..\..\..\ThirdParty\mbedtls\include\mbedtls\md.h" />
+    <ClInclude Include="..\..\..\ThirdParty\mbedtls\include\mbedtls\md2.h" />
+    <ClInclude Include="..\..\..\ThirdParty\mbedtls\include\mbedtls\md4.h" />
+    <ClInclude Include="..\..\..\ThirdParty\mbedtls\include\mbedtls\md5.h" />
+    <ClInclude Include="..\..\..\ThirdParty\mbedtls\include\mbedtls\md_internal.h" />
+    <ClInclude Include="..\..\..\ThirdParty\mbedtls\include\mbedtls\memory_buffer_alloc.h" />
+    <ClInclude Include="..\..\..\ThirdParty\mbedtls\include\mbedtls\net.h" />
+    <ClInclude Include="..\..\..\ThirdParty\mbedtls\include\mbedtls\net_sockets.h" />
+    <ClInclude Include="..\..\..\ThirdParty\mbedtls\include\mbedtls\nist_kw.h" />
+    <ClInclude Include="..\..\..\ThirdParty\mbedtls\include\mbedtls\oid.h" />
+    <ClInclude Include="..\..\..\ThirdParty\mbedtls\include\mbedtls\padlock.h" />
+    <ClInclude Include="..\..\..\ThirdParty\mbedtls\include\mbedtls\pem.h" />
+    <ClInclude Include="..\..\..\ThirdParty\mbedtls\include\mbedtls\pk.h" />
+    <ClInclude Include="..\..\..\ThirdParty\mbedtls\include\mbedtls\pkcs11.h" />
+    <ClInclude Include="..\..\..\ThirdParty\mbedtls\include\mbedtls\pkcs12.h" />
+    <ClInclude Include="..\..\..\ThirdParty\mbedtls\include\mbedtls\pkcs5.h" />
+    <ClInclude Include="..\..\..\ThirdParty\mbedtls\include\mbedtls\pk_internal.h" />
+    <ClInclude Include="..\..\..\ThirdParty\mbedtls\include\mbedtls\platform.h" />
+    <ClInclude Include="..\..\..\ThirdParty\mbedtls\include\mbedtls\platform_time.h" />
+    <ClInclude Include="..\..\..\ThirdParty\mbedtls\include\mbedtls\platform_util.h" />
+    <ClInclude Include="..\..\..\ThirdParty\mbedtls\include\mbedtls\poly1305.h" />
+    <ClInclude Include="..\..\..\ThirdParty\mbedtls\include\mbedtls\psa_util.h" />
+    <ClInclude Include="..\..\..\ThirdParty\mbedtls\include\mbedtls\ripemd160.h" />
+    <ClInclude Include="..\..\..\ThirdParty\mbedtls\include\mbedtls\rsa.h" />
+    <ClInclude Include="..\..\..\ThirdParty\mbedtls\include\mbedtls\rsa_internal.h" />
+    <ClInclude Include="..\..\..\ThirdParty\mbedtls\include\mbedtls\sha1.h" />
+    <ClInclude Include="..\..\..\ThirdParty\mbedtls\include\mbedtls\sha256.h" />
+    <ClInclude Include="..\..\..\ThirdParty\mbedtls\include\mbedtls\sha512.h" />
+    <ClInclude Include="..\..\..\ThirdParty\mbedtls\include\mbedtls\ssl.h" />
+    <ClInclude Include="..\..\..\ThirdParty\mbedtls\include\mbedtls\ssl_cache.h" />
+    <ClInclude Include="..\..\..\ThirdParty\mbedtls\include\mbedtls\ssl_ciphersuites.h" />
+    <ClInclude Include="..\..\..\ThirdParty\mbedtls\include\mbedtls\ssl_cookie.h" />
+    <ClInclude Include="..\..\..\ThirdParty\mbedtls\include\mbedtls\ssl_internal.h" />
+    <ClInclude Include="..\..\..\ThirdParty\mbedtls\include\mbedtls\ssl_ticket.h" />
+    <ClInclude Include="..\..\..\ThirdParty\mbedtls\include\mbedtls\ssl_tls13_keys.h" />
+    <ClInclude Include="..\..\..\ThirdParty\mbedtls\include\mbedtls\threading.h" />
+    <ClInclude Include="..\..\..\ThirdParty\mbedtls\include\mbedtls\timing.h" />
+    <ClInclude Include="..\..\..\ThirdParty\mbedtls\include\mbedtls\version.h" />
+    <ClInclude Include="..\..\..\ThirdParty\mbedtls\include\mbedtls\x509.h" />
+    <ClInclude Include="..\..\..\ThirdParty\mbedtls\include\mbedtls\x509_crl.h" />
+    <ClInclude Include="..\..\..\ThirdParty\mbedtls\include\mbedtls\x509_crt.h" />
+    <ClInclude Include="..\..\..\ThirdParty\mbedtls\include\mbedtls\x509_csr.h" />
+    <ClInclude Include="..\..\..\ThirdParty\mbedtls\include\mbedtls\xtea.h" />
+    <ClInclude Include="mbedtls_config.h" />
+    <ClInclude Include="demo_config.h" />
+    <ClInclude Include="FreeRTOSConfig.h" />
+    <ClInclude Include="FreeRTOSIPConfig.h" />
+    <ClInclude Include="core_mqtt_config.h" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Basic_TLS/WIN32.vcxproj.filters
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Basic_TLS/WIN32.vcxproj.filters
@@ -1,0 +1,749 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="FreeRTOS">
+      <UniqueIdentifier>{af3445a1-4908-4170-89ed-39345d90d30c}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="FreeRTOS\Source">
+      <UniqueIdentifier>{f32be356-4763-4cae-9020-974a2638cb08}</UniqueIdentifier>
+      <Extensions>*.c</Extensions>
+    </Filter>
+    <Filter Include="FreeRTOS\Source\Portable">
+      <UniqueIdentifier>{88f409e6-d396-4ac5-94bd-7a99c914be46}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="FreeRTOS+">
+      <UniqueIdentifier>{e5ad4ec7-23dc-4295-8add-2acaee488f5a}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="FreeRTOS\Source\include">
+      <UniqueIdentifier>{d2dcd641-8d91-492b-852f-5563ffadaec6}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="FreeRTOS+\FreeRTOS+TCP">
+      <UniqueIdentifier>{8672fa26-b119-481f-8b8d-086419c01a3e}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="FreeRTOS+\FreeRTOS+TCP\portable">
+      <UniqueIdentifier>{4570be11-ec96-4b55-ac58-24b50ada980a}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="FreeRTOS+\FreeRTOS+TCP\include">
+      <UniqueIdentifier>{5d93ed51-023a-41ad-9243-8d230165d34b}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="DemoTasks">
+      <UniqueIdentifier>{b71e974a-9f28-4815-972b-d930ba8a34d0}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="FreeRTOS+\FreeRTOS IoT Libraries">
+      <UniqueIdentifier>{60717407-397f-4ea5-8492-3314acdd25f0}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="FreeRTOS+\FreeRTOS IoT Libraries\standard">
+      <UniqueIdentifier>{8a90222f-d723-4b4e-8e6e-c57afaf7fa92}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="FreeRTOS+\FreeRTOS IoT Libraries\standard\coreMQTT">
+      <UniqueIdentifier>{2d17d5e6-ed70-4e42-9693-f7a63baf4948}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="FreeRTOS+\FreeRTOS IoT Libraries\standard\coreMQTT\src">
+      <UniqueIdentifier>{7158b0be-01e7-42d1-8d3f-c75118a596a2}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="FreeRTOS+\FreeRTOS IoT Libraries\standard\coreMQTT\include">
+      <UniqueIdentifier>{6ad56e6d-c330-4830-8f4b-c75b05dfa866}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="FreeRTOS+\FreeRTOS IoT Libraries\platform">
+      <UniqueIdentifier>{84613aa2-91dc-4e1a-a3b3-823b6d7bf0e0}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="FreeRTOS+\mbedtls">
+      <UniqueIdentifier>{7bedd2e3-adbb-4c95-9632-445132b459ce}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="FreeRTOS+\mbedtls\include">
+      <UniqueIdentifier>{07a14673-4d02-4780-a099-6b8c654dff91}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="FreeRTOS+\mbedtls\library">
+      <UniqueIdentifier>{e875c5e3-40a2-4408-941e-5e1a951cc663}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="FreeRTOS+\FreeRTOS IoT Libraries\platform\freertos">
+      <UniqueIdentifier>{fcf93295-15e2-4a84-a5e9-b3c162e9f061}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="FreeRTOS+\FreeRTOS IoT Libraries\platform\freertos\mbedtls">
+      <UniqueIdentifier>{8a0aa896-6b3a-49b3-997e-681f0d1949ae}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="FreeRTOS+\FreeRTOS IoT Libraries\platform\freertos\transport">
+      <UniqueIdentifier>{c5a01679-3e7a-4320-97ac-ee5b872c1650}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="FreeRTOS+\FreeRTOS IoT Libraries\platform\freertos\transport\include">
+      <UniqueIdentifier>{c992824d-4198-46b2-8d59-5f99ab9946ab}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="FreeRTOS+\FreeRTOS IoT Libraries\platform\freertos\transport\src">
+      <UniqueIdentifier>{6a35782c-bc09-42d5-a850-98bcb668a4dc}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\..\..\FreeRTOS\Source\portable\MSVC-MingW\port.c">
+      <Filter>FreeRTOS\Source\Portable</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\FreeRTOS\Source\timers.c">
+      <Filter>FreeRTOS\Source</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\FreeRTOS\Source\list.c">
+      <Filter>FreeRTOS\Source</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\FreeRTOS\Source\queue.c">
+      <Filter>FreeRTOS\Source</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\FreeRTOS\Source\tasks.c">
+      <Filter>FreeRTOS\Source</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\FreeRTOS_UDP_IP.c">
+      <Filter>FreeRTOS+\FreeRTOS+TCP</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\FreeRTOS_DHCP.c">
+      <Filter>FreeRTOS+\FreeRTOS+TCP</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\FreeRTOS_DNS.c">
+      <Filter>FreeRTOS+\FreeRTOS+TCP</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\FreeRTOS_Sockets.c">
+      <Filter>FreeRTOS+\FreeRTOS+TCP</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\portable\BufferManagement\BufferAllocation_2.c">
+      <Filter>FreeRTOS+\FreeRTOS+TCP\portable</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\portable\NetworkInterface\WinPCap\NetworkInterface.c">
+      <Filter>FreeRTOS+\FreeRTOS+TCP\portable</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\FreeRTOS_ARP.c">
+      <Filter>FreeRTOS+\FreeRTOS+TCP</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\FreeRTOS_IP.c">
+      <Filter>FreeRTOS+\FreeRTOS+TCP</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\FreeRTOS_TCP_IP.c">
+      <Filter>FreeRTOS+\FreeRTOS+TCP</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\FreeRTOS_TCP_WIN.c">
+      <Filter>FreeRTOS+\FreeRTOS+TCP</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\FreeRTOS\Source\event_groups.c">
+      <Filter>FreeRTOS\Source</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\FreeRTOS\Source\portable\MemMang\heap_4.c">
+      <Filter>FreeRTOS\Source\Portable</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\FreeRTOS_Stream_Buffer.c">
+      <Filter>FreeRTOS+\FreeRTOS+TCP</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\FreeRTOS\Source\stream_buffer.c">
+      <Filter>FreeRTOS\Source</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\aes.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\aesni.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\arc4.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\aria.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\asn1parse.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\asn1write.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\base64.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\bignum.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\blowfish.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\camellia.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\ccm.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\certs.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\chacha20.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\chachapoly.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\cipher.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\cipher_wrap.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\cmac.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\ctr_drbg.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\debug.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\des.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\dhm.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\ecdh.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\ecdsa.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\ecjpake.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\ecp.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\ecp_curves.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\entropy.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\entropy_poll.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\error.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\gcm.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\havege.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\hkdf.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\hmac_drbg.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\md.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\md_wrap.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\md2.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\md4.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\md5.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\memory_buffer_alloc.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\net_sockets.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\nist_kw.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\oid.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\padlock.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\pem.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\pk.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\pk_wrap.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\pkcs5.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\pkcs11.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\pkcs12.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\pkparse.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\pkwrite.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\platform.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\platform_util.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\poly1305.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\ripemd160.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\rsa.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\rsa_internal.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\sha1.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\sha256.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\sha512.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\ssl_cache.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\ssl_ciphersuites.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\ssl_cli.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\ssl_cookie.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\ssl_msg.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\ssl_srv.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\ssl_ticket.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\ssl_tls.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\ssl_tls13_keys.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\threading.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\timing.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\version.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\version_features.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\x509.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\x509_create.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\x509_crl.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\x509_crt.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\x509_csr.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\x509write_crt.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\x509write_csr.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\mbedtls\library\xtea.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\Common\demo_logging.c" />
+    <ClCompile Include="..\Common\main.c" />
+    <ClCompile Include="DemoTasks\BasicTLSMQTTExample.c">
+      <Filter>DemoTasks</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\Source\Application-Protocols\coreMQTT\source\core_mqtt_serializer.c">
+      <Filter>FreeRTOS+\FreeRTOS IoT Libraries\standard\coreMQTT\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\Source\Application-Protocols\coreMQTT\source\core_mqtt_state.c">
+      <Filter>FreeRTOS+\FreeRTOS IoT Libraries\standard\coreMQTT\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\Source\Application-Protocols\coreMQTT\source\core_mqtt.c">
+      <Filter>FreeRTOS+\FreeRTOS IoT Libraries\standard\coreMQTT\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\Source\Application-Protocols\platform\freertos\mbedtls\mbedtls_freertos_port.c">
+      <Filter>FreeRTOS+\FreeRTOS IoT Libraries\platform\freertos\mbedtls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\Source\Application-Protocols\platform\freertos\mbedtls\mbedtls_error.c">
+      <Filter>FreeRTOS+\FreeRTOS IoT Libraries\platform\freertos\mbedtls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\Source\Application-Protocols\platform\freertos\retry_utils\retry_utils_freertos.c">
+      <Filter>FreeRTOS+\FreeRTOS IoT Libraries\platform\freertos</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\Source\Application-Protocols\platform\freertos\transport\src\tls_freertos.c">
+      <Filter>FreeRTOS+\FreeRTOS IoT Libraries\platform\freertos\transport\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\Source\Application-Protocols\platform\freertos\transport\src\freertos_sockets_wrapper.c">
+      <Filter>FreeRTOS+\FreeRTOS IoT Libraries\platform\freertos\transport\src</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\include\NetworkInterface.h">
+      <Filter>FreeRTOS+\FreeRTOS+TCP\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\include\FreeRTOS_DNS.h">
+      <Filter>FreeRTOS+\FreeRTOS+TCP\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\include\FreeRTOS_Sockets.h">
+      <Filter>FreeRTOS+\FreeRTOS+TCP\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\include\FreeRTOS_UDP_IP.h">
+      <Filter>FreeRTOS+\FreeRTOS+TCP\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\FreeRTOS\Source\include\timers.h">
+      <Filter>FreeRTOS\Source\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\FreeRTOS\Source\include\event_groups.h">
+      <Filter>FreeRTOS\Source\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\FreeRTOS\Source\include\FreeRTOS.h">
+      <Filter>FreeRTOS\Source\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\FreeRTOS\Source\include\queue.h">
+      <Filter>FreeRTOS\Source\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\FreeRTOS\Source\include\semphr.h">
+      <Filter>FreeRTOS\Source\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\FreeRTOS\Source\include\task.h">
+      <Filter>FreeRTOS\Source\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\FreeRTOS\Source\portable\MSVC-MingW\portmacro.h">
+      <Filter>FreeRTOS\Source\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\include\FreeRTOS_IP_Private.h">
+      <Filter>FreeRTOS+\FreeRTOS+TCP\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\include\NetworkBufferManagement.h">
+      <Filter>FreeRTOS+\FreeRTOS+TCP\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\include\FreeRTOS_ARP.h">
+      <Filter>FreeRTOS+\FreeRTOS+TCP\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\include\FreeRTOS_DHCP.h">
+      <Filter>FreeRTOS+\FreeRTOS+TCP\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\include\FreeRTOS_IP.h">
+      <Filter>FreeRTOS+\FreeRTOS+TCP\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\include\FreeRTOS_TCP_IP.h">
+      <Filter>FreeRTOS+\FreeRTOS+TCP\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\include\FreeRTOS_TCP_WIN.h">
+      <Filter>FreeRTOS+\FreeRTOS+TCP\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\include\FreeRTOSIPConfigDefaults.h">
+      <Filter>FreeRTOS+\FreeRTOS+TCP\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\include\IPTraceMacroDefaults.h">
+      <Filter>FreeRTOS+\FreeRTOS+TCP\include</Filter>
+    </ClInclude>
+    <ClInclude Include="FreeRTOSConfig.h" />
+    <ClInclude Include="FreeRTOSIPConfig.h" />
+    <ClInclude Include="..\..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\include\FreeRTOS_Stream_Buffer.h">
+      <Filter>FreeRTOS+\FreeRTOS+TCP\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\FreeRTOS\Source\include\portable.h">
+      <Filter>FreeRTOS\Source\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\FreeRTOS\Source\include\projdefs.h">
+      <Filter>FreeRTOS\Source\include</Filter>
+    </ClInclude>
+    <ClInclude Include="demo_config.h" />
+    <ClInclude Include="..\..\..\Source\Application-Protocols\coreMQTT\source\include\core_mqtt_serializer.h">
+      <Filter>FreeRTOS+\FreeRTOS IoT Libraries\standard\coreMQTT\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\Source\Application-Protocols\coreMQTT\source\include\core_mqtt_state.h">
+      <Filter>FreeRTOS+\FreeRTOS IoT Libraries\standard\coreMQTT\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\Source\Application-Protocols\coreMQTT\source\include\core_mqtt.h">
+      <Filter>FreeRTOS+\FreeRTOS IoT Libraries\standard\coreMQTT\include</Filter>
+    </ClInclude>
+    <ClInclude Include="core_mqtt_config.h" />
+    <ClInclude Include="..\..\..\Source\Application-Protocols\platform\include\transport_interface.h">
+      <Filter>FreeRTOS+\FreeRTOS IoT Libraries\platform</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\Source\Application-Protocols\platform\include\retry_utils.h">
+      <Filter>FreeRTOS+\FreeRTOS IoT Libraries\platform</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\aes.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\aesni.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\arc4.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\aria.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\asn1.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\asn1write.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\base64.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\bignum.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\blowfish.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\bn_mul.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\camellia.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\ccm.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\certs.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\chacha20.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\chachapoly.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\check_config.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\cipher.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\cipher_internal.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\cmac.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\compat-1.3.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\config.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\ctr_drbg.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\debug.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\des.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\dhm.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\ecdh.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\ecdsa.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\ecjpake.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\ecp.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\ecp_internal.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\entropy.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\entropy_poll.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\error.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\gcm.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\havege.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\hkdf.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\hmac_drbg.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\md.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\md_internal.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\md2.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\md4.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\md5.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\memory_buffer_alloc.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\net.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\net_sockets.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\nist_kw.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\oid.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\padlock.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\pem.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\pk.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\pk_internal.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\pkcs5.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\pkcs11.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\pkcs12.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\platform.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\platform_time.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\platform_util.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\poly1305.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\psa_util.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\ripemd160.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\rsa.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\rsa_internal.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\sha1.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\sha256.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\sha512.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\ssl.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\ssl_cache.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\ssl_ciphersuites.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\ssl_cookie.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\ssl_internal.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\ssl_ticket.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\ssl_tls13_keys.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\threading.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\timing.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\version.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\x509.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\x509_crl.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\x509_crt.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\x509_csr.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\mbedtls\include\mbedtls\xtea.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="mbedtls_config.h" />
+    <ClInclude Include="..\..\..\Source\Application-Protocols\platform\freertos\mbedtls\mbedtls_error.h">
+      <Filter>FreeRTOS+\FreeRTOS IoT Libraries\platform\freertos\mbedtls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\Source\Application-Protocols\platform\freertos\mbedtls\threading_alt.h">
+      <Filter>FreeRTOS+\FreeRTOS IoT Libraries\platform\freertos\mbedtls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\Source\Application-Protocols\platform\freertos\transport\include\freertos_sockets_wrapper.h">
+      <Filter>FreeRTOS+\FreeRTOS IoT Libraries\platform\freertos\transport\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\Source\Application-Protocols\platform\freertos\transport\include\tls_freertos.h">
+      <Filter>FreeRTOS+\FreeRTOS IoT Libraries\platform\freertos\transport\include</Filter>
+    </ClInclude>
+  </ItemGroup>
+</Project>

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Basic_TLS/core_mqtt_config.h
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Basic_TLS/core_mqtt_config.h
@@ -1,0 +1,65 @@
+/*
+ * FreeRTOS Kernel V10.3.0
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://www.FreeRTOS.org
+ * http://aws.amazon.com/freertos
+ */
+#ifndef CORE_MQTT_CONFIG_H
+#define CORE_MQTT_CONFIG_H
+
+/**************************************************/
+/******* DO NOT CHANGE the following order ********/
+/**************************************************/
+
+/* Include logging header files and define logging macros in the following order:
+ * 1. Include the header file "logging_levels.h".
+ * 2. Define the LIBRARY_LOG_NAME and LIBRARY_LOG_LEVEL macros depending on
+ * the logging configuration for MQTT.
+ * 3. Include the header file "logging_stack.h", if logging is enabled for MQTT.
+ */
+
+#include "logging_levels.h"
+
+/* Logging configuration for the MQTT library. */
+#ifndef LIBRARY_LOG_NAME
+    #define LIBRARY_LOG_NAME    "MQTT"
+#endif
+
+#ifndef LIBRARY_LOG_LEVEL
+    #define LIBRARY_LOG_LEVEL    LOG_ERROR
+#endif
+
+#include "logging_stack.h"
+/************ End of logging configuration ****************/
+
+/**
+ * @brief The maximum number of MQTT PUBLISH messages that may be pending
+ * acknowledgement at any time.
+ *
+ * QoS 1 and 2 MQTT PUBLISHes require acknowledgment from the server before
+ * they can be completed. While they are awaiting the acknowledgment, the
+ * client must maintain information about their state. The value of this
+ * macro sets the limit on how many simultaneous PUBLISH states an MQTT
+ * context maintains.
+ */
+#define MQTT_STATE_ARRAY_MAX_COUNT    10U
+
+#endif /* ifndef CORE_MQTT_CONFIG_H */

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Basic_TLS/core_mqtt_config.h
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Basic_TLS/core_mqtt_config.h
@@ -22,8 +22,8 @@
  * http://www.FreeRTOS.org
  * http://aws.amazon.com/freertos
  */
-#ifndef CORE_MQTT_CONFIG_H_
-#define CORE_MQTT_CONFIG_H_
+#ifndef CORE_MQTT_CONFIG_H
+#define CORE_MQTT_CONFIG_H
 
 /**************************************************/
 /******* DO NOT CHANGE the following order ********/

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Basic_TLS/core_mqtt_config.h
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Basic_TLS/core_mqtt_config.h
@@ -22,8 +22,8 @@
  * http://www.FreeRTOS.org
  * http://aws.amazon.com/freertos
  */
-#ifndef CORE_MQTT_CONFIG_H
-#define CORE_MQTT_CONFIG_H
+#ifndef CORE_MQTT_CONFIG_H_
+#define CORE_MQTT_CONFIG_H_
 
 /**************************************************/
 /******* DO NOT CHANGE the following order ********/

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Basic_TLS/demo_config.h
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Basic_TLS/demo_config.h
@@ -1,0 +1,127 @@
+/*
+ * FreeRTOS Kernel V10.3.0
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://www.FreeRTOS.org
+ * http://aws.amazon.com/freertos
+ *
+ */
+
+#ifndef DEMO_CONFIG_H
+#define DEMO_CONFIG_H
+
+/* FreeRTOS config include. */
+#include "FreeRTOSConfig.h"
+
+/**************************************************/
+/******* DO NOT CHANGE the following order ********/
+/**************************************************/
+
+/* Include logging header files and define logging macros in the following order:
+ * 1. Include the header file "logging_levels.h".
+ * 2. Define the LIBRARY_LOG_NAME and LIBRARY_LOG_LEVEL macros depending on
+ * the logging configuration for DEMO.
+ * 3. Include the header file "logging_stack.h", if logging is enabled for DEMO.
+ */
+
+#include "logging_levels.h"
+
+/* Logging configuration for the Demo. */
+#ifndef LIBRARY_LOG_NAME
+    #define LIBRARY_LOG_NAME    "MQTTDemo"
+#endif
+
+#ifndef LIBRARY_LOG_LEVEL
+    #define LIBRARY_LOG_LEVEL    LOG_INFO
+#endif
+#include "logging_stack.h"
+
+/************ End of logging configuration ****************/
+
+/**
+ * @brief The MQTT client identifier used in this example.  Each client identifier
+ * must be unique; so edit as required to ensure that no two clients connecting to
+ * the same broker use the same client identifier.
+ *
+ * #define democonfigCLIENT_IDENTIFIER    "insert here."
+ */
+
+
+/**
+ * @brief Endpoint of the MQTT broker to connect to.
+ *
+ * This demo application can be run with any MQTT broker, that supports server
+ * authentication.
+ *
+ * For AWS IoT MQTT broker, this is the Thing's REST API Endpoint.
+ *
+ * @note Your AWS IoT Core endpoint can be found in the AWS IoT console under
+ * Settings/Custom Endpoint, or using the describe-endpoint REST API (with
+ * AWS CLI command line tool).
+ *
+ * #define democonfigMQTT_BROKER_ENDPOINT    "...insert here..."
+ */
+
+
+/**
+ * @brief The port to use for the demo.
+ *
+ * In general, port 8883 is for secured MQTT connections.
+ *
+ * @note Port 443 requires use of the ALPN TLS extension with the ALPN protocol
+ * name. When using port 8883, ALPN is not required.
+ *
+ * #define democonfigMQTT_BROKER_PORT    "...insert here..."
+ */
+
+
+/**
+ * @brief Server's root CA certificate.
+ *
+ * For AWS IoT MQTT broker, this certificate is used to identify the AWS IoT
+ * server and is publicly available. Refer to the AWS documentation available
+ * in the link below.
+ * https://docs.aws.amazon.com/iot/latest/developerguide/server-authentication.html#server-authentication-certs
+ *
+ * @note This certificate should be PEM-encoded.
+ *
+ * Must include the PEM header and footer:
+ * "-----BEGIN CERTIFICATE-----\n"\
+ * "...base64 data...\n"\
+ * "-----END CERTIFICATE-----\n"
+ *
+ * #define democonfigROOT_CA_PEM    "...insert here..."
+ */
+
+
+/**
+ * @brief Set the stack size of the main demo task.
+ *
+ * In the Windows port, this stack only holds a structure. The actual
+ * stack is created by an operating system thread.
+ */
+#define democonfigDEMO_STACKSIZE         configMINIMAL_STACK_SIZE
+
+/**
+ * @brief Size of the network buffer for MQTT packets.
+ */
+#define democonfigNETWORK_BUFFER_SIZE    ( 1024U )
+
+#endif /* DEMO_CONFIG_H */

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Basic_TLS/demo_config.h
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Basic_TLS/demo_config.h
@@ -88,7 +88,7 @@
  * @note Port 443 requires use of the ALPN TLS extension with the ALPN protocol
  * name. When using port 8883, ALPN is not required.
  *
- * #define democonfigMQTT_BROKER_PORT    "...insert here..."
+ * #define democonfigMQTT_BROKER_PORT    ( insert here )
  */
 
 

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Basic_TLS/demo_config.h
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Basic_TLS/demo_config.h
@@ -60,7 +60,7 @@
  * must be unique; so edit as required to ensure that no two clients connecting to
  * the same broker use the same client identifier.
  *
- * #define democonfigCLIENT_IDENTIFIER    "insert here."
+ * #define democonfigCLIENT_IDENTIFIER    "...insert here..."
  */
 
 

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Basic_TLS/mbedtls_config.h
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Basic_TLS/mbedtls_config.h
@@ -1,0 +1,151 @@
+/*
+ *  Copyright (C) 2006-2018, ARM Limited, All Rights Reserved
+ *  SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
+ *
+ *  This file is provided under the Apache License 2.0, or the
+ *  GNU General Public License v2.0 or later.
+ *
+ *  **********
+ *  Apache License 2.0:
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  **********
+ *
+ *  **********
+ *  GNU General Public License v2.0 or later:
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *  **********
+ *
+ *  This repository uses Mbed TLS under Apache 2.0
+ */
+
+/* This file configures mbed TLS for FreeRTOS. */
+
+#ifndef MBEDTLS_CONFIG_H_
+#define MBEDTLS_CONFIG_H_
+
+/* FreeRTOS include. */
+#include "FreeRTOS.h"
+
+/* Generate errors if deprecated functions are used. */
+#define MBEDTLS_DEPRECATED_REMOVED
+
+/* Place AES tables in ROM. */
+#define MBEDTLS_AES_ROM_TABLES
+
+/* Enable the following cipher modes. */
+#define MBEDTLS_CIPHER_MODE_CBC
+#define MBEDTLS_CIPHER_MODE_CFB
+#define MBEDTLS_CIPHER_MODE_CTR
+
+/* Enable the following cipher padding modes. */
+#define MBEDTLS_CIPHER_PADDING_PKCS7
+#define MBEDTLS_CIPHER_PADDING_ONE_AND_ZEROS
+#define MBEDTLS_CIPHER_PADDING_ZEROS_AND_LEN
+#define MBEDTLS_CIPHER_PADDING_ZEROS
+
+/* Cipher suite configuration. */
+#define MBEDTLS_REMOVE_ARC4_CIPHERSUITES
+#define MBEDTLS_ECP_DP_SECP256R1_ENABLED
+#define MBEDTLS_ECP_NIST_OPTIM
+#define MBEDTLS_KEY_EXCHANGE_ECDHE_RSA_ENABLED
+#define MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED
+
+/* Enable all SSL alert messages. */
+#define MBEDTLS_SSL_ALL_ALERT_MESSAGES
+
+/* Enable the following SSL features. */
+#define MBEDTLS_SSL_ENCRYPT_THEN_MAC
+#define MBEDTLS_SSL_EXTENDED_MASTER_SECRET
+#define MBEDTLS_SSL_MAX_FRAGMENT_LENGTH
+#define MBEDTLS_SSL_PROTO_TLS1_2
+#define MBEDTLS_SSL_ALPN
+#define MBEDTLS_SSL_SERVER_NAME_INDICATION
+
+/* Check certificate key usage. */
+#define MBEDTLS_X509_CHECK_KEY_USAGE
+#define MBEDTLS_X509_CHECK_EXTENDED_KEY_USAGE
+
+/* Disable platform entropy functions. */
+#define MBEDTLS_NO_PLATFORM_ENTROPY
+
+/* Enable the following mbed TLS features. */
+#define MBEDTLS_AES_C
+#define MBEDTLS_ASN1_PARSE_C
+#define MBEDTLS_ASN1_WRITE_C
+#define MBEDTLS_BASE64_C
+#define MBEDTLS_BIGNUM_C
+#define MBEDTLS_CIPHER_C
+#define MBEDTLS_CTR_DRBG_C
+#define MBEDTLS_ECDH_C
+#define MBEDTLS_ECDSA_C
+#define MBEDTLS_ECP_C
+#define MBEDTLS_ENTROPY_C
+#define MBEDTLS_GCM_C
+#define MBEDTLS_MD_C
+#define MBEDTLS_OID_C
+#define MBEDTLS_PEM_PARSE_C
+#define MBEDTLS_PK_C
+#define MBEDTLS_PK_PARSE_C
+#define MBEDTLS_PKCS1_V15
+#define MBEDTLS_PLATFORM_C
+#define MBEDTLS_RSA_C
+#define MBEDTLS_SHA1_C
+#define MBEDTLS_SHA256_C
+#define MBEDTLS_SSL_CLI_C
+#define MBEDTLS_SSL_TLS_C
+#define MBEDTLS_THREADING_ALT
+#define MBEDTLS_THREADING_C
+#define MBEDTLS_X509_USE_C
+#define MBEDTLS_X509_CRT_PARSE_C
+
+/* Set the memory allocation functions on FreeRTOS. */
+void * mbedtls_platform_calloc( size_t nmemb,
+                                size_t size );
+void mbedtls_platform_free( void * ptr );
+#define MBEDTLS_PLATFORM_MEMORY
+#define MBEDTLS_PLATFORM_CALLOC_MACRO    mbedtls_platform_calloc
+#define MBEDTLS_PLATFORM_FREE_MACRO      mbedtls_platform_free
+
+/* The network send and receive functions on FreeRTOS. */
+int mbedtls_platform_send( void * ctx,
+                           const unsigned char * buf,
+                           size_t len );
+int mbedtls_platform_recv( void * ctx,
+                           unsigned char * buf,
+                           size_t len );
+
+/* The entropy poll function. */
+int mbedtls_platform_entropy_poll( void * data,
+                                   unsigned char * output,
+                                   size_t len,
+                                   size_t * olen );
+
+#include "mbedtls/check_config.h"
+
+#endif /* ifndef MBEDTLS_CONFIG_H_ */

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Basic_TLS/mqtt_basic_tls_demo.sln
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Basic_TLS/mqtt_basic_tls_demo.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29215.179
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "RTOSDemo", "WIN32.vcxproj", "{C686325E-3261-42F7-AEB1-DDE5280E1CEB}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Win32 = Debug|Win32
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{C686325E-3261-42F7-AEB1-DDE5280E1CEB}.Debug|Win32.ActiveCfg = Debug|Win32
+		{C686325E-3261-42F7-AEB1-DDE5280E1CEB}.Debug|Win32.Build.0 = Debug|Win32
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {150F08BF-9D61-4CC2-8DBF-1335172A1EA4}
+	EndGlobalSection
+	GlobalSection(TestCaseManagementSettings) = postSolution
+		CategoryFile = FreeRTOS_Plus_TCP_Minimal.vsmdi
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
<!--- Title -->

Description
-----------
Porting MQTT basic TLS demo from CSDK. 

Demo shows use of the managed MQTT API over a server-authenticated connection.

Test Steps
-----------
Configure demo as usual -- ensure democonfigROOT_CA_PEM in demo_config.h is defined to proceed with server authentication.


TBD: Adding and maintaining record of outgoing publish packets to allow for retransmission in mutual auth and server auth demos.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
