### PR TITLE
Rename PKCS files to core.

### DIFF
--- a/FreeRTOS-Plus/Demo/corePKCS11_MQTT_Mutual_Auth_Windows_Simulator/WIN32.vcxproj
+++ b/FreeRTOS-Plus/Demo/corePKCS11_MQTT_Mutual_Auth_Windows_Simulator/WIN32.vcxproj
@@ -165,10 +165,10 @@
     <ClCompile Include="..\..\..\FreeRTOS-Plus\Source\Application-Protocols\coreMQTT\source\core_mqtt_state.c" />
     <ClCompile Include="..\..\..\FreeRTOS-Plus\Source\Application-Protocols\coreMQTT\source\core_mqtt.c" />
     <ClCompile Include="..\..\Source\Application-Protocols\platform\freertos\transport\src\tls_freertos_pkcs11.c" />
-    <ClCompile Include="..\..\Source\corePKCS11\source\iot_pkcs11.c" />
-    <ClCompile Include="..\..\Source\corePKCS11\source\iot_pki_utils.c" />
-    <ClCompile Include="..\..\Source\corePKCS11\source\portable\mbedtls\iot_pkcs11_mbedtls.c" />
-    <ClCompile Include="..\..\Source\corePKCS11\source\portable\windows\iot_pkcs11_pal.c" />
+    <ClCompile Include="..\..\Source\corePKCS11\source\core_pkcs11.c" />
+    <ClCompile Include="..\..\Source\corePKCS11\source\core_pki_utils.c" />
+    <ClCompile Include="..\..\Source\corePKCS11\source\portable\mbedtls\core_pkcs11_mbedtls.c" />
+    <ClCompile Include="..\..\Source\corePKCS11\source\portable\windows\core_pkcs11_pal.c" />
     <ClCompile Include="..\..\ThirdParty\mbedtls\library\aes.c" />
     <ClCompile Include="..\..\ThirdParty\mbedtls\library\aesni.c" />
     <ClCompile Include="..\..\ThirdParty\mbedtls\library\arc4.c" />
@@ -292,9 +292,9 @@
     <ClInclude Include="..\..\..\Source\Application-Protocols\coreMQTT\source\include\core_mqtt_serializer.h" />
     <ClInclude Include="..\..\..\Source\Application-Protocols\coreMQTT\source\include\core_mqtt_state.h" />
     <ClInclude Include="..\..\..\Source\Application-Protocols\coreMQTT\source\include\core_mqtt.h" />
-    <ClInclude Include="..\..\Source\corePKCS11\source\include\iot_pkcs11.h" />
-    <ClInclude Include="..\..\Source\corePKCS11\source\include\iot_pkcs11_pal.h" />
-    <ClInclude Include="..\..\Source\corePKCS11\source\include\iot_pki_utils.h" />
+    <ClInclude Include="..\..\Source\corePKCS11\source\include\core_pkcs11.h" />
+    <ClInclude Include="..\..\Source\corePKCS11\source\include\core_pkcs11_pal.h" />
+    <ClInclude Include="..\..\Source\corePKCS11\source\include\core_pki_utils.h" />
     <ClInclude Include="..\..\ThirdParty\mbedtls\include\mbedtls\aes.h" />
     <ClInclude Include="..\..\ThirdParty\mbedtls\include\mbedtls\aesni.h" />
     <ClInclude Include="..\..\ThirdParty\mbedtls\include\mbedtls\arc4.h" />

--- a/FreeRTOS-Plus/Demo/corePKCS11_MQTT_Mutual_Auth_Windows_Simulator/WIN32.vcxproj.filters
+++ b/FreeRTOS-Plus/Demo/corePKCS11_MQTT_Mutual_Auth_Windows_Simulator/WIN32.vcxproj.filters
@@ -182,16 +182,16 @@
     <ClCompile Include="..\coreMQTT_Windows_Simulator\Common\demo_logging.c">
       <Filter>Common</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\Source\corePKCS11\source\iot_pkcs11.c">
+    <ClCompile Include="..\..\Source\corePKCS11\source\core_pkcs11.c">
       <Filter>corePKCS11</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\Source\corePKCS11\source\iot_pki_utils.c">
