### PR TITLE
Improve connection sharing demo

### DIFF
--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Multitask/DemoTasks/MultitaskMQTTExample.c
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Multitask/DemoTasks/MultitaskMQTTExample.c
@@ -416,8 +416,13 @@ static MQTTStatus_t prvMQTTConnect( MQTTContext_t * pxMQTTContext,
 /**
  * @brief Resume a session by resending publishes if a session is present in
  * the broker, or reestablish subscriptions if not.
+ *
+ * @param[in] xSessionPresent The session present flag from the broker.
+ *
+ * @return `MQTTSuccess` if it succeeds in resending publishes, else an
+ * appropriate error code from `MQTT_Publish()`
  */
-static void prvResumeSession( bool xSessionPresent );
+static MQTTStatus_t prvResumeSession( bool xSessionPresent );
 
 /**
  * @brief Form a TCP connection to a server.
@@ -840,12 +845,12 @@ static MQTTStatus_t prvMQTTConnect( MQTTContext_t * pxMQTTContext,
                             mqttexampleCONNACK_RECV_TIMEOUT_MS,
                             &xSessionPresent );
 
-    LogInfo( ( "Session present: %d", xSessionPresent ) );
+    LogInfo( ( "Session present: %d\n", xSessionPresent ) );
 
     /* Resume a session if desired. */
     if( ( xResult == MQTTSuccess ) && !xCleanSession )
     {
-        prvResumeSession( xSessionPresent );
+        xResult = prvResumeSession( xSessionPresent );
     }
 
     return xResult;
@@ -853,9 +858,9 @@ static MQTTStatus_t prvMQTTConnect( MQTTContext_t * pxMQTTContext,
 
 /*-----------------------------------------------------------*/
 
-static void prvResumeSession( bool xSessionPresent )
+static MQTTStatus_t prvResumeSession( bool xSessionPresent )
 {
-    MQTTStatus_t xResult;
+    MQTTStatus_t xResult = MQTTSuccess;
 
     /* Resend publishes if session is present. NOTE: It's possible that some
      * of the operations that were in progress during the network interruption
@@ -882,6 +887,12 @@ static void prvResumeSession( bool xSessionPresent )
                 /* Set the DUP flag. */
                 xFoundAck.xOriginalCommand.pxCmdContext->pxPublishInfo->dup = true;
                 xResult = MQTT_Publish( &globalMqttContext, xFoundAck.xOriginalCommand.pxCmdContext->pxPublishInfo, packetId );
+
+                if( xResult != MQTTSuccess )
+                {
+                    LogError( ( "Error in resending publishes. Error code=%s\n", MQTT_Status_strerror( xResult ) ) );
+                    break;
+                }
             }
 
             packetId = MQTT_PublishToResend( &globalMqttContext, &cursor );
@@ -946,13 +957,15 @@ static void prvResumeSession( bool xSessionPresent )
             configASSERT( xCommandAdded == pdTRUE );
         }
     }
