### PR TITLE
Move corePKCS11 forward and update to latest core_pkcs11.h

### DIFF
--- a/FreeRTOS-Plus/Demo/corePKCS11_MQTT_Mutual_Auth_Windows_Simulator/core_pkcs11_config.h
+++ b/FreeRTOS-Plus/Demo/corePKCS11_MQTT_Mutual_Auth_Windows_Simulator/core_pkcs11_config.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS V1.4.8
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
@@ -19,8 +19,8 @@
  * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  *
- * http://aws.amazon.com/freertos
  * http://www.FreeRTOS.org
+ * http://aws.amazon.com/freertos
  */
 
 

--- a/FreeRTOS-Plus/Demo/corePKCS11_MQTT_Mutual_Auth_Windows_Simulator/core_pkcs11_config.h
+++ b/FreeRTOS-Plus/Demo/corePKCS11_MQTT_Mutual_Auth_Windows_Simulator/core_pkcs11_config.h
@@ -19,10 +19,10 @@
  * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  *
- * http://www.FreeRTOS.org
- * http://aws.amazon.com/freertos
+ * https://www.FreeRTOS.org
+ * https://github.com/FreeRTOS
+ *
  */
-
 
 /**
  * @file core_pkcs11_config.h

--- a/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/WIN32.vcxproj
+++ b/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/WIN32.vcxproj
@@ -58,7 +58,7 @@
     </Midl>
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>..\..\..\FreeRTOS-Plus\Source\Utilities\logging;..\..\..\FreeRTOS-Plus\Source\corePKCS11\source\include;..\..\..\FreeRTOS-Plus\Source\corePKCS11\source\portable\mbedtls\include;..\..\..\FreeRTOS-Plus\Source\corePKCS11\source\dependency\3rdparty\pkcs11;..\..\ThirdParty\mbedtls\include;..\..\..\FreeRTOS-Plus\Source\corePKCS11\source\dependency\3rdparty\mbedtls_utils;..\..\..\FreeRTOS\Source\include;..\..\..\FreeRTOS\Source\portable\MSVC-MingW;examples;.;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\..\FreeRTOS-Plus\Source\Utilities\logging;..\..\..\FreeRTOS-Plus\Source\corePKCS11\source\include;..\..\..\FreeRTOS-Plus\Source\corePKCS11\source\dependency\3rdparty\pkcs11;..\..\ThirdParty\mbedtls\include;..\..\..\FreeRTOS-Plus\Source\corePKCS11\source\dependency\3rdparty\mbedtls_utils;..\..\..\FreeRTOS\Source\include;..\..\..\FreeRTOS\Source\portable\MSVC-MingW;examples;.;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;_WIN32_WINNT=0x0500;WINVER=0x400;_CRT_SECURE_NO_WARNINGS;MBEDTLS_CONFIG_FILE="aws_mbedtls_config.h";CONFIG_MEDTLS_USE_AFR_MEMORY;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>false</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
@@ -358,7 +358,7 @@
     <ClInclude Include="..\..\Source\corePKCS11\source\include\core_pkcs11.h" />
     <ClInclude Include="..\..\Source\corePKCS11\source\include\core_pkcs11_pal.h" />
     <ClInclude Include="..\..\Source\corePKCS11\source\include\core_pki_utils.h" />
-    <ClInclude Include="..\..\Source\corePKCS11\source\portable\mbedtls\threading_alt.h" />
+    <ClInclude Include="threading_alt.h" />
     <ClInclude Include="aws_mbedtls_config.h" />
     <ClInclude Include="examples\demo_helpers.h" />
     <ClInclude Include="examples\pkcs11_demos.h" />

--- a/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/WIN32.vcxproj.filters
+++ b/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/WIN32.vcxproj.filters
@@ -412,8 +412,8 @@
     <ClInclude Include="..\..\Source\corePKCS11\source\include\core_pki_utils.h">
       <Filter>corePKCS11\include</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\Source\corePKCS11\source\portable\mbedtls\threading_alt.h">
-      <Filter>corePKCS11\include</Filter>
+    <ClInclude Include="threading_alt.h">
+      <Filter>examples</Filter>
     </ClInclude>
     <ClInclude Include="..\..\ThirdParty\mbedtls\include\mbedtls\aes.h">
       <Filter>3rdparty\mbedtls\include</Filter>

--- a/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/core_pkcs11_config.h
+++ b/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/core_pkcs11_config.h
@@ -20,7 +20,7 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  *
  * https://www.FreeRTOS.org
- * https://aws.amazon.com/freertos
+ * https://github.com/FreeRTOS
  */
 
 /**

--- a/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/core_pkcs11_config.h
+++ b/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/core_pkcs11_config.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS V1.4.8
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
@@ -19,8 +19,8 @@
  * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  *
- * http://aws.amazon.com/freertos
  * http://www.FreeRTOS.org
+ * http://aws.amazon.com/freertos
  */
 
 /**

--- a/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/core_pkcs11_config.h
+++ b/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/core_pkcs11_config.h
@@ -19,8 +19,8 @@
  * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  *
- * http://www.FreeRTOS.org
- * http://aws.amazon.com/freertos
+ * https://www.FreeRTOS.org
+ * https://aws.amazon.com/freertos
  */
 
 /**

--- a/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/core_pkcs11_config.h
+++ b/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/core_pkcs11_config.h
@@ -21,6 +21,7 @@
  *
  * https://www.FreeRTOS.org
  * https://github.com/FreeRTOS
+ *
  */
 
 /**

--- a/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/examples/demo_helpers.c
+++ b/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/examples/demo_helpers.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS PKCS #11 V1.0.3
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
@@ -19,10 +19,9 @@
  * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  *
- * http://aws.amazon.com/freertos
  * http://www.FreeRTOS.org
+ * http://aws.amazon.com/freertos
  */