+    <ClCompile Include="..\..\Source\corePKCS11\source\core_pki_utils.c">
       <Filter>corePKCS11</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\Source\corePKCS11\source\portable\mbedtls\iot_pkcs11_mbedtls.c">
+    <ClCompile Include="..\..\Source\corePKCS11\source\portable\mbedtls\core_pkcs11_mbedtls.c">
       <Filter>corePKCS11</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\Source\corePKCS11\source\portable\windows\iot_pkcs11_pal.c">
+    <ClCompile Include="..\..\Source\corePKCS11\source\portable\windows\core_pkcs11_pal.c">
       <Filter>corePKCS11</Filter>
     </ClCompile>
     <ClCompile Include="..\..\ThirdParty\mbedtls\library\aes.c">
@@ -560,13 +560,13 @@
     <ClInclude Include="core_mqtt_config.h">
       <Filter>coreMQTT</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\Source\corePKCS11\source\include\iot_pkcs11.h">
+    <ClInclude Include="..\..\Source\corePKCS11\source\include\core_pkcs11.h">
       <Filter>corePKCS11\include</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\Source\corePKCS11\source\include\iot_pkcs11_pal.h">
+    <ClInclude Include="..\..\Source\corePKCS11\source\include\core_pkcs11_pal.h">
       <Filter>corePKCS11\include</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\Source\corePKCS11\source\include\iot_pki_utils.h">
+    <ClInclude Include="..\..\Source\corePKCS11\source\include\core_pki_utils.h">
       <Filter>corePKCS11\include</Filter>
     </ClInclude>
     <ClInclude Include="..\..\ThirdParty\mbedtls\library\common.h">

--- a/FreeRTOS-Plus/Demo/corePKCS11_MQTT_Mutual_Auth_Windows_Simulator/core_pkcs11_config.h
+++ b/FreeRTOS-Plus/Demo/corePKCS11_MQTT_Mutual_Auth_Windows_Simulator/core_pkcs11_config.h
@@ -30,8 +30,8 @@
  */
 
 
-#ifndef _core_pkcs11_CONFIG_H_
-#define _core_pkcs11_CONFIG_H_
+#ifndef _CORE_PKCS11_CONFIG_H_
+#define _CORE_PKCS11_CONFIG_H_
 
 #include "FreeRTOS.h"
 
@@ -180,4 +180,4 @@
  */
 #define pkcs11configLABEL_ROOT_CERTIFICATE                 ( "Root Cert" )
 
-#endif /* _AWS_PKCS11_CONFIG_H_ include guard. */
+#endif /* _CORE_PKCS11_CONFIG_H_ include guard. */

--- a/FreeRTOS-Plus/Demo/corePKCS11_MQTT_Mutual_Auth_Windows_Simulator/core_pkcs11_config.h
+++ b/FreeRTOS-Plus/Demo/corePKCS11_MQTT_Mutual_Auth_Windows_Simulator/core_pkcs11_config.h
@@ -25,13 +25,13 @@
 
 
 /**
- * @file iot_pkcs11_config.h
+ * @file core_pkcs11_config.h
  * @brief PCKS#11 config options.
  */
 
 
-#ifndef _IOT_PKCS11_CONFIG_H_
-#define _IOT_PKCS11_CONFIG_H_
+#ifndef _core_pkcs11_CONFIG_H_
+#define _core_pkcs11_CONFIG_H_
 
 #include "FreeRTOS.h"
 
@@ -59,12 +59,12 @@
 #include "logging_stack.h"
 
 /**
- * @brief Malloc API used by iot_pkcs11.h
+ * @brief Malloc API used by core_pkcs11.h
  */
 #define PKCS11_MALLOC                                      pvPortMalloc
 
 /**
- * @brief Free API used by iot_pkcs11.h
+ * @brief Free API used by core_pkcs11.h
  */
 #define PKCS11_FREE                                        vPortFree
 

