### PR TITLE
Have metrics collector return amount written

### DIFF
--- a/FreeRTOS-Plus/Demo/AWS/Device_Defender_Windows_Simulator/Device_Defender_Demo/metrics_collector.c
+++ b/FreeRTOS-Plus/Demo/AWS/Device_Defender_Windows_Simulator/Device_Defender_Demo/metrics_collector.c
@@ -120,9 +120,6 @@ eMetricsCollectorStatus eGetOpenTcpPorts( uint16_t * pusOutTcpPortsArray,
 
     if( eStatus == eMetricsCollectorSuccess )
     {
-        /* Set the out value for number of open TCP ports. */
-        *pulOutNumTcpOpenPorts = xMetrics.xTCPPortList.uxCount;
-
         /* Fill the output array with as many TCP ports as will fit in the
          * given array. */
         if( pusOutTcpPortsArray != NULL )
@@ -137,6 +134,14 @@ eMetricsCollectorStatus eGetOpenTcpPorts( uint16_t * pusOutTcpPortsArray,
             }
 
             memcpy( pusOutTcpPortsArray, &xMetrics.xTCPPortList.usTCPPortList, ulCopyAmount * sizeof( uint16_t ) );
+
+            /* Return the number of elements copied to the array. */
+            *pulOutNumTcpOpenPorts = ulCopyAmount;
+        }
+        else
+        {
+            /* Return the total number of open ports. */
+            *pulOutNumTcpOpenPorts = xMetrics.xTCPPortList.uxCount;
         }
     }
 
@@ -169,8 +174,6 @@ eMetricsCollectorStatus eGetOpenUdpPorts( uint16_t * pusOutUdpPortsArray,
 
     if( eStatus == eMetricsCollectorSuccess )
     {
-        *pulOutNumUdpOpenPorts = xMetrics.xUDPPortList.uxCount;
-
         /* Fill the output array with as many UDP ports as will fit in the
          * given array. */
         if( pusOutUdpPortsArray != NULL )
@@ -185,6 +188,14 @@ eMetricsCollectorStatus eGetOpenUdpPorts( uint16_t * pusOutUdpPortsArray,
             }
 
             memcpy( pusOutUdpPortsArray, &xMetrics.xUDPPortList.usUDPPortList, ulCopyAmount * sizeof( uint16_t ) );
+
+            /* Return the number of elements copied to the array. */
+            *pulOutNumUdpOpenPorts = ulCopyAmount;
+        }
+        else
+        {
+            /* Return the total number of open ports. */
+            *pulOutNumUdpOpenPorts = xMetrics.xUDPPortList.uxCount;
         }
     }
 
@@ -220,9 +231,6 @@ eMetricsCollectorStatus eGetEstablishedConnections( Connection_t * pxOutConnecti
 
     if( eStatus == eMetricsCollectorSuccess )
     {
-        /* We consider only TCP sockets for open connections. */
-        *pulOutNumEstablishedConnections = xMetrics.xTCPSocketList.uxCount;
-
         /* Fill the output array with as many TCP socket infos as will fit in
          * the given array. */
         if( pxOutConnectionsArray != NULL )
@@ -249,6 +257,14 @@ eMetricsCollectorStatus eGetEstablishedConnections( Connection_t * pxOutConnecti
                 pxOutConnectionsArray[ i ].usRemotePort =
                     xMetrics.xTCPSocketList.xTCPList[ i ].usRemotePort;
             }
+
+            /* Return the number of elements copied to the array. */
+            *pulOutNumEstablishedConnections = ulCopyAmount;
+        }
+        else
+        {
+            /* Return the total number of established connections. */
+            *pulOutNumEstablishedConnections = xMetrics.xTCPSocketList.uxCount;
         }
     }
 

--- a/FreeRTOS-Plus/Demo/AWS/Device_Defender_Windows_Simulator/Device_Defender_Demo/metrics_collector.h
+++ b/FreeRTOS-Plus/Demo/AWS/Device_Defender_Windows_Simulator/Device_Defender_Demo/metrics_collector.h
@@ -75,9 +75,9 @@ typedef struct Connection
  *
  * @param[out] pxOutNetworkStats The network stats.
  *
