### PR TITLE
Filter mbedtls headers in Visual Studio Project for Shadow Demo

### DIFF
--- a/FreeRTOS-Plus/Demo/AWS/Device_Shadow_Windows_Simulator/Device_Shadow_Demo/WIN32.vcxproj.filters
+++ b/FreeRTOS-Plus/Demo/AWS/Device_Shadow_Windows_Simulator/Device_Shadow_Demo/WIN32.vcxproj.filters
@@ -165,244 +165,246 @@
     <ClCompile Include="..\..\..\..\Source\Application-Protocols\network_transport\freertos_plus_tcp\sockets_wrapper.c">
       <Filter>FreeRTOS+\FreeRTOS IoT Libraries\platform\transport</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\aes.c" >
+    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\aes.c">
       <Filter>FreeRTOS+\mbedtls\library</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\aesni.c" >
+    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\aesni.c">
       <Filter>FreeRTOS+\mbedtls\library</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\arc4.c" >
+    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\arc4.c">
       <Filter>FreeRTOS+\mbedtls\library</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\aria.c" >
+    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\aria.c">
       <Filter>FreeRTOS+\mbedtls\library</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\asn1parse.c" >
+    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\asn1parse.c">
       <Filter>FreeRTOS+\mbedtls\library</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\asn1write.c" >
+    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\asn1write.c">
       <Filter>FreeRTOS+\mbedtls\library</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\base64.c" >
+    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\base64.c">
       <Filter>FreeRTOS+\mbedtls\library</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\bignum.c" >
+    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\bignum.c">
       <Filter>FreeRTOS+\mbedtls\library</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\blowfish.c" >
+    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\blowfish.c">
       <Filter>FreeRTOS+\mbedtls\library</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\camellia.c" >
+    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\camellia.c">
       <Filter>FreeRTOS+\mbedtls\library</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\ccm.c" >
+    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\ccm.c">
       <Filter>FreeRTOS+\mbedtls\library</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\certs.c" >
+    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\certs.c">
       <Filter>FreeRTOS+\mbedtls\library</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\chacha20.c" >
+    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\chacha20.c">
       <Filter>FreeRTOS+\mbedtls\library</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\chachapoly.c" >
+    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\chachapoly.c">
       <Filter>FreeRTOS+\mbedtls\library</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\cipher.c" >
+    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\cipher.c">
       <Filter>FreeRTOS+\mbedtls\library</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\cipher_wrap.c" >
+    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\cipher_wrap.c">
       <Filter>FreeRTOS+\mbedtls\library</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\cmac.c" >
+    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\cmac.c">
       <Filter>FreeRTOS+\mbedtls\library</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\ctr_drbg.c" >
+    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\ctr_drbg.c">
       <Filter>FreeRTOS+\mbedtls\library</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\debug.c" >
+    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\debug.c">
       <Filter>FreeRTOS+\mbedtls\library</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\des.c" >
+    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\des.c">
       <Filter>FreeRTOS+\mbedtls\library</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\dhm.c" >
+    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\dhm.c">
       <Filter>FreeRTOS+\mbedtls\library</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\ecdh.c" >
+    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\ecdh.c">
       <Filter>FreeRTOS+\mbedtls\library</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\ecdsa.c" >
+    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\ecdsa.c">
       <Filter>FreeRTOS+\mbedtls\library</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\ecjpake.c" >
+    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\ecjpake.c">
       <Filter>FreeRTOS+\mbedtls\library</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\ecp.c" >
+    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\ecp.c">
       <Filter>FreeRTOS+\mbedtls\library</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\ecp_curves.c" >
+    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\ecp_curves.c">
       <Filter>FreeRTOS+\mbedtls\library</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\entropy.c" >
+    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\entropy.c">
       <Filter>FreeRTOS+\mbedtls\library</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\entropy_poll.c" >
+    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\entropy_poll.c">
       <Filter>FreeRTOS+\mbedtls\library</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\error.c" >
+    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\error.c">
       <Filter>FreeRTOS+\mbedtls\library</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\gcm.c" >
+    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\gcm.c">
       <Filter>FreeRTOS+\mbedtls\library</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\havege.c" >
+    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\havege.c">
       <Filter>FreeRTOS+\mbedtls\library</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\hkdf.c" >
+    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\hkdf.c">
       <Filter>FreeRTOS+\mbedtls\library</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\hmac_drbg.c" >
+    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\hmac_drbg.c">
       <Filter>FreeRTOS+\mbedtls\library</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\md.c" >
+    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\md.c">
       <Filter>FreeRTOS+\mbedtls\library</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\md2.c" >
+    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\md2.c">
       <Filter>FreeRTOS+\mbedtls\library</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\md4.c" >
+    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\md4.c">
       <Filter>FreeRTOS+\mbedtls\library</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\md5.c" >
+    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\md5.c">
       <Filter>FreeRTOS+\mbedtls\library</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\memory_buffer_alloc.c" >
+    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\memory_buffer_alloc.c">
       <Filter>FreeRTOS+\mbedtls\library</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\net_sockets.c" >
