### PR TITLE
Fix logging issue causing mangled new lines

### DIFF
--- a/FreeRTOS-Plus/Demo/AWS/Device_Shadow_Windows_Simulator/Device_Shadow_Demo/FreeRTOSConfig.h
+++ b/FreeRTOS-Plus/Demo/AWS/Device_Shadow_Windows_Simulator/Device_Shadow_Demo/FreeRTOSConfig.h
@@ -187,8 +187,6 @@
 /* The UDP port to which print messages are sent. */
 #define configPRINT_PORT                    ( 15000 )
 
-/* Choose CRLF as the new-line character for logging. */
-#define configLOGGING_NEW_LINE              "\r\n"
 
 #if ( defined( _MSC_VER ) && ( _MSC_VER <= 1600 ) && !defined( snprintf ) )
     /* Map to Windows names. */

--- a/FreeRTOS-Plus/Demo/AWS/Device_Shadow_Windows_Simulator/Device_Shadow_Demo/FreeRTOSConfig.h
+++ b/FreeRTOS-Plus/Demo/AWS/Device_Shadow_Windows_Simulator/Device_Shadow_Demo/FreeRTOSConfig.h
@@ -124,7 +124,7 @@
 
 /* Only used when running in the FreeRTOS Windows simulator.  Defines the
  * priority of the task used to simulate Ethernet interrupts. */
-#define configMAC_ISR_SIMULATOR_PRIORITY          ( configMAX_PRIORITIES - 1 )
+#define configMAC_ISR_SIMULATOR_PRIORITY    ( configMAX_PRIORITIES - 1 )
 
 /* This demo creates a virtual network connection by accessing the raw Ethernet
  * or WiFi data to and from a real network connection.  Many computers have more
@@ -135,63 +135,60 @@
  * results in the wired network being used, while setting
  * configNETWORK_INTERFACE_TO_USE to 2 results in the wireless network being
  * used. */
-#define configNETWORK_INTERFACE_TO_USE            ( 0L )
+#define configNETWORK_INTERFACE_TO_USE      ( 0L )
 
 /* The address to which logging is sent should UDP logging be enabled. */
-#define configUDP_LOGGING_ADDR0                   192
-#define configUDP_LOGGING_ADDR1                   168
-#define configUDP_LOGGING_ADDR2                   0
-#define configUDP_LOGGING_ADDR3                   11
+#define configUDP_LOGGING_ADDR0             192
+#define configUDP_LOGGING_ADDR1             168
+#define configUDP_LOGGING_ADDR2             0
+#define configUDP_LOGGING_ADDR3             11
 
 /* Default MAC address configuration.  The demo creates a virtual network
  * connection that uses this MAC address by accessing the raw Ethernet/WiFi data
  * to and from a real network connection on the host PC.  See the
  * configNETWORK_INTERFACE_TO_USE definition above for information on how to
  * configure the real network connection to use. */
-#define configMAC_ADDR0                           0x00
-#define configMAC_ADDR1                           0x11
-#define configMAC_ADDR2                           0x11
-#define configMAC_ADDR3                           0x11
-#define configMAC_ADDR4                           0x11
-#define configMAC_ADDR5                           0x41
+#define configMAC_ADDR0                     0x00
+#define configMAC_ADDR1                     0x11
+#define configMAC_ADDR2                     0x11
+#define configMAC_ADDR3                     0x11
+#define configMAC_ADDR4                     0x11
+#define configMAC_ADDR5                     0x41
 
 /* Default IP address configuration.  Used in ipconfigUSE_DNS is set to 0, or
  * ipconfigUSE_DNS is set to 1 but a DNS server cannot be contacted. */
-#define configIP_ADDR0                            10
-#define configIP_ADDR1                            10
-#define configIP_ADDR2                            10
-#define configIP_ADDR3                            200
+#define configIP_ADDR0                      10
+#define configIP_ADDR1                      10
+#define configIP_ADDR2                      10
+#define configIP_ADDR3                      200
 
 /* Default gateway IP address configuration.  Used in ipconfigUSE_DNS is set to
  * 0, or ipconfigUSE_DNS is set to 1 but a DNS server cannot be contacted. */
-#define configGATEWAY_ADDR0                       10
-#define configGATEWAY_ADDR1                       10
-#define configGATEWAY_ADDR2                       10
-#define configGATEWAY_ADDR3                       1
+#define configGATEWAY_ADDR0                 10
+#define configGATEWAY_ADDR1                 10
+#define configGATEWAY_ADDR2                 10
+#define configGATEWAY_ADDR3                 1
 
 /* Default DNS server configuration.  OpenDNS addresses are 208.67.222.222 and
  * 208.67.220.220.  Used in ipconfigUSE_DNS is set to 0, or ipconfigUSE_DNS is set
  * to 1 but a DNS server cannot be contacted.*/
-#define configDNS_SERVER_ADDR0                    208
-#define configDNS_SERVER_ADDR1                    67
-#define configDNS_SERVER_ADDR2                    222
-#define configDNS_SERVER_ADDR3                    222
+#define configDNS_SERVER_ADDR0              208
+#define configDNS_SERVER_ADDR1              67
+#define configDNS_SERVER_ADDR2              222
+#define configDNS_SERVER_ADDR3              222
 
 /* Default netmask configuration.  Used in ipconfigUSE_DNS is set to 0, or
  * ipconfigUSE_DNS is set to 1 but a DNS server cannot be contacted. */
-#define configNET_MASK0                           255
-#define configNET_MASK1                           0
-#define configNET_MASK2                           0
-#define configNET_MASK3                           0
+#define configNET_MASK0                     255
+#define configNET_MASK1                     0
+#define configNET_MASK2                     0
+#define configNET_MASK3                     0
 
 /* The UDP port to which print messages are sent. */
-#define configPRINT_PORT                          ( 15000 )
+#define configPRINT_PORT                    ( 15000 )
 
-/* Task pool definitions for the demos of IoT Libraries. */
-#define configTASKPOOL_ENABLE_ASSERTS             1
-#define configTASKPOOL_NUMBER_OF_WORKERS          1
-#define configTASKPOOL_WORKER_PRIORITY            tskIDLE_PRIORITY
-#define configTASKPOOL_WORKER_STACK_SIZE_BYTES    2048
+/* Choose CRLF as the new-line character for logging. */
+#define configLOGGING_NEW_LINE              "\r\n"
 
 #if ( defined( _MSC_VER ) && ( _MSC_VER <= 1600 ) && !defined( snprintf ) )
     /* Map to Windows names. */

--- a/FreeRTOS-Plus/Demo/Common/Logging/windows/Logging_WinSim.c
+++ b/FreeRTOS-Plus/Demo/Common/Logging/windows/Logging_WinSim.c
@@ -71,9 +71,9 @@
 /* A block time of zero simply means don't block. */
 #define dlDONT_BLOCK                    0
 
-/* Choose LF as the default new-line character. */
+/* Choose CRLF as the default new-line character. */
 #ifndef configLOGGING_NEW_LINE
