### PR TITLE
Add helpful asterisk comments to the shadow demo.

### DIFF
--- a/FreeRTOS-Plus/Demo/AWS/Device_Shadow_Windows_Simulator/Device_Shadow_Demo/DemoTasks/ShadowDemoMainExample.c
+++ b/FreeRTOS-Plus/Demo/AWS/Device_Shadow_Windows_Simulator/Device_Shadow_Demo/DemoTasks/ShadowDemoMainExample.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.0
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
@@ -19,9 +19,10 @@
  * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  *
- * http://www.FreeRTOS.org
- * http://aws.amazon.com/freertos
+ * https://www.FreeRTOS.org
+ * https://github.com/FreeRTOS
  *
+ * 1 tab == 4 spaces!
  */
 
 /*

--- a/FreeRTOS-Plus/Demo/AWS/Device_Shadow_Windows_Simulator/Device_Shadow_Demo/DemoTasks/ShadowDemoMainExample.c
+++ b/FreeRTOS-Plus/Demo/AWS/Device_Shadow_Windows_Simulator/Device_Shadow_Demo/DemoTasks/ShadowDemoMainExample.c
@@ -778,7 +778,7 @@ void prvShadowDemoTask( void * pvParameters )
 
     /****************************** Disconnect. *******************************/
 
-    /* The MQTT session is always disconnected, even there were prior failures. */
+    /* The MQTT session is always disconnected, even if there were prior failures. */
     demoStatus = xDisconnectMqttSession( &xMqttContext, &xNetworkContext );
 
     /* This demo performs only Device Shadow operations. If matching the Shadow


### PR DESCRIPTION
<!--- Title -->

Description
-----------
This PR adds the beautiful helpful asterisk line comments to section out the prvShadowDemoTask() function, like the MQTT demos do.

I also flatten out the if/else better to check for pass before each step instead of nesting it.

Test Steps
-----------
Run the Shadow demo per usual.

Related Issue
-----------
N/A

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