+    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\net_sockets.c">
       <Filter>FreeRTOS+\mbedtls\library</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\nist_kw.c" >
+    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\nist_kw.c">
       <Filter>FreeRTOS+\mbedtls\library</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\oid.c" >
+    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\oid.c">
       <Filter>FreeRTOS+\mbedtls\library</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\padlock.c" >
+    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\padlock.c">
       <Filter>FreeRTOS+\mbedtls\library</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\pem.c" >
+    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\pem.c">
       <Filter>FreeRTOS+\mbedtls\library</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\pk.c" >
+    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\pk.c">
       <Filter>FreeRTOS+\mbedtls\library</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\pkcs11.c" >
+    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\pkcs11.c">
       <Filter>FreeRTOS+\mbedtls\library</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\pkcs12.c" >
+    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\pkcs12.c">
       <Filter>FreeRTOS+\mbedtls\library</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\pkcs5.c" >
+    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\pkcs5.c">
       <Filter>FreeRTOS+\mbedtls\library</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\pkparse.c" >
+    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\pkparse.c">
       <Filter>FreeRTOS+\mbedtls\library</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\pkwrite.c" >
+    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\pkwrite.c">
       <Filter>FreeRTOS+\mbedtls\library</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\pk_wrap.c" >
+    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\pk_wrap.c">
       <Filter>FreeRTOS+\mbedtls\library</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\platform.c" >
+    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\platform.c">
       <Filter>FreeRTOS+\mbedtls\library</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\platform_util.c" >
+    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\platform_util.c">
       <Filter>FreeRTOS+\mbedtls\library</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\poly1305.c" >
+    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\poly1305.c">
       <Filter>FreeRTOS+\mbedtls\library</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\ripemd160.c" >
+    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\ripemd160.c">
       <Filter>FreeRTOS+\mbedtls\library</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\rsa.c" >
+    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\rsa.c">
       <Filter>FreeRTOS+\mbedtls\library</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\rsa_internal.c" >
+    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\rsa_internal.c">
       <Filter>FreeRTOS+\mbedtls\library</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\sha1.c" >
+    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\sha1.c">
       <Filter>FreeRTOS+\mbedtls\library</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\sha256.c" >
+    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\sha256.c">
       <Filter>FreeRTOS+\mbedtls\library</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\sha512.c" >
+    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\sha512.c">
       <Filter>FreeRTOS+\mbedtls\library</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\ssl_cache.c" >
+    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\ssl_cache.c">
       <Filter>FreeRTOS+\mbedtls\library</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\ssl_ciphersuites.c" >
+    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\ssl_ciphersuites.c">
       <Filter>FreeRTOS+\mbedtls\library</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\ssl_cli.c" >
+    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\ssl_cli.c">
       <Filter>FreeRTOS+\mbedtls\library</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\ssl_cookie.c" >
+    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\ssl_cookie.c">
       <Filter>FreeRTOS+\mbedtls\library</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\ssl_msg.c" >
+    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\ssl_msg.c">
       <Filter>FreeRTOS+\mbedtls\library</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\ssl_srv.c" >
+    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\ssl_srv.c">
       <Filter>FreeRTOS+\mbedtls\library</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\ssl_ticket.c" >
+    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\ssl_ticket.c">
       <Filter>FreeRTOS+\mbedtls\library</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\ssl_tls.c" >
+    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\ssl_tls.c">
       <Filter>FreeRTOS+\mbedtls\library</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\ssl_tls13_keys.c" >
+    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\ssl_tls13_keys.c">
       <Filter>FreeRTOS+\mbedtls\library</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\threading.c" >
+    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\threading.c">
       <Filter>FreeRTOS+\mbedtls\library</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\timing.c" >
+    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\timing.c">
       <Filter>FreeRTOS+\mbedtls\library</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\version.c" >
+    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\version.c">
       <Filter>FreeRTOS+\mbedtls\library</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\version_features.c" >
+    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\version_features.c">
       <Filter>FreeRTOS+\mbedtls\library</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\x509.c" >
+    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\x509.c">
       <Filter>FreeRTOS+\mbedtls\library</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\x509write_crt.c" >
+    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\x509write_crt.c">
       <Filter>FreeRTOS+\mbedtls\library</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\x509write_csr.c" >
+    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\x509write_csr.c">
       <Filter>FreeRTOS+\mbedtls\library</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\x509_create.c" >
+    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\x509_create.c">
       <Filter>FreeRTOS+\mbedtls\library</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\x509_crl.c" >
+    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\x509_crl.c">
       <Filter>FreeRTOS+\mbedtls\library</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\x509_crt.c" >
+    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\x509_crt.c">
       <Filter>FreeRTOS+\mbedtls\library</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\x509_csr.c" >
+    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\x509_csr.c">
       <Filter>FreeRTOS+\mbedtls\library</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\xtea.c" />
+    <ClCompile Include="..\..\..\..\ThirdParty\mbedtls\library\xtea.c">
+      <Filter>FreeRTOS+\mbedtls\library</Filter>
+    </ClCompile>
     <ClCompile Include="DemoTasks\shadow_demo_helpers.c">
       <Filter>DemoTasks</Filter>
     </ClCompile>

