### PR TITLE
Add demo config for disabling SNI

### DIFF
--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Basic_TLS/DemoTasks/BasicTLSMQTTExample.c
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Basic_TLS/DemoTasks/BasicTLSMQTTExample.c
@@ -485,11 +485,7 @@ static TlsTransportStatus_t prvConnectToServerWithBackoffRetries( NetworkCredent
     /* Set the credentials for establishing a TLS connection. */
     pxNetworkCredentials->pRootCa = ( const unsigned char * ) democonfigROOT_CA_PEM;
     pxNetworkCredentials->rootCaSize = sizeof( democonfigROOT_CA_PEM );
-
-    /* When using a local Mosquitto server setup, SNI needs to be disabled for
-     * an MQTT broker that only has an IP address but no hostname. However,
-     * SNI should be enabled whenever possible. */
-    pxNetworkCredentials->disableSni = pdTRUE;
+    pxNetworkCredentials->disableSni = democonfigDISABLE_SNI;
     /* Initialize reconnect attempts and interval. */
     RetryUtils_ParamsReset( &xReconnectParams );
     xReconnectParams.maxRetryAttempts = MAX_RETRY_ATTEMPTS;

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Basic_TLS/demo_config.h
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Basic_TLS/demo_config.h
@@ -110,6 +110,14 @@
  * #define democonfigROOT_CA_PEM    "...insert here..."
  */
 
+/**
+ * @brief An option to disable Server Name Indication.
+ *
+ * @note When using a local Mosquitto server setup, SNI needs to be disabled
+ * for an MQTT broker that only has an IP address but no hostname. However,
+ * SNI should be enabled whenever possible.
+ */
+#define democonfigDISABLE_SNI            ( pdFALSE )
 
 /**
  * @brief Set the stack size of the main demo task.

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Multitask/DemoTasks/MultitaskMQTTExample.c
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Multitask/DemoTasks/MultitaskMQTTExample.c
@@ -879,6 +879,7 @@ static BaseType_t prvConnectNetwork( NetworkContext_t * pxNetworkContext )
         xNetworkCredentials.clientCertSize = sizeof( democonfigCLIENT_CERTIFICATE_PEM );
         xNetworkCredentials.pPrivateKey = ( const unsigned char * ) democonfigCLIENT_PRIVATE_KEY_PEM;
         xNetworkCredentials.privateKeySize = sizeof( democonfigCLIENT_PRIVATE_KEY_PEM );
+        xNetworkCredentials.disableSni = democonfigDISABLE_SNI;
     #else /* if defined( democonfigUSE_TLS ) && ( democonfigUSE_TLS == 1 ) */
         PlaintextTransportStatus_t xNetworkStatus = PLAINTEXT_TRANSPORT_CONNECT_FAILURE;
     #endif /* if defined( democonfigUSE_TLS ) && ( democonfigUSE_TLS == 1 ) */

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Multitask/demo_config.h
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Multitask/demo_config.h
@@ -145,11 +145,19 @@
  */
 
 /**
+ * @brief An option to disable Server Name Indication.
+ *
+ * @note When using a local Mosquitto server setup, SNI needs to be disabled
+ * for an MQTT broker that only has an IP address but no hostname. However,
+ * SNI should be enabled whenever possible.
+ */
+#define democonfigDISABLE_SNI       ( pdFALSE )
+
+/**
  * @brief Whether to use mutual authentication. If this macro is not set to 1
  * or not defined, then plaintext TCP will be used instead of TLS over TCP.
  */
-#define democonfigUSE_TLS    1
-
+#define democonfigUSE_TLS           1
 
 /**
  * @brief Set the stack size of the main demo task.

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Mutual_Auth/DemoTasks/MutualAuthMQTTExample.c
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Mutual_Auth/DemoTasks/MutualAuthMQTTExample.c
@@ -557,11 +557,23 @@ static TlsTransportStatus_t prvConnectToServerWithBackoffRetries( NetworkCredent
     RetryUtilsStatus_t xRetryUtilsStatus = RetryUtilsSuccess;
     RetryUtilsParams_t xReconnectParams;
 
-    /* ALPN protocols must be a NULL-terminated list of strings. Therefore,
-     * the first entry will contain the actual ALPN protocol string while the
-     * second entry must remain NULL. */
-    char * pcAlpnProtocols[] = { NULL, NULL };
+    #ifdef democonfigUSE_AWS_IOT_CORE_BROKER
 
+        /* ALPN protocols must be a NULL-terminated list of strings. Therefore,
+         * the first entry will contain the actual ALPN protocol string while the
+         * second entry must remain NULL. */
+        char * pcAlpnProtocols[] = { NULL, NULL };
+
+        /* The ALPN string changes depending on whether username/password authentication is used. */
+        #ifdef democonfigCLIENT_USERNAME
+            pcAlpnProtocols[ 0 ] = AWS_IOT_CUSTOM_AUTH_ALPN;
+        #else
+            pcAlpnProtocols[ 0 ] = AWS_IOT_MQTT_ALPN;
+        #endif
+        pxNetworkCredentials->pAlpnProtos = pcAlpnProtocols;
+    #endif /* ifdef democonfigUSE_AWS_IOT_CORE_BROKER */
+
+    pxNetworkCredentials->disableSni = pdDISABLE_SNI;
     /* Set the credentials for establishing a TLS connection. */
     pxNetworkCredentials->pRootCa = ( const unsigned char * ) democonfigROOT_CA_PEM;
     pxNetworkCredentials->rootCaSize = sizeof( democonfigROOT_CA_PEM );
@@ -571,22 +583,6 @@ static TlsTransportStatus_t prvConnectToServerWithBackoffRetries( NetworkCredent
         pxNetworkCredentials->pPrivateKey = ( const unsigned char * ) democonfigCLIENT_PRIVATE_KEY_PEM;
         pxNetworkCredentials->privateKeySize = sizeof( democonfigCLIENT_PRIVATE_KEY_PEM );
     #endif
-    #ifdef democonfigUSE_AWS_IOT_CORE_BROKER
-        pxNetworkCredentials->disableSni = pdFALSE;
-        /* The ALPN string changes depending on whether username/password authentication is used. */
-        #ifdef democonfigCLIENT_USERNAME
-            pcAlpnProtocols[ 0 ] = AWS_IOT_CUSTOM_AUTH_ALPN;
-        #else
-            pcAlpnProtocols[ 0 ] = AWS_IOT_MQTT_ALPN;
-        #endif
-        pxNetworkCredentials->pAlpnProtos = pcAlpnProtocols;
-    #else /* ifdef democonfigUSE_AWS_IOT_CORE_BROKER */
-
-        /* When using a local Mosquitto server setup, SNI needs to be disabled for
-         * an MQTT broker that only has an IP address but no hostname. However,
-         * SNI should be enabled whenever possible. */
-        pxNetworkCredentials->disableSni = pdTRUE;
-    #endif /* ifdef democonfigUSE_AWS_IOT_CORE_BROKER */
     /* Initialize reconnect attempts and interval. */
     RetryUtils_ParamsReset( &xReconnectParams );
     xReconnectParams.maxRetryAttempts = MAX_RETRY_ATTEMPTS;

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Mutual_Auth/DemoTasks/MutualAuthMQTTExample.c
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Mutual_Auth/DemoTasks/MutualAuthMQTTExample.c
@@ -573,7 +573,7 @@ static TlsTransportStatus_t prvConnectToServerWithBackoffRetries( NetworkCredent
         pxNetworkCredentials->pAlpnProtos = pcAlpnProtocols;
     #endif /* ifdef democonfigUSE_AWS_IOT_CORE_BROKER */
 
-    pxNetworkCredentials->disableSni = pdDISABLE_SNI;
+    pxNetworkCredentials->disableSni = democonfigDISABLE_SNI;
     /* Set the credentials for establishing a TLS connection. */
     pxNetworkCredentials->pRootCa = ( const unsigned char * ) democonfigROOT_CA_PEM;
     pxNetworkCredentials->rootCaSize = sizeof( democonfigROOT_CA_PEM );

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Mutual_Auth/demo_config.h
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Mutual_Auth/demo_config.h
@@ -144,6 +144,15 @@
  */
 
 /**
+ * @brief An option to disable Server Name Indication.
+ *
+ * @note When using a local Mosquitto server setup, SNI needs to be disabled
+ * for an MQTT broker that only has an IP address but no hostname. However,
+ * SNI should be enabled whenever possible.
+ */
+#define democonfigDISABLE_SNI    ( pdFALSE )
+
+/**
  * @brief Configuration that indicates if the demo connection is made to the AWS IoT Core MQTT broker.
  *
  * If username/password based authentication is used, the demo will use appropriate TLS ALPN and


### PR DESCRIPTION
<!--- Title -->
This creates a democonfigDISABLE_SNI option for the demos so that it can easily be toggled by users who are using a local MQTT broker with no hostname. It should be enabled by default though.

Description
-----------
<!--- Describe your changes in detail. -->

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