-
 /* FreeRTOS includes. */
 #include "FreeRTOS.h"
 #include "task.h"

--- a/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/examples/demo_helpers.c
+++ b/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/examples/demo_helpers.c
@@ -20,7 +20,7 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  *
  * https://www.FreeRTOS.org
- * https://aws.amazon.com/freertos
+ * https://github.com/FreeRTOS
  */
 /* FreeRTOS includes. */
 #include "FreeRTOS.h"

--- a/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/examples/demo_helpers.c
+++ b/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/examples/demo_helpers.c
@@ -19,8 +19,8 @@
  * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  *
- * http://www.FreeRTOS.org
- * http://aws.amazon.com/freertos
+ * https://www.FreeRTOS.org
+ * https://aws.amazon.com/freertos
  */
 /* FreeRTOS includes. */
 #include "FreeRTOS.h"

--- a/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/examples/demo_helpers.c
+++ b/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/examples/demo_helpers.c
@@ -21,7 +21,9 @@
  *
  * https://www.FreeRTOS.org
  * https://github.com/FreeRTOS
+ *
  */
+
 /* FreeRTOS includes. */
 #include "FreeRTOS.h"
 #include "task.h"

--- a/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/examples/demo_helpers.h
+++ b/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/examples/demo_helpers.h
@@ -19,8 +19,8 @@
  * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  *
- * http://www.FreeRTOS.org
- * http://aws.amazon.com/freertos
+ * https://www.FreeRTOS.org
+ * https://aws.amazon.com/freertos
  */
 #ifndef _DEMO_HELPER_FUNCTIONS_
 #define _DEMO_HELPER_FUNCTIONS_

--- a/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/examples/demo_helpers.h
+++ b/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/examples/demo_helpers.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS PKCS #11 V1.0.3
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
@@ -19,8 +19,8 @@
  * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  *
- * http://aws.amazon.com/freertos
  * http://www.FreeRTOS.org
+ * http://aws.amazon.com/freertos
  */
 #ifndef _DEMO_HELPER_FUNCTIONS_
 #define _DEMO_HELPER_FUNCTIONS_

