### PR TITLE
Add CMock back for the integration tests.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,3 +16,6 @@
 [submodule "FreeRTOS-Plus/Source/coreJSON"]
 	path = FreeRTOS-Plus/Source/coreJSON
 	url = https://github.com/FreeRTOS/coreJSON
+[submodule "FreeRTOS-Plus/Test/CMock"]
+	path = FreeRTOS-Plus/Test/CMock
+	url = https://github.com/ThrowTheSwitch/CMock


### PR DESCRIPTION
<!--- Title -->

Description
-----------
Add CMock submodule back for +TCP integration tests. I overlooked the dependency in the PR https://github.com/FreeRTOS/FreeRTOS/pull/307.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