-    #define configLOGGING_NEW_LINE    "\n"
+    #define configLOGGING_NEW_LINE    "\r\n"
 #endif
 
 /*-----------------------------------------------------------*/

--- a/FreeRTOS-Plus/Demo/Common/Logging/windows/Logging_WinSim.c
+++ b/FreeRTOS-Plus/Demo/Common/Logging/windows/Logging_WinSim.c
@@ -71,11 +71,6 @@
 /* A block time of zero simply means don't block. */
 #define dlDONT_BLOCK                    0
 
-/* Choose CRLF as the default new-line character. */
-#ifndef configLOGGING_NEW_LINE
-    #define configLOGGING_NEW_LINE    "\r\n"
-#endif
-
 /*-----------------------------------------------------------*/
 
 /*
@@ -291,7 +286,7 @@ void vLoggingPrintf( const char * pcFormat,
             pcTaskName = pcNoTask;
         }
 
-        if( strcmp( pcFormat, configLOGGING_NEW_LINE ) != 0 )
+        if( strcmp( pcFormat, "\r\n" ) != 0 )
         {
             xLength = snprintf( cPrintString, dlMAX_PRINT_STRING_LENGTH, "%lu %lu [%s] ",
                                 xMessageNumber++,

--- a/FreeRTOS-Plus/Demo/Common/Logging/windows/Logging_WinSim.c
+++ b/FreeRTOS-Plus/Demo/Common/Logging/windows/Logging_WinSim.c
@@ -71,6 +71,11 @@
 /* A block time of zero simply means don't block. */
 #define dlDONT_BLOCK                    0
 
+/* Choose LF as the default new-line character. */
+#ifndef configLOGGING_NEW_LINE
+    #define configLOGGING_NEW_LINE    "\n"
+#endif
+
 /*-----------------------------------------------------------*/
 
 /*
@@ -286,7 +291,7 @@ void vLoggingPrintf( const char * pcFormat,
             pcTaskName = pcNoTask;
         }
 
-        if( strcmp( pcFormat, "\n" ) != 0 )
+        if( strcmp( pcFormat, configLOGGING_NEW_LINE ) != 0 )
         {
             xLength = snprintf( cPrintString, dlMAX_PRINT_STRING_LENGTH, "%lu %lu [%s] ",
                                 xMessageNumber++,

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Minimal_Windows_Simulator/main.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Minimal_Windows_Simulator/main.c
@@ -153,11 +153,11 @@ int main( void )
      * vApplicationIPNetworkEventHook() below).  The address values passed in here
      * are used if ipconfigUSE_DHCP is set to 0, or if ipconfigUSE_DHCP is set to 1
      * but a DHCP server cannot be	contacted. */
-    FreeRTOS_debug_printf( ( "FreeRTOS_IPInit\n" ) );
+    FreeRTOS_debug_printf( ( "FreeRTOS_IPInit\r\n" ) );
     FreeRTOS_IPInit( ucIPAddress, ucNetMask, ucGatewayAddress, ucDNSServerAddress, ucMACAddress );
 
     /* Start the RTOS scheduler. */
-    FreeRTOS_debug_printf( ( "vTaskStartScheduler\n" ) );
+    FreeRTOS_debug_printf( ( "vTaskStartScheduler\r\n" ) );
     vTaskStartScheduler();
 
     /* If all is well, the scheduler will now be running, and the following
@@ -196,7 +196,7 @@ void vAssertCalled( const char * pcFile,
     ( void ) pcFileName;
     ( void ) ulLineNumber;
 
-    FreeRTOS_debug_printf( ( "vAssertCalled( %s, %ld\n", pcFile, ulLine ) );
+    FreeRTOS_debug_printf( ( "vAssertCalled( %s, %ld\r\n", pcFile, ulLine ) );
 
     /* Setting ulBlockVariable to a non-zero value in the debugger will allow
      * this function to be exited. */
@@ -307,9 +307,9 @@ static void prvMiscInitialisation( void )
 
     /* Seed the random number generator. */
     time( &xTimeNow );
-    FreeRTOS_debug_printf( ( "Seed for randomiser: %lu\n", xTimeNow ) );
+    FreeRTOS_debug_printf( ( "Seed for randomiser: %lu\r\n", xTimeNow ) );
     prvSRand( ( uint32_t ) xTimeNow );
-    FreeRTOS_debug_printf( ( "Random numbers: %08X %08X %08X %08X\n", ipconfigRAND32(), ipconfigRAND32(), ipconfigRAND32(), ipconfigRAND32() ) );
+    FreeRTOS_debug_printf( ( "Random numbers: %08X %08X %08X %08X\r\n", ipconfigRAND32(), ipconfigRAND32(), ipconfigRAND32(), ipconfigRAND32() ) );
 }
 /*-----------------------------------------------------------*/
 

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Basic_TLS/FreeRTOSConfig.h
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Basic_TLS/FreeRTOSConfig.h
@@ -187,8 +187,6 @@
 /* The UDP port to which print messages are sent. */
 #define configPRINT_PORT                    ( 15000 )
 
-/* Choose CRLF as the new-line character for logging. */
-#define configLOGGING_NEW_LINE              "\r\n"
 
 #if ( defined( _MSC_VER ) && ( _MSC_VER <= 1600 ) && !defined( snprintf ) )
     /* Map to Windows names. */

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Basic_TLS/FreeRTOSConfig.h
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Basic_TLS/FreeRTOSConfig.h
@@ -124,7 +124,7 @@
 
 /* Only used when running in the FreeRTOS Windows simulator.  Defines the
  * priority of the task used to simulate Ethernet interrupts. */
-#define configMAC_ISR_SIMULATOR_PRIORITY          ( configMAX_PRIORITIES - 1 )
+#define configMAC_ISR_SIMULATOR_PRIORITY    ( configMAX_PRIORITIES - 1 )
 
 /* This demo creates a virtual network connection by accessing the raw Ethernet
  * or WiFi data to and from a real network connection.  Many computers have more
@@ -135,63 +135,60 @@
  * results in the wired network being used, while setting
  * configNETWORK_INTERFACE_TO_USE to 2 results in the wireless network being
  * used. */
-#define configNETWORK_INTERFACE_TO_USE            ( 0L )
+#define configNETWORK_INTERFACE_TO_USE      ( 0L )
 
 /* The address to which logging is sent should UDP logging be enabled. */
-#define configUDP_LOGGING_ADDR0                   192
-#define configUDP_LOGGING_ADDR1                   168
-#define configUDP_LOGGING_ADDR2                   0
-#define configUDP_LOGGING_ADDR3                   11
+#define configUDP_LOGGING_ADDR0             192
+#define configUDP_LOGGING_ADDR1             168
+#define configUDP_LOGGING_ADDR2             0
+#define configUDP_LOGGING_ADDR3             11
 
 /* Default MAC address configuration.  The demo creates a virtual network
  * connection that uses this MAC address by accessing the raw Ethernet/WiFi data
  * to and from a real network connection on the host PC.  See the
  * configNETWORK_INTERFACE_TO_USE definition above for information on how to
  * configure the real network connection to use. */
