### PR TITLE
Delete unused headers in the PlaintextMQTTExample.c

### DIFF
--- a/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_plain_text/DemoTasks/PlaintextMQTTExample.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_plain_text/DemoTasks/PlaintextMQTTExample.c
@@ -46,10 +46,6 @@
 #include "FreeRTOS.h"
 #include "task.h"
 
-/* FreeRTOS+TCP includes. */
-#include "FreeRTOS_IP.h"
-#include "FreeRTOS_Sockets.h"
-
 /* Demo Specific configs. */
 #include "demo_config.h"
 

--- a/FreeRTOS-Plus/Source/FreeRTOS-IoT-Libraries-LTS-Beta2/c_sdk/platform/freertos/transport/include/plaintext_freertos.h
+++ b/FreeRTOS-Plus/Source/FreeRTOS-IoT-Libraries-LTS-Beta2/c_sdk/platform/freertos/transport/include/plaintext_freertos.h
@@ -47,6 +47,9 @@
 
 /************ End of logging configuration ****************/
 
+/* FreeRTOS+TCP include. */
+#include "FreeRTOS_Sockets.h"
+
 /* Transport interface include. */
 #include "transport_interface.h"
 


### PR DESCRIPTION
- None of the types in FreeRTOS_IP.h and FreeRTOS_Sockets.h are used in PlaintextMQTTExample.c.
- Add the FreeRTOS_Sockets.h where it is needed in plaintext_freertos.h, just like it is in tls_freertos.h.
  Having the header files needed in the same file as the type that is being used helps customers not guess what header files they will need.

<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