--- a/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/examples/demo_helpers.h
+++ b/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/examples/demo_helpers.h
@@ -20,7 +20,7 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  *
  * https://www.FreeRTOS.org
- * https://aws.amazon.com/freertos
+ * https://github.com/FreeRTOS
  */
 #ifndef _DEMO_HELPER_FUNCTIONS_
 #define _DEMO_HELPER_FUNCTIONS_

--- a/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/examples/demo_helpers.h
+++ b/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/examples/demo_helpers.h
@@ -21,7 +21,9 @@
  *
  * https://www.FreeRTOS.org
  * https://github.com/FreeRTOS
+ *
  */
+
 #ifndef _DEMO_HELPER_FUNCTIONS_
 #define _DEMO_HELPER_FUNCTIONS_
 

--- a/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/examples/management_and_rng.c
+++ b/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/examples/management_and_rng.c
@@ -20,7 +20,7 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  *
  * https://www.FreeRTOS.org
- * https://aws.amazon.com/freertos
+ * https://github.com/FreeRTOS
  */
 /* FreeRTOS includes. */
 #include "FreeRTOS.h"

--- a/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/examples/management_and_rng.c
+++ b/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/examples/management_and_rng.c
@@ -19,8 +19,8 @@
  * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  *
- * http://www.FreeRTOS.org
- * http://aws.amazon.com/freertos
+ * https://www.FreeRTOS.org
+ * https://aws.amazon.com/freertos
  */
 /* FreeRTOS includes. */
 #include "FreeRTOS.h"

--- a/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/examples/management_and_rng.c
+++ b/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/examples/management_and_rng.c
@@ -21,7 +21,7 @@
  *
  * https://www.FreeRTOS.org
  * https://github.com/FreeRTOS
- * 
+ *
  */
 
 /* FreeRTOS includes. */

--- a/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/examples/management_and_rng.c
+++ b/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/examples/management_and_rng.c
@@ -21,7 +21,9 @@
  *
  * https://www.FreeRTOS.org
  * https://github.com/FreeRTOS
+ * 
  */
+
 /* FreeRTOS includes. */
 #include "FreeRTOS.h"
 #include "task.h"

--- a/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/examples/management_and_rng.c
+++ b/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/examples/management_and_rng.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS PKCS #11 V1.0.3
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
@@ -19,8 +19,8 @@
  * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  *
- * http://aws.amazon.com/freertos
  * http://www.FreeRTOS.org
+ * http://aws.amazon.com/freertos
  */
 /* FreeRTOS includes. */
 #include "FreeRTOS.h"

--- a/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/examples/mechanisms_and_digests.c
+++ b/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/examples/mechanisms_and_digests.c
@@ -20,7 +20,7 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  *
  * https://www.FreeRTOS.org
- * https://aws.amazon.com/freertos
+ * https://github.com/FreeRTOS
  */
 /* FreeRTOS includes. */
 #include "FreeRTOS.h"

--- a/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/examples/mechanisms_and_digests.c
+++ b/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/examples/mechanisms_and_digests.c
@@ -19,8 +19,8 @@
  * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  *
- * http://www.FreeRTOS.org
- * http://aws.amazon.com/freertos
+ * https://www.FreeRTOS.org
+ * https://aws.amazon.com/freertos
  */
 /* FreeRTOS includes. */
 #include "FreeRTOS.h"

--- a/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/examples/mechanisms_and_digests.c
+++ b/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/examples/mechanisms_and_digests.c
@@ -21,7 +21,9 @@
  *
  * https://www.FreeRTOS.org
  * https://github.com/FreeRTOS
+ *
  */
+
 /* FreeRTOS includes. */
 #include "FreeRTOS.h"
 #include "task.h"

--- a/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/examples/mechanisms_and_digests.c
+++ b/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/examples/mechanisms_and_digests.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS PKCS #11 V1.0.3
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
@@ -19,8 +19,8 @@
  * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  *
