### PR TITLE
Fix issues with CI header check with .gitmodules and directories

### DIFF
--- a/.github/scripts/check-header.py
+++ b/.github/scripts/check-header.py
@@ -43,6 +43,11 @@ class HeaderChecker:
         if self.isIgnoredFile(path):
             return True
 
+        # Skip if entry is a directory.
+        if os.path.isdir(path):
+            print('Skipping valid file check on directory path: %s' % path)
+            return True
+
         # Don't need entire file. Read sufficienly large chunk of file that should contain the header
         with open(path, encoding='utf-8', errors='ignore') as file:
             chunk = file.read(len(''.join(self.header)) + self.padding)
@@ -164,7 +169,8 @@ def main():
     checker.ignoreExtension('.vcxproj',
                             '.vcxproj.filters',
                             '.sln'
-                            '.md')
+                            '.md,'
+                            '.gitmodules')
 
     checker.ignoreFile(os.path.split(__file__)[-1], # Add self
                        'mbedtls_config.h')


### PR DESCRIPTION
The PR #419 updates `.gitmodules` and adds a submodule (a.k.a a folder), but the `FreeRTOS-Header-Checker / File Header Checks` check is failing as it does not correctly handle `.gitmodules` and folders. This PR updates the script to ignore these 2 kinds of entries from being inspected