### PR TITLE
Check the return value of MQTT_Disconnect in the demo loops

### DIFF
--- a/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_keep_alive/DemoTasks/KeepAliveMQTTExample.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_keep_alive/DemoTasks/KeepAliveMQTTExample.c
@@ -505,7 +505,7 @@ static void prvMQTTDemoTask( void * pvParameters )
         /* Send an MQTT Disconnect packet over the already connected TCP socket.
          * There is no corresponding response for the disconnect packet. After
          * sending disconnect, client must close the network connection. */
-        LogInfo( ( "Disconnecting the MQTT connection with %s.\r\n", 
+        LogInfo( ( "Disconnecting the MQTT connection with %s.\r\n",
                    democonfigMQTT_BROKER_ENDPOINT ) );
         xMQTTStatus = MQTT_Disconnect( &xMQTTContext );
         configASSERT( xMQTTStatus == MQTTSuccess );

--- a/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_mutual_auth/DemoTasks/MutualAuthMQTTExample.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_mutual_auth/DemoTasks/MutualAuthMQTTExample.c
@@ -396,7 +396,7 @@ static void prvMQTTDemoTask( void * pvParameters )
         /* Attempt to establish TLS session with MQTT broker. If connection fails,
          * retry after a timeout. Timeout value will be exponentially increased
          * until  the maximum number of attempts are reached or the maximum timeout
-         * value is reached. The function returns a failure status if the TCP 
+         * value is reached. The function returns a failure status if the TCP
          * connection cannot be established to the broker after the configured
          * number of attempts. */
         xNetworkStatus = prvConnectToServerWithBackoffRetries( &xNetworkCredentials,
@@ -456,9 +456,9 @@ static void prvMQTTDemoTask( void * pvParameters )
 
         /* Send an MQTT Disconnect packet over the already connected TLS over
          * TCP connection. There is no corresponding response for the disconnect
-         * packet. After sending disconnect, client must close the network 
+         * packet. After sending disconnect, client must close the network
          * connection. */
-        LogInfo( ( "Disconnecting the MQTT connection with %s.\r\n", 
+        LogInfo( ( "Disconnecting the MQTT connection with %s.\r\n",
                    democonfigMQTT_BROKER_ENDPOINT ) );
         xMQTTStatus = MQTT_Disconnect( &xMQTTContext );
         configASSERT( xMQTTStatus == MQTTSuccess );
@@ -476,7 +476,7 @@ static void prvMQTTDemoTask( void * pvParameters )
         /* Wait for some time between two iterations to ensure that we do not
          * bombard the broker. */
         LogInfo( ( "prvMQTTDemoTask() completed an iteration successfully. "
-                   "Total free heap is %u.\r\n", 
+                   "Total free heap is %u.\r\n",
                    xPortGetFreeHeapSize() ) );
         LogInfo( ( "Demo completed successfully.\r\n" ) );
         LogInfo( ( "Short delay before starting the next iteration.... \r\n\r\n" ) );

--- a/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_mutual_auth/DemoTasks/MutualAuthMQTTExample.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_mutual_auth/DemoTasks/MutualAuthMQTTExample.c
@@ -394,10 +394,11 @@ static void prvMQTTDemoTask( void * pvParameters )
         /****************************** Connect. ******************************/
 
         /* Attempt to establish TLS session with MQTT broker. If connection fails,
-         * retry after a timeout. Timeout value will be exponentially increased until
-         * the maximum number of attempts are reached or the maximum timeout value is reached.
-         * The function returns a failure status if the TCP connection cannot be established
-         * to the broker after the configured number of attempts. */
+         * retry after a timeout. Timeout value will be exponentially increased
+         * until  the maximum number of attempts are reached or the maximum timeout
+         * value is reached. The function returns a failure status if the TCP 
+         * connection cannot be established to the broker after the configured
+         * number of attempts. */
         xNetworkStatus = prvConnectToServerWithBackoffRetries( &xNetworkCredentials,
                                                                &xNetworkContext );
         configASSERT( xNetworkStatus == TLS_TRANSPORT_SUCCESS );
@@ -409,9 +410,9 @@ static void prvMQTTDemoTask( void * pvParameters )
 
         /**************************** Subscribe. ******************************/
 
-        /* If server rejected the subscription request, attempt to resubscribe to topic.
-         * Attempts are made according to the exponential backoff retry strategy
-         * implemented in retryUtils. */
+        /* If server rejected the subscription request, attempt to resubscribe to
+         * topic. Attempts are made according to the exponential backoff retry
+         * strategy implemented in retryUtils. */
         prvMQTTSubscribeWithBackoffRetries( &xMQTTContext );
 
         /* Process incoming packet from the broker. After sending the subscribe, the
@@ -424,15 +425,16 @@ static void prvMQTTDemoTask( void * pvParameters )
         xMQTTStatus = MQTT_ProcessLoop( &xMQTTContext, mqttexamplePROCESS_LOOP_TIMEOUT_MS );
         configASSERT( xMQTTStatus == MQTTSuccess );
 
-        /**************************** Publish and Keep Alive Loop. ******************************/
+        /****************** Publish and Keep Alive Loop. **********************/
         /* Publish messages with QoS1, send and process Keep alive messages. */
         for( ulPublishCount = 0; ulPublishCount < ulMaxPublishCount; ulPublishCount++ )
         {
             LogInfo( ( "Publish to the MQTT topic %s.\r\n", mqttexampleTOPIC ) );
             prvMQTTPublishToTopic( &xMQTTContext );
 
-            /* Process incoming publish echo, since application subscribed to the same
-             * topic, the broker will send publish message back to the application. */
+            /* Process incoming publish echo, since application subscribed to the
+             * same topic, the broker will send publish message back to the
+             * application. */
             LogInfo( ( "Attempt to receive publish message from broker.\r\n" ) );
             xMQTTStatus = MQTT_ProcessLoop( &xMQTTContext, mqttexamplePROCESS_LOOP_TIMEOUT_MS );
             configASSERT( xMQTTStatus == MQTTSuccess );
@@ -442,7 +444,7 @@ static void prvMQTTDemoTask( void * pvParameters )
             vTaskDelay( mqttexampleDELAY_BETWEEN_PUBLISHES_TICKS );
         }
 
-        /************************ Unsubscribe from the topic. **************************/
+        /******************** Unsubscribe from the topic. *********************/
         LogInfo( ( "Unsubscribe from the MQTT topic %s.\r\n", mqttexampleTOPIC ) );
         prvMQTTUnsubscribeFromTopic( &xMQTTContext );
 
@@ -450,26 +452,32 @@ static void prvMQTTDemoTask( void * pvParameters )
         xMQTTStatus = MQTT_ProcessLoop( &xMQTTContext, mqttexamplePROCESS_LOOP_TIMEOUT_MS );
         configASSERT( xMQTTStatus == MQTTSuccess );
 
-        /**************************** Disconnect. ******************************/
+        /**************************** Disconnect. *****************************/
 
-        /* Send an MQTT Disconnect packet over the already connected TLS over TCP connection.
-         * There is no corresponding response for the disconnect packet. After sending
-         * disconnect, client must close the network connection. */
-        LogInfo( ( "Disconnecting the MQTT connection with %s.\r\n", democonfigMQTT_BROKER_ENDPOINT ) );
-        MQTT_Disconnect( &xMQTTContext );
+        /* Send an MQTT Disconnect packet over the already connected TLS over
+         * TCP connection. There is no corresponding response for the disconnect
+         * packet. After sending disconnect, client must close the network 
+         * connection. */
+        LogInfo( ( "Disconnecting the MQTT connection with %s.\r\n", 
+                   democonfigMQTT_BROKER_ENDPOINT ) );
+        xMQTTStatus = MQTT_Disconnect( &xMQTTContext );
+        configASSERT( xMQTTStatus == MQTTSuccess );
 
         /* Close the network connection.  */
         TLS_FreeRTOS_Disconnect( &xNetworkContext );
 
-        /* Reset SUBACK status for each topic filter after completion of subscription request cycle. */
+        /* Reset SUBACK status for each topic filter after completion of
+         * subscription request cycle. */
         for( ulTopicCount = 0; ulTopicCount < mqttexampleTOPIC_COUNT; ulTopicCount++ )
         {
             xTopicFilterContext[ ulTopicCount ].xSubAckStatus = MQTTSubAckFailure;
         }
 
         /* Wait for some time between two iterations to ensure that we do not
-         * the broker. */
-        LogInfo( ( "prvMQTTDemoTask() completed an iteration successfully. Total free heap is %u.\r\n", xPortGetFreeHeapSize() ) );
+         * bombard the broker. */
+        LogInfo( ( "prvMQTTDemoTask() completed an iteration successfully. "
+                   "Total free heap is %u.\r\n", 
+                   xPortGetFreeHeapSize() ) );
         LogInfo( ( "Demo completed successfully.\r\n" ) );
         LogInfo( ( "Short delay before starting the next iteration.... \r\n\r\n" ) );
         vTaskDelay( mqttexampleDELAY_BETWEEN_DEMO_ITERATIONS_TICKS );

--- a/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_plain_text/DemoTasks/PlaintextMQTTExample.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_plain_text/DemoTasks/PlaintextMQTTExample.c
@@ -406,7 +406,7 @@ static void prvMQTTDemoTask( void * pvParameters )
         /* Send an MQTT Disconnect packet over the already connected TCP socket.
          * There is no corresponding response for the disconnect packet. After
          * sending disconnect, client must close the network connection. */
-        LogInfo( ( "Disconnecting the MQTT connection with %s.\r\n", 
+        LogInfo( ( "Disconnecting the MQTT connection with %s.\r\n",
                    democonfigMQTT_BROKER_ENDPOINT ) );
         xMQTTStatus = MQTT_Disconnect( &xMQTTContext );
         configASSERT( xMQTTStatus == MQTTSuccess );
@@ -424,7 +424,7 @@ static void prvMQTTDemoTask( void * pvParameters )
         /* Wait for some time between two iterations to ensure that we do not
          * bombard the broker. */
         LogInfo( ( "prvMQTTDemoTask() completed an iteration successfully. "
-                   "Total free heap is %u.\r\n", 
+                   "Total free heap is %u.\r\n",
                    xPortGetFreeHeapSize() ) );
         LogInfo( ( "Demo completed successfully.\r\n" ) );
         LogInfo( ( "Short delay before starting the next iteration.... \r\n\r\n" ) );

--- a/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_plain_text/DemoTasks/PlaintextMQTTExample.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_plain_text/DemoTasks/PlaintextMQTTExample.c
@@ -358,8 +358,8 @@ static void prvMQTTDemoTask( void * pvParameters )
         /* Attempt to connect to the MQTT broker. If connection fails, retry after
          * a timeout. Timeout value will be exponentially increased until the maximum
          * number of attempts are reached or the maximum timeout value is reached.
-         * The function returns a failure status if the TCP connection cannot be established
-         * to the broker after the configured number of attempts. */
+         * The function returns a failure status if the TCP connection cannot be
+         * established to the broker after the configured number of attempts. */
         xNetworkStatus = prvConnectToServerWithBackoffRetries( &xNetworkContext );
         configASSERT( xNetworkStatus == PLAINTEXT_TRANSPORT_SUCCESS );
 
@@ -370,12 +370,12 @@ static void prvMQTTDemoTask( void * pvParameters )
 
         /**************************** Subscribe. ******************************/
 
-        /* If server rejected the subscription request, attempt to resubscribe to topic.
-         * Attempts are made according to the exponential backoff retry strategy
-         * implemented in retryUtils. */
+        /* If server rejected the subscription request, attempt to resubscribe to
+         * topic. Attempts are made according to the exponential backoff retry
+         * strategy implemented in retryUtils. */
         prvMQTTSubscribeWithBackoffRetries( &xMQTTContext );
 
-        /**************************** Publish and Keep Alive Loop. ******************************/
+        /******************* Publish and Keep Alive Loop. *********************/
         /* Publish messages with QoS0, send and process Keep alive messages. */
         for( ulPublishCount = 0; ulPublishCount < ulMaxPublishCount; ulPublishCount++ )
         {
@@ -393,7 +393,7 @@ static void prvMQTTDemoTask( void * pvParameters )
             vTaskDelay( mqttexampleDELAY_BETWEEN_PUBLISHES );
         }
 
-        /************************ Unsubscribe from the topic. **************************/
+        /******************** Unsubscribe from the topic. *********************/
         LogInfo( ( "Unsubscribe from the MQTT topic %s.\r\n", mqttexampleTOPIC ) );
         prvMQTTUnsubscribeFromTopic( &xMQTTContext );
 
@@ -401,13 +401,15 @@ static void prvMQTTDemoTask( void * pvParameters )
         xMQTTStatus = MQTT_ProcessLoop( &xMQTTContext, mqttexamplePROCESS_LOOP_TIMEOUT_MS );
         configASSERT( xMQTTStatus == MQTTSuccess );
 
-        /**************************** Disconnect. ******************************/
+        /**************************** Disconnect. *****************************/
 
         /* Send an MQTT Disconnect packet over the already connected TCP socket.
-         * There is no corresponding response for the disconnect packet. After sending
-         * disconnect, client must close the network connection. */
-        LogInfo( ( "Disconnecting the MQTT connection with %s.\r\n", democonfigMQTT_BROKER_ENDPOINT ) );
-        MQTT_Disconnect( &xMQTTContext );
+         * There is no corresponding response for the disconnect packet. After
+         * sending disconnect, client must close the network connection. */
+        LogInfo( ( "Disconnecting the MQTT connection with %s.\r\n", 
+                   democonfigMQTT_BROKER_ENDPOINT ) );
+        xMQTTStatus = MQTT_Disconnect( &xMQTTContext );
+        configASSERT( xMQTTStatus == MQTTSuccess );
 
         /* Close the network connection.  */
         xNetworkStatus = Plaintext_FreeRTOS_Disconnect( &xNetworkContext );
@@ -420,8 +422,10 @@ static void prvMQTTDemoTask( void * pvParameters )
         }
 
         /* Wait for some time between two iterations to ensure that we do not
-         * bombard the public test mosquitto broker. */
-        LogInfo( ( "prvMQTTDemoTask() completed an iteration successfully. Total free heap is %u.\r\n", xPortGetFreeHeapSize() ) );
+         * bombard the broker. */
+        LogInfo( ( "prvMQTTDemoTask() completed an iteration successfully. "
+                   "Total free heap is %u.\r\n", 
+                   xPortGetFreeHeapSize() ) );
         LogInfo( ( "Demo completed successfully.\r\n" ) );
         LogInfo( ( "Short delay before starting the next iteration.... \r\n\r\n" ) );
         vTaskDelay( mqttexampleDELAY_BETWEEN_DEMO_ITERATIONS );

--- a/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/pkcs11/mqtt_mutal_auth_with_pkcs11/DemoTasks/MutualAuthMQTTExample.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/pkcs11/mqtt_mutal_auth_with_pkcs11/DemoTasks/MutualAuthMQTTExample.c
@@ -341,8 +341,8 @@ static void prvMQTTDemoTask( void * pvParameters )
     {
         /****************************** Connect. ******************************/
 
-        /* Establish a TLS connection with the MQTT broker. This example connects to
-         * the MQTT broker as specified by democonfigMQTT_BROKER_ENDPOINT and
+        /* Establish a TLS connection with the MQTT broker. This example connects
+         * to the MQTT broker as specified by democonfigMQTT_BROKER_ENDPOINT and
          * democonfigMQTT_BROKER_PORT in the demo_config.h file. */
         LogInfo( ( "Creating a TLS connection to %s:%u.\r\n",
                    democonfigMQTT_BROKER_ENDPOINT,
@@ -378,15 +378,15 @@ static void prvMQTTDemoTask( void * pvParameters )
         xMQTTStatus = MQTT_ProcessLoop( &xMQTTContext, mqttexamplePROCESS_LOOP_TIMEOUT_MS );
         configASSERT( xMQTTStatus == MQTTSuccess );
 
-        /**************************** Publish and Keep Alive Loop. ******************************/
+        /******************* Publish and Keep Alive Loop. *********************/
         /* Publish messages with QoS1, send and process Keep alive messages. */
         for( ulPublishCount = 0; ulPublishCount < ulMaxPublishCount; ulPublishCount++ )
         {
             LogInfo( ( "Publish to the MQTT topic %s.\r\n", mqttexampleTOPIC ) );
             prvMQTTPublishToTopic( &xMQTTContext );
 
-            /* Process incoming publish echo, since application subscribed to the same
-             * topic, the broker will send publish message back to the application. */
+            /* Process incoming publish echo, since application subscribed to the
+             * same topic, the broker will send publish message back to the application. */
             LogInfo( ( "Attempt to receive publish message from broker.\r\n" ) );
             xMQTTStatus = MQTT_ProcessLoop( &xMQTTContext, mqttexamplePROCESS_LOOP_TIMEOUT_MS );
             configASSERT( xMQTTStatus == MQTTSuccess );
@@ -396,7 +396,7 @@ static void prvMQTTDemoTask( void * pvParameters )
             vTaskDelay( mqttexampleDELAY_BETWEEN_PUBLISHES_TICKS );
         }
 
-        /************************ Unsubscribe from the topic. **************************/
+        /******************** Unsubscribe from the topic. *********************/
         LogInfo( ( "Unsubscribe from the MQTT topic %s.\r\n", mqttexampleTOPIC ) );
         prvMQTTUnsubscribeFromTopic( &xMQTTContext );
 
@@ -406,18 +406,22 @@ static void prvMQTTDemoTask( void * pvParameters )
 
         /**************************** Disconnect. ******************************/
 
-        /* Send an MQTT Disconnect packet over the already connected TLS over TCP connection.
-         * There is no corresponding response for the disconnect packet. After sending
-         * disconnect, client must close the network connection. */
-        LogInfo( ( "Disconnecting the MQTT connection with %s.\r\n", democonfigMQTT_BROKER_ENDPOINT ) );
-        MQTT_Disconnect( &xMQTTContext );
+        /* Send an MQTT Disconnect packet over the already connected TLS over TCP
+         * connection. There is no corresponding response for the disconnect packet.
+         * After sending disconnect, client must close the network connection. */
+        LogInfo( ( "Disconnecting the MQTT connection with %s.\r\n", 
+                   democonfigMQTT_BROKER_ENDPOINT ) );
+        xMQTTStatus = MQTT_Disconnect( &xMQTTContext );
+        configASSERT( xMQTTStatus == MQTTSuccess );
 
         /* Close the network connection.  */
         TLS_FreeRTOS_Disconnect( &xNetworkContext );
 
         /* Wait for some time between two iterations to ensure that we do not
-         * the broker. */
-        LogInfo( ( "prvMQTTDemoTask() completed an iteration successfully. Total free heap is %u.\r\n", xPortGetFreeHeapSize() ) );
+         * bombard the broker. */
+        LogInfo( ( "prvMQTTDemoTask() completed an iteration successfully. "
+                   "Total free heap is %u.\r\n",
+                   xPortGetFreeHeapSize() ) );
         LogInfo( ( "Demo completed successfully.\r\n" ) );
         LogInfo( ( "Short delay before starting the next iteration.... \r\n\r\n" ) );
         vTaskDelay( mqttexampleDELAY_BETWEEN_DEMO_ITERATIONS_TICKS );

--- a/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/pkcs11/mqtt_mutal_auth_with_pkcs11/DemoTasks/MutualAuthMQTTExample.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/pkcs11/mqtt_mutal_auth_with_pkcs11/DemoTasks/MutualAuthMQTTExample.c
@@ -409,7 +409,7 @@ static void prvMQTTDemoTask( void * pvParameters )
         /* Send an MQTT Disconnect packet over the already connected TLS over TCP
          * connection. There is no corresponding response for the disconnect packet.
          * After sending disconnect, client must close the network connection. */
-        LogInfo( ( "Disconnecting the MQTT connection with %s.\r\n", 
+        LogInfo( ( "Disconnecting the MQTT connection with %s.\r\n",
                    democonfigMQTT_BROKER_ENDPOINT ) );
         xMQTTStatus = MQTT_Disconnect( &xMQTTContext );
         configASSERT( xMQTTStatus == MQTTSuccess );


### PR DESCRIPTION
This PR:
- Checks the return value of MQTT_Disconnect() in the subscribe-publish loop.
- Fix the line lengths of existing comments.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