- * http://aws.amazon.com/freertos
  * http://www.FreeRTOS.org
+ * http://aws.amazon.com/freertos
  */
 /* FreeRTOS includes. */
 #include "FreeRTOS.h"

--- a/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/examples/objects.c
+++ b/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/examples/objects.c
@@ -20,7 +20,7 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  *
  * https://www.FreeRTOS.org
- * https://aws.amazon.com/freertos
+ * https://github.com/FreeRTOS
  */
 /* FreeRTOS includes. */
 #include "FreeRTOS.h"

--- a/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/examples/objects.c
+++ b/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/examples/objects.c
@@ -19,8 +19,8 @@
  * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  *
- * http://www.FreeRTOS.org
- * http://aws.amazon.com/freertos
+ * https://www.FreeRTOS.org
+ * https://aws.amazon.com/freertos
  */
 /* FreeRTOS includes. */
 #include "FreeRTOS.h"

--- a/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/examples/objects.c
+++ b/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/examples/objects.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS PKCS #11 V1.0.3
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
@@ -19,8 +19,8 @@
  * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  *
- * http://aws.amazon.com/freertos
  * http://www.FreeRTOS.org
+ * http://aws.amazon.com/freertos
  */
 /* FreeRTOS includes. */
 #include "FreeRTOS.h"
@@ -185,17 +185,17 @@ static void prvObjectImporting( void )
     /* Specify certificate subject. */
     xCertificateTemplate.xSubject.type = CKA_SUBJECT;
     xCertificateTemplate.xSubject.pValue = xSubject;
-    xCertificateTemplate.xSubject.ulValueLen = strlen( ( const char * ) xSubject );
+    xCertificateTemplate.xSubject.ulValueLen = sizeof( xSubject ) - 1UL;
 
     /* Point to contents of certificate. */
     xCertificateTemplate.xValue.type = CKA_VALUE;
     xCertificateTemplate.xValue.pValue = ( CK_VOID_PTR ) pkcs11demo_RSA_CERTIFICATE;
-    xCertificateTemplate.xValue.ulValueLen = ( CK_ULONG ) sizeof( pkcs11demo_RSA_CERTIFICATE );
+    xCertificateTemplate.xValue.ulValueLen = ( CK_ULONG ) sizeof( pkcs11demo_RSA_CERTIFICATE ) - 1UL;
     
     /* Specify certificate label. */
     xCertificateTemplate.xLabel.type = CKA_LABEL;
     xCertificateTemplate.xLabel.pValue = ( CK_VOID_PTR ) pucLabel;
-    xCertificateTemplate.xLabel.ulValueLen = strlen( ( const char * ) pucLabel );
+    xCertificateTemplate.xLabel.ulValueLen = sizeof( pucLabel ) - 1UL;
     
     /* Specify certificate type as x509. */
     xCertificateTemplate.xCertificateType.type = CKA_CERTIFICATE_TYPE;

--- a/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/examples/objects.c
+++ b/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/examples/objects.c
@@ -21,7 +21,9 @@
  *
  * https://www.FreeRTOS.org
  * https://github.com/FreeRTOS
+ *
  */
+
 /* FreeRTOS includes. */
 #include "FreeRTOS.h"
 #include "task.h"

--- a/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/examples/pkcs11_demos.h
+++ b/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/examples/pkcs11_demos.h
@@ -21,7 +21,9 @@
  *
  * https://www.FreeRTOS.org
  * https://github.com/FreeRTOS
+ *
  */
+
 #ifndef _PKCS11_DEMOS_h_
 #define _PKCS11_DEMOS_h_
 

--- a/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/examples/pkcs11_demos.h
+++ b/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/examples/pkcs11_demos.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS PKCS #11 V1.0.3
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
@@ -19,8 +19,8 @@
  * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  *
- * http://aws.amazon.com/freertos
  * http://www.FreeRTOS.org
+ * http://aws.amazon.com/freertos
  */
 #ifndef _PKCS11_DEMOS_h_
 #define _PKCS11_DEMOS_h_