--- a/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/WIN32.vcxproj
+++ b/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/WIN32.vcxproj
@@ -230,10 +230,10 @@
     <ClCompile Include="..\..\Source\corePKCS11\3rdparty\mbedtls\library\xtea.c" />
     <ClCompile Include="..\..\Source\corePKCS11\3rdparty\mbedtls_utils\mbedtls_error.c" />
     <ClCompile Include="..\..\Source\corePKCS11\3rdparty\mbedtls_utils\mbedtls_utils.c" />
-    <ClCompile Include="..\..\Source\corePKCS11\source\iot_pkcs11.c" />
-    <ClCompile Include="..\..\Source\corePKCS11\source\iot_pki_utils.c" />
-    <ClCompile Include="..\..\Source\corePKCS11\source\portable\mbedtls\iot_pkcs11_mbedtls.c" />
-    <ClCompile Include="..\..\Source\corePKCS11\source\portable\windows\iot_pkcs11_pal.c" />
+    <ClCompile Include="..\..\Source\corePKCS11\source\core_pkcs11.c" />
+    <ClCompile Include="..\..\Source\corePKCS11\source\core_pki_utils.c" />
+    <ClCompile Include="..\..\Source\corePKCS11\source\portable\mbedtls\core_pkcs11_mbedtls.c" />
+    <ClCompile Include="..\..\Source\corePKCS11\source\portable\windows\core_pkcs11_pal.c" />
     <ClCompile Include="examples\demo_helpers.c" />
     <ClCompile Include="examples\management_and_rng.c" />
     <ClCompile Include="examples\objects.c" />
@@ -333,9 +333,9 @@
     <ClInclude Include="..\..\Source\corePKCS11\3rdparty\pkcs11\pkcs11.h" />
     <ClInclude Include="..\..\Source\corePKCS11\3rdparty\pkcs11\pkcs11f.h" />
     <ClInclude Include="..\..\Source\corePKCS11\3rdparty\pkcs11\pkcs11t.h" />
-    <ClInclude Include="..\..\Source\corePKCS11\source\include\iot_pkcs11.h" />
-    <ClInclude Include="..\..\Source\corePKCS11\source\include\iot_pkcs11_pal.h" />
-    <ClInclude Include="..\..\Source\corePKCS11\source\include\iot_pki_utils.h" />
+    <ClInclude Include="..\..\Source\corePKCS11\source\include\core_pkcs11.h" />
+    <ClInclude Include="..\..\Source\corePKCS11\source\include\core_pkcs11_pal.h" />
+    <ClInclude Include="..\..\Source\corePKCS11\source\include\core_pki_utils.h" />
     <ClInclude Include="..\..\Source\corePKCS11\source\portable\mbedtls\threading_alt.h" />
     <ClInclude Include="..\Common\Logging\logging_levels.h" />
     <ClInclude Include="..\Common\Logging\logging_stack.h" />

--- a/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/WIN32.vcxproj.filters
+++ b/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/WIN32.vcxproj.filters
@@ -89,16 +89,16 @@
     <ClCompile Include="examples\sign_and_verify.c">
       <Filter>examples</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\Source\corePKCS11\source\portable\mbedtls\iot_pkcs11_mbedtls.c">
+    <ClCompile Include="..\..\Source\corePKCS11\source\portable\mbedtls\core_pkcs11_mbedtls.c">
       <Filter>corePKCS11\source</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\Source\corePKCS11\source\iot_pkcs11.c">
+    <ClCompile Include="..\..\Source\corePKCS11\source\core_pkcs11.c">
       <Filter>corePKCS11\source</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\Source\corePKCS11\source\iot_pki_utils.c">
+    <ClCompile Include="..\..\Source\corePKCS11\source\core_pki_utils.c">
       <Filter>corePKCS11\source</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\Source\corePKCS11\source\portable\windows\iot_pkcs11_pal.c">
+    <ClCompile Include="..\..\Source\corePKCS11\source\portable\windows\core_pkcs11_pal.c">
       <Filter>corePKCS11\source</Filter>
     </ClCompile>
     <ClCompile Include="..\..\Source\corePKCS11\3rdparty\mbedtls_utils\mbedtls_error.c">
@@ -382,13 +382,13 @@
     <ClInclude Include="examples\demo_helpers.h">
       <Filter>examples</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\Source\corePKCS11\source\include\iot_pkcs11.h">
