### PR TITLE
Add username/password authentication for MQTT Mutual Auth Demo

### DIFF
--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Mutual_Auth/DemoTasks/MutualAuthMQTTExample.c
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Mutual_Auth/DemoTasks/MutualAuthMQTTExample.c
@@ -537,8 +537,8 @@ static TlsTransportStatus_t prvConnectToServerWithBackoffRetries( NetworkCredent
         pxNetworkCredentials->privateKeySize = sizeof( democonfigCLIENT_PRIVATE_KEY_PEM );
     #endif
     #ifdef democonfigUSE_AWS_IOT_CORE_BROKER
-        /* SNI and ALPN need to be enabled for AWS IoT. */
         pxNetworkCredentials->disableSni = pdFALSE;
+        /* The ALPN string changes depending on whether username/password authentication is used. */
         #ifdef CLIENT_USERNAME
             pxNetworkCredentials->pAlpnProtos = AWS_IOT_PASSWORD_ALPN;
             pxNetworkCredentials->alpnProtosLen = AWS_IOT_PASSWORD_ALPN_LENGTH;
@@ -546,7 +546,7 @@ static TlsTransportStatus_t prvConnectToServerWithBackoffRetries( NetworkCredent
             pxNetworkCredentials->pAlpnProtos = AWS_IOT_MQTT_ALPN;
             pxNetworkCredentials->alpnProtosLen = AWS_IOT_MQTT_ALPN_LENGTH;
         #endif
-    #endif
+    #endif /* ifdef democonfigUSE_AWS_IOT_CORE_BROKER */
     /* Initialize reconnect attempts and interval. */
     RetryUtils_ParamsReset( &xReconnectParams );
     xReconnectParams.maxRetryAttempts = MAX_RETRY_ATTEMPTS;

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Mutual_Auth/DemoTasks/MutualAuthMQTTExample.c
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Mutual_Auth/DemoTasks/MutualAuthMQTTExample.c
@@ -415,16 +415,6 @@ static void prvMQTTDemoTask( void * pvParameters )
          * strategy implemented in retryUtils. */
         prvMQTTSubscribeWithBackoffRetries( &xMQTTContext );
 
-        /* Process incoming packet from the broker. After sending the subscribe, the
-         * client may receive a publish before it receives a subscribe ack. Therefore,
-         * call generic incoming packet processing function. Since this demo is
-         * subscribing to the topic to which no one is publishing, probability of
-         * receiving Publish message before subscribe ack is zero; but application
-         * must be ready to receive any packet.  This demo uses the generic packet
-         * processing function everywhere to highlight this fact. */
-        xMQTTStatus = MQTT_ProcessLoop( &xMQTTContext, mqttexamplePROCESS_LOOP_TIMEOUT_MS );
-        configASSERT( xMQTTStatus == MQTTSuccess );
-
         /****************** Publish and Keep Alive Loop. **********************/
         /* Publish messages with QoS1, send and process Keep alive messages. */
         for( ulPublishCount = 0; ulPublishCount < ulMaxPublishCount; ulPublishCount++ )

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Mutual_Auth/DemoTasks/MutualAuthMQTTExample.c
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Mutual_Auth/DemoTasks/MutualAuthMQTTExample.c
@@ -199,12 +199,12 @@
  * @brief This is the ALPN (Application-Layer Protocol Negotiation) string
  * required by AWS IoT for password-based authentication using TCP port 443.
  */
-#define AWS_IOT_PASSWORD_ALPN                             "\x04mqtt"
+#define AWS_IOT_CUSTOM_AUTH_ALPN                          "\x04mqtt"
 
 /**
  * @brief Length of password ALPN.
  */
-#define AWS_IOT_PASSWORD_ALPN_LENGTH                      ( ( uint16_t ) ( sizeof( AWS_IOT_PASSWORD_ALPN ) - 1 ) )
+#define AWS_IOT_CUSTOM_AUTH_ALPN_LENGTH                   ( ( uint16_t ) ( sizeof( AWS_IOT_CUSTOM_AUTH_ALPN ) - 1 ) )
 
 /**
  * @brief Milliseconds per second.
@@ -538,8 +538,8 @@ static TlsTransportStatus_t prvConnectToServerWithBackoffRetries( NetworkCredent
         pxNetworkCredentials->disableSni = pdFALSE;
         /* The ALPN string changes depending on whether username/password authentication is used. */
         #ifdef CLIENT_USERNAME
-            pxNetworkCredentials->pAlpnProtos = AWS_IOT_PASSWORD_ALPN;
-            pxNetworkCredentials->alpnProtosLen = AWS_IOT_PASSWORD_ALPN_LENGTH;
+            pxNetworkCredentials->pAlpnProtos = AWS_IOT_CUSTOM_AUTH_ALPN;
+            pxNetworkCredentials->alpnProtosLen = AWS_IOT_CUSTOM_AUTH_ALPN_LENGTH;
         #else
             pxNetworkCredentials->pAlpnProtos = AWS_IOT_MQTT_ALPN;
             pxNetworkCredentials->alpnProtosLen = AWS_IOT_MQTT_ALPN_LENGTH;

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Mutual_Auth/DemoTasks/MutualAuthMQTTExample.c
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Mutual_Auth/DemoTasks/MutualAuthMQTTExample.c
@@ -70,8 +70,7 @@
     #error "Please define Root CA certificate of the MQTT broker(democonfigROOT_CA_PEM) in demo_config.h."
 #endif
 
-/* The AWS IoT message broker requires either a set of client certificate/private key
- * or username/password to authenticate the client. */
+/* If no username is defined, then a client certificate/key is required. */
 #ifndef democonfigCLIENT_USERNAME
     #ifndef democonfigCLIENT_CERTIFICATE_PEM
         #error "Please define client certificate(democonfigCLIENT_CERTIFICATE_PEM) in demo_config.h."

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Mutual_Auth/DemoTasks/MutualAuthMQTTExample.c
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Mutual_Auth/DemoTasks/MutualAuthMQTTExample.c
@@ -545,8 +545,11 @@ static TlsTransportStatus_t prvConnectToServerWithBackoffRetries( NetworkCredent
             pxNetworkCredentials->alpnProtosLen = AWS_IOT_MQTT_ALPN_LENGTH;
         #endif
     #else
-        /* SNI needs to be disabled for an MQTT broker that has no hostname. */
-        pxNetworkCredentials->disableSni = pdTRUE;
+
+        /* SNI needs to be disabled for an MQTT broker that has no hostname:
+         *
+         * pxNetworkCredentials->disableSni = pdTRUE;
+         */
     #endif /* ifdef democonfigUSE_AWS_IOT_CORE_BROKER */
     /* Initialize reconnect attempts and interval. */
     RetryUtils_ParamsReset( &xReconnectParams );

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Mutual_Auth/DemoTasks/MutualAuthMQTTExample.c
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Mutual_Auth/DemoTasks/MutualAuthMQTTExample.c
@@ -240,7 +240,7 @@
 #ifdef democonfigCLIENT_USERNAME
 
 /**
- * @brief Append the username with the metrics string if #CLIENT_USERNAME is defined.
+ * @brief Append the username with the metrics string if #democonfigCLIENT_USERNAME is defined.
  *
  * This is to support both metrics reporting and username/password based client
  * authentication by AWS IoT.

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Mutual_Auth/DemoTasks/MutualAuthMQTTExample.c
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Mutual_Auth/DemoTasks/MutualAuthMQTTExample.c
@@ -89,7 +89,7 @@
 /* AWS IoT MQTT broker port needs to be 443 for client authentication based on
  * username/password. */
     #if defined( democonfigUSE_AWS_IOT_CORE_BROKER ) && democonfigMQTT_BROKER_PORT != 443
-        #error "Broker port(democonfigMQTT_BROKER_PORT) should be defined as 443 in demo_config.h for client authentication based on username/password."
+        #error "Broker port(democonfigMQTT_BROKER_PORT) should be defined as 443 in demo_config.h for client authentication based on username/password in AWS IoT Core."
     #endif
 #endif /* ifndef democonfigCLIENT_USERNAME */
 
@@ -183,7 +183,7 @@
 /**
  * @brief ALPN (Application-Layer Protocol Negotiation) protocol name for AWS IoT MQTT.
  *
- * This will be used if the AWS_MQTT_PORT is configured as 443 for AWS IoT MQTT broker.
+ * This will be used if democonfigMQTT_BROKER_PORT is configured as 443 for the AWS IoT MQTT broker.
  * Please see more details about the ALPN protocol for AWS IoT MQTT endpoint
  * in the link below.
  * https://aws.amazon.com/blogs/iot/mqtt-with-tls-client-authentication-on-port-443-why-it-is-useful-and-how-it-works/

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Mutual_Auth/DemoTasks/MutualAuthMQTTExample.c
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Mutual_Auth/DemoTasks/MutualAuthMQTTExample.c
@@ -210,11 +210,11 @@
  * Provide default values for undefined configuration settings.
  */
 #ifndef democonfigOS_NAME
-    #define democonfigOS_NAME    "Windows"
+    #define democonfigOS_NAME    "FreeRTOS"
 #endif
 
 #ifndef democonfigOS_VERSION
-    #define democonfigOS_VERSION    "10"
+    #define democonfigOS_VERSION    "10.3.0"
 #endif
 
 #ifndef democonfigHARDWARE_PLATFORM_NAME

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Mutual_Auth/DemoTasks/MutualAuthMQTTExample.c
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Mutual_Auth/DemoTasks/MutualAuthMQTTExample.c
@@ -594,7 +594,7 @@ static void prvCreateMQTTConnectionWithBroker( MQTTContext_t * pxMQTTContext,
         xConnectInfo.pUserName = democonfigCLIENT_USERNAME;
         xConnectInfo.userNameLength = ( uint16_t ) strlen( democonfigCLIENT_USERNAME );
         xConnectInfo.pPassword = democonfigCLIENT_PASSWORD;
-        xConnectInfo.passwordLength = ( uint16_t ) strlen( CLIENT_PASSWORD );
+        xConnectInfo.passwordLength = ( uint16_t ) strlen( democonfigCLIENT_PASSWORD );
     #endif /* ifdef CLIENT_USERNAME */
 
     /* Send MQTT CONNECT packet to broker. LWT is not used in this demo, so it

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Mutual_Auth/DemoTasks/MutualAuthMQTTExample.c
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Mutual_Auth/DemoTasks/MutualAuthMQTTExample.c
@@ -528,8 +528,6 @@ static TlsTransportStatus_t prvConnectToServerWithBackoffRetries( NetworkCredent
     /* Set the credentials for establishing a TLS connection. */
     pxNetworkCredentials->pRootCa = ( const unsigned char * ) democonfigROOT_CA_PEM;
     pxNetworkCredentials->rootCaSize = sizeof( democonfigROOT_CA_PEM );
-    /* SNI needs to be disabled for a local Mosquitto server. */
-    pxNetworkCredentials->disableSni = pdTRUE;
     #ifdef democonfigCLIENT_CERTIFICATE_PEM
         pxNetworkCredentials->pClientCert = ( const unsigned char * ) democonfigCLIENT_CERTIFICATE_PEM;
         pxNetworkCredentials->clientCertSize = sizeof( democonfigCLIENT_CERTIFICATE_PEM );
@@ -546,6 +544,9 @@ static TlsTransportStatus_t prvConnectToServerWithBackoffRetries( NetworkCredent
             pxNetworkCredentials->pAlpnProtos = AWS_IOT_MQTT_ALPN;
             pxNetworkCredentials->alpnProtosLen = AWS_IOT_MQTT_ALPN_LENGTH;
         #endif
+    #else
+        /* SNI needs to be disabled for an MQTT broker that has no hostname. */
+        pxNetworkCredentials->disableSni = pdTRUE;
     #endif /* ifdef democonfigUSE_AWS_IOT_CORE_BROKER */
     /* Initialize reconnect attempts and interval. */
     RetryUtils_ParamsReset( &xReconnectParams );

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Mutual_Auth/DemoTasks/MutualAuthMQTTExample.c
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Mutual_Auth/DemoTasks/MutualAuthMQTTExample.c
@@ -545,7 +545,10 @@ static TlsTransportStatus_t prvConnectToServerWithBackoffRetries( NetworkCredent
             pxNetworkCredentials->alpnProtosLen = AWS_IOT_MQTT_ALPN_LENGTH;
         #endif
     #else
-        /* SNI needs to be disabled for an MQTT broker that has no hostname. */
+
+        /* When using a local Mosquitto server setup, SNI needs to be disabled for
+         * an MQTT broker that only has an IP address but no hostname. However,
+         * SNI should be enabled whenever possible. */
         pxNetworkCredentials->disableSni = pdTRUE;
     #endif /* ifdef democonfigUSE_AWS_IOT_CORE_BROKER */
     /* Initialize reconnect attempts and interval. */

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Mutual_Auth/DemoTasks/MutualAuthMQTTExample.c
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Mutual_Auth/DemoTasks/MutualAuthMQTTExample.c
@@ -500,8 +500,6 @@ static TlsTransportStatus_t prvConnectToServerWithBackoffRetries( NetworkCredent
     #ifdef democonfigCLIENT_CERTIFICATE_PEM
         pxNetworkCredentials->pClientCert = ( const unsigned char * ) democonfigCLIENT_CERTIFICATE_PEM;
         pxNetworkCredentials->clientCertSize = sizeof( democonfigCLIENT_CERTIFICATE_PEM );
-    #endif
-    #ifdef democonfigCLIENT_PRIVATE_KEY_PEM
         pxNetworkCredentials->pPrivateKey = ( const unsigned char * ) democonfigCLIENT_PRIVATE_KEY_PEM;
         pxNetworkCredentials->privateKeySize = sizeof( democonfigCLIENT_PRIVATE_KEY_PEM );
     #endif

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Mutual_Auth/DemoTasks/MutualAuthMQTTExample.c
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Mutual_Auth/DemoTasks/MutualAuthMQTTExample.c
@@ -594,7 +594,7 @@ static void prvCreateMQTTConnectionWithBroker( MQTTContext_t * pxMQTTContext,
         xConnectInfo.userNameLength = ( uint16_t ) strlen( democonfigCLIENT_USERNAME );
         xConnectInfo.pPassword = democonfigCLIENT_PASSWORD;
         xConnectInfo.passwordLength = ( uint16_t ) strlen( democonfigCLIENT_PASSWORD );
-    #endif /* ifdef CLIENT_USERNAME */
+    #endif /* ifdef democonfigCLIENT_USERNAME */
 
     /* Send MQTT CONNECT packet to broker. LWT is not used in this demo, so it
      * is passed as NULL. */

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Mutual_Auth/DemoTasks/MutualAuthMQTTExample.c
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Mutual_Auth/DemoTasks/MutualAuthMQTTExample.c
@@ -545,11 +545,8 @@ static TlsTransportStatus_t prvConnectToServerWithBackoffRetries( NetworkCredent
             pxNetworkCredentials->alpnProtosLen = AWS_IOT_MQTT_ALPN_LENGTH;
         #endif
     #else
-
-        /* SNI needs to be disabled for an MQTT broker that has no hostname:
-         *
-         * pxNetworkCredentials->disableSni = pdTRUE;
-         */
+        /* SNI needs to be disabled for an MQTT broker that has no hostname. */
+        pxNetworkCredentials->disableSni = pdTRUE;
     #endif /* ifdef democonfigUSE_AWS_IOT_CORE_BROKER */
     /* Initialize reconnect attempts and interval. */
     RetryUtils_ParamsReset( &xReconnectParams );

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Mutual_Auth/DemoTasks/MutualAuthMQTTExample.c
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Mutual_Auth/DemoTasks/MutualAuthMQTTExample.c
@@ -537,6 +537,7 @@ static TlsTransportStatus_t prvConnectToServerWithBackoffRetries( NetworkCredent
         pxNetworkCredentials->privateKeySize = sizeof( democonfigCLIENT_PRIVATE_KEY_PEM );
     #endif
     #ifdef democonfigUSE_AWS_IOT_CORE_BROKER
+        /* SNI and ALPN need to be enabled for AWS IoT. */
         pxNetworkCredentials->disableSni = pdFALSE;
         #ifdef CLIENT_USERNAME
             pxNetworkCredentials->pAlpnProtos = AWS_IOT_PASSWORD_ALPN;

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Mutual_Auth/DemoTasks/MutualAuthMQTTExample.c
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Mutual_Auth/DemoTasks/MutualAuthMQTTExample.c
@@ -579,12 +579,10 @@ static TlsTransportStatus_t prvConnectToServerWithBackoffRetries( NetworkCredent
     #ifdef democonfigUSE_AWS_IOT_CORE_BROKER
         pxNetworkCredentials->disableSni = pdFALSE;
         /* The ALPN string changes depending on whether username/password authentication is used. */
-        #ifdef CLIENT_USERNAME
+        #ifdef democonfigCLIENT_USERNAME
             pxNetworkCredentials->pAlpnProtos = AWS_IOT_CUSTOM_AUTH_ALPN;
-            pxNetworkCredentials->alpnProtosLen = AWS_IOT_CUSTOM_AUTH_ALPN_LENGTH;
         #else
             pxNetworkCredentials->pAlpnProtos = AWS_IOT_MQTT_ALPN;
-            pxNetworkCredentials->alpnProtosLen = AWS_IOT_MQTT_ALPN_LENGTH;
         #endif
     #else
 
@@ -675,7 +673,7 @@ static void prvCreateMQTTConnectionWithBroker( MQTTContext_t * pxMQTTContext,
      * the keep-alive period, the MQTT library will send PINGREQ packets. */
     xConnectInfo.keepAliveSeconds = mqttexampleKEEP_ALIVE_TIMEOUT_SECONDS;
 
-    /* Use the username and password for authentication, if they are defined. */
+    /* Append metrics when connecting to the AWS IoT Core broker. */
     #ifdef democonfigUSE_AWS_IOT_CORE_BROKER
         #ifdef democonfigCLIENT_USERNAME
             xConnectInfo.pUserName = CLIENT_USERNAME_WITH_METRICS;
@@ -683,11 +681,11 @@ static void prvCreateMQTTConnectionWithBroker( MQTTContext_t * pxMQTTContext,
             xConnectInfo.pPassword = democonfigCLIENT_PASSWORD;
             xConnectInfo.passwordLength = ( uint16_t ) strlen( democonfigCLIENT_PASSWORD );
         #else
-            connectInfo.pUserName = AWS_IOT_METRICS_STRING;
-            connectInfo.userNameLength = AWS_IOT_METRICS_STRING_LENGTH;
+            xConnectInfo.pUserName = AWS_IOT_METRICS_STRING;
+            xConnectInfo.userNameLength = AWS_IOT_METRICS_STRING_LENGTH;
             /* Password for authentication is not used. */
-            connectInfo.pPassword = NULL;
-            connectInfo.passwordLength = 0U;
+            xConnectInfo.pPassword = NULL;
+            xConnectInfo.passwordLength = 0U;
         #endif /* ifdef democonfigCLIENT_USERNAME */
     #else /* ifdef democonfigUSE_AWS_IOT_CORE_BROKER */
         #ifdef democonfigCLIENT_USERNAME

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Mutual_Auth/DemoTasks/MutualAuthMQTTExample.c
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Mutual_Auth/DemoTasks/MutualAuthMQTTExample.c
@@ -214,11 +214,11 @@
 #endif
 
 #ifndef democonfigOS_VERSION
-    #define democonfigOS_VERSION    "10.3.0"
+    #define democonfigOS_VERSION    tskKERNEL_VERSION_NUMBER
 #endif
 
 #ifndef democonfigHARDWARE_PLATFORM_NAME
-    #define democonfigHARDWARE_PLATFORM_NAME    "PC"
+    #define democonfigHARDWARE_PLATFORM_NAME    "WinSim"
 #endif
 
 #ifndef democonfigMQTT_LIB

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Mutual_Auth/demo_config.h
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Mutual_Auth/demo_config.h
@@ -144,6 +144,13 @@
  */
 
 /**
+ * @brief For AWS IoT MQTT broker, the appropriate ALPN and SNI configurations
+ *  are passed to the demo when this macro is defined.
+ *
+ * #define democonfigUSE_AWS_IOT_CORE_BROKER
+ */
+
+/**
  * @brief The username value for authenticating client to the MQTT broker when
  * username/password based client authentication is used.
  *

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Mutual_Auth/demo_config.h
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Mutual_Auth/demo_config.h
@@ -144,10 +144,14 @@
  */
 
 /**
- * @brief For AWS IoT MQTT broker, the appropriate ALPN and SNI configurations
- *  are passed to the demo when this macro is defined.
+ * @brief Configuration that indicates if the demo connection is made to the AWS IoT Core MQTT broker.
  *
- * #define democonfigUSE_AWS_IOT_CORE_BROKER
+ * If username/password based authentication is used, the demo will use appropriate TLS ALPN and
+ * SNI configurations as required for the Custom Authentication feature of AWS IoT.
+ * For more information, refer to the following documentation:
+ * https://docs.aws.amazon.com/iot/latest/developerguide/custom-auth.html#custom-auth-mqtt
+ *
+ * #define democonfigUSE_AWS_IOT_CORE_BROKER    ( 1 )
  */
 
 /**

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Mutual_Auth/demo_config.h
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Mutual_Auth/demo_config.h
@@ -192,14 +192,14 @@
  * on. The current value is given as an example. Please update for your specific
  * operating system version.
  */
-#define democonfigOS_VERSION                "10.3.0"
+#define democonfigOS_VERSION                tskKERNEL_VERSION_NUMBER
 
 /**
  * @brief The name of the hardware platform the application is running on. The
  * current value is given as an example. Please update for your specific
  * hardware platform.
  */
-#define democonfigHARDWARE_PLATFORM_NAME    "PC"
+#define democonfigHARDWARE_PLATFORM_NAME    "WinSim"
 
 /**
  * @brief The name of the MQTT library used and its version, following an "@"

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Mutual_Auth/demo_config.h
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Mutual_Auth/demo_config.h
@@ -181,16 +181,43 @@
  */
 
 /**
+ * @brief The name of the operating system that the application is running on.
+ * The current value is given as an example. Please update for your specific
+ * operating system.
+ */
+#define democonfigOS_NAME                   "Windows"
+
+/**
+ * @brief The version of the operating system that the application is running
+ * on. The current value is given as an example. Please update for your specific
+ * operating system version.
+ */
+#define democonfigOS_VERSION                "10"
+
+/**
+ * @brief The name of the hardware platform the application is running on. The
+ * current value is given as an example. Please update for your specific
+ * hardware platform.
+ */
+#define democonfigHARDWARE_PLATFORM_NAME    "PC"
+
+/**
+ * @brief The name of the MQTT library used and its version, following an "@"
+ * symbol.
+ */
+#define democonfigMQTT_LIB                  "core-mqtt@1.0.0"
+
+/**
  * @brief Set the stack size of the main demo task.
  *
  * In the Windows port, this stack only holds a structure. The actual
  * stack is created by an operating system thread.
  */
-#define democonfigDEMO_STACKSIZE         configMINIMAL_STACK_SIZE
+#define democonfigDEMO_STACKSIZE            configMINIMAL_STACK_SIZE
 
 /**
  * @brief Size of the network buffer for MQTT packets.
  */
-#define democonfigNETWORK_BUFFER_SIZE    ( 1024U )
+#define democonfigNETWORK_BUFFER_SIZE       ( 1024U )
 
 #endif /* DEMO_CONFIG_H */

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Mutual_Auth/demo_config.h
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Mutual_Auth/demo_config.h
@@ -185,14 +185,14 @@
  * The current value is given as an example. Please update for your specific
  * operating system.
  */
-#define democonfigOS_NAME                   "Windows"
+#define democonfigOS_NAME                   "FreeRTOS"
 
 /**
  * @brief The version of the operating system that the application is running
  * on. The current value is given as an example. Please update for your specific
  * operating system version.
  */
-#define democonfigOS_VERSION                "10"
+#define democonfigOS_VERSION                "10.3.0"
 
 /**
  * @brief The name of the hardware platform the application is running on. The

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Mutual_Auth/demo_config.h
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Mutual_Auth/demo_config.h
@@ -144,6 +144,20 @@
  */
 
 /**
+ * @brief The username value for authenticating client to the MQTT broker when
+ * username/password based client authentication is used.
+ *
+ * #define democonfigCLIENT_USERNAME    "...insert here..."
+ */
+
+/**
+ * @brief The password value for authenticating client to the MQTT broker when
+ * username/password based client authentication is used.
+ *
+ * #define democonfigCLIENT_PASSWORD    "...insert here..."
+ */
+
+/**
  * @brief Set the stack size of the main demo task.
  *
  * In the Windows port, this stack only holds a structure. The actual

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Mutual_Auth/demo_config.h
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Mutual_Auth/demo_config.h
@@ -147,12 +147,24 @@
  * @brief The username value for authenticating client to the MQTT broker when
  * username/password based client authentication is used.
  *
+ * For AWS IoT MQTT broker, refer to the AWS IoT documentation below for
+ * details regarding client authentication with a username and password.
+ * https://docs.aws.amazon.com/iot/latest/developerguide/custom-authentication.html
+ * An authorizer setup needs to be done, as mentioned in the above link, to use
+ * username/password based client authentication.
+ *
  * #define democonfigCLIENT_USERNAME    "...insert here..."
  */
 
 /**
  * @brief The password value for authenticating client to the MQTT broker when
  * username/password based client authentication is used.
+ *
+ * For AWS IoT MQTT broker, refer to the AWS IoT documentation below for
+ * details regarding client authentication with a username and password.
+ * https://docs.aws.amazon.com/iot/latest/developerguide/custom-authentication.html
+ * An authorizer setup needs to be done, as mentioned in the above link, to use
+ * username/password based client authentication.
  *
  * #define democonfigCLIENT_PASSWORD    "...insert here..."
  */


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->
MQTT allows authentication through a username/password in the CONNECT packet. This PR allows the username/password to be passed that way through a config macro.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
