### PR TITLE
Run CBMC with new malloc flags.

### DIFF
--- a/FreeRTOS/Test/CBMC/proofs/MakefileCommon.json
+++ b/FreeRTOS/Test/CBMC/proofs/MakefileCommon.json
@@ -34,7 +34,10 @@
 	"--object-bits 7",
 	"--32",
 	"--bounds-check",
-	"--pointer-check"
+	"--pointer-check",
+        "--pointer-primitive-check",
+	"--malloc-fail-null",
+	"--malloc-may-fail"
     ],
 
     "FORWARD_SLASH": ["/"],


### PR DESCRIPTION
This pull request runs the CBMC proofs with the new malloc flags that change the model of malloc:  With these flags, malloc will either fail and return NULL or succeed and return a valid pointer.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