--- a/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/examples/pkcs11_demos.h
+++ b/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/examples/pkcs11_demos.h
@@ -19,8 +19,8 @@
  * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  *
- * http://www.FreeRTOS.org
- * http://aws.amazon.com/freertos
+ * https://www.FreeRTOS.org
+ * https://aws.amazon.com/freertos
  */
 #ifndef _PKCS11_DEMOS_h_
 #define _PKCS11_DEMOS_h_

--- a/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/examples/pkcs11_demos.h
+++ b/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/examples/pkcs11_demos.h
@@ -20,7 +20,7 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  *
  * https://www.FreeRTOS.org
- * https://aws.amazon.com/freertos
+ * https://github.com/FreeRTOS
  */
 #ifndef _PKCS11_DEMOS_h_
 #define _PKCS11_DEMOS_h_

--- a/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/examples/sign_and_verify.c
+++ b/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/examples/sign_and_verify.c
@@ -20,7 +20,7 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  *
  * https://www.FreeRTOS.org
- * https://aws.amazon.com/freertos
+ * https://github.com/FreeRTOS
  */
 /* FreeRTOS includes. */
 #include "FreeRTOS.h"

--- a/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/examples/sign_and_verify.c
+++ b/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/examples/sign_and_verify.c
@@ -151,6 +151,7 @@ void vPKCS11SignVerifyDemo( void )
      */
     xResult = xFindObjectWithLabelAndClass( hSession, 
             pkcs11configLABEL_DEVICE_PRIVATE_KEY_FOR_TLS, 
+            strlen( pkcs11configLABEL_DEVICE_PRIVATE_KEY_FOR_TLS ), 
             CKO_PRIVATE_KEY,
             &xPrivateKeyHandle );
     configASSERT( xResult == CKR_OK );
@@ -160,6 +161,7 @@ void vPKCS11SignVerifyDemo( void )
      * demo. */
     xResult = xFindObjectWithLabelAndClass( hSession, 
             pkcs11configLABEL_DEVICE_PUBLIC_KEY_FOR_TLS, 
+            strlen( pkcs11configLABEL_DEVICE_PUBLIC_KEY_FOR_TLS ), 
             CKO_PRIVATE_KEY,
             &xPublicKeyHandle );
     configASSERT( xResult == CKR_OK );

--- a/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/examples/sign_and_verify.c
+++ b/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/examples/sign_and_verify.c
@@ -19,8 +19,8 @@
  * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  *
- * http://www.FreeRTOS.org
- * http://aws.amazon.com/freertos
+ * https://www.FreeRTOS.org
+ * https://aws.amazon.com/freertos
  */
 /* FreeRTOS includes. */
 #include "FreeRTOS.h"

--- a/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/examples/sign_and_verify.c
+++ b/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/examples/sign_and_verify.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS PKCS #11 V1.0.3
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
@@ -19,8 +19,8 @@
  * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  *
- * http://aws.amazon.com/freertos
  * http://www.FreeRTOS.org
+ * http://aws.amazon.com/freertos
  */
 /* FreeRTOS includes. */
 #include "FreeRTOS.h"
@@ -151,7 +151,7 @@ void vPKCS11SignVerifyDemo( void )
      */
     xResult = xFindObjectWithLabelAndClass( hSession, 
             pkcs11configLABEL_DEVICE_PRIVATE_KEY_FOR_TLS, 
-            strlen( pkcs11configLABEL_DEVICE_PRIVATE_KEY_FOR_TLS ), 
+            sizeof( pkcs11configLABEL_DEVICE_PRIVATE_KEY_FOR_TLS ) - 1UL, 
             CKO_PRIVATE_KEY,
             &xPrivateKeyHandle );
     configASSERT( xResult == CKR_OK );
@@ -161,7 +161,7 @@ void vPKCS11SignVerifyDemo( void )
      * demo. */
     xResult = xFindObjectWithLabelAndClass( hSession, 
             pkcs11configLABEL_DEVICE_PUBLIC_KEY_FOR_TLS, 
-            strlen( pkcs11configLABEL_DEVICE_PUBLIC_KEY_FOR_TLS ), 
+            sizeof( pkcs11configLABEL_DEVICE_PUBLIC_KEY_FOR_TLS ) - 1UL, 
             CKO_PRIVATE_KEY,
             &xPublicKeyHandle );
     configASSERT( xResult == CKR_OK );

--- a/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/examples/sign_and_verify.c
+++ b/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/examples/sign_and_verify.c
@@ -21,7 +21,9 @@
  *
  * https://www.FreeRTOS.org
  * https://github.com/FreeRTOS
+ *
  */
+
 /* FreeRTOS includes. */
 #include "FreeRTOS.h"
 #include "task.h"

--- a/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/pkcs11_demo_config.h
+++ b/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/pkcs11_demo_config.h
@@ -19,8 +19,8 @@
  * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  *
- * http://www.FreeRTOS.org
- * http://aws.amazon.com/freertos
+ * https://www.FreeRTOS.org
+ * https://aws.amazon.com/freertos
  */
 
 #ifndef _PKCS11_DEMO_CONFIG_

--- a/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/pkcs11_demo_config.h
+++ b/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/pkcs11_demo_config.h
@@ -20,7 +20,7 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  *
  * https://www.FreeRTOS.org
- * https://aws.amazon.com/freertos
+ * https://github.com/FreeRTOS
  */
 
 #ifndef _PKCS11_DEMO_CONFIG_

--- a/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/pkcs11_demo_config.h
+++ b/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/pkcs11_demo_config.h
@@ -21,6 +21,7 @@
  *
  * https://www.FreeRTOS.org
  * https://github.com/FreeRTOS
+ *
  */
 
 #ifndef _PKCS11_DEMO_CONFIG_

--- a/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/threading_alt.h
+++ b/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/threading_alt.h
@@ -19,8 +19,8 @@
  * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  *
- * http://www.FreeRTOS.org
- * http://aws.amazon.com/freertos
+ * https://www.FreeRTOS.org
+ * https://aws.amazon.com/freertos
  */
 
 #ifndef __THREADING_ALT_H__

--- a/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/threading_alt.h
+++ b/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/threading_alt.h
@@ -1,5 +1,5 @@
 /*
- * corePKCS11 V2.0.0
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
@@ -12,15 +12,15 @@
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF NY KIND, EXPRESS OR
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
  * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
  * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
  * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  *
- * http://aws.amazon.com/freertos
  * http://www.FreeRTOS.org
+ * http://aws.amazon.com/freertos
  */
 
 #ifndef __THREADING_ALT_H__

--- a/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/threading_alt.h
+++ b/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/threading_alt.h
@@ -20,7 +20,8 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  *
  * https://www.FreeRTOS.org
- * https://aws.amazon.com/freertos
+ * https://github.com/FreeRTOS
+ *
  */
 
 #ifndef __THREADING_ALT_H__

--- a/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/threading_alt.h
+++ b/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/threading_alt.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS V202011.00
+ * corePKCS11 V2.0.0
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
@@ -12,48 +12,38 @@
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF NY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
  * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
  * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
  * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  *
- * http://www.FreeRTOS.org
  * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
  */
 
-#ifndef _PKCS11_DEMO_CONFIG_
-#define _PKCS11_DEMO_CONFIG_
+#ifndef __THREADING_ALT_H__
+#define __THREADING_ALT_H__
 
-/*
- * @brief this macro defines the stack size for the PKCS #11 demo task.
- */
-#define configPKCS11_DEMO_STACK_SIZE                200
 
-/*
- * @brief set this macro to "1" in order to run the PKCS #11 management and
- * random number generator demo.
- */
-#define configPKCS11_MANAGEMENT_AND_RNG_DEMO        1
+#include "FreeRTOS.h"
+#include "semphr.h"
 
