### PR TITLE
Update the submodule pointer for FreeRTOS-Plus-TCP

### DIFF
--- a/FreeRTOS-Plus/Demo/AWS/Device_Shadow_Windows_Simulator/Device_Shadow_Demo/DemoTasks/ShadowDemoMainExample.c
+++ b/FreeRTOS-Plus/Demo/AWS/Device_Shadow_Windows_Simulator/Device_Shadow_Demo/DemoTasks/ShadowDemoMainExample.c
@@ -283,7 +283,6 @@ static void prvUpdateDeltaHandler( MQTTPublishInfo_t * pxPublishInfo )
                               pxPublishInfo->payloadLength,
                               "version",
                               sizeof( "version" ) - 1,
-                              '.',
                               &pcOutValue,
                               ( size_t * ) &ulOutValueLength );
     }
@@ -320,7 +319,6 @@ static void prvUpdateDeltaHandler( MQTTPublishInfo_t * pxPublishInfo )
                               pxPublishInfo->payloadLength,
                               "state.powerOn",
                               sizeof( "state.powerOn" ) - 1,
-                              '.',
                               &pcOutValue,
                               ( size_t * ) &ulOutValueLength );
     }
@@ -410,7 +408,6 @@ static void prvUpdateAcceptedHandler( MQTTPublishInfo_t * pxPublishInfo )
                               pxPublishInfo->payloadLength,
                               "clientToken",
                               sizeof( "clientToken" ) - 1,
-                              '.',
                               &pcOutValue,
                               ( size_t * ) &ulOutValueLength );
     }


### PR DESCRIPTION
Description
-----------
This PR updates the FreeRTOS-Plus-TCP submodule pointer to point to v2.3.1 (from v2.3.0).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