-#define configMAC_ADDR0                           0x00
-#define configMAC_ADDR1                           0x11
-#define configMAC_ADDR2                           0x11
-#define configMAC_ADDR3                           0x11
-#define configMAC_ADDR4                           0x11
-#define configMAC_ADDR5                           0x41
+#define configMAC_ADDR0                     0x00
+#define configMAC_ADDR1                     0x11
+#define configMAC_ADDR2                     0x11
+#define configMAC_ADDR3                     0x11
+#define configMAC_ADDR4                     0x11
+#define configMAC_ADDR5                     0x41
 
 /* Default IP address configuration.  Used in ipconfigUSE_DNS is set to 0, or
  * ipconfigUSE_DNS is set to 1 but a DNS server cannot be contacted. */
-#define configIP_ADDR0                            10
-#define configIP_ADDR1                            10
-#define configIP_ADDR2                            10
-#define configIP_ADDR3                            200
+#define configIP_ADDR0                      10
+#define configIP_ADDR1                      10
+#define configIP_ADDR2                      10
+#define configIP_ADDR3                      200
 
 /* Default gateway IP address configuration.  Used in ipconfigUSE_DNS is set to
  * 0, or ipconfigUSE_DNS is set to 1 but a DNS server cannot be contacted. */
-#define configGATEWAY_ADDR0                       10
-#define configGATEWAY_ADDR1                       10
-#define configGATEWAY_ADDR2                       10
-#define configGATEWAY_ADDR3                       1
+#define configGATEWAY_ADDR0                 10
+#define configGATEWAY_ADDR1                 10
+#define configGATEWAY_ADDR2                 10
+#define configGATEWAY_ADDR3                 1
 
 /* Default DNS server configuration.  OpenDNS addresses are 208.67.222.222 and
  * 208.67.220.220.  Used in ipconfigUSE_DNS is set to 0, or ipconfigUSE_DNS is set
  * to 1 but a DNS server cannot be contacted.*/
-#define configDNS_SERVER_ADDR0                    208
-#define configDNS_SERVER_ADDR1                    67
-#define configDNS_SERVER_ADDR2                    222
-#define configDNS_SERVER_ADDR3                    222
+#define configDNS_SERVER_ADDR0              208
+#define configDNS_SERVER_ADDR1              67
+#define configDNS_SERVER_ADDR2              222
+#define configDNS_SERVER_ADDR3              222
 
 /* Default netmask configuration.  Used in ipconfigUSE_DNS is set to 0, or
  * ipconfigUSE_DNS is set to 1 but a DNS server cannot be contacted. */
-#define configNET_MASK0                           255
-#define configNET_MASK1                           0
-#define configNET_MASK2                           0
-#define configNET_MASK3                           0
+#define configNET_MASK0                     255
+#define configNET_MASK1                     0
+#define configNET_MASK2                     0
+#define configNET_MASK3                     0
 
 /* The UDP port to which print messages are sent. */
-#define configPRINT_PORT                          ( 15000 )
+#define configPRINT_PORT                    ( 15000 )
 
-/* Task pool definitions for the demos of IoT Libraries. */
-#define configTASKPOOL_ENABLE_ASSERTS             1
-#define configTASKPOOL_NUMBER_OF_WORKERS          1
-#define configTASKPOOL_WORKER_PRIORITY            tskIDLE_PRIORITY
-#define configTASKPOOL_WORKER_STACK_SIZE_BYTES    2048
+/* Choose CRLF as the new-line character for logging. */
+#define configLOGGING_NEW_LINE              "\r\n"
 
 #if ( defined( _MSC_VER ) && ( _MSC_VER <= 1600 ) && !defined( snprintf ) )
     /* Map to Windows names. */

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Keep_Alive/FreeRTOSConfig.h
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Keep_Alive/FreeRTOSConfig.h
@@ -189,8 +189,6 @@
 /* The UDP port to which print messages are sent. */
 #define configPRINT_PORT                    ( 15000 )
 
-/* Choose CRLF as the new-line character for logging. */
-#define configLOGGING_NEW_LINE              "\r\n"
 
 #if ( defined( _MSC_VER ) && ( _MSC_VER <= 1600 ) && !defined( snprintf ) )
     /* Map to Windows names. */

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Keep_Alive/FreeRTOSConfig.h
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Keep_Alive/FreeRTOSConfig.h
@@ -126,7 +126,7 @@
 
 /* Only used when running in the FreeRTOS Windows simulator.  Defines the
  * priority of the task used to simulate Ethernet interrupts. */
-#define configMAC_ISR_SIMULATOR_PRIORITY          ( configMAX_PRIORITIES - 1 )
+#define configMAC_ISR_SIMULATOR_PRIORITY    ( configMAX_PRIORITIES - 1 )
 
 /* This demo creates a virtual network connection by accessing the raw Ethernet
  * or WiFi data to and from a real network connection.  Many computers have more
@@ -137,63 +137,60 @@
  * results in the wired network being used, while setting
  * configNETWORK_INTERFACE_TO_USE to 2 results in the wireless network being
  * used. */
-#define configNETWORK_INTERFACE_TO_USE            ( 0L )
+#define configNETWORK_INTERFACE_TO_USE      ( 0L )
 
 /* The address to which logging is sent should UDP logging be enabled. */
-#define configUDP_LOGGING_ADDR0                   192
-#define configUDP_LOGGING_ADDR1                   168
-#define configUDP_LOGGING_ADDR2                   0
-#define configUDP_LOGGING_ADDR3                   11
+#define configUDP_LOGGING_ADDR0             192
+#define configUDP_LOGGING_ADDR1             168
+#define configUDP_LOGGING_ADDR2             0
+#define configUDP_LOGGING_ADDR3             11
 
 /* Default MAC address configuration.  The demo creates a virtual network
  * connection that uses this MAC address by accessing the raw Ethernet/WiFi data
  * to and from a real network connection on the host PC.  See the
  * configNETWORK_INTERFACE_TO_USE definition above for information on how to
  * configure the real network connection to use. */
-#define configMAC_ADDR0                           0x00
-#define configMAC_ADDR1                           0x11
-#define configMAC_ADDR2                           0x11
-#define configMAC_ADDR3                           0x11
-#define configMAC_ADDR4                           0x11
-#define configMAC_ADDR5                           0x41
+#define configMAC_ADDR0                     0x00
+#define configMAC_ADDR1                     0x11
+#define configMAC_ADDR2                     0x11
+#define configMAC_ADDR3                     0x11
+#define configMAC_ADDR4                     0x11
+#define configMAC_ADDR5                     0x41
 
 /* Default IP address configuration.  Used in ipconfigUSE_DNS is set to 0, or
  * ipconfigUSE_DNS is set to 1 but a DNS server cannot be contacted. */