-/*
- * @brief set this macro to "1" in order to run the PKCS #11 mechanisms and
- * digest demo.
- */
-#define configPKCS11_MECHANISMS_AND_DIGESTS_DEMO    0
-
-/*
- * @brief set this macro to "1" in order to run the PKCS #11 object demo.
- */
-#define configPKCS11_OBJECT_DEMO                    0
-
-/*
- * @brief set this macro to "1" in order to run the PKCS #11 sign and verify 
- * demo.
+/**
+ * @brief Mutex struct used to synchronize mbed TLS operations.
  *
- * @warning This demo relies on the objects created in the object demo.
  */
-#define configPKCS11_SIGN_AND_VERIFY_DEMO           0
+typedef struct
+{
+    SemaphoreHandle_t mutex; /**< @brief FreeRTOS semaphore. */
+    char is_valid;           /**< @brief Flag used by mbedTLS to track wether a mutex is valid. */
+} mbedtls_threading_mutex_t;
 
-#endif
+extern void mbedtls_threading_set_alt( void ( * mutex_init )( mbedtls_threading_mutex_t * ),
+                                       void ( * mutex_free )( mbedtls_threading_mutex_t * ),
+                                       int ( * mutex_lock )( mbedtls_threading_mutex_t * ),
+                                       int ( * mutex_unlock )( mbedtls_threading_mutex_t * ) );
+
+
+#endif /* ifndef __THREADING_ALT_H__ */

--- a/FreeRTOS-Plus/Source/Application-Protocols/network_transport/freertos_plus_tcp/using_mbedtls_pkcs11/using_mbedtls_pkcs11.c
+++ b/FreeRTOS-Plus/Source/Application-Protocols/network_transport/freertos_plus_tcp/using_mbedtls_pkcs11/using_mbedtls_pkcs11.c
@@ -517,6 +517,7 @@ static CK_RV readCertificateIntoContext( SSLContext_t * pSslContext,
     /* Get the handle of the certificate. */
     xResult = xFindObjectWithLabelAndClass( pSslContext->xP11Session,
                                             pcLabelName,
+                                            strlen( pcLabelName ),
                                             xClass,
                                             &xCertObj );
 
@@ -630,6 +631,7 @@ static CK_RV initializeClientKeys( SSLContext_t * pxCtx )
         /* Get the handle of the device private key. */
         xResult = xFindObjectWithLabelAndClass( pxCtx->xP11Session,
                                                 pkcs11configLABEL_DEVICE_PRIVATE_KEY_FOR_TLS,
+                                                strlen( pkcs11configLABEL_DEVICE_PRIVATE_KEY_FOR_TLS ),
                                                 CKO_PRIVATE_KEY,
                                                 &pxCtx->xP11PrivateKey );
     }

--- a/FreeRTOS-Plus/Source/Application-Protocols/network_transport/freertos_plus_tcp/using_mbedtls_pkcs11/using_mbedtls_pkcs11.c
+++ b/FreeRTOS-Plus/Source/Application-Protocols/network_transport/freertos_plus_tcp/using_mbedtls_pkcs11/using_mbedtls_pkcs11.c
@@ -631,7 +631,7 @@ static CK_RV initializeClientKeys( SSLContext_t * pxCtx )
         /* Get the handle of the device private key. */
         xResult = xFindObjectWithLabelAndClass( pxCtx->xP11Session,
                                                 pkcs11configLABEL_DEVICE_PRIVATE_KEY_FOR_TLS,
-                                                strlen( pkcs11configLABEL_DEVICE_PRIVATE_KEY_FOR_TLS ),
+                                                sizeof( pkcs11configLABEL_DEVICE_PRIVATE_KEY_FOR_TLS ) - 1UL,
                                                 CKO_PRIVATE_KEY,
                                                 &pxCtx->xP11PrivateKey );
     }


### PR DESCRIPTION
Move corePKCS11 forward and update to latest core_pkcs11.h

Description
-----------
core_pkcs11.h has a small API change to avoid usage of strlen.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
