### PR TITLE
FR Header Checks: Update expected file header. Support ignores.

### DIFF
--- a/.github/scripts/check-header.py
+++ b/.github/scripts/check-header.py
@@ -100,7 +100,6 @@ def main():
         ' * https://www.FreeRTOS.org\n',
         ' * https://github.com/FreeRTOS\n',
         ' *\n',
-        ' * 1 tab == 4 spaces!\n',
         ' */\n',
     ]
 


### PR DESCRIPTION
- Remove the ` * 1 tab == 4 spaces ` remark from header check.
- Add ignore mechanism 
- Use ignore mechanism to skip checks for certain file extensions, filenames, including the checker script itself


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