-#define configIP_ADDR0                            10
-#define configIP_ADDR1                            10
-#define configIP_ADDR2                            10
-#define configIP_ADDR3                            200
+#define configIP_ADDR0                      10
+#define configIP_ADDR1                      10
+#define configIP_ADDR2                      10
+#define configIP_ADDR3                      200
 
 /* Default gateway IP address configuration.  Used in ipconfigUSE_DNS is set to
  * 0, or ipconfigUSE_DNS is set to 1 but a DNS server cannot be contacted. */
-#define configGATEWAY_ADDR0                       10
-#define configGATEWAY_ADDR1                       10
-#define configGATEWAY_ADDR2                       10
-#define configGATEWAY_ADDR3                       1
+#define configGATEWAY_ADDR0                 10
+#define configGATEWAY_ADDR1                 10
+#define configGATEWAY_ADDR2                 10
+#define configGATEWAY_ADDR3                 1
 
 /* Default DNS server configuration.  OpenDNS addresses are 208.67.222.222 and
  * 208.67.220.220.  Used in ipconfigUSE_DNS is set to 0, or ipconfigUSE_DNS is set
  * to 1 but a DNS server cannot be contacted.*/
-#define configDNS_SERVER_ADDR0                    208
-#define configDNS_SERVER_ADDR1                    67
-#define configDNS_SERVER_ADDR2                    222
-#define configDNS_SERVER_ADDR3                    222
+#define configDNS_SERVER_ADDR0              208
+#define configDNS_SERVER_ADDR1              67
+#define configDNS_SERVER_ADDR2              222
+#define configDNS_SERVER_ADDR3              222
 
 /* Default netmask configuration.  Used in ipconfigUSE_DNS is set to 0, or
  * ipconfigUSE_DNS is set to 1 but a DNS server cannot be contacted. */
-#define configNET_MASK0                           255
-#define configNET_MASK1                           0
-#define configNET_MASK2                           0
-#define configNET_MASK3                           0
+#define configNET_MASK0                     255
+#define configNET_MASK1                     0
+#define configNET_MASK2                     0
+#define configNET_MASK3                     0
 
 /* The UDP port to which print messages are sent. */
-#define configPRINT_PORT                          ( 15000 )
+#define configPRINT_PORT                    ( 15000 )
 
-/* Task pool definitions for the demos of IoT Libraries. */
-#define configTASKPOOL_ENABLE_ASSERTS             1
-#define configTASKPOOL_NUMBER_OF_WORKERS          1
-#define configTASKPOOL_WORKER_PRIORITY            tskIDLE_PRIORITY
-#define configTASKPOOL_WORKER_STACK_SIZE_BYTES    2048
+/* Choose CRLF as the new-line character for logging. */
+#define configLOGGING_NEW_LINE              "\r\n"
 
 #if ( defined( _MSC_VER ) && ( _MSC_VER <= 1600 ) && !defined( snprintf ) )
     /* Map to Windows names. */

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Multitask/FreeRTOSConfig.h
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Multitask/FreeRTOSConfig.h
@@ -189,8 +189,6 @@
 /* The UDP port to which print messages are sent. */
 #define configPRINT_PORT                    ( 15000 )
 
-/* Choose CRLF as the new-line character for logging. */
-#define configLOGGING_NEW_LINE              "\r\n"
 
 #if ( defined( _MSC_VER ) && ( _MSC_VER <= 1600 ) && !defined( snprintf ) )
     /* Map to Windows names. */

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Multitask/FreeRTOSConfig.h
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Multitask/FreeRTOSConfig.h
@@ -126,7 +126,7 @@
 
 /* Only used when running in the FreeRTOS Windows simulator.  Defines the
  * priority of the task used to simulate Ethernet interrupts. */
-#define configMAC_ISR_SIMULATOR_PRIORITY          ( configMAX_PRIORITIES - 1 )
+#define configMAC_ISR_SIMULATOR_PRIORITY    ( configMAX_PRIORITIES - 1 )
 
 /* This demo creates a virtual network connection by accessing the raw Ethernet
  * or WiFi data to and from a real network connection.  Many computers have more
@@ -137,63 +137,60 @@
  * results in the wired network being used, while setting
  * configNETWORK_INTERFACE_TO_USE to 2 results in the wireless network being
  * used. */
-#define configNETWORK_INTERFACE_TO_USE            ( 0L )
+#define configNETWORK_INTERFACE_TO_USE      ( 0L )
 
 /* The address to which logging is sent should UDP logging be enabled. */
-#define configUDP_LOGGING_ADDR0                   192
-#define configUDP_LOGGING_ADDR1                   168
-#define configUDP_LOGGING_ADDR2                   0
-#define configUDP_LOGGING_ADDR3                   11
+#define configUDP_LOGGING_ADDR0             192
+#define configUDP_LOGGING_ADDR1             168
+#define configUDP_LOGGING_ADDR2             0
+#define configUDP_LOGGING_ADDR3             11
 
 /* Default MAC address configuration.  The demo creates a virtual network
  * connection that uses this MAC address by accessing the raw Ethernet/WiFi data
  * to and from a real network connection on the host PC.  See the
  * configNETWORK_INTERFACE_TO_USE definition above for information on how to
  * configure the real network connection to use. */
-#define configMAC_ADDR0                           0x00
-#define configMAC_ADDR1                           0x11
-#define configMAC_ADDR2                           0x11
-#define configMAC_ADDR3                           0x11
-#define configMAC_ADDR4                           0x11
-#define configMAC_ADDR5                           0x41
+#define configMAC_ADDR0                     0x00
+#define configMAC_ADDR1                     0x11
+#define configMAC_ADDR2                     0x11
+#define configMAC_ADDR3                     0x11
+#define configMAC_ADDR4                     0x11
+#define configMAC_ADDR5                     0x41
 
 /* Default IP address configuration.  Used in ipconfigUSE_DNS is set to 0, or
  * ipconfigUSE_DNS is set to 1 but a DNS server cannot be contacted. */
-#define configIP_ADDR0                            10
-#define configIP_ADDR1                            10
-#define configIP_ADDR2                            10
-#define configIP_ADDR3                            200
+#define configIP_ADDR0                      10
+#define configIP_ADDR1                      10
+#define configIP_ADDR2                      10
+#define configIP_ADDR3                      200
 
 /* Default gateway IP address configuration.  Used in ipconfigUSE_DNS is set to
  * 0, or ipconfigUSE_DNS is set to 1 but a DNS server cannot be contacted. */
-#define configGATEWAY_ADDR0                       10
-#define configGATEWAY_ADDR1                       10
-#define configGATEWAY_ADDR2                       10
-#define configGATEWAY_ADDR3                       1
+#define configGATEWAY_ADDR0                 10
+#define configGATEWAY_ADDR1                 10
+#define configGATEWAY_ADDR2                 10
+#define configGATEWAY_ADDR3                 1
 
 /* Default DNS server configuration.  OpenDNS addresses are 208.67.222.222 and
  * 208.67.220.220.  Used in ipconfigUSE_DNS is set to 0, or ipconfigUSE_DNS is set
  * to 1 but a DNS server cannot be contacted.*/
