### PR TITLE
Update transport interface to remove const qualifier from send/recv

### DIFF
--- a/FreeRTOS-Plus/Source/Application-Protocols/platform/include/transport_interface.h
+++ b/FreeRTOS-Plus/Source/Application-Protocols/platform/include/transport_interface.h
@@ -165,7 +165,7 @@ typedef struct NetworkContext NetworkContext_t;
  * @return The number of bytes received or a negative error code.
  */
 /* @[define_transportrecv] */
-typedef int32_t ( * TransportRecv_t )( const NetworkContext_t * pNetworkContext,
+typedef int32_t ( * TransportRecv_t )( NetworkContext_t * pNetworkContext,
                                        void * pBuffer,
                                        size_t bytesToRecv );
 /* @[define_transportrecv] */
@@ -181,7 +181,7 @@ typedef int32_t ( * TransportRecv_t )( const NetworkContext_t * pNetworkContext,
  * @return The number of bytes sent or a negative error code.
  */
 /* @[define_transportsend] */
-typedef int32_t ( * TransportSend_t )( const NetworkContext_t * pNetworkContext,
+typedef int32_t ( * TransportSend_t )( NetworkContext_t * pNetworkContext,
                                        const void * pBuffer,
                                        size_t bytesToSend );
 /* @[define_transportsend] */


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->
This removes a warning involving const qualifiers. The `NetworkContext_t *` cannot be declared as `const` in `TransportRecv` and `TransportSend` because `mbedtls_ssl_write` and `mbedtls_ssl_read` require non-const pointers. Therefore, the const qualifier is removed from `transport_interface.h`.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
