### PR TITLE
Fix build warning due to header fileand unreferenced parameter

### DIFF
--- a/FreeRTOS-Plus/Demo/AWS/Device_Shadow_Windows_Simulator/Device_Shadow_Demo/DemoTasks/ShadowDemoMainExample.c
+++ b/FreeRTOS-Plus/Demo/AWS/Device_Shadow_Windows_Simulator/Device_Shadow_Demo/DemoTasks/ShadowDemoMainExample.c
@@ -50,6 +50,7 @@
 /* Standard includes. */
 #include <stdlib.h>
 #include <string.h>
+#include <stdio.h>
 
 /* Kernel includes. */
 #include "FreeRTOS.h"
@@ -565,6 +566,9 @@ void vStartShadowDemo( void )
 void prvShadowDemoTask( void * pvParameters )
 {
     BaseType_t demoStatus = pdPASS;
+
+    /* Remove compiler warnings about unused parameters. */
+    ( void ) pvParameters;
 
     /* A buffer containing the update document. It has static duration to prevent
      * it from being placed on the call stack. */


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->
- Add header file for snprintf to prevent building warning in Visual Studio.
- Add for compiler warning about unused parameters.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