-#define configDNS_SERVER_ADDR0                    208
-#define configDNS_SERVER_ADDR1                    67
-#define configDNS_SERVER_ADDR2                    222
-#define configDNS_SERVER_ADDR3                    222
+#define configDNS_SERVER_ADDR0              208
+#define configDNS_SERVER_ADDR1              67
+#define configDNS_SERVER_ADDR2              222
+#define configDNS_SERVER_ADDR3              222
 
 /* Default netmask configuration.  Used in ipconfigUSE_DNS is set to 0, or
  * ipconfigUSE_DNS is set to 1 but a DNS server cannot be contacted. */
-#define configNET_MASK0                           255
-#define configNET_MASK1                           0
-#define configNET_MASK2                           0
-#define configNET_MASK3                           0
+#define configNET_MASK0                     255
+#define configNET_MASK1                     0
+#define configNET_MASK2                     0
+#define configNET_MASK3                     0
 
 /* The UDP port to which print messages are sent. */
-#define configPRINT_PORT                          ( 15000 )
+#define configPRINT_PORT                    ( 15000 )
 
-/* Task pool definitions for the demos of IoT Libraries. */
-#define configTASKPOOL_ENABLE_ASSERTS             1
-#define configTASKPOOL_NUMBER_OF_WORKERS          1
-#define configTASKPOOL_WORKER_PRIORITY            tskIDLE_PRIORITY
-#define configTASKPOOL_WORKER_STACK_SIZE_BYTES    2048
+/* Choose CRLF as the new-line character for logging. */
+#define configLOGGING_NEW_LINE              "\r\n"
 
 #if ( defined( _MSC_VER ) && ( _MSC_VER <= 1600 ) && !defined( snprintf ) )
     /* Map to Windows names. */

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Mutual_Auth/FreeRTOSConfig.h
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Mutual_Auth/FreeRTOSConfig.h
@@ -187,8 +187,6 @@
 /* The UDP port to which print messages are sent. */
 #define configPRINT_PORT                    ( 15000 )
 
-/* Choose CRLF as the new-line character for logging. */
-#define configLOGGING_NEW_LINE              "\r\n"
 
 #if ( defined( _MSC_VER ) && ( _MSC_VER <= 1600 ) && !defined( snprintf ) )
     /* Map to Windows names. */

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Mutual_Auth/FreeRTOSConfig.h
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Mutual_Auth/FreeRTOSConfig.h
@@ -124,7 +124,7 @@
 
 /* Only used when running in the FreeRTOS Windows simulator.  Defines the
  * priority of the task used to simulate Ethernet interrupts. */
-#define configMAC_ISR_SIMULATOR_PRIORITY          ( configMAX_PRIORITIES - 1 )
+#define configMAC_ISR_SIMULATOR_PRIORITY    ( configMAX_PRIORITIES - 1 )
 
 /* This demo creates a virtual network connection by accessing the raw Ethernet
  * or WiFi data to and from a real network connection.  Many computers have more
@@ -135,63 +135,60 @@
  * results in the wired network being used, while setting
  * configNETWORK_INTERFACE_TO_USE to 2 results in the wireless network being
  * used. */
-#define configNETWORK_INTERFACE_TO_USE            ( 0L )
+#define configNETWORK_INTERFACE_TO_USE      ( 0L )
 
 /* The address to which logging is sent should UDP logging be enabled. */
-#define configUDP_LOGGING_ADDR0                   192
-#define configUDP_LOGGING_ADDR1                   168
-#define configUDP_LOGGING_ADDR2                   0
-#define configUDP_LOGGING_ADDR3                   11
+#define configUDP_LOGGING_ADDR0             192
+#define configUDP_LOGGING_ADDR1             168
+#define configUDP_LOGGING_ADDR2             0
+#define configUDP_LOGGING_ADDR3             11
 
 /* Default MAC address configuration.  The demo creates a virtual network
  * connection that uses this MAC address by accessing the raw Ethernet/WiFi data
  * to and from a real network connection on the host PC.  See the
  * configNETWORK_INTERFACE_TO_USE definition above for information on how to
  * configure the real network connection to use. */
-#define configMAC_ADDR0                           0x00
-#define configMAC_ADDR1                           0x11
-#define configMAC_ADDR2                           0x11
-#define configMAC_ADDR3                           0x11
-#define configMAC_ADDR4                           0x11
-#define configMAC_ADDR5                           0x41
+#define configMAC_ADDR0                     0x00
+#define configMAC_ADDR1                     0x11
+#define configMAC_ADDR2                     0x11
+#define configMAC_ADDR3                     0x11
+#define configMAC_ADDR4                     0x11
+#define configMAC_ADDR5                     0x41
 
 /* Default IP address configuration.  Used in ipconfigUSE_DNS is set to 0, or
  * ipconfigUSE_DNS is set to 1 but a DNS server cannot be contacted. */
-#define configIP_ADDR0                            10
-#define configIP_ADDR1                            10
-#define configIP_ADDR2                            10
-#define configIP_ADDR3                            200
+#define configIP_ADDR0                      10
+#define configIP_ADDR1                      10
+#define configIP_ADDR2                      10
+#define configIP_ADDR3                      200
 
 /* Default gateway IP address configuration.  Used in ipconfigUSE_DNS is set to
  * 0, or ipconfigUSE_DNS is set to 1 but a DNS server cannot be contacted. */
-#define configGATEWAY_ADDR0                       10
-#define configGATEWAY_ADDR1                       10
-#define configGATEWAY_ADDR2                       10
-#define configGATEWAY_ADDR3                       1
+#define configGATEWAY_ADDR0                 10
+#define configGATEWAY_ADDR1                 10
+#define configGATEWAY_ADDR2                 10
+#define configGATEWAY_ADDR3                 1
 
 /* Default DNS server configuration.  OpenDNS addresses are 208.67.222.222 and
  * 208.67.220.220.  Used in ipconfigUSE_DNS is set to 0, or ipconfigUSE_DNS is set
  * to 1 but a DNS server cannot be contacted.*/
-#define configDNS_SERVER_ADDR0                    208
-#define configDNS_SERVER_ADDR1                    67
-#define configDNS_SERVER_ADDR2                    222
-#define configDNS_SERVER_ADDR3                    222
+#define configDNS_SERVER_ADDR0              208
+#define configDNS_SERVER_ADDR1              67
+#define configDNS_SERVER_ADDR2              222
+#define configDNS_SERVER_ADDR3              222
 
 /* Default netmask configuration.  Used in ipconfigUSE_DNS is set to 0, or
  * ipconfigUSE_DNS is set to 1 but a DNS server cannot be contacted. */
