### PR TITLE
Delete all the guidance to use the public mosquitto broker.

### DIFF
--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Keep_Alive/demo_config.h
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Keep_Alive/demo_config.h
@@ -98,12 +98,6 @@
  * Virtual Private Network(VPN), connection to the Mosquitto broker may not
  * work.
  *
- * As an alternative option, a publicly hosted Mosquitto broker can also be
- * used as an MQTT broker end point. This can be done by updating the config
- * democonfigMQTT_BROKER_ENDPOINT to "test.mosquitto.org". However, this is not
- * recommended due the possible downtimes of the broker as indicated by the
- * documentation in https://test.mosquitto.org/.
- *
  * #define democonfigMQTT_BROKER_ENDPOINT				"insert here."
  */
 

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Plain_Text/demo_config.h
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Plain_Text/demo_config.h
@@ -98,12 +98,6 @@
  * Virtual Private Network(VPN), connection to the Mosquitto broker may not
  * work.
  *
- * As an alternative option, a publicly hosted Mosquitto broker can also be
- * used as an MQTT broker end point. This can be done by updating the config
- * democonfigMQTT_BROKER_ENDPOINT to "test.mosquitto.org". However, this is not
- * recommended due the possible downtimes of the broker as indicated by the
- * documentation in https://test.mosquitto.org/.
- *
  * #define democonfigMQTT_BROKER_ENDPOINT				"insert here."
  */
 

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Serializer/demo_config.h
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Serializer/demo_config.h
@@ -98,12 +98,6 @@
  * Virtual Private Network(VPN), connection to the Mosquitto broker may not
  * work.
  *
- * As an alternative option, a publicly hosted Mosquitto broker can also be
- * used as an MQTT broker end point. This can be done by updating the config
- * democonfigMQTT_BROKER_ENDPOINT to "test.mosquitto.org". However, this is not
- * recommended due the possible downtimes of the broker as indicated by the
- * documentation in https://test.mosquitto.org/.
- *
  * #define democonfigMQTT_BROKER_ENDPOINT				"insert here."
  */
 


### PR DESCRIPTION
* We do not have service level guarantees on the public broker, so it not recommended to have customers use the third party host.
* We tell customers they can use the public broker, but then we tell them that it is unstable. It is better to not tell customers at all to use it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