+    <ClInclude Include="..\..\Source\corePKCS11\source\include\core_pkcs11.h">
       <Filter>corePKCS11\include</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\Source\corePKCS11\source\include\iot_pkcs11_pal.h">
+    <ClInclude Include="..\..\Source\corePKCS11\source\include\core_pkcs11_pal.h">
       <Filter>corePKCS11\include</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\Source\corePKCS11\source\include\iot_pki_utils.h">
+    <ClInclude Include="..\..\Source\corePKCS11\source\include\core_pki_utils.h">
       <Filter>corePKCS11\include</Filter>
     </ClInclude>
     <ClInclude Include="..\..\Source\corePKCS11\source\portable\mbedtls\threading_alt.h">

--- a/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/core_pkcs11_config.h
+++ b/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/core_pkcs11_config.h
@@ -24,13 +24,13 @@
  */
 
 /**
- * @file iot_pkcs11_config.h
+ * @file core_pkcs11_config.h
  * @brief PCKS#11 config options.
  */
 
 
-#ifndef _IOT_PKCS11_CONFIG_H_
-#define _IOT_PKCS11_CONFIG_H_
+#ifndef _core_pkcs11_CONFIG_H_
+#define _core_pkcs11_CONFIG_H_
 
 #include "FreeRTOS.h"
 
@@ -59,12 +59,12 @@
 #include "logging_stack.h"
 
 /**
- * @brief Malloc API used by iot_pkcs11.h
+ * @brief Malloc API used by core_pkcs11.h
  */
 #define PKCS11_MALLOC pvPortMalloc
 
 /**
- * @brief Free API used by iot_pkcs11.h
+ * @brief Free API used by core_pkcs11.h
  */
 #define PKCS11_FREE vPortFree
 

--- a/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/core_pkcs11_config.h
+++ b/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/core_pkcs11_config.h
@@ -29,8 +29,8 @@
  */
 
 
-#ifndef _core_pkcs11_CONFIG_H_
-#define _core_pkcs11_CONFIG_H_
+#ifndef _CORE_PKCS11_CONFIG_H_
+#define _CORE_PKCS11_CONFIG_H_
 
 #include "FreeRTOS.h"
 
@@ -170,4 +170,4 @@
 */
 #define pkcs11configLABEL_ROOT_CERTIFICATE                 "Root Cert"
 
-#endif /* _AWS_PKCS11_CONFIG_H_ include guard. */
+#endif /* _CORE_PKCS11_CONFIG_H_ */

--- a/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/examples/demo_helpers.c
+++ b/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/examples/demo_helpers.c
@@ -31,8 +31,8 @@
 #include "stdio.h"
 
 /* PKCS #11 includes. */
-#include "iot_pkcs11_config.h"
-#include "iot_pkcs11.h"
+#include "core_pkcs11_config.h"
+#include "core_pkcs11.h"
 #include "pkcs11.h"
 
 /* mbed TLS includes. */

--- a/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/examples/demo_helpers.h
+++ b/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/examples/demo_helpers.h
@@ -25,7 +25,7 @@
 #ifndef _DEMO_HELPER_FUNCTIONS_
 #define _DEMO_HELPER_FUNCTIONS_
 
-#include "iot_pkcs11.h"
+#include "core_pkcs11.h"
 #include "threading_alt.h"
 #include "mbedtls/pk.h"
 

--- a/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/examples/management_and_rng.c
+++ b/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/examples/management_and_rng.c
@@ -30,8 +30,8 @@
 #include "stdio.h"
 
 /* PKCS #11 includes. */
-#include "iot_pkcs11_config.h"
-#include "iot_pkcs11.h"
+#include "core_pkcs11_config.h"
+#include "core_pkcs11.h"
 #include "pkcs11.h"
 
 /* Demo include. */

--- a/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/examples/mechanisms_and_digests.c
+++ b/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/examples/mechanisms_and_digests.c
@@ -30,8 +30,8 @@
 #include "stdio.h"
 
 /* PKCS #11 includes. */