-#define configNET_MASK0                           255
-#define configNET_MASK1                           0
-#define configNET_MASK2                           0
-#define configNET_MASK3                           0
+#define configNET_MASK0                     255
+#define configNET_MASK1                     0
+#define configNET_MASK2                     0
+#define configNET_MASK3                     0
 
 /* The UDP port to which print messages are sent. */
-#define configPRINT_PORT                          ( 15000 )
+#define configPRINT_PORT                    ( 15000 )
 
-/* Task pool definitions for the demos of IoT Libraries. */
-#define configTASKPOOL_ENABLE_ASSERTS             1
-#define configTASKPOOL_NUMBER_OF_WORKERS          1
-#define configTASKPOOL_WORKER_PRIORITY            tskIDLE_PRIORITY
-#define configTASKPOOL_WORKER_STACK_SIZE_BYTES    2048
+/* Choose CRLF as the new-line character for logging. */
+#define configLOGGING_NEW_LINE              "\r\n"
 
 #if ( defined( _MSC_VER ) && ( _MSC_VER <= 1600 ) && !defined( snprintf ) )
     /* Map to Windows names. */

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Plain_Text/FreeRTOSConfig.h
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Plain_Text/FreeRTOSConfig.h
@@ -137,7 +137,7 @@
  * results in the wired network being used, while setting
  * configNETWORK_INTERFACE_TO_USE to 2 results in the wireless network being
  * used. */
-#define configNETWORK_INTERFACE_TO_USE      ( 2L )
+#define configNETWORK_INTERFACE_TO_USE      ( 0L )
 
 /* The address to which logging is sent should UDP logging be enabled. */
 #define configUDP_LOGGING_ADDR0             192

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Plain_Text/FreeRTOSConfig.h
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Plain_Text/FreeRTOSConfig.h
@@ -189,8 +189,6 @@
 /* The UDP port to which print messages are sent. */
 #define configPRINT_PORT                    ( 15000 )
 
-/* Choose CRLF as the new-line character for logging. */
-#define configLOGGING_NEW_LINE              "\r\n"
 
 #if ( defined( _MSC_VER ) && ( _MSC_VER <= 1600 ) && !defined( snprintf ) )
     /* Map to Windows names. */

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Plain_Text/FreeRTOSConfig.h
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Plain_Text/FreeRTOSConfig.h
@@ -126,7 +126,7 @@
 
 /* Only used when running in the FreeRTOS Windows simulator.  Defines the
  * priority of the task used to simulate Ethernet interrupts. */
-#define configMAC_ISR_SIMULATOR_PRIORITY          ( configMAX_PRIORITIES - 1 )
+#define configMAC_ISR_SIMULATOR_PRIORITY    ( configMAX_PRIORITIES - 1 )
 
 /* This demo creates a virtual network connection by accessing the raw Ethernet
  * or WiFi data to and from a real network connection.  Many computers have more
@@ -137,63 +137,60 @@
  * results in the wired network being used, while setting
  * configNETWORK_INTERFACE_TO_USE to 2 results in the wireless network being
  * used. */
-#define configNETWORK_INTERFACE_TO_USE            ( 0L )
+#define configNETWORK_INTERFACE_TO_USE      ( 0L )
 
 /* The address to which logging is sent should UDP logging be enabled. */
-#define configUDP_LOGGING_ADDR0                   192
-#define configUDP_LOGGING_ADDR1                   168
-#define configUDP_LOGGING_ADDR2                   0
-#define configUDP_LOGGING_ADDR3                   11
+#define configUDP_LOGGING_ADDR0             192
+#define configUDP_LOGGING_ADDR1             168
+#define configUDP_LOGGING_ADDR2             0
+#define configUDP_LOGGING_ADDR3             11
 
 /* Default MAC address configuration.  The demo creates a virtual network
  * connection that uses this MAC address by accessing the raw Ethernet/WiFi data
  * to and from a real network connection on the host PC.  See the
  * configNETWORK_INTERFACE_TO_USE definition above for information on how to
  * configure the real network connection to use. */
-#define configMAC_ADDR0                           0x00
-#define configMAC_ADDR1                           0x11
-#define configMAC_ADDR2                           0x11
-#define configMAC_ADDR3                           0x11
-#define configMAC_ADDR4                           0x11
-#define configMAC_ADDR5                           0x41
+#define configMAC_ADDR0                     0x00
+#define configMAC_ADDR1                     0x11
+#define configMAC_ADDR2                     0x11
+#define configMAC_ADDR3                     0x11
+#define configMAC_ADDR4                     0x11
+#define configMAC_ADDR5                     0x41
 
 /* Default IP address configuration.  Used in ipconfigUSE_DNS is set to 0, or
  * ipconfigUSE_DNS is set to 1 but a DNS server cannot be contacted. */
-#define configIP_ADDR0                            10
-#define configIP_ADDR1                            10
-#define configIP_ADDR2                            10
-#define configIP_ADDR3                            200
+#define configIP_ADDR0                      10
+#define configIP_ADDR1                      10
+#define configIP_ADDR2                      10
+#define configIP_ADDR3                      200
 
 /* Default gateway IP address configuration.  Used in ipconfigUSE_DNS is set to
  * 0, or ipconfigUSE_DNS is set to 1 but a DNS server cannot be contacted. */
-#define configGATEWAY_ADDR0                       10
-#define configGATEWAY_ADDR1                       10
-#define configGATEWAY_ADDR2                       10
-#define configGATEWAY_ADDR3                       1
+#define configGATEWAY_ADDR0                 10
+#define configGATEWAY_ADDR1                 10
+#define configGATEWAY_ADDR2                 10
+#define configGATEWAY_ADDR3                 1
 
 /* Default DNS server configuration.  OpenDNS addresses are 208.67.222.222 and
  * 208.67.220.220.  Used in ipconfigUSE_DNS is set to 0, or ipconfigUSE_DNS is set
  * to 1 but a DNS server cannot be contacted.*/
-#define configDNS_SERVER_ADDR0                    208
-#define configDNS_SERVER_ADDR1                    67
-#define configDNS_SERVER_ADDR2                    222
-#define configDNS_SERVER_ADDR3                    222
+#define configDNS_SERVER_ADDR0              208
+#define configDNS_SERVER_ADDR1              67
+#define configDNS_SERVER_ADDR2              222
+#define configDNS_SERVER_ADDR3              222
 
 /* Default netmask configuration.  Used in ipconfigUSE_DNS is set to 0, or
  * ipconfigUSE_DNS is set to 1 but a DNS server cannot be contacted. */
-#define configNET_MASK0                           255
-#define configNET_MASK1                           0
-#define configNET_MASK2                           0
-#define configNET_MASK3                           0
+#define configNET_MASK0                     255
+#define configNET_MASK1                     0
+#define configNET_MASK2                     0
+#define configNET_MASK3                     0
 
 /* The UDP port to which print messages are sent. */
-#define configPRINT_PORT                          ( 15000 )
+#define configPRINT_PORT                    ( 15000 )
 