+
+    return xResult;
 }
 
 /*-----------------------------------------------------------*/
 
 static BaseType_t prvSocketConnect( NetworkContext_t * pxNetworkContext )
 {
-    bool xConnected = false;
+    BaseType_t xConnected = pdFAIL;
     RetryUtilsStatus_t xRetryUtilsStatus = RetryUtilsSuccess;
     RetryUtilsParams_t xReconnectParams;
 
@@ -986,25 +999,27 @@ static BaseType_t prvSocketConnect( NetworkContext_t * pxNetworkContext )
         /* Establish a TCP connection with the MQTT broker. This example connects to
          * the MQTT broker as specified in democonfigMQTT_BROKER_ENDPOINT and
          * democonfigMQTT_BROKER_PORT at the top of this file. */
-        LogInfo( ( "Creating a TCP connection to %s:%d.",
-                   democonfigMQTT_BROKER_ENDPOINT,
-                   democonfigMQTT_BROKER_PORT ) );
-
         #if defined( democonfigUSE_TLS ) && ( democonfigUSE_TLS == 1 )
+            LogInfo( ( "Creating a TLS connection to %s:%d.",
+                       democonfigMQTT_BROKER_ENDPOINT,
+                       democonfigMQTT_BROKER_PORT ) );
             xNetworkStatus = TLS_FreeRTOS_Connect( pxNetworkContext,
                                                    democonfigMQTT_BROKER_ENDPOINT,
                                                    democonfigMQTT_BROKER_PORT,
                                                    &xNetworkCredentials,
                                                    mqttexampleTRANSPORT_SEND_RECV_TIMEOUT_MS,
                                                    mqttexampleTRANSPORT_SEND_RECV_TIMEOUT_MS );
-            xConnected = ( xNetworkStatus == TLS_TRANSPORT_SUCCESS ) ? true : false;
-        #else
+            xConnected = ( xNetworkStatus == TLS_TRANSPORT_SUCCESS ) ? pdPASS : pdFAIL;
+        #else  /* if defined( democonfigUSE_TLS ) && ( democonfigUSE_TLS == 1 ) */
+            LogInfo( ( "Creating a TCP connection to %s:%d.",
+                       democonfigMQTT_BROKER_ENDPOINT,
+                       democonfigMQTT_BROKER_PORT ) );
             xNetworkStatus = Plaintext_FreeRTOS_Connect( pxNetworkContext,
                                                          democonfigMQTT_BROKER_ENDPOINT,
                                                          democonfigMQTT_BROKER_PORT,
                                                          mqttexampleTRANSPORT_SEND_RECV_TIMEOUT_MS,
                                                          mqttexampleTRANSPORT_SEND_RECV_TIMEOUT_MS );
-            xConnected = ( xNetworkStatus == PLAINTEXT_TRANSPORT_SUCCESS ) ? true : false;
+            xConnected = ( xNetworkStatus == PLAINTEXT_TRANSPORT_SUCCESS ) ? pdPASS : pdFAIL;
         #endif /* if defined( democonfigUSE_TLS ) && ( democonfigUSE_TLS == 1 ) */
 
         if( !xConnected )
@@ -1017,7 +1032,7 @@ static BaseType_t prvSocketConnect( NetworkContext_t * pxNetworkContext )
         {
             LogError( ( "Connection to the broker failed. All attempts exhausted." ) );
         }
-    } while( ( xConnected != true ) && ( xRetryUtilsStatus == RetryUtilsSuccess ) );
+    } while( ( xConnected != pdPASS ) && ( xRetryUtilsStatus == RetryUtilsSuccess ) );
 
     /* Set the socket wakeup callback. */
     if( xConnected )
@@ -1029,7 +1044,7 @@ static BaseType_t prvSocketConnect( NetworkContext_t * pxNetworkContext )
                                       sizeof( &( prvMQTTClientSocketWakeupCallback ) ) );
     }
 
-    return ( xConnected ) ? pdPASS : pdFAIL;
+    return xConnected;
 }
 
 /*-----------------------------------------------------------*/