-#include "iot_pkcs11_config.h"
-#include "iot_pkcs11.h"
+#include "core_pkcs11_config.h"
+#include "core_pkcs11.h"
 #include "pkcs11.h"
 
 /* Demo includes. */

--- a/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/examples/objects.c
+++ b/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/examples/objects.c
@@ -30,8 +30,8 @@
 #include "stdio.h"
 
 /* PKCS #11 includes. */
-#include "iot_pkcs11_config.h"
-#include "iot_pkcs11.h"
+#include "core_pkcs11_config.h"
+#include "core_pkcs11.h"
 #include "pkcs11.h"
 
 /* mbed TLS includes. */
@@ -150,7 +150,7 @@ static void prvObjectImporting( void )
     CK_BYTE xSubject[] = "TestSubject";
 
 
-    /* The PKCS11_CertificateTemplate_t is a custom struct defined in "iot_pkcs11.h"
+    /* The PKCS11_CertificateTemplate_t is a custom struct defined in "core_pkcs11.h"
      * in order to make it easier to import a certificate. This struct will be
      * populated with the parameters necessary to import the certificate into the
      * Cryptoki library.

--- a/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/examples/pkcs11_demos.h
+++ b/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/examples/pkcs11_demos.h
@@ -46,7 +46,7 @@ void vPKCS11ObjectDemo( void );
  * PKCS #11 can be used to sign a message, and verify the integrity of a message
  * using private and public keys.
  *
- * This demo will also cover the "iot_pkcs11.h" functions, and how they can be
+ * This demo will also cover the "core_pkcs11.h" functions, and how they can be
  * used to make the PKCS #11 flow easier to use.
  *
  * Warning: This demo depends on the objects created in the objects demo.

--- a/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/examples/sign_and_verify.c
+++ b/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/examples/sign_and_verify.c
@@ -30,10 +30,10 @@
 #include "stdio.h"
 
 /* PKCS #11 includes. */
-#include "iot_pkcs11_config.h"
-#include "iot_pkcs11.h"
+#include "core_pkcs11_config.h"
+#include "core_pkcs11.h"
 #include "pkcs11.h"
-#include "iot_pki_utils.h"
+#include "core_pki_utils.h"
 
 /* Demo includes. */
 #include "demo_helpers.h"
@@ -106,7 +106,7 @@ void vPKCS11SignVerifyDemo( void )
     configASSERT( pxFunctionList->C_InitToken != NULL );
     configASSERT( pxFunctionList->C_GetTokenInfo != NULL );
 
-    /* Instead of using the vStart helper, we will  use the "iot_pkcs11.h" 
+    /* Instead of using the vStart helper, we will  use the "core_pkcs11.h" 
      * functions that help wrap around some common PKCS #11 use cases. 
      *
      * This function will:

--- a/FreeRTOS-Plus/Source/Application-Protocols/platform/freertos/transport/include/tls_freertos_pkcs11.h
+++ b/FreeRTOS-Plus/Source/Application-Protocols/platform/freertos/transport/include/tls_freertos_pkcs11.h
@@ -71,7 +71,7 @@
 #include "mbedtls/pk_internal.h"
 
 /* PKCS #11 includes. */
-#include "iot_pkcs11.h"
+#include "core_pkcs11.h"
 
 /**
  * @brief Secured connection context.

--- a/FreeRTOS-Plus/Source/Application-Protocols/platform/freertos/transport/src/tls_freertos_pkcs11.c
+++ b/FreeRTOS-Plus/Source/Application-Protocols/platform/freertos/transport/src/tls_freertos_pkcs11.c
@@ -48,10 +48,10 @@
 #include "mbedtls_error.h"
 
 /* PKCS #11 includes. */
-#include "iot_pkcs11_config.h"
-#include "iot_pkcs11.h"
+#include "core_pkcs11_config.h"
+#include "core_pkcs11.h"
 #include "pkcs11.h"
-#include "iot_pki_utils.h"
+#include "core_pki_utils.h"
 
 /*-----------------------------------------------------------*/
 


### PR DESCRIPTION
Rename PKCS files to core.

Description
-----------
Removes "iot" prefix and changes it to "core".

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