--- a/FreeRTOS-Plus/Demo/AWS/Device_Shadow_Windows_Simulator/Device_Shadow_Demo/WIN32.vcxproj.filters
+++ b/FreeRTOS-Plus/Demo/AWS/Device_Shadow_Windows_Simulator/Device_Shadow_Demo/WIN32.vcxproj.filters
@@ -518,85 +518,245 @@
     <ClInclude Include="..\..\..\..\Source\Application-Protocols\network_transport\freertos_plus_tcp\using_mbedtls\using_mbedtls.h">
       <Filter>FreeRTOS+\FreeRTOS IoT Libraries\platform\transport\include</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\aes.h" />
-    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\aesni.h" />
-    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\arc4.h" />
-    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\aria.h" />
-    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\asn1.h" />
-    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\asn1write.h" />
-    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\base64.h" />
-    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\bignum.h" />
-    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\blowfish.h" />
-    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\bn_mul.h" />
-    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\camellia.h" />
-    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\ccm.h" />
-    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\certs.h" />
-    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\chacha20.h" />
-    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\chachapoly.h" />
-    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\check_config.h" />
-    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\cipher.h" />
-    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\cipher_internal.h" />
-    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\cmac.h" />
-    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\compat-1.3.h" />
-    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\config.h" />
-    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\ctr_drbg.h" />
-    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\debug.h" />
-    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\des.h" />
-    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\dhm.h" />
-    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\ecdh.h" />
-    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\ecdsa.h" />
-    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\ecjpake.h" />
-    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\ecp.h" />
-    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\ecp_internal.h" />
-    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\entropy.h" />
-    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\entropy_poll.h" />
-    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\error.h" />
-    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\gcm.h" />
-    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\havege.h" />
-    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\hkdf.h" />
-    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\hmac_drbg.h" />
-    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\md.h" />
-    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\md2.h" />
-    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\md4.h" />
-    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\md5.h" />
-    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\md_internal.h" />
-    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\memory_buffer_alloc.h" />
-    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\net.h" />
-    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\net_sockets.h" />
-    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\nist_kw.h" />
-    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\oid.h" />
-    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\padlock.h" />
-    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\pem.h" />
-    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\pk.h" />
-    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\pkcs11.h" />
-    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\pkcs12.h" />
-    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\pkcs5.h" />
-    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\pk_internal.h" />
-    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\platform.h" />
-    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\platform_time.h" />
-    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\platform_util.h" />
-    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\poly1305.h" />
-    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\psa_util.h" />
-    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\ripemd160.h" />
-    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\rsa.h" />
-    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\rsa_internal.h" />
-    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\sha1.h" />
-    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\sha256.h" />
-    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\sha512.h" />
-    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\ssl.h" />
-    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\ssl_cache.h" />
-    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\ssl_ciphersuites.h" />
-    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\ssl_cookie.h" />
-    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\ssl_internal.h" />
-    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\ssl_ticket.h" />
-    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\ssl_tls13_keys.h" />
-    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\threading.h" />
-    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\timing.h" />
-    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\version.h" />
-    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\x509.h" />
-    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\x509_crl.h" />
-    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\x509_crt.h" />
-    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\x509_csr.h" />
-    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\xtea.h" />
+    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\aes.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\aesni.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\arc4.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\aria.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\asn1.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\asn1write.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\base64.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\bignum.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\blowfish.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\bn_mul.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\camellia.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\ccm.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\certs.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\chacha20.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\chachapoly.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\check_config.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\cipher.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\cipher_internal.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\cmac.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\compat-1.3.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\config.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\ctr_drbg.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\debug.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\des.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\dhm.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\ecdh.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\ecdsa.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\ecjpake.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\ecp.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\ecp_internal.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\entropy.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\entropy_poll.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\error.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\gcm.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\havege.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\hkdf.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\hmac_drbg.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\md.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\md2.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\md4.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\md5.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\md_internal.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\memory_buffer_alloc.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\net.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\net_sockets.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\nist_kw.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\oid.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\padlock.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\pem.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\pk.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\pkcs11.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\pkcs12.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\pkcs5.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\pk_internal.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\platform.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\platform_time.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\platform_util.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\poly1305.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\psa_util.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\ripemd160.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\rsa.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\rsa_internal.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\sha1.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\sha256.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\sha512.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\ssl.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\ssl_cache.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\ssl_ciphersuites.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\ssl_cookie.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\ssl_internal.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\ssl_ticket.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\ssl_tls13_keys.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\threading.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\timing.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\version.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\x509.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\x509_crl.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\x509_crt.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\x509_csr.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\ThirdParty\mbedtls\include\mbedtls\xtea.h">
+      <Filter>FreeRTOS+\mbedtls\include</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->
The mbedtls headers were not filtered before, causing them to all be bundled up in the root directory of the Visual Studio Project. This fixes them so that they show under `FreeRTOS+/mbedtls/include` instead.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