@@ -1037,8 +1052,6 @@ static BaseType_t prvSocketConnect( NetworkContext_t * pxNetworkContext )
 static BaseType_t prvSocketDisconnect( NetworkContext_t * pxNetworkContext )
 {
     BaseType_t xDisconnected = pdFAIL;
-
-    LogInfo( ( "Disconnecting TCP connection.\n" ) );
 
     /* Set the wakeup callback to NULL since the socket will disconnect. */
     ( void ) FreeRTOS_setsockopt( pxNetworkContext->tcpSocket,
@@ -1048,9 +1061,11 @@ static BaseType_t prvSocketDisconnect( NetworkContext_t * pxNetworkContext )
                                   sizeof( void * ) );
 
     #if defined( democonfigUSE_TLS ) && ( democonfigUSE_TLS == 1 )
+        LogInfo( ( "Disconnecting TLS connection.\n" ) );
         TLS_FreeRTOS_Disconnect( pxNetworkContext );
         xDisconnected = pdPASS;
     #else
+        LogInfo( ( "Disconnecting TCP connection.\n" ) );
         PlaintextTransportStatus_t xNetworkStatus = PLAINTEXT_TRANSPORT_CONNECT_FAILURE;
         xNetworkStatus = Plaintext_FreeRTOS_Disconnect( pxNetworkContext );
         xDisconnected = ( xNetworkStatus == PLAINTEXT_TRANSPORT_SUCCESS ) ? pdPASS : pdFAIL;
@@ -1141,7 +1156,7 @@ static AckInfo_t prvGetAwaitingOperation( uint16_t usPacketId,
 
     if( xFoundAck.usPacketId == MQTT_PACKET_ID_INVALID )
     {
-        LogError( ( "No ack found for packet id %u.", usPacketId ) );
+        LogError( ( "No ack found for packet id %u.\n", usPacketId ) );
     }
 
     return xFoundAck;
@@ -1168,7 +1183,7 @@ static void prvAddSubscription( const char * pcTopicFilter,
             /* If a subscription already exists, don't do anything. */
             if( pxSubscriptions[ i ].pxResponseQueue == pxQueue )
             {
-                LogWarn( ( "Subscription already exists." ) );
+                LogWarn( ( "Subscription already exists.\n" ) );
                 ulAvailableIndex = mqttexampleSUBSCRIPTIONS_MAX_COUNT;
                 break;
             }
@@ -1382,7 +1397,7 @@ static MQTTStatus_t prvProcessCommand( Command_t * pxCommand )
          * information. */
         if( !xAckAdded )
         {
-            LogError( ( "No memory to wait for acknowledgment for packet %u", usPacketId ) );
+            LogError( ( "No memory to wait for acknowledgment for packet %u\n", usPacketId ) );
 
             /* All operations that can wait for acks (publish, subscribe, unsubscribe)
              * require a context. */
@@ -1452,7 +1467,7 @@ static void prvHandleIncomingPublish( MQTTPublishInfo_t * pxPublishInfo )
      * receive these publishes. */
     if( !xRelayedPublish )
     {
-        LogWarn( ( "Publish received on topic %.*s with no subscription.",
+        LogWarn( ( "Publish received on topic %.*s with no subscription.\n",
                    pxPublishInfo->topicNameLength,
                    pxPublishInfo->pTopicName ) );
         xPublishCopied = prvCopyPublishToQueue( pxPublishInfo, xDefaultResponseQueue );
@@ -1496,7 +1511,7 @@ static void prvHandleSubscriptionAcks( MQTTPacketInfo_t * pxPacketInfo,
             }
             else
             {
-                LogError( ( "Subscription to %.*s failed.",
+                LogError( ( "Subscription to %.*s failed.\n",
                             pxSubscribeInfo[ i ].topicFilterLength,
                             pxSubscribeInfo[ i ].pTopicFilter ) );
             }
@@ -1572,7 +1587,7 @@ static void prvEventCallback( MQTTContext_t * pMqttContext,
                 }
                 else
                 {
-                    LogError( ( "No subscription or unsubscribe operation found matching packet id %u.", packetIdentifier ) );
+                    LogError( ( "No subscription or unsubscribe operation found matching packet id %u.\n", packetIdentifier ) );
                 }
 
                 break;
@@ -1587,12 +1602,12 @@ static void prvEventCallback( MQTTContext_t * pMqttContext,
                 /* Nothing to be done from application as library handles
                  * PINGRESP. */
                 LogWarn( ( "PINGRESP should not be handled by the application "
-                           "callback when using MQTT_ProcessLoop.\n\n" ) );
+                           "callback when using MQTT_ProcessLoop.\n" ) );
                 break;
 
             /* Any other packet type is invalid. */
             default:
-                LogError( ( "Unknown packet type received:(%02x).\n\n",
+                LogError( ( "Unknown packet type received:(%02x).\n",
                             pPacketInfo->type ) );
         }
     }
@@ -1627,7 +1642,7 @@ static void prvCommandLoop( void )
         /* Add connect operation to front of queue if status was not successful. */
         if( xStatus != MQTTSuccess )
         {
-            LogError( ( "MQTT operation failed with status %s",
+            LogError( ( "MQTT operation failed with status %s\n",
                         MQTT_Status_strerror( xStatus ) ) );
             prvCreateCommand( RECONNECT, NULL, NULL, &xNewCommand );
             xCommandAdded = xQueueSendToFront( xCommandQueue, &xNewCommand, mqttexampleDEMO_TICKS_TO_WAIT );
@@ -1881,7 +1896,6 @@ void prvSubscribeTask( void * pvParameters )
     xSubscribeInfo.pTopicFilter = mqttexampleSUBSCRIBE_TOPIC_FILTER;
     xSubscribeInfo.topicFilterLength = ( uint16_t ) strlen( xSubscribeInfo.pTopicFilter );
     LogInfo( ( "Topic filter: %.*s", xSubscribeInfo.topicFilterLength, xSubscribeInfo.pTopicFilter ) );
-    LogInfo( ( "Filter length: %d", xSubscribeInfo.topicFilterLength ) );
 
     /* Create the context and subscribe command. */
     prvInitializeCommandContext( &xContext );

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Multitask/FreeRTOSIPConfig.h
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Multitask/FreeRTOSIPConfig.h
@@ -124,7 +124,7 @@ extern UBaseType_t uxRand();
  * is not set to 1 then the network event hook will never be called.  See
  * http://www.FreeRTOS.org/FreeRTOS-Plus/FreeRTOS_Plus_UDP/API/vApplicationIPNetworkEventHook.shtml
  */
-#define ipconfigUSE_NETWORK_EVENT_HOOK                        1
+#define ipconfigUSE_NETWORK_EVENT_HOOK                 1
 
 /* Sockets have a send block time attribute.  If FreeRTOS_sendto() is called but
  * a network buffer cannot be obtained then the calling task is held in the Blocked
@@ -138,7 +138,7 @@ extern UBaseType_t uxRand();
  * ipconfigMAX_SEND_BLOCK_TIME_TICKS is specified in RTOS ticks.  A time in
  * milliseconds can be converted to a time in ticks by dividing the time in
  * milliseconds by portTICK_PERIOD_MS. */
-#define ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS                 ( 5000 / portTICK_PERIOD_MS )
+#define ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS          ( 5000 / portTICK_PERIOD_MS )
 
 /* If ipconfigUSE_DHCP is 1 then FreeRTOS+TCP will attempt to retrieve an IP
  * address, netmask, DNS server address and gateway address from a DHCP server.  If
@@ -147,7 +147,7 @@ extern UBaseType_t uxRand();
  * set to 1 if a valid configuration cannot be obtained from a DHCP server for any
  * reason.  The static configuration used is that passed into the stack by the
  * FreeRTOS_IPInit() function call. */
-#define ipconfigUSE_DHCP                                      1
+#define ipconfigUSE_DHCP                               1
 
 /* When ipconfigUSE_DHCP is set to 1, DHCP requests will be sent out at
  * increasing time intervals until either a reply is received from a DHCP server
@@ -156,7 +156,7 @@ extern UBaseType_t uxRand();
  * static IP address passed as a parameter to FreeRTOS_IPInit() if the
  * re-transmission time interval reaches ipconfigMAXIMUM_DISCOVER_TX_PERIOD without
  * a DHCP reply being received. */
-#define ipconfigMAXIMUM_DISCOVER_TX_PERIOD                    ( 120000 / portTICK_PERIOD_MS )
+#define ipconfigMAXIMUM_DISCOVER_TX_PERIOD             ( 120000 / portTICK_PERIOD_MS )
 
 /* The ARP cache is a table that maps IP addresses to MAC addresses.  The IP
  * stack can only send a UDP message to a remove IP address if it knowns the MAC
@@ -167,19 +167,19 @@ extern UBaseType_t uxRand();
  * cache then the UDP message is replaced by a ARP message that solicits the
  * required MAC address information.  ipconfigARP_CACHE_ENTRIES defines the maximum
  * number of entries that can exist in the ARP table at any one time. */
-#define ipconfigARP_CACHE_ENTRIES                             6
+#define ipconfigARP_CACHE_ENTRIES                      6
 
 /* ARP requests that do not result in an ARP response will be re-transmitted a
  * maximum of ipconfigMAX_ARP_RETRANSMISSIONS times before the ARP request is
  * aborted. */
-#define ipconfigMAX_ARP_RETRANSMISSIONS                       ( 5 )
+#define ipconfigMAX_ARP_RETRANSMISSIONS                ( 5 )
 
 /* ipconfigMAX_ARP_AGE defines the maximum time between an entry in the ARP
  * table being created or refreshed and the entry being removed because it is stale.
  * New ARP requests are sent for ARP cache entries that are nearing their maximum
  * age.  ipconfigMAX_ARP_AGE is specified in tens of seconds, so a value of 150 is
  * equal to 1500 seconds (or 25 minutes). */
-#define ipconfigMAX_ARP_AGE                                   150
+#define ipconfigMAX_ARP_AGE                            150
 
 /* Implementing FreeRTOS_inet_addr() necessitates the use of string handling
  * routines, which are relatively large.  To save code space the full
@@ -191,19 +191,19 @@ extern UBaseType_t uxRand();
  * ipconfigINCLUDE_FULL_INET_ADDR is set to 1 then both FreeRTOS_inet_addr() and
  * FreeRTOS_indet_addr_quick() are available.  If ipconfigINCLUDE_FULL_INET_ADDR is
  * not set to 1 then only FreeRTOS_indet_addr_quick() is available. */
-#define ipconfigINCLUDE_FULL_INET_ADDR                        1
+#define ipconfigINCLUDE_FULL_INET_ADDR                 1
 
 /* ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS defines the total number of network buffer that
  * are available to the IP stack.  The total number of network buffers is limited
  * to ensure the total amount of RAM that can be consumed by the IP stack is capped
  * to a pre-determinable value. */
-#define ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS                60
+#define ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS         60
 
 /* A FreeRTOS queue is used to send events from application tasks to the IP
  * stack.  ipconfigEVENT_QUEUE_LENGTH sets the maximum number of events that can
  * be queued for processing at any one time.  The event queue must be a minimum of
  * 5 greater than the total number of network buffers. */
-#define ipconfigEVENT_QUEUE_LENGTH                            ( ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS + 5 )
+#define ipconfigEVENT_QUEUE_LENGTH                     ( ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS + 5 )
 
 /* The address of a socket is the combination of its IP address and its port
  * number.  FreeRTOS_bind() is used to manually allocate a port number to a socket
@@ -217,48 +217,48 @@ extern UBaseType_t uxRand();
  * ipconfigALLOW_SOCKET_SEND_WITHOUT_BIND is set to 0 then calling FreeRTOS_sendto()
  * on a socket that has not yet been bound will result in the send operation being
  * aborted. */
-#define ipconfigALLOW_SOCKET_SEND_WITHOUT_BIND                1
+#define ipconfigALLOW_SOCKET_SEND_WITHOUT_BIND         1
 
 /* Defines the Time To Live (TTL) values used in outgoing UDP packets. */
-#define ipconfigUDP_TIME_TO_LIVE                              128
-#define ipconfigTCP_TIME_TO_LIVE                              128 /* also defined in FreeRTOSIPConfigDefaults.h */
+#define ipconfigUDP_TIME_TO_LIVE                       128
+#define ipconfigTCP_TIME_TO_LIVE                       128        /* also defined in FreeRTOSIPConfigDefaults.h */
 
 /* USE_TCP: Use TCP and all its features */
-#define ipconfigUSE_TCP                                       ( 1 )
+#define ipconfigUSE_TCP                                ( 1 )
 
 /* Use the TCP socket wake context with a callback. */
-#define ipconfigSOCKET_HAS_USER_WAKE_CALLBACK_WITH_CONTEXT    ( 1 )
+#define ipconfigSOCKET_HAS_USER_WAKE_CALLBACK          ( 1 )
 
 /* USE_WIN: Let TCP use windowing mechanism. */
-#define ipconfigUSE_TCP_WIN                                   ( 1 )
+#define ipconfigUSE_TCP_WIN                            ( 1 )
 
 /* The MTU is the maximum number of bytes the payload of a network frame can
  * contain.  For normal Ethernet V2 frames the maximum MTU is 1500.  Setting a
  * lower value can save RAM, depending on the buffer management scheme used.  If
  * ipconfigCAN_FRAGMENT_OUTGOING_PACKETS is 1 then (ipconfigNETWORK_MTU - 28) must
  * be divisible by 8. */
-#define ipconfigNETWORK_MTU                                   1200
+#define ipconfigNETWORK_MTU                            1200
 
 /* Set ipconfigUSE_DNS to 1 to include a basic DNS client/resolver.  DNS is used
  * through the FreeRTOS_gethostbyname() API function. */
-#define ipconfigUSE_DNS                                       1
+#define ipconfigUSE_DNS                                1
 
 /* If ipconfigREPLY_TO_INCOMING_PINGS is set to 1 then the IP stack will
  * generate replies to incoming ICMP echo (ping) requests. */
-#define ipconfigREPLY_TO_INCOMING_PINGS                       1
+#define ipconfigREPLY_TO_INCOMING_PINGS                1
 
 /* If ipconfigSUPPORT_OUTGOING_PINGS is set to 1 then the
  * FreeRTOS_SendPingRequest() API function is available. */
-#define ipconfigSUPPORT_OUTGOING_PINGS                        0
+#define ipconfigSUPPORT_OUTGOING_PINGS                 0
 
 /* If ipconfigSUPPORT_SELECT_FUNCTION is set to 1 then the FreeRTOS_select()
  * (and associated) API function is available. */
-#define ipconfigSUPPORT_SELECT_FUNCTION                       1
+#define ipconfigSUPPORT_SELECT_FUNCTION                1
 
 /* If ipconfigFILTER_OUT_NON_ETHERNET_II_FRAMES is set to 1 then Ethernet frames
  * that are not in Ethernet II format will be dropped.  This option is included for
  * potential future IP stack developments. */
-#define ipconfigFILTER_OUT_NON_ETHERNET_II_FRAMES             1
+#define ipconfigFILTER_OUT_NON_ETHERNET_II_FRAMES      1
 
 /* If ipconfigETHERNET_DRIVER_FILTERS_FRAME_TYPES is set to 1 then it is the
  * responsibility of the Ethernet interface to filter out packets that are of no
@@ -268,30 +268,30 @@ extern UBaseType_t uxRand();
  * because the packet will already have been passed into the stack).  If the
  * Ethernet driver does all the necessary filtering in hardware then software
  * filtering can be removed by using a value other than 1 or 0. */
-#define ipconfigETHERNET_DRIVER_FILTERS_FRAME_TYPES           1
+#define ipconfigETHERNET_DRIVER_FILTERS_FRAME_TYPES    1
 
 /* The windows simulator cannot really simulate MAC interrupts, and needs to
  * block occasionally to allow other tasks to run. */
-#define configWINDOWS_MAC_INTERRUPT_SIMULATOR_DELAY           ( 20 / portTICK_PERIOD_MS )
+#define configWINDOWS_MAC_INTERRUPT_SIMULATOR_DELAY    ( 20 / portTICK_PERIOD_MS )
 
 /* Advanced only: in order to access 32-bit fields in the IP packets with
  * 32-bit memory instructions, all packets will be stored 32-bit-aligned, plus 16-bits.
  * This has to do with the contents of the IP-packets: all 32-bit fields are
  * 32-bit-aligned, plus 16-bit(!) */
-#define ipconfigPACKET_FILLER_SIZE                            2
+#define ipconfigPACKET_FILLER_SIZE                     2
 
 /* Define the size of the pool of TCP window descriptors.  On the average, each
  * TCP socket will use up to 2 x 6 descriptors, meaning that it can have 2 x 6
  * outstanding packets (for Rx and Tx).  When using up to 10 TP sockets
  * simultaneously, one could define TCP_WIN_SEG_COUNT as 120. */
-#define ipconfigTCP_WIN_SEG_COUNT                             240
+#define ipconfigTCP_WIN_SEG_COUNT                      240
 
 /* Each TCP socket has a circular buffers for Rx and Tx, which have a fixed
  * maximum size.  Define the size of Rx buffer for TCP sockets. */
-#define ipconfigTCP_RX_BUFFER_LENGTH                          ( 1000 )
+#define ipconfigTCP_RX_BUFFER_LENGTH                   ( 1000 )
 
 /* Define the size of Tx buffer for TCP sockets. */
-#define ipconfigTCP_TX_BUFFER_LENGTH                          ( 1000 )
+#define ipconfigTCP_TX_BUFFER_LENGTH                   ( 1000 )
 
 /* When using call-back handlers, the driver may check if the handler points to
  * real program memory (RAM or flash) or just has a random non-zero value. */

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Multitask/demo_config.h
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Multitask/demo_config.h
@@ -154,13 +154,77 @@
  * for an MQTT broker that only has an IP address but no hostname. However,
  * SNI should be enabled whenever possible.
  */
-#define democonfigDISABLE_SNI       ( pdFALSE )
+#define democonfigDISABLE_SNI    ( pdFALSE )
+
+/**
+ * @brief Configuration that indicates if the demo connection is made to the AWS IoT Core MQTT broker.
+ *
+ * If username/password based authentication is used, the demo will use appropriate TLS ALPN and
+ * SNI configurations as required for the Custom Authentication feature of AWS IoT.
+ * For more information, refer to the following documentation:
+ * https://docs.aws.amazon.com/iot/latest/developerguide/custom-auth.html#custom-auth-mqtt
+ *
+ * #define democonfigUSE_AWS_IOT_CORE_BROKER    ( 1 )
+ */
+
+/**
+ * @brief The username value for authenticating client to the MQTT broker when
+ * username/password based client authentication is used.
+ *
+ * For AWS IoT MQTT broker, refer to the AWS IoT documentation below for
+ * details regarding client authentication with a username and password.
+ * https://docs.aws.amazon.com/iot/latest/developerguide/custom-authentication.html
+ * An authorizer setup needs to be done, as mentioned in the above link, to use
+ * username/password based client authentication.
+ *
+ * #define democonfigCLIENT_USERNAME    "...insert here..."
+ */
+
+/**
+ * @brief The password value for authenticating client to the MQTT broker when
+ * username/password based client authentication is used.
+ *
+ * For AWS IoT MQTT broker, refer to the AWS IoT documentation below for
+ * details regarding client authentication with a username and password.
+ * https://docs.aws.amazon.com/iot/latest/developerguide/custom-authentication.html
+ * An authorizer setup needs to be done, as mentioned in the above link, to use
+ * username/password based client authentication.
+ *
+ * #define democonfigCLIENT_PASSWORD    "...insert here..."
+ */
+
+/**
+ * @brief The name of the operating system that the application is running on.
+ * The current value is given as an example. Please update for your specific
+ * operating system.
+ */
+#define democonfigOS_NAME                   "FreeRTOS"
+
+/**
+ * @brief The version of the operating system that the application is running
+ * on. The current value is given as an example. Please update for your specific
+ * operating system version.
+ */
+#define democonfigOS_VERSION                tskKERNEL_VERSION_NUMBER
+
+/**
+ * @brief The name of the hardware platform the application is running on. The
+ * current value is given as an example. Please update for your specific
+ * hardware platform.
+ */
+#define democonfigHARDWARE_PLATFORM_NAME    "WinSim"
+
+/**
+ * @brief The name of the MQTT library used and its version, following an "@"
+ * symbol.
+ */
+#define democonfigMQTT_LIB                  "core-mqtt@1.0.0"
 
 /**
  * @brief Whether to use mutual authentication. If this macro is not set to 1
  * or not defined, then plaintext TCP will be used instead of TLS over TCP.
  */
-#define democonfigUSE_TLS           1
+#define democonfigUSE_TLS                   1
 
 /**
  * @brief Set the stack size of the main demo task.
@@ -168,6 +232,6 @@
  * In the Windows port, this stack only holds a structure. The actual
  * stack is created by an operating system thread.
  */
-#define democonfigDEMO_STACKSIZE    configMINIMAL_STACK_SIZE
+#define democonfigDEMO_STACKSIZE            configMINIMAL_STACK_SIZE
 
 #endif /* DEMO_CONFIG_H */


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->
Makes changes to the connection sharing demo after feedback. Changes include:
* Add a daemon socket listener so that the process loop will only execute if data is available on the socket.
* Set process loop timeout to 0 so that other commands do not have to wait for a process loop that isn't doing anything.
* Creates an additional publisher task to show multiple tasks publishing simultaneously.
* Clarify what is meant by "synchronous" and "asynchronous" publishes.
* Fix possible race condition in task notification waits.
* Move task notification wait loops to its own function.
* The `prvMQTTConnect` function was doing more than just connecting, so it was split into more functions.
* Minor name changes for clarity.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->
Tested locally against mosquitto and the AWS IoT Broker.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
