### PR TITLE
Support simultaneous connections in mbedTLS transport wrapper

### DIFF
--- a/FreeRTOS-Plus/Source/FreeRTOS-IoT-Libraries-LTS-Beta2/c_sdk/platform/freertos/transport/include/tls_freertos.h
+++ b/FreeRTOS-Plus/Source/FreeRTOS-IoT-Libraries-LTS-Beta2/c_sdk/platform/freertos/transport/include/tls_freertos.h
@@ -70,12 +70,14 @@
  */
 typedef struct SSLContext
 {
-    mbedtls_ssl_config config;            /**< @brief SSL connection configuration. */
-    mbedtls_ssl_context context;          /**< @brief SSL connection context */
-    mbedtls_x509_crt_profile certProfile; /**< @brief Certificate security profile for this connection. */
-    mbedtls_x509_crt rootCa;              /**< @brief Root CA certificate context. */
-    mbedtls_x509_crt clientCert;          /**< @brief Client certificate context. */
-    mbedtls_pk_context privKey;           /**< @brief Client private key context. */
+    mbedtls_ssl_config config;               /**< @brief SSL connection configuration. */
+    mbedtls_ssl_context context;             /**< @brief SSL connection context. */
+    mbedtls_x509_crt_profile certProfile;    /**< @brief Certificate security profile for this connection. */
+    mbedtls_x509_crt rootCa;                 /**< @brief Root CA certificate context. */
+    mbedtls_x509_crt clientCert;             /**< @brief Client certificate context. */
+    mbedtls_pk_context privKey;              /**< @brief Client private key context. */
+    mbedtls_entropy_context entropyContext;  /**< @brief Entropy context for random number generation. */
+    mbedtls_ctr_drbg_context ctrDrgbContext; /**< @brief CTR DRBG context for random number generation. */
 } SSLContext_t;
 
 /**

--- a/FreeRTOS-Plus/Source/FreeRTOS-IoT-Libraries-LTS-Beta2/c_sdk/platform/freertos/transport/src/tls_freertos.c
+++ b/FreeRTOS-Plus/Source/FreeRTOS-IoT-Libraries-LTS-Beta2/c_sdk/platform/freertos/transport/src/tls_freertos.c
@@ -107,8 +107,8 @@ static TlsTransportStatus_t tlsSetup( NetworkContext_t * pNetworkContext,
 /**
  * @brief Initialize mbedTLS.
  *
- * @param[in,out] entropyContext mbed TLS entropy context for generation of random numbers.
- * @param[in,out] ctrDrgbContext mbed TLS CTR DRBG context for generation of random numbers.
+ * @param[out] entropyContext mbed TLS entropy context for generation of random numbers.
+ * @param[out] ctrDrgbContext mbed TLS CTR DRBG context for generation of random numbers.
  *
  * @return #TLS_TRANSPORT_SUCCESS, or #TLS_TRANSPORT_INTERNAL_ERROR.
  */

--- a/FreeRTOS-Plus/Source/FreeRTOS-IoT-Libraries-LTS-Beta2/c_sdk/platform/freertos/transport/src/tls_freertos.c
+++ b/FreeRTOS-Plus/Source/FreeRTOS-IoT-Libraries-LTS-Beta2/c_sdk/platform/freertos/transport/src/tls_freertos.c
@@ -112,8 +112,8 @@ static TlsTransportStatus_t tlsSetup( NetworkContext_t * pNetworkContext,
  *
  * @return #TLS_TRANSPORT_SUCCESS, or #TLS_TRANSPORT_INTERNAL_ERROR.
  */
-static TlsTransportStatus_t initMbedtls( mbedtls_entropy_context entropyContext,
-                                         mbedtls_ctr_drbg_context ctrDrgbContext );
+static TlsTransportStatus_t initMbedtls( mbedtls_entropy_context * pEntropyContext,
+                                         mbedtls_ctr_drbg_context * pCtrDrgbContext );
 
 /*-----------------------------------------------------------*/
 
@@ -357,8 +357,8 @@ static TlsTransportStatus_t tlsSetup( NetworkContext_t * pNetworkContext,
 
 /*-----------------------------------------------------------*/
 
-static TlsTransportStatus_t initMbedtls( mbedtls_entropy_context entropyContext,
-                                         mbedtls_ctr_drbg_context ctrDrgbContext )
+static TlsTransportStatus_t initMbedtls( mbedtls_entropy_context * pEntropyContext,
+                                         mbedtls_ctr_drbg_context * pCtrDrgbContext )
 {
     TlsTransportStatus_t returnStatus = TLS_TRANSPORT_SUCCESS;
     int mbedtlsError = 0;
@@ -370,11 +370,11 @@ static TlsTransportStatus_t initMbedtls( mbedtls_entropy_context entropyContext,
                                mbedtls_platform_mutex_unlock );
 
     /* Initialize contexts for random number generation. */
-    mbedtls_entropy_init( &entropyContext );
-    mbedtls_ctr_drbg_init( &ctrDrgbContext );
+    mbedtls_entropy_init( pEntropyContext );
+    mbedtls_ctr_drbg_init( pCtrDrgbContext );
 
     /* Add a strong entropy source. At least one is required. */
-    mbedtlsError = mbedtls_entropy_add_source( &entropyContext,
+    mbedtlsError = mbedtls_entropy_add_source( pEntropyContext,
                                                mbedtls_platform_entropy_poll,
                                                NULL,
                                                32,
@@ -391,9 +391,9 @@ static TlsTransportStatus_t initMbedtls( mbedtls_entropy_context entropyContext,
     if( returnStatus == TLS_TRANSPORT_SUCCESS )
     {
         /* Seed the random number generator. */
-        mbedtlsError = mbedtls_ctr_drbg_seed( &ctrDrgbContext,
+        mbedtlsError = mbedtls_ctr_drbg_seed( pCtrDrgbContext,
                                               mbedtls_entropy_func,
-                                              &entropyContext,
+                                              pEntropyContext,
                                               NULL,
                                               0 );
 
@@ -464,8 +464,8 @@ TlsTransportStatus_t TLS_FreeRTOS_Connect( NetworkContext_t * pNetworkContext,
     /* Initialize mbedtls. */
     if( returnStatus == TLS_TRANSPORT_SUCCESS )
     {
-        returnStatus = initMbedtls( pNetworkContext->sslContext.entropyContext,
-                                    pNetworkContext->sslContext.ctrDrgbContext );
+        returnStatus = initMbedtls( &( pNetworkContext->sslContext.entropyContext ),
+                                    &( pNetworkContext->sslContext.ctrDrgbContext ) );
     }
 
     /* Perform TLS handshake. */


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->
When calling `TLS_FreeRTOS_Disconnect`, `mbedtls_entropy_free` and `mbedtls_ctr_drbg_free` are called. If `TLS_FreeRTOS_Send` or `TLS_FreeRTOS_Recv` is called afterwards from another connection, then it will fail because the entropy context has been freed. This adds the entropy context as part of the network context object so that each connection has one to prevent that.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
