### PR TITLE
Fix conflicting definition of SdkLog from config files

### DIFF
--- a/FreeRTOS-Plus/Demo/AWS/Device_Shadow_Windows_Simulator/Device_Shadow_Demo/core_mqtt_config.h
+++ b/FreeRTOS-Plus/Demo/AWS/Device_Shadow_Windows_Simulator/Device_Shadow_Demo/core_mqtt_config.h
@@ -56,7 +56,9 @@ extern void vLoggingPrintf( const char * pcFormatString,
 
 /* Map the SdkLog macro to the logging function to enable logging
  * on Windows simulator. */
-#define SdkLog( message )    vLoggingPrintf message
+#ifndef SdkLog
+    #define SdkLog( message )    vLoggingPrintf message
+#endif
 
 #include "logging_stack.h"
 /************ End of logging configuration ****************/

--- a/FreeRTOS-Plus/Demo/AWS/Device_Shadow_Windows_Simulator/Device_Shadow_Demo/demo_config.h
+++ b/FreeRTOS-Plus/Demo/AWS/Device_Shadow_Windows_Simulator/Device_Shadow_Demo/demo_config.h
@@ -61,7 +61,9 @@ extern void vLoggingPrintf( const char * pcFormatString,
 
 /* Map the SdkLog macro to the logging function to enable logging
  * on Windows simulator. */
-#define SdkLog( message )    vLoggingPrintf message
+#ifndef SdkLog
+    #define SdkLog( message )    vLoggingPrintf message
+#endif
 
 #include "logging_stack.h"
 

--- a/FreeRTOS-Plus/Demo/AWS/Device_Shadow_Windows_Simulator/Device_Shadow_Demo/shadow_config.h
+++ b/FreeRTOS-Plus/Demo/AWS/Device_Shadow_Windows_Simulator/Device_Shadow_Demo/shadow_config.h
@@ -53,7 +53,9 @@ extern void vLoggingPrintf( const char * pcFormatString,
 
 /* Map the SdkLog macro to the logging function to enable logging
  * on Windows simulator. */
-#define SdkLog( message )    vLoggingPrintf message
+#ifndef SdkLog
+    #define SdkLog( message )    vLoggingPrintf message
+#endif
 
 #include "logging_stack.h"
 

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Basic_TLS/core_mqtt_config.h
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Basic_TLS/core_mqtt_config.h
@@ -56,7 +56,9 @@ extern void vLoggingPrintf( const char * pcFormatString,
 
 /* Map the SdkLog macro to the logging function to enable logging
  * on Windows simulator. */
-#define SdkLog( message )    vLoggingPrintf message
+#ifndef SdkLog
+    #define SdkLog( message )    vLoggingPrintf message
+#endif
 
 #include "logging_stack.h"
 /************ End of logging configuration ****************/

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Basic_TLS/demo_config.h
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Basic_TLS/demo_config.h
@@ -61,7 +61,9 @@ extern void vLoggingPrintf( const char * pcFormatString,
 
 /* Map the SdkLog macro to the logging function to enable logging
  * on Windows simulator. */
-#define SdkLog( message )    vLoggingPrintf message
+#ifndef SdkLog
+    #define SdkLog( message )    vLoggingPrintf message
+#endif
 
 #include "logging_stack.h"
 

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Keep_Alive/core_mqtt_config.h
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Keep_Alive/core_mqtt_config.h
@@ -58,7 +58,9 @@ extern void vLoggingPrintf( const char * pcFormatString,
 
 /* Map the SdkLog macro to the logging function to enable logging
  * on Windows simulator. */
-#define SdkLog( message )    vLoggingPrintf message
+#ifndef SdkLog
+    #define SdkLog( message )    vLoggingPrintf message
+#endif
 
 #include "logging_stack.h"
 /************ End of logging configuration ****************/

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Keep_Alive/demo_config.h
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Keep_Alive/demo_config.h
@@ -59,7 +59,9 @@ extern void vLoggingPrintf( const char * pcFormatString,
 
 /* Map the SdkLog macro to the logging function to enable logging
  * on Windows simulator. */
-#define SdkLog( message )    vLoggingPrintf message
+#ifndef SdkLog
+    #define SdkLog( message )    vLoggingPrintf message
+#endif
 
 #include "logging_stack.h"
 

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Multitask/core_mqtt_config.h
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Multitask/core_mqtt_config.h
@@ -58,7 +58,9 @@ extern void vLoggingPrintf( const char * pcFormatString,
 
 /* Map the SdkLog macro to the logging function to enable logging
  * on Windows simulator. */
-#define SdkLog( message )    vLoggingPrintf message
+#ifndef SdkLog
+    #define SdkLog( message )    vLoggingPrintf message
+#endif
 
 #include "logging_stack.h"
 /************ End of logging configuration ****************/

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Multitask/demo_config.h
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Multitask/demo_config.h
@@ -58,7 +58,9 @@ extern void vLoggingPrintf( const char * pcFormatString,
 
 /* Map the SdkLog macro to the logging function to enable logging
  * on Windows simulator. */
-#define SdkLog( message )    vLoggingPrintf message
+#ifndef SdkLog
+    #define SdkLog( message )    vLoggingPrintf message
+#endif
 
 #include "logging_stack.h"
 
@@ -261,13 +263,9 @@ extern void vLoggingPrintf( const char * pcFormatString,
 
 
 
-
-
-
-
 /**********************************************************************************
- * Error checks and derived values only below here - do not edit below here. -----*
- **********************************************************************************/
+* Error checks and derived values only below here - do not edit below here. -----*
+**********************************************************************************/
 
 
 /* Compile time error for some undefined configs, and provide default values
@@ -277,14 +275,15 @@ extern void vLoggingPrintf( const char * pcFormatString,
 #endif
 
 #ifndef democonfigCLIENT_IDENTIFIER
-    /**
-     * @brief The MQTT client identifier used in this example.  Each client identifier
-     * must be unique so edit as required to ensure no two clients connecting to the
-     * same broker use the same client identifier.  Using a #define is for convenience
-     * of demonstration only - production devices should use something unique to the
-     * device that can be read from software - such as a production serial number.
-     */
-     #error  "Please define democonfigCLIENT_IDENTIFIER in demo_config.h to something unique for this device."
+
+/**
+ * @brief The MQTT client identifier used in this example.  Each client identifier
+ * must be unique so edit as required to ensure no two clients connecting to the
+ * same broker use the same client identifier.  Using a #define is for convenience
+ * of demonstration only - production devices should use something unique to the
+ * device that can be read from software - such as a production serial number.
+ */
+    #error  "Please define democonfigCLIENT_IDENTIFIER in demo_config.h to something unique for this device."
 #endif
 
 
@@ -296,11 +295,11 @@ extern void vLoggingPrintf( const char * pcFormatString,
 /* If no username is defined, then a client certificate/key is required. */
     #ifndef democonfigCLIENT_USERNAME
 
-        /*
-         *!!! Please note democonfigCLIENT_PRIVATE_KEY_PEM in used for
-         *!!! convenience of demonstration only.  Production devices should
-         *!!! store keys securely, such as within a secure element.
-         */
+/*
+ *!!! Please note democonfigCLIENT_PRIVATE_KEY_PEM in used for
+ *!!! convenience of demonstration only.  Production devices should
+ *!!! store keys securely, such as within a secure element.
+ */
 
         #ifndef democonfigCLIENT_CERTIFICATE_PEM
             #error "Please define client certificate(democonfigCLIENT_CERTIFICATE_PEM) in demo_config.h."
@@ -393,12 +392,12 @@ extern void vLoggingPrintf( const char * pcFormatString,
 /**
  * @brief Length of client identifier.
  */
-#define democonfigCLIENT_IDENTIFIER_LENGTH           ( ( uint16_t ) ( sizeof( democonfigCLIENT_IDENTIFIER ) - 1 ) )
+#define democonfigCLIENT_IDENTIFIER_LENGTH    ( ( uint16_t ) ( sizeof( democonfigCLIENT_IDENTIFIER ) - 1 ) )
 
 /**
  * @brief Length of MQTT server host name.
  */
-#define democonfigBROKER_ENDPOINT_LENGTH             ( ( uint16_t ) ( sizeof( democonfigMQTT_BROKER_ENDPOINT ) - 1 ) )
+#define democonfigBROKER_ENDPOINT_LENGTH      ( ( uint16_t ) ( sizeof( democonfigMQTT_BROKER_ENDPOINT ) - 1 ) )
 
 
 #endif /* DEMO_CONFIG_H */

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Mutual_Auth/core_mqtt_config.h
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Mutual_Auth/core_mqtt_config.h
@@ -56,7 +56,9 @@ extern void vLoggingPrintf( const char * pcFormatString,
 
 /* Map the SdkLog macro to the logging function to enable logging
  * on Windows simulator. */
-#define SdkLog( message )    vLoggingPrintf message
+#ifndef SdkLog
+    #define SdkLog( message )    vLoggingPrintf message
+#endif
 
 #include "logging_stack.h"
 /************ End of logging configuration ****************/

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Mutual_Auth/demo_config.h
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Mutual_Auth/demo_config.h
@@ -61,7 +61,9 @@ extern void vLoggingPrintf( const char * pcFormatString,
 
 /* Map the SdkLog macro to the logging function to enable logging
  * on Windows simulator. */
-#define SdkLog( message )    vLoggingPrintf message
+#ifndef SdkLog
+    #define SdkLog( message )    vLoggingPrintf message
+#endif
 
 #include "logging_stack.h"
 

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Plain_Text/core_mqtt_config.h
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Plain_Text/core_mqtt_config.h
@@ -58,7 +58,9 @@ extern void vLoggingPrintf( const char * pcFormatString,
 
 /* Map the SdkLog macro to the logging function to enable logging
  * on Windows simulator. */
-#define SdkLog( message )    vLoggingPrintf message
+#ifndef SdkLog
+    #define SdkLog( message )    vLoggingPrintf message
+#endif
 
 #include "logging_stack.h"
 /************ End of logging configuration ****************/

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Plain_Text/demo_config.h
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Plain_Text/demo_config.h
@@ -59,7 +59,9 @@ extern void vLoggingPrintf( const char * pcFormatString,
 
 /* Map the SdkLog macro to the logging function to enable logging
  * on Windows simulator. */
-#define SdkLog( message )    vLoggingPrintf message
+#ifndef SdkLog
+    #define SdkLog( message )    vLoggingPrintf message
+#endif
 
 #include "logging_stack.h"
 

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Serializer/core_mqtt_config.h
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Serializer/core_mqtt_config.h
@@ -58,7 +58,9 @@ extern void vLoggingPrintf( const char * pcFormatString,
 
 /* Map the SdkLog macro to the logging function to enable logging
  * on Windows simulator. */
-#define SdkLog( message )    vLoggingPrintf message
+#ifndef SdkLog
+    #define SdkLog( message )    vLoggingPrintf message
+#endif
 
 #include "logging_stack.h"
 /************ End of logging configuration ****************/

--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Serializer/demo_config.h
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Serializer/demo_config.h
@@ -59,7 +59,9 @@ extern void vLoggingPrintf( const char * pcFormatString,
 
 /* Map the SdkLog macro to the logging function to enable logging
  * on Windows simulator. */
-#define SdkLog( message )    vLoggingPrintf message
+#ifndef SdkLog
+    #define SdkLog( message )    vLoggingPrintf message
+#endif
 
 #include "logging_stack.h"
 

--- a/FreeRTOS-Plus/Demo/corePKCS11_MQTT_Mutual_Auth_Windows_Simulator/core_mqtt_config.h
+++ b/FreeRTOS-Plus/Demo/corePKCS11_MQTT_Mutual_Auth_Windows_Simulator/core_mqtt_config.h
@@ -56,7 +56,9 @@ extern void vLoggingPrintf( const char * pcFormatString,
 
 /* Map the SdkLog macro to the logging function to enable logging
  * on Windows simulator. */
-#define SdkLog( message )    vLoggingPrintf message
+#ifndef SdkLog
+    #define SdkLog( message )    vLoggingPrintf message
+#endif
 
 #include "logging_stack.h"
 /************ End of logging configuration ****************/

--- a/FreeRTOS-Plus/Demo/corePKCS11_MQTT_Mutual_Auth_Windows_Simulator/core_pkcs11_config.h
+++ b/FreeRTOS-Plus/Demo/corePKCS11_MQTT_Mutual_Auth_Windows_Simulator/core_pkcs11_config.h
@@ -65,7 +65,9 @@ extern void vLoggingPrintf( const char * pcFormatString,
 
 /* Map the SdkLog macro to the logging function to enable logging
  * on Windows simulator. */
-#define SdkLog( message )    vLoggingPrintf message
+#ifndef SdkLog
+    #define SdkLog( message )    vLoggingPrintf message
+#endif
 
 #include "logging_stack.h"
 

--- a/FreeRTOS-Plus/Demo/corePKCS11_MQTT_Mutual_Auth_Windows_Simulator/demo_config.h
+++ b/FreeRTOS-Plus/Demo/corePKCS11_MQTT_Mutual_Auth_Windows_Simulator/demo_config.h
@@ -61,7 +61,9 @@ extern void vLoggingPrintf( const char * pcFormatString,
 
 /* Map the SdkLog macro to the logging function to enable logging
  * on Windows simulator. */
-#define SdkLog( message )    vLoggingPrintf message
+#ifndef SdkLog
+    #define SdkLog( message )    vLoggingPrintf message
+#endif
 
 #include "logging_stack.h"
 

--- a/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/core_pkcs11_config.h
+++ b/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/core_pkcs11_config.h
@@ -65,7 +65,9 @@ extern void vLoggingPrintf( const char * pcFormatString,
 
 /* Map the SdkLog macro to the logging function to enable logging
  * on Windows simulator. */
-#define SdkLog( message )    vLoggingPrintf message
+#ifndef SdkLog
+    #define SdkLog( message )    vLoggingPrintf message
+#endif
 
 #include "logging_stack.h"
 

--- a/FreeRTOS-Plus/Source/Application-Protocols/network_transport/freertos_plus_tcp/sockets_wrapper.h
+++ b/FreeRTOS-Plus/Source/Application-Protocols/network_transport/freertos_plus_tcp/sockets_wrapper.h
@@ -62,7 +62,9 @@ extern void vLoggingPrintf( const char * pcFormatString,
 
 /* Map the SdkLog macro to the logging function to enable logging
  * on Windows simulator. */
-#define SdkLog( message )    vLoggingPrintf message
+#ifndef SdkLog
+    #define SdkLog( message )    vLoggingPrintf message
+#endif
 
 #include "logging_stack.h"
 

--- a/FreeRTOS-Plus/Source/Application-Protocols/network_transport/freertos_plus_tcp/using_mbedtls/using_mbedtls.h
+++ b/FreeRTOS-Plus/Source/Application-Protocols/network_transport/freertos_plus_tcp/using_mbedtls/using_mbedtls.h
@@ -57,7 +57,9 @@ extern void vLoggingPrintf( const char * pcFormatString,
 
 /* Map the SdkLog macro to the logging function to enable logging
  * on Windows simulator. */
-#define SdkLog( message )    vLoggingPrintf message
+#ifndef SdkLog
+    #define SdkLog( message )    vLoggingPrintf message
+#endif
 
 #include "logging_stack.h"
 

--- a/FreeRTOS-Plus/Source/Application-Protocols/network_transport/freertos_plus_tcp/using_mbedtls_pkcs11/using_mbedtls_pkcs11.h
+++ b/FreeRTOS-Plus/Source/Application-Protocols/network_transport/freertos_plus_tcp/using_mbedtls_pkcs11/using_mbedtls_pkcs11.h
@@ -60,7 +60,9 @@ extern void vLoggingPrintf( const char * pcFormatString,
 
 /* Map the SdkLog macro to the logging function to enable logging
  * on Windows simulator. */
-#define SdkLog( message )    vLoggingPrintf message
+#ifndef SdkLog
+    #define SdkLog( message )    vLoggingPrintf message
+#endif
 
 #include "logging_stack.h"
 

--- a/FreeRTOS-Plus/Source/Application-Protocols/network_transport/freertos_plus_tcp/using_plaintext/using_plaintext.h
+++ b/FreeRTOS-Plus/Source/Application-Protocols/network_transport/freertos_plus_tcp/using_plaintext/using_plaintext.h
@@ -52,7 +52,9 @@ extern void vLoggingPrintf( const char * pcFormatString,
 
 /* Map the SdkLog macro to the logging function to enable logging
  * on Windows simulator. */
-#define SdkLog( message )    vLoggingPrintf message
+#ifndef SdkLog
+    #define SdkLog( message )    vLoggingPrintf message
+#endif
 
 #include "logging_stack.h"
 


### PR DESCRIPTION
#### Problem 
When there are different definitions of `SdkLog` in different config files (like `demo_config.h` and `core_mqtt_config.h` files) and the config files are included in the same translation unit, there is compiler warning of conflicting definitions. 

#### Fix 
Add `#ifndef` guards around the `SdkLog` definitions in config files to avoid multiple definitions in a translation unit. 

#### Note 
For most cases, the user may need to define the `SdkLog` macro ONLY once for the entire project build. An alternative way to define the macro for the whole project is by setting its default value in the `FreeRTOS-Plus/Source/Utilities/Logging/logging_stack.h` file