### PR TITLE
Add "Connection: close" header check to S3 download demos

### DIFF
--- a/FreeRTOS-Plus/Demo/coreHTTP_Windows_Simulator/HTTP_S3_Download/DemoTasks/S3DownloadHTTPExample.c
+++ b/FreeRTOS-Plus/Demo/coreHTTP_Windows_Simulator/HTTP_S3_Download/DemoTasks/S3DownloadHTTPExample.c
@@ -302,7 +302,6 @@ static void prvHTTPDemoTask( void * pvParameters )
     /* The transport layer interface used by the HTTP Client library. */
     TransportInterface_t xTransportInterface;
     TlsTransportParams_t xTlsTransportParams = { 0 };
-    BaseType_t xIsConnectionEstablished = pdFALSE;
     /* HTTP Client library return status. */
     HTTPStatus_t xHTTPStatus = HTTPSuccess;
     UBaseType_t uxDemoRunCount = 0UL;
@@ -758,6 +757,15 @@ static BaseType_t prvDownloadS3ObjectFile( const TransportInterface_t * pxTransp
 
         if( xHTTPStatus == HTTPSuccess )
         {
+            LogDebug( ( "Received HTTP response from %s%s...",
+                        cServerHost, pcPath ) );
+            LogDebug( ( "Response Headers:\n%.*s",
+                        ( int32_t ) xResponse.headersLen,
+                        xResponse.pHeaders ) );
+            LogInfo( ( "Response Body:\n%.*s\n",
+                       ( int32_t ) xResponse.bodyLen,
+                       xResponse.pBody ) );
+
             /* Check that we received a valid status code */
             if( xResponse.statusCode != httpexampleHTTP_STATUS_CODE_PARTIAL_CONTENT )
             {
@@ -785,15 +793,6 @@ static BaseType_t prvDownloadS3ObjectFile( const TransportInterface_t * pxTransp
                     break;
                 }
             }
-
-            LogDebug( ( "Received HTTP response from %s%s...",
-                        cServerHost, pcPath ) );
-            LogDebug( ( "Response Headers:\n%.*s",
-                        ( int32_t ) xResponse.headersLen,
-                        xResponse.pHeaders ) );
-            LogInfo( ( "Response Body:\n%.*s\n",
-                       ( int32_t ) xResponse.bodyLen,
-                       xResponse.pBody ) );
 
             /* We increment by the content length because the server may not
              * have sent us the range we request. */

--- a/FreeRTOS-Plus/Demo/coreHTTP_Windows_Simulator/HTTP_S3_Download/DemoTasks/S3DownloadHTTPExample.c
+++ b/FreeRTOS-Plus/Demo/coreHTTP_Windows_Simulator/HTTP_S3_Download/DemoTasks/S3DownloadHTTPExample.c
@@ -770,28 +770,26 @@ static BaseType_t prvDownloadS3ObjectFile( const TransportInterface_t * pxTransp
                     break;
                 }
             }
-            else
+
+            LogDebug( ( "Received HTTP response from %s%s...",
+                        cServerHost, pcPath ) );
+            LogDebug( ( "Response Headers:\n%.*s",
+                        ( int32_t ) xResponse.headersLen,
+                        xResponse.pHeaders ) );
+            LogInfo( ( "Response Body:\n%.*s\n",
+                       ( int32_t ) xResponse.bodyLen,
+                       xResponse.pBody ) );
+
+            /* We increment by the content length because the server may not
+             * have sent us the range we request. */
+            xCurByte += xResponse.contentLength;
+
+            if( ( xFileSize - xCurByte ) < xNumReqBytes )
             {
-                LogDebug( ( "Received HTTP response from %s%s...",
-                            cServerHost, pcPath ) );
-                LogDebug( ( "Response Headers:\n%.*s",
-                            ( int32_t ) xResponse.headersLen,
-                            xResponse.pHeaders ) );
-                LogInfo( ( "Response Body:\n%.*s\n",
-                           ( int32_t ) xResponse.bodyLen,
-                           xResponse.pBody ) );
-
-                /* We increment by the content length because the server may not
-                 * have sent us the range we request. */
-                xCurByte += xResponse.contentLength;
-
-                if( ( xFileSize - xCurByte ) < xNumReqBytes )
-                {
-                    xNumReqBytes = xFileSize - xCurByte;
-                }
-
-                xStatus = ( xResponse.statusCode == httpexampleHTTP_STATUS_CODE_PARTIAL_CONTENT ) ? pdPASS : pdFAIL;
+                xNumReqBytes = xFileSize - xCurByte;
             }
+
+            xStatus = ( xResponse.statusCode == httpexampleHTTP_STATUS_CODE_PARTIAL_CONTENT ) ? pdPASS : pdFAIL;
         }
         else
         {


### PR DESCRIPTION
In the download demos, S3 will close the connection with the client after 100 requests, presenting issues for larger files. Adding a check for the "Connection: close" header (sent by the server), and re-establishing the connection if found, will allow for the application to resume downloading.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