-/* Task pool definitions for the demos of IoT Libraries. */
-#define configTASKPOOL_ENABLE_ASSERTS             1
-#define configTASKPOOL_NUMBER_OF_WORKERS          1
-#define configTASKPOOL_WORKER_PRIORITY            tskIDLE_PRIORITY
-#define configTASKPOOL_WORKER_STACK_SIZE_BYTES    2048
+/* Choose CRLF as the new-line character for logging. */
+#define configLOGGING_NEW_LINE              "\r\n"
 
 #if ( defined( _MSC_VER ) && ( _MSC_VER <= 1600 ) && !defined( snprintf ) )
     /* Map to Windows names. */

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Plain_Text/FreeRTOSConfig.h
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Plain_Text/FreeRTOSConfig.h
@@ -137,7 +137,7 @@
  * results in the wired network being used, while setting
  * configNETWORK_INTERFACE_TO_USE to 2 results in the wireless network being
  * used. */
-#define configNETWORK_INTERFACE_TO_USE      ( 0L )
+#define configNETWORK_INTERFACE_TO_USE      ( 2L )
 
 /* The address to which logging is sent should UDP logging be enabled. */
 #define configUDP_LOGGING_ADDR0             192

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Serializer/FreeRTOSConfig.h
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Serializer/FreeRTOSConfig.h
@@ -189,8 +189,6 @@
 /* The UDP port to which print messages are sent. */
 #define configPRINT_PORT                    ( 15000 )
 
-/* Choose CRLF as the new-line character for logging. */
-#define configLOGGING_NEW_LINE              "\r\n"
 
 #if ( defined( _MSC_VER ) && ( _MSC_VER <= 1600 ) && !defined( snprintf ) )
     /* Map to Windows names. */

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Serializer/FreeRTOSConfig.h
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Serializer/FreeRTOSConfig.h
@@ -126,7 +126,7 @@
 
 /* Only used when running in the FreeRTOS Windows simulator.  Defines the
  * priority of the task used to simulate Ethernet interrupts. */
-#define configMAC_ISR_SIMULATOR_PRIORITY          ( configMAX_PRIORITIES - 1 )
+#define configMAC_ISR_SIMULATOR_PRIORITY    ( configMAX_PRIORITIES - 1 )
 
 /* This demo creates a virtual network connection by accessing the raw Ethernet
  * or WiFi data to and from a real network connection.  Many computers have more
@@ -137,63 +137,60 @@
  * results in the wired network being used, while setting
  * configNETWORK_INTERFACE_TO_USE to 2 results in the wireless network being
  * used. */
-#define configNETWORK_INTERFACE_TO_USE            ( 0L )
+#define configNETWORK_INTERFACE_TO_USE      ( 0L )
 
 /* The address to which logging is sent should UDP logging be enabled. */
-#define configUDP_LOGGING_ADDR0                   192
-#define configUDP_LOGGING_ADDR1                   168
-#define configUDP_LOGGING_ADDR2                   0
-#define configUDP_LOGGING_ADDR3                   11
+#define configUDP_LOGGING_ADDR0             192
+#define configUDP_LOGGING_ADDR1             168
+#define configUDP_LOGGING_ADDR2             0
+#define configUDP_LOGGING_ADDR3             11
 
 /* Default MAC address configuration.  The demo creates a virtual network
  * connection that uses this MAC address by accessing the raw Ethernet/WiFi data
  * to and from a real network connection on the host PC.  See the
  * configNETWORK_INTERFACE_TO_USE definition above for information on how to
  * configure the real network connection to use. */
-#define configMAC_ADDR0                           0x00
-#define configMAC_ADDR1                           0x11
-#define configMAC_ADDR2                           0x11
-#define configMAC_ADDR3                           0x11
-#define configMAC_ADDR4                           0x11
-#define configMAC_ADDR5                           0x41
+#define configMAC_ADDR0                     0x00
+#define configMAC_ADDR1                     0x11
+#define configMAC_ADDR2                     0x11
+#define configMAC_ADDR3                     0x11
+#define configMAC_ADDR4                     0x11
+#define configMAC_ADDR5                     0x41
 
 /* Default IP address configuration.  Used in ipconfigUSE_DNS is set to 0, or
  * ipconfigUSE_DNS is set to 1 but a DNS server cannot be contacted. */
-#define configIP_ADDR0                            10
-#define configIP_ADDR1                            10
-#define configIP_ADDR2                            10
-#define configIP_ADDR3                            200
+#define configIP_ADDR0                      10
+#define configIP_ADDR1                      10
+#define configIP_ADDR2                      10
+#define configIP_ADDR3                      200
 
 /* Default gateway IP address configuration.  Used in ipconfigUSE_DNS is set to
  * 0, or ipconfigUSE_DNS is set to 1 but a DNS server cannot be contacted. */
-#define configGATEWAY_ADDR0                       10
-#define configGATEWAY_ADDR1                       10
-#define configGATEWAY_ADDR2                       10
-#define configGATEWAY_ADDR3                       1
+#define configGATEWAY_ADDR0                 10
+#define configGATEWAY_ADDR1                 10
+#define configGATEWAY_ADDR2                 10
+#define configGATEWAY_ADDR3                 1
 
 /* Default DNS server configuration.  OpenDNS addresses are 208.67.222.222 and
  * 208.67.220.220.  Used in ipconfigUSE_DNS is set to 0, or ipconfigUSE_DNS is set
  * to 1 but a DNS server cannot be contacted.*/
-#define configDNS_SERVER_ADDR0                    208
-#define configDNS_SERVER_ADDR1                    67
-#define configDNS_SERVER_ADDR2                    222
-#define configDNS_SERVER_ADDR3                    222
+#define configDNS_SERVER_ADDR0              208
+#define configDNS_SERVER_ADDR1              67
+#define configDNS_SERVER_ADDR2              222
+#define configDNS_SERVER_ADDR3              222
 
 /* Default netmask configuration.  Used in ipconfigUSE_DNS is set to 0, or
  * ipconfigUSE_DNS is set to 1 but a DNS server cannot be contacted. */
-#define configNET_MASK0                           255
-#define configNET_MASK1                           0
-#define configNET_MASK2                           0
-#define configNET_MASK3                           0
+#define configNET_MASK0                     255
+#define configNET_MASK1                     0
+#define configNET_MASK2                     0
+#define configNET_MASK3                     0
 
 /* The UDP port to which print messages are sent. */
-#define configPRINT_PORT                          ( 15000 )
+#define configPRINT_PORT                    ( 15000 )
 
-/* Task pool definitions for the demos of IoT Libraries. */
-#define configTASKPOOL_ENABLE_ASSERTS             1
-#define configTASKPOOL_NUMBER_OF_WORKERS          1
-#define configTASKPOOL_WORKER_PRIORITY            tskIDLE_PRIORITY
-#define configTASKPOOL_WORKER_STACK_SIZE_BYTES    2048
+/* Choose CRLF as the new-line character for logging. */
+#define configLOGGING_NEW_LINE              "\r\n"
 
 #if ( defined( _MSC_VER ) && ( _MSC_VER <= 1600 ) && !defined( snprintf ) )
     /* Map to Windows names. */