- * @return #MetricsCollectorSuccess if the network stats are successfully obtained;
- * #MetricsCollectorBadParameter if invalid parameters are passed;
- * #MetricsCollectorCollectionFailed if the collection methods failed.
+ * @return #eMetricsCollectorSuccess if the network stats are successfully obtained;
+ * #eMetricsCollectorBadParameter if invalid parameters are passed;
+ * #eMetricsCollectorCollectionFailed if the collection methods failed.
  */
 eMetricsCollectorStatus eGetNetworkStats( NetworkStats_t * pxOutNetworkStats );
 
@@ -91,11 +91,12 @@ eMetricsCollectorStatus eGetNetworkStats( NetworkStats_t * pxOutNetworkStats );
  * can be NULL, if only the number of open ports is needed.
  * @param[in] ulTcpPortsArrayLength Length of the pusOutTcpPortsArray, if it is not
  * NULL.
- * @param[out] pulOutNumTcpOpenPorts Number of the open TCP ports.
+ * @param[out] pulOutNumTcpOpenPorts Number of open TCP ports if @p
+ * pusOutTcpPortsArray NULL, else number of TCP ports written.
  *
- * @return #MetricsCollectorSuccess if open TCP ports are successfully obtained;
- * #MetricsCollectorBadParameter if invalid parameters are passed;
- * #MetricsCollectorCollectionFailed if the collection methods failed.
+ * @return #eMetricsCollectorSuccess if open TCP ports are successfully obtained;
+ * #eMetricsCollectorBadParameter if invalid parameters are passed;
+ * #eMetricsCollectorCollectionFailed if the collection methods failed.
  */
 eMetricsCollectorStatus eGetOpenTcpPorts( uint16_t * pusOutTcpPortsArray,
                                           uint32_t ulTcpPortsArrayLength,
@@ -111,11 +112,12 @@ eMetricsCollectorStatus eGetOpenTcpPorts( uint16_t * pusOutTcpPortsArray,
  * be NULL, if only number of open ports is needed.
  * @param[in] ulUdpPortsArrayLength Length of the pusOutUdpPortsArray, if it is not
  * NULL.
- * @param[out] pulOutNumUdpOpenPorts Number of the open UDP ports.
+ * @param[out] pulOutNumUdpOpenPorts Number of open UDP ports if @p
+ * pusOutUdpPortsArray NULL, else number of UDP ports written.
  *
- * @return #MetricsCollectorSuccess if open UDP ports are successfully obtained;
- * #MetricsCollectorBadParameter if invalid parameters are passed;
- * #MetricsCollectorCollectionFailed if the collection methods failed.
+ * @return #eMetricsCollectorSuccess if open UDP ports are successfully obtained;
+ * #eMetricsCollectorBadParameter if invalid parameters are passed;
+ * #eMetricsCollectorCollectionFailed if the collection methods failed.
  */
 eMetricsCollectorStatus eGetOpenUdpPorts( uint16_t * pusOutUdpPortsArray,
                                           uint32_t ulUdpPortsArrayLength,
@@ -133,11 +135,12 @@ eMetricsCollectorStatus eGetOpenUdpPorts( uint16_t * pusOutUdpPortsArray,
  * needed.
  * @param[in] ulConnectionsArrayLength Length of the pxOutConnectionsArray, if it
  * is not NULL.
- * @param[out] pulOutNumEstablishedConnections Number of the established connections.
+ * @param[out] pulOutNumEstablishedConnections Number of established connections if @p
+ * pusOutNumEstablishedConnections NULL, else number of established connections written.
  *
- * @return #MetricsCollectorSuccess if established connections are successfully obtained;
- * #MetricsCollectorBadParameter if invalid parameters are passed;
- * #MetricsCollectorCollectionFailed if the collection methods failed.
+ * @return #eMetricsCollectorSuccess if established connections are successfully obtained;
+ * #eMetricsCollectorBadParameter if invalid parameters are passed;
+ * #eMetricsCollectorCollectionFailed if the collection methods failed.
  */
 eMetricsCollectorStatus eGetEstablishedConnections( Connection_t * pxOutConnectionsArray,
                                                     uint32_t ulConnectionsArrayLength,


### PR DESCRIPTION
Description
-----------
Have metrics collector methods update their output amount with number of entries written in the case that the output buffer is not NULL. Previously they always outputted total number of items, even if less were written due to insufficient buffer. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
