### PR TITLE
Remove extraneous call to MQTT_ProcessLoop

### DIFF
--- a/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_mutual_auth/DemoTasks/MutualAuthMQTTExample.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS-IoT-Libraries-LTS-Beta2/mqtt/mqtt_mutual_auth/DemoTasks/MutualAuthMQTTExample.c
@@ -415,16 +415,6 @@ static void prvMQTTDemoTask( void * pvParameters )
          * strategy implemented in retryUtils. */
         prvMQTTSubscribeWithBackoffRetries( &xMQTTContext );
 
-        /* Process incoming packet from the broker. After sending the subscribe, the
-         * client may receive a publish before it receives a subscribe ack. Therefore,
-         * call generic incoming packet processing function. Since this demo is
-         * subscribing to the topic to which no one is publishing, probability of
-         * receiving Publish message before subscribe ack is zero; but application
-         * must be ready to receive any packet.  This demo uses the generic packet
-         * processing function everywhere to highlight this fact. */
-        xMQTTStatus = MQTT_ProcessLoop( &xMQTTContext, mqttexamplePROCESS_LOOP_TIMEOUT_MS );
-        configASSERT( xMQTTStatus == MQTTSuccess );
-
         /****************** Publish and Keep Alive Loop. **********************/
         /* Publish messages with QoS1, send and process Keep alive messages. */
         for( ulPublishCount = 0; ulPublishCount < ulMaxPublishCount; ulPublishCount++ )


### PR DESCRIPTION
Remove unncessary call to `MQTT_Process﻿Loop` after the `prvMQTTSubscribeWithBackoffRetries` call in MQTT mutual auth demo. 

Call to `MQTT_ProcessLoop` is not required as the `prvMQTTSubscribeWithBackoffRetries` private function _does_ call `MQTT_ProcessLoop` function (to receive SUBACK response from broker)
