### PR TITLE
Match @param style for all MQTT demos

### DIFF
--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Keep_Alive/DemoTasks/KeepAliveMQTTExample.c
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Keep_Alive/DemoTasks/KeepAliveMQTTExample.c
@@ -196,7 +196,7 @@ static void prvMQTTDemoTask( void * pvParameters );
  * Timeout value will exponentially increase until maximum
  * timeout value is reached or the number of attempts are exhausted.
  *
- * @param pxNetworkContext The output parameter to return the created network context.
+ * @param[out] pxNetworkContext The output parameter to return the created network context.
  *
  * @return The status of the final connection attempt.
  */
@@ -205,8 +205,8 @@ static PlaintextTransportStatus_t prvConnectToServerWithBackoffRetries( NetworkC
 /**
  * @brief Sends an MQTT Connect packet over the already connected TCP socket.
  *
- * @param pxMQTTContext MQTT context pointer.
- * @param pxNetworkContext Network context.
+ * @param[in, out] pxMQTTContext MQTT context pointer.
+ * @param[in] pxNetworkContext Network context.
  *
  */
 static void prvCreateMQTTConnectionWithBroker( MQTTContext_t * pxMQTTContext,
@@ -217,7 +217,7 @@ static void prvCreateMQTTConnectionWithBroker( MQTTContext_t * pxMQTTContext,
  * information from Subscribe ACK. Called by the event callback after processing
  * an incoming SUBACK packet.
  *
- * @param Server response to the subscription request.
+ * @param[in] Server response to the subscription request.
  */
 static void prvUpdateSubAckStatus( MQTTPacketInfo_t * pxPacketInfo );
 
@@ -226,14 +226,14 @@ static void prvUpdateSubAckStatus( MQTTPacketInfo_t * pxPacketInfo );
  * this file. In the case of a Subscribe ACK failure, then subscription is
  * retried using an exponential backoff strategy with jitter.
  *
- * @param pxMQTTContext MQTT context pointer.
+ * @param[in] pxMQTTContext MQTT context pointer.
  */
 static void prvMQTTSubscribeWithBackoffRetries( MQTTContext_t * pxMQTTContext );
 
 /**
  * @brief  Publishes a message mqttexampleMESSAGE on mqttexampleTOPIC topic.
  *
- * @param pxMQTTContext MQTT context pointer.
+ * @param[in] pxMQTTContext MQTT context pointer.
  */
 static void prvMQTTPublishToTopic( MQTTContext_t * pxMQTTContext );
 
@@ -241,7 +241,7 @@ static void prvMQTTPublishToTopic( MQTTContext_t * pxMQTTContext );
  * @brief Unsubscribes from the previously subscribed topic as specified
  * in mqttexampleTOPIC.
  *
- * @param pxMQTTContext MQTT context pointer.
+ * @param[in] pxMQTTContext MQTT context pointer.
  */
 static void prvMQTTUnsubscribeFromTopic( MQTTContext_t * pxMQTTContext );
 
@@ -256,9 +256,9 @@ static uint32_t prvGetTimeMs( void );
  * @brief Process a response or ack to an MQTT request (PING, SUBSCRIBE
  * or UNSUBSCRIBE). This function processes PINGRESP, SUBACK, UNSUBACK
  *
- * @param pxIncomingPacket is a pointer to structure containing deserialized
+ * @param[in] pxIncomingPacket is a pointer to structure containing deserialized
  * MQTT response.
- * @param usPacketId is the packet identifier from the ack received.
+ * @param[in] usPacketId is the packet identifier from the ack received.
  */
 static void prvMQTTProcessResponse( MQTTPacketInfo_t * pxIncomingPacket,
                                     uint16_t usPacketId );
@@ -266,7 +266,7 @@ static void prvMQTTProcessResponse( MQTTPacketInfo_t * pxIncomingPacket,
 /**
  * @brief Process incoming Publish message.
  *
- * @param pxPublishInfo is a pointer to structure containing deserialized
+ * @param[in] pxPublishInfo is a pointer to structure containing deserialized
  * Publish message.
  */
 static void prvMQTTProcessIncomingPublish( MQTTPublishInfo_t * pxPublishInfo );
@@ -277,7 +277,7 @@ static void prvMQTTProcessIncomingPublish( MQTTPublishInfo_t * pxPublishInfo );
  *
  * This should only be called after a control packet has been sent.
  *
- * @param pxTimer The auto-reload software timer for handling keep alive.
+ * @param[in] pxTimer The auto-reload software timer for handling keep alive.
  *
  * @return The status returned by #xTimerReset.
  */
@@ -289,7 +289,7 @@ static BaseType_t prvCheckTimeoutThenResetTimer( TimerHandle_t pxTimer );
  * Its responsibility is to send a PINGREQ packet if a PINGRESP is not pending
  * and no control packets have been sent after some given interval.
  *
- * @param pxTimer The auto-reload software timer for handling keep alive.
+ * @param[in] pxTimer The auto-reload software timer for handling keep alive.
  */
 static void prvKeepAliveTimerCallback( TimerHandle_t pxTimer );
 
@@ -297,9 +297,9 @@ static void prvKeepAliveTimerCallback( TimerHandle_t pxTimer );
  * @brief The application callback function for getting the incoming publish
  * and incoming acks reported from the MQTT library.
  *
- * @param pxMQTTContext MQTT context pointer.
- * @param pxPacketInfo Packet Info pointer for the incoming packet.
- * @param pxDeserializedInfo Deserialized information from the incoming packet.
+ * @param[in] pxMQTTContext MQTT context pointer.
+ * @param[in] pxPacketInfo Packet Info pointer for the incoming packet.
+ * @param[in] pxDeserializedInfo Deserialized information from the incoming packet.
  */
 static void prvEventCallback( MQTTContext_t * pxMQTTContext,
                               MQTTPacketInfo_t * pxPacketInfo,

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Keep_Alive/DemoTasks/KeepAliveMQTTExample.c
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Keep_Alive/DemoTasks/KeepAliveMQTTExample.c
@@ -196,7 +196,7 @@ static void prvMQTTDemoTask( void * pvParameters );
  * Timeout value will exponentially increase until maximum
  * timeout value is reached or the number of attempts are exhausted.
  *
- * @param[out] pxNetworkContext The output parameter to return the created network context.
+ * @param[out] pxNetworkContext The parameter to return the created network context.
  *
  * @return The status of the final connection attempt.
  */

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Multitask/mbedtls_config.h
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Multitask/mbedtls_config.h
@@ -46,8 +46,8 @@
 
 /* This file configures mbed TLS for FreeRTOS. */
 
-#ifndef MBEDTLS_CONFIG_H_
-#define MBEDTLS_CONFIG_H_
+#ifndef MBEDTLS_CONFIG_H
+#define MBEDTLS_CONFIG_H
 
 /* FreeRTOS include. */
 #include "FreeRTOS.h"
@@ -148,4 +148,4 @@ int mbedtls_platform_entropy_poll( void * data,
 
 #include "mbedtls/check_config.h"
 
-#endif /* ifndef MBEDTLS_CONFIG_H_ */
+#endif /* ifndef MBEDTLS_CONFIG_H */

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Mutual_Auth/DemoTasks/MutualAuthMQTTExample.c
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Mutual_Auth/DemoTasks/MutualAuthMQTTExample.c
@@ -275,7 +275,7 @@ static void prvMQTTDemoTask( void * pvParameters );
  * Timeout value will exponentially increase until maximum
  * timeout value is reached or the number of attempts are exhausted.
  *
- * @param[out] pxNetworkContext The output parameter to return the created network context.
+ * @param[out] pxNetworkContext The parameter to return the created network context.
  *
  * @return The status of the final connection attempt.
  */

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Mutual_Auth/mbedtls_config.h
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Mutual_Auth/mbedtls_config.h
@@ -46,8 +46,8 @@
 
 /* This file configures mbed TLS for FreeRTOS. */
 
-#ifndef MBEDTLS_CONFIG_H_
-#define MBEDTLS_CONFIG_H_
+#ifndef MBEDTLS_CONFIG_H
+#define MBEDTLS_CONFIG_H
 
 /* FreeRTOS include. */
 #include "FreeRTOS.h"
@@ -148,4 +148,4 @@ int mbedtls_platform_entropy_poll( void * data,
 
 #include "mbedtls/check_config.h"
 
-#endif /* ifndef MBEDTLS_CONFIG_H_ */
+#endif /* ifndef MBEDTLS_CONFIG_H */

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Plain_Text/DemoTasks/PlaintextMQTTExample.c
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Plain_Text/DemoTasks/PlaintextMQTTExample.c
@@ -173,7 +173,7 @@ static void prvMQTTDemoTask( void * pvParameters );
  * Timeout value will exponentially increase until maximum
  * timeout value is reached or the number of attempts are exhausted.
  *
- * @param[out] pxNetworkContext The output parameter to return the created network context.
+ * @param[out] pxNetworkContext The parameter to return the created network context.
  *
  * @return The status of the final connection attempt.
  */

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Plain_Text/DemoTasks/PlaintextMQTTExample.c
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Plain_Text/DemoTasks/PlaintextMQTTExample.c
@@ -21,6 +21,7 @@
  *
  * http://www.FreeRTOS.org
  * http://aws.amazon.com/freertos
+ *
  */
 
 /*
@@ -172,7 +173,7 @@ static void prvMQTTDemoTask( void * pvParameters );
  * Timeout value will exponentially increase until maximum
  * timeout value is reached or the number of attempts are exhausted.
  *
- * @param pxNetworkContext The output parameter to return the created network context.
+ * @param[out] pxNetworkContext The output parameter to return the created network context.
  *
  * @return The status of the final connection attempt.
  */
@@ -181,8 +182,8 @@ static PlaintextTransportStatus_t prvConnectToServerWithBackoffRetries( NetworkC
 /**
  * @brief Sends an MQTT Connect packet over the already connected TCP socket.
  *
- * @param pxMQTTContext MQTT context pointer.
- * @param pxNetworkContext Network context.
+ * @param[in, out] pxMQTTContext MQTT context pointer.
+ * @param[in] pxNetworkContext Network context.
  *
  */
 static void prvCreateMQTTConnectionWithBroker( MQTTContext_t * pxMQTTContext,
@@ -193,7 +194,7 @@ static void prvCreateMQTTConnectionWithBroker( MQTTContext_t * pxMQTTContext,
  * information from Subscribe ACK. Called by the event callback after processing
  * an incoming SUBACK packet.
  *
- * @param Server response to the subscription request.
+ * @param[in] Server response to the subscription request.
  */
 static void prvUpdateSubAckStatus( MQTTPacketInfo_t * pxPacketInfo );
 
@@ -202,14 +203,14 @@ static void prvUpdateSubAckStatus( MQTTPacketInfo_t * pxPacketInfo );
  * this file. In the case of a Subscribe ACK failure, then subscription is
  * retried using an exponential backoff strategy with jitter.
  *
- * @param pxMQTTContext MQTT context pointer.
+ * @param[in] pxMQTTContext MQTT context pointer.
  */
 static void prvMQTTSubscribeWithBackoffRetries( MQTTContext_t * pxMQTTContext );
 
 /**
  * @brief Publishes a message mqttexampleMESSAGE on mqttexampleTOPIC topic.
  *
- * @param pxMQTTContext MQTT context pointer.
+ * @param[in] pxMQTTContext MQTT context pointer.
  */
 static void prvMQTTPublishToTopic( MQTTContext_t * pxMQTTContext );
 
@@ -217,7 +218,7 @@ static void prvMQTTPublishToTopic( MQTTContext_t * pxMQTTContext );
  * @brief Unsubscribes from the previously subscribed topic as specified
  * in mqttexampleTOPIC.
  *
- * @param pxMQTTContext MQTT context pointer.
+ * @param[in] pxMQTTContext MQTT context pointer.
  */
 static void prvMQTTUnsubscribeFromTopic( MQTTContext_t * pxMQTTContext );
 
@@ -230,11 +231,11 @@ static uint32_t prvGetTimeMs( void );
 
 /**
  * @brief Process a response or ack to an MQTT request (PING, SUBSCRIBE
- * or UNSUBSCRIBE). This function processes PINGRESP, SUBACK, UNSUBACK
+ * or UNSUBSCRIBE). This function processes PINGRESP, SUBACK, and UNSUBACK.
  *
- * @param pxIncomingPacket is a pointer to structure containing deserialized
+ * @param[in] pxIncomingPacket is a pointer to structure containing deserialized
  * MQTT response.
- * @param usPacketId is the packet identifier from the ack received.
+ * @param[in] usPacketId is the packet identifier from the ack received.
  */
 static void prvMQTTProcessResponse( MQTTPacketInfo_t * pxIncomingPacket,
                                     uint16_t usPacketId );
@@ -242,7 +243,7 @@ static void prvMQTTProcessResponse( MQTTPacketInfo_t * pxIncomingPacket,
 /**
  * @brief Process incoming Publish message.
  *
- * @param pxPublishInfo is a pointer to structure containing deserialized
+ * @param[in] pxPublishInfo is a pointer to structure containing deserialized
  * Publish message.
  */
 static void prvMQTTProcessIncomingPublish( MQTTPublishInfo_t * pxPublishInfo );
@@ -251,9 +252,9 @@ static void prvMQTTProcessIncomingPublish( MQTTPublishInfo_t * pxPublishInfo );
  * @brief The application callback function for getting the incoming publish
  * and incoming acks reported from the MQTT library.
  *
- * @param pxMQTTContext MQTT context pointer.
- * @param pxPacketInfo Packet Info pointer for the incoming packet.
- * @param pxDeserializedInfo Deserialized information from the incoming packet.
+ * @param[in] pxMQTTContext MQTT context pointer.
+ * @param[in] pxPacketInfo Packet Info pointer for the incoming packet.
+ * @param[in] pxDeserializedInfo Deserialized information from the incoming packet.
  */
 static void prvEventCallback( MQTTContext_t * pxMQTTContext,
                               MQTTPacketInfo_t * pxPacketInfo,
@@ -367,7 +368,7 @@ static void prvMQTTDemoTask( void * pvParameters )
 
         /**************************** Subscribe. ******************************/
 
-        /* If server rejected the subscription request, attempt to resubscribe to 
+        /* If server rejected the subscription request, attempt to resubscribe to
          * the topic. Attempts are made according to the exponential backoff retry
          * strategy declared in retry_utils.h. */
         prvMQTTSubscribeWithBackoffRetries( &xMQTTContext );
@@ -383,7 +384,7 @@ static void prvMQTTDemoTask( void * pvParameters )
              * to the same topic, the broker will send the same publish message
              * back to the application. */
             LogInfo( ( "Attempt to receive publish message from broker." ) );
-            xMQTTStatus = MQTT_ProcessLoop( &xMQTTContext, 
+            xMQTTStatus = MQTT_ProcessLoop( &xMQTTContext,
                                             mqttexamplePROCESS_LOOP_TIMEOUT_MS );
             configASSERT( xMQTTStatus == MQTTSuccess );
 
@@ -397,7 +398,7 @@ static void prvMQTTDemoTask( void * pvParameters )
         prvMQTTUnsubscribeFromTopic( &xMQTTContext );
 
         /* Process the incoming packet from the broker. */
-        xMQTTStatus = MQTT_ProcessLoop( &xMQTTContext, 
+        xMQTTStatus = MQTT_ProcessLoop( &xMQTTContext,
                                         mqttexamplePROCESS_LOOP_TIMEOUT_MS );
         configASSERT( xMQTTStatus == MQTTSuccess );
 
@@ -406,7 +407,7 @@ static void prvMQTTDemoTask( void * pvParameters )
         /* Send an MQTT Disconnect packet over the connected TCP socket.
          * There is no corresponding response for a disconnect packet. After
          * sending the disconnect, the client must close the network connection. */
-        LogInfo( ( "Disconnecting the MQTT connection with %s.", 
+        LogInfo( ( "Disconnecting the MQTT connection with %s.",
                    democonfigMQTT_BROKER_ENDPOINT ) );
         xMQTTStatus = MQTT_Disconnect( &xMQTTContext );
         configASSERT( xMQTTStatus == MQTTSuccess );

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Plain_Text/core_mqtt_config.h
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Plain_Text/core_mqtt_config.h
@@ -24,8 +24,8 @@
  *
  * 1 tab == 4 spaces!
  */
-#ifndef CORE_MQTT_CONFIG_H_
-#define CORE_MQTT_CONFIG_H_
+#ifndef CORE_MQTT_CONFIG_H
+#define CORE_MQTT_CONFIG_H
 
 /**************************************************/
 /******* DO NOT CHANGE the following order ********/
@@ -64,4 +64,4 @@
  */
 #define MQTT_STATE_ARRAY_MAX_COUNT    10U
 
-#endif /* ifndef CORE_MQTT_CONFIG_H_ */
+#endif /* ifndef CORE_MQTT_CONFIG_H */

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Serializer/DemoTasks/SerializerMQTTExample.c
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Serializer/DemoTasks/SerializerMQTTExample.c
@@ -179,16 +179,14 @@ static Socket_t prvCreateTCPConnectionToBroker( void );
  * Timeout value will exponentially increase until maximum
  * timeout value is reached or the number of attempts are exhausted.
  *
- * @param xMQTTSocket is a TCP socket that is connected to an MQTT broker.
- *
  * @return The socket of the final connection attempt.
  */
-static Socket_t prvConnectToServerWithBackoffRetries();
+static Socket_t prvConnectToServerWithBackoffRetries( void );
 
 /**
  * @brief Sends an MQTT Connect packet over the already connected TCP socket.
  *
- * @param xMQTTSocket is a TCP socket that is connected to an MQTT broker.
+ * @param[in, out] xMQTTSocket is a TCP socket that is connected to an MQTT broker.
  *
  */
 static void prvCreateMQTTConnectionWithBroker( Socket_t xMQTTSocket );
@@ -197,7 +195,7 @@ static void prvCreateMQTTConnectionWithBroker( Socket_t xMQTTSocket );
  * @brief Performs a graceful shutdown and close of the socket passed in as its
  * parameter.
  *
- * @param xMQTTSocket is a TCP socket that is connected to an MQTT broker to which
+ * @param[in, out] xMQTTSocket is a TCP socket that is connected to an MQTT broker to which
  * an MQTT connection has been established.
  */
 static void prvGracefulShutDown( Socket_t xSocket );
@@ -206,7 +204,7 @@ static void prvGracefulShutDown( Socket_t xSocket );
  * @brief Subscribes to the topic as specified in mqttexampleTOPIC at the top of
  * this file.
  *
- * @param xMQTTSocket is a TCP socket that is connected to an MQTT broker to which
+ * @param[in] xMQTTSocket is a TCP socket that is connected to an MQTT broker to which
  * an MQTT connection has been established.
  */
 static void prvMQTTSubscribeToTopic( Socket_t xMQTTSocket );
@@ -216,7 +214,7 @@ static void prvMQTTSubscribeToTopic( Socket_t xMQTTSocket );
  * this file. In the case of a Subscribe ACK failure, then subscription is
  * retried using an exponential backoff strategy with jitter.
  *
- * @param xMQTTSocket is a TCP socket that is connected to an MQTT broker to which
+ * @param[in] xMQTTSocket is a TCP socket that is connected to an MQTT broker to which
  * an MQTT connection has been established.
  */
 static void prvMQTTSubscribeWithBackoffRetries( Socket_t xMQTTSocket );
@@ -226,14 +224,14 @@ static void prvMQTTSubscribeWithBackoffRetries( Socket_t xMQTTSocket );
  * information from Subscribe ACK. Called by the event callback after processing
  * an incoming SUBACK packet.
  *
- * @param Server response to the subscription request.
+ * @param[in] Server response to the subscription request.
  */
 static void prvMQTTUpdateSubAckStatus( MQTTPacketInfo_t * pxPacketInfo );
 
 /**
- * @brief  Publishes a message mqttexampleMESSAGE on mqttexampleTOPIC topic.
+ * @brief Publishes a message mqttexampleMESSAGE on mqttexampleTOPIC topic.
  *
- * @param xMQTTSocket is a TCP socket that is connected to an MQTT broker to which
+ * @param[in] xMQTTSocket is a TCP socket that is connected to an MQTT broker to which
  * an MQTT connection has been established.
  */
 static void prvMQTTPublishToTopic( Socket_t xMQTTSocket );
@@ -242,7 +240,7 @@ static void prvMQTTPublishToTopic( Socket_t xMQTTSocket );
  * @brief Unsubscribes from the previously subscribed topic as specified
  * in mqttexampleTOPIC.
  *
- * @param xMQTTSocket is a TCP socket that is connected to an MQTT broker to which
+ * @param[in] xMQTTSocket is a TCP socket that is connected to an MQTT broker to which
  * an MQTT connection has been established.
  */
 static void prvMQTTUnsubscribeFromTopic( Socket_t xMQTTSocket );
@@ -251,7 +249,7 @@ static void prvMQTTUnsubscribeFromTopic( Socket_t xMQTTSocket );
  * @brief Send MQTT Ping Request to the broker.
  * Ping request is used to keep connection to the broker alive.
  *
- * @param xMQTTSocket is a TCP socket that is connected to an MQTT broker to which
+ * @param[in] xMQTTSocket is a TCP socket that is connected to an MQTT broker to which
  * an MQTT connection has been established.
  */
 static void prvMQTTKeepAlive( Socket_t xMQTTSocket );
@@ -259,7 +257,7 @@ static void prvMQTTKeepAlive( Socket_t xMQTTSocket );
 /**
  * @brief Disconnect From the MQTT broker.
  *
- * @param xMQTTSocket is a TCP socket that is connected to an MQTT broker to which
+ * @param[in] xMQTTSocket is a TCP socket that is connected to an MQTT broker to which
  * an MQTT connection has been established.
  */
 static void prvMQTTDisconnect( Socket_t xMQTTSocket );
@@ -268,9 +266,9 @@ static void prvMQTTDisconnect( Socket_t xMQTTSocket );
  * @brief Process a response or ack to an MQTT request (PING, SUBSCRIBE
  * or UNSUBSCRIBE). This function processes PING_RESP, SUB_ACK, UNSUB_ACK
  *
- * @param pxIncomingPacket is a pointer to structure containing deserialized
+ * @param[in] pxIncomingPacket is a pointer to structure containing deserialized
  * MQTT response.
- * @param usPacketId is the packet identifier from the ack received.
+ * @param[in] usPacketId is the packet identifier from the ack received.
  */
 static void prvMQTTProcessResponse( MQTTPacketInfo_t * pxIncomingPacket,
                                     uint16_t usPacketId );
@@ -278,7 +276,7 @@ static void prvMQTTProcessResponse( MQTTPacketInfo_t * pxIncomingPacket,
 /**
  * @brief Process incoming Publish message.
  *
- * @param pxPublishInfo is a pointer to structure containing deserialized
+ * @param[in] pxPublishInfo is a pointer to structure containing deserialized
  * Publish message.
  */
 static void prvMQTTProcessIncomingPublish( MQTTPublishInfo_t * pxPublishInfo );
@@ -287,7 +285,7 @@ static void prvMQTTProcessIncomingPublish( MQTTPublishInfo_t * pxPublishInfo );
  * @brief Receive and validate MQTT packet from the broker, determine the type
  * of the packet and processes the packet based on the type.
  *
- * @param xMQTTSocket is a TCP socket that is connected to an MQTT broker to which
+ * @param[in] xMQTTSocket is a TCP socket that is connected to an MQTT broker to which
  * an MQTT connection has been established.
  */
 static void prvMQTTProcessIncomingPacket( Socket_t xMQTTSocket );


### PR DESCRIPTION
Description
-----------
<!--- Describe your changes in detail. -->
Some demos like plaintext, serializer, and keep alive do not use @param[in] or @param[out] and instead use @param only. This PR makes it so that style matches. In addition, because `FREERTOS_CONFIG_H` has no trailing underscore, `CORE_MQTT_CONFIG_H_` is changed to `CORE_MQTT_CONFIG_H` and same for `MBEDTLS_CONFIG_H_`

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