--- a/FreeRTOS-Plus/Demo/corePKCS11_MQTT_Mutual_Auth_Windows_Simulator/FreeRTOSConfig.h
+++ b/FreeRTOS-Plus/Demo/corePKCS11_MQTT_Mutual_Auth_Windows_Simulator/FreeRTOSConfig.h
@@ -187,8 +187,6 @@
 /* The UDP port to which print messages are sent. */
 #define configPRINT_PORT                    ( 15000 )
 
-/* Choose CRLF as the new-line character for logging. */
-#define configLOGGING_NEW_LINE              "\r\n"
 
 #if ( defined( _MSC_VER ) && ( _MSC_VER <= 1600 ) && !defined( snprintf ) )
     /* Map to Windows names. */

--- a/FreeRTOS-Plus/Demo/corePKCS11_MQTT_Mutual_Auth_Windows_Simulator/FreeRTOSConfig.h
+++ b/FreeRTOS-Plus/Demo/corePKCS11_MQTT_Mutual_Auth_Windows_Simulator/FreeRTOSConfig.h
@@ -124,7 +124,7 @@
 
 /* Only used when running in the FreeRTOS Windows simulator.  Defines the
  * priority of the task used to simulate Ethernet interrupts. */
-#define configMAC_ISR_SIMULATOR_PRIORITY          ( configMAX_PRIORITIES - 1 )
+#define configMAC_ISR_SIMULATOR_PRIORITY    ( configMAX_PRIORITIES - 1 )
 
 /* This demo creates a virtual network connection by accessing the raw Ethernet
  * or WiFi data to and from a real network connection.  Many computers have more
@@ -135,63 +135,60 @@
  * results in the wired network being used, while setting
  * configNETWORK_INTERFACE_TO_USE to 2 results in the wireless network being
  * used. */
-#define configNETWORK_INTERFACE_TO_USE            ( 0L )
+#define configNETWORK_INTERFACE_TO_USE      ( 0L )
 
 /* The address to which logging is sent should UDP logging be enabled. */
-#define configUDP_LOGGING_ADDR0                   192
-#define configUDP_LOGGING_ADDR1                   168
-#define configUDP_LOGGING_ADDR2                   0
-#define configUDP_LOGGING_ADDR3                   11
+#define configUDP_LOGGING_ADDR0             192
+#define configUDP_LOGGING_ADDR1             168
+#define configUDP_LOGGING_ADDR2             0
+#define configUDP_LOGGING_ADDR3             11
 
 /* Default MAC address configuration.  The demo creates a virtual network
  * connection that uses this MAC address by accessing the raw Ethernet/WiFi data
  * to and from a real network connection on the host PC.  See the
  * configNETWORK_INTERFACE_TO_USE definition above for information on how to
  * configure the real network connection to use. */
-#define configMAC_ADDR0                           0x00
-#define configMAC_ADDR1                           0x11
-#define configMAC_ADDR2                           0x11
-#define configMAC_ADDR3                           0x11
-#define configMAC_ADDR4                           0x11
-#define configMAC_ADDR5                           0x41
+#define configMAC_ADDR0                     0x00
+#define configMAC_ADDR1                     0x11
+#define configMAC_ADDR2                     0x11
+#define configMAC_ADDR3                     0x11
+#define configMAC_ADDR4                     0x11
+#define configMAC_ADDR5                     0x41
 
 /* Default IP address configuration.  Used in ipconfigUSE_DNS is set to 0, or
  * ipconfigUSE_DNS is set to 1 but a DNS server cannot be contacted. */
-#define configIP_ADDR0                            10
-#define configIP_ADDR1                            10
-#define configIP_ADDR2                            10
-#define configIP_ADDR3                            200
+#define configIP_ADDR0                      10
+#define configIP_ADDR1                      10
+#define configIP_ADDR2                      10
+#define configIP_ADDR3                      200
 
 /* Default gateway IP address configuration.  Used in ipconfigUSE_DNS is set to
  * 0, or ipconfigUSE_DNS is set to 1 but a DNS server cannot be contacted. */
-#define configGATEWAY_ADDR0                       10
-#define configGATEWAY_ADDR1                       10
-#define configGATEWAY_ADDR2                       10
-#define configGATEWAY_ADDR3                       1
+#define configGATEWAY_ADDR0                 10
+#define configGATEWAY_ADDR1                 10
+#define configGATEWAY_ADDR2                 10
+#define configGATEWAY_ADDR3                 1
 
 /* Default DNS server configuration.  OpenDNS addresses are 208.67.222.222 and
  * 208.67.220.220.  Used in ipconfigUSE_DNS is set to 0, or ipconfigUSE_DNS is set
  * to 1 but a DNS server cannot be contacted.*/
-#define configDNS_SERVER_ADDR0                    208
-#define configDNS_SERVER_ADDR1                    67
-#define configDNS_SERVER_ADDR2                    222
-#define configDNS_SERVER_ADDR3                    222
+#define configDNS_SERVER_ADDR0              208
+#define configDNS_SERVER_ADDR1              67
+#define configDNS_SERVER_ADDR2              222
+#define configDNS_SERVER_ADDR3              222
 
 /* Default netmask configuration.  Used in ipconfigUSE_DNS is set to 0, or
  * ipconfigUSE_DNS is set to 1 but a DNS server cannot be contacted. */
-#define configNET_MASK0                           255
-#define configNET_MASK1                           0
-#define configNET_MASK2                           0
-#define configNET_MASK3                           0
+#define configNET_MASK0                     255
+#define configNET_MASK1                     0
+#define configNET_MASK2                     0
+#define configNET_MASK3                     0
 
 /* The UDP port to which print messages are sent. */
-#define configPRINT_PORT                          ( 15000 )
+#define configPRINT_PORT                    ( 15000 )
 
-/* Task pool definitions for the demos of IoT Libraries. */
-#define configTASKPOOL_ENABLE_ASSERTS             1
-#define configTASKPOOL_NUMBER_OF_WORKERS          1
-#define configTASKPOOL_WORKER_PRIORITY            tskIDLE_PRIORITY
-#define configTASKPOOL_WORKER_STACK_SIZE_BYTES    2048
+/* Choose CRLF as the new-line character for logging. */
+#define configLOGGING_NEW_LINE              "\r\n"
 
 #if ( defined( _MSC_VER ) && ( _MSC_VER <= 1600 ) && !defined( snprintf ) )
     /* Map to Windows names. */


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->
The Windows implementation of `vLoggingPrintf` used `\n` as the default new-line character. However, the demos used `\r\n`, so it would append the extra parameters such as `pcTaskName` to the end of each new-line message. This fixes it by setting the default new-line character to `\r\n`.

In addition, any `configTASKPOOL` macros are removed as they are not being used at all.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
