### PR TITLE
Map errors from FreeRTOS+TCP to mbedTLS port and interpret retriable errors

### DIFF
--- a/FreeRTOS-Plus/Source/Application-Protocols/network_transport/freertos_plus_tcp/using_plaintext/using_plaintext.c
+++ b/FreeRTOS-Plus/Source/Application-Protocols/network_transport/freertos_plus_tcp/using_plaintext/using_plaintext.c
@@ -122,14 +122,21 @@ int32_t Plaintext_FreeRTOS_recv( NetworkContext_t * pNetworkContext,
 {
     PlaintextTransportParams_t * pPlaintextTransportParams = NULL;
     int32_t socketStatus = 0;
+    BaseType_t recvCount = 0;
 
     configASSERT( ( pNetworkContext != NULL ) && ( pNetworkContext->pParams != NULL ) );
 
     pPlaintextTransportParams = pNetworkContext->pParams;
-    socketStatus = FreeRTOS_recv( pPlaintextTransportParams->tcpSocket,
-                                  pBuffer,
-                                  bytesToRecv,
-                                  0 );
+
+    if( ( bytesToRecv > 1 ) ||
+        ( recvCount = FreeRTOS_recvcount( pNetworkContext->tcpSocket ) > 0 ) )
+    {
+        socketStatus = FreeRTOS_recv( pNetworkContext->tcpSocket, pBuffer, bytesToRecv, 0 );
+    }
+    else
+    {
+        socketStatus = ( int32_t ) recvCount;
+    }
 
     return socketStatus;
 }

--- a/FreeRTOS-Plus/Source/Application-Protocols/network_transport/freertos_plus_tcp/using_plaintext/using_plaintext.c
+++ b/FreeRTOS-Plus/Source/Application-Protocols/network_transport/freertos_plus_tcp/using_plaintext/using_plaintext.c
@@ -128,6 +128,8 @@ int32_t Plaintext_FreeRTOS_recv( NetworkContext_t * pNetworkContext,
 
     pPlaintextTransportParams = pNetworkContext->pParams;
 
+    /* When 1 byte is requested without any available data in the TCP socket's
+     * Rx stream, this function immediately returns 0. */
     if( ( bytesToRecv > 1 ) ||
         ( recvCount = FreeRTOS_recvcount( pPlaintextTransportParams->tcpSocket ) > 0 ) )
     {

--- a/FreeRTOS-Plus/Source/Application-Protocols/network_transport/freertos_plus_tcp/using_plaintext/using_plaintext.c
+++ b/FreeRTOS-Plus/Source/Application-Protocols/network_transport/freertos_plus_tcp/using_plaintext/using_plaintext.c
@@ -127,8 +127,15 @@ int32_t Plaintext_FreeRTOS_recv( NetworkContext_t * pNetworkContext,
 
     pPlaintextTransportParams = pNetworkContext->pParams;
 
-    /* When 1 byte is requested without any available data in the TCP socket's
-     * Rx stream, this function immediately returns 0 without blocking. */
+    /* The TCP socket may have a receive block time.  If bytesToRecv is greater 
+     * than 1 then a frame is likely already part way through reception and 
+     * blocking to wait for the desired number of bytes to be available is the
+     * most efficient thing to do.  If bytesToRecv is 1 then this may be a 
+     * speculative call to read to find the start of a new frame, in which case 
+     * blocking is not desirable as it could block an entire protocol agent 
+     * task for the duration of the read block time and therefore negatively 
+     * impact performance.  So if bytesToRecv is 1 then don't call recv unless 
+     * it is known that bytes are already available. */
     if( bytesToRecv == 1 )
     {
         socketStatus = ( int32_t ) FreeRTOS_recvcount( pPlaintextTransportParams->tcpSocket );

--- a/FreeRTOS-Plus/Source/Application-Protocols/network_transport/freertos_plus_tcp/using_plaintext/using_plaintext.c
+++ b/FreeRTOS-Plus/Source/Application-Protocols/network_transport/freertos_plus_tcp/using_plaintext/using_plaintext.c
@@ -129,9 +129,12 @@ int32_t Plaintext_FreeRTOS_recv( NetworkContext_t * pNetworkContext,
     pPlaintextTransportParams = pNetworkContext->pParams;
 
     if( ( bytesToRecv > 1 ) ||
-        ( recvCount = FreeRTOS_recvcount( pNetworkContext->tcpSocket ) > 0 ) )
+        ( recvCount = FreeRTOS_recvcount( pPlaintextTransportParams->tcpSocket ) > 0 ) )
     {
-        socketStatus = FreeRTOS_recv( pNetworkContext->tcpSocket, pBuffer, bytesToRecv, 0 );
+        socketStatus = FreeRTOS_recv( pPlaintextTransportParams->tcpSocket,
+                                      pBuffer,
+                                      bytesToRecv,
+                                      0 );
     }
     else
     {

--- a/FreeRTOS-Plus/Source/Application-Protocols/network_transport/freertos_plus_tcp/using_plaintext/using_plaintext.c
+++ b/FreeRTOS-Plus/Source/Application-Protocols/network_transport/freertos_plus_tcp/using_plaintext/using_plaintext.c
@@ -131,14 +131,6 @@ int32_t Plaintext_FreeRTOS_recv( NetworkContext_t * pNetworkContext,
                                   bytesToRecv,
                                   0 );
 
-    if( socketStatus == -pdFREERTOS_ERRNO_ENOSPC )
-    {
-        /* The TCP buffers could not accept any more bytes so zero bytes were sent
-         * but this is not necessarily an error that should cause a disconnect
-         * unless it persists. */
-        socketStatus = 0;
-    }
-
     return socketStatus;
 }
 

--- a/FreeRTOS-Plus/Source/Application-Protocols/network_transport/freertos_plus_tcp/using_plaintext/using_plaintext.c
+++ b/FreeRTOS-Plus/Source/Application-Protocols/network_transport/freertos_plus_tcp/using_plaintext/using_plaintext.c
@@ -131,6 +131,14 @@ int32_t Plaintext_FreeRTOS_recv( NetworkContext_t * pNetworkContext,
                                   bytesToRecv,
                                   0 );
 
+    if( socketStatus == -pdFREERTOS_ERRNO_ENOSPC )
+    {
+        /* The TCP buffers could not accept any more bytes so zero bytes were sent
+         * but this is not necessarily an error that should cause a disconnect
+         * unless it persists. */
+        socketStatus = 0;
+    }
+
     return socketStatus;
 }
 
@@ -148,6 +156,14 @@ int32_t Plaintext_FreeRTOS_send( NetworkContext_t * pNetworkContext,
                                   pBuffer,
                                   bytesToSend,
                                   0 );
+
+    if( socketStatus == -pdFREERTOS_ERRNO_ENOSPC )
+    {
+        /* The TCP buffers could not accept any more bytes so zero bytes were sent
+         * but this is not necessarily an error that should cause a disconnect
+         * unless it persists. */
+        socketStatus = 0;
+    }
 
     return socketStatus;
 }

--- a/FreeRTOS-Plus/Source/Application-Protocols/network_transport/freertos_plus_tcp/using_plaintext/using_plaintext.h
+++ b/FreeRTOS-Plus/Source/Application-Protocols/network_transport/freertos_plus_tcp/using_plaintext/using_plaintext.h
@@ -117,9 +117,11 @@ PlaintextTransportStatus_t Plaintext_FreeRTOS_Connect( NetworkContext_t * pNetwo
 PlaintextTransportStatus_t Plaintext_FreeRTOS_Disconnect( const NetworkContext_t * pNetworkContext );
 
 /**
- * @brief Receives data from an established TCP connection. When the number of
- * bytes requested is 1, the TCP socket’s Rx stream is checked for available bytes
- * to read. If there are none, this function immediately returns 0 without blocking.
+ * @brief Receives data from an established TCP connection.
+ * 
+ * @note When the number of bytes requested is 1, the TCP socket’s Rx stream
+ * is checked for available bytes to read. If there are none, this function
+ * immediately returns 0 without blocking.
  *
  * @param[in] pNetworkContext The network context containing the TCP socket
  * handle.

--- a/FreeRTOS-Plus/Source/Application-Protocols/network_transport/freertos_plus_tcp/using_plaintext/using_plaintext.h
+++ b/FreeRTOS-Plus/Source/Application-Protocols/network_transport/freertos_plus_tcp/using_plaintext/using_plaintext.h
@@ -118,8 +118,8 @@ PlaintextTransportStatus_t Plaintext_FreeRTOS_Disconnect( const NetworkContext_t
 
 /**
  * @brief Receives data from an established TCP connection. When the number of
- * bytes to read is 1, the TCP socket’s Rx stream is checked for available bytes
- * to read. If there are none, the function immediately returns.
+ * bytes requested is 1, the TCP socket’s Rx stream is checked for available bytes
+ * to read. If there are none, this function immediately returns 0 without blocking.
  *
  * @param[in] pNetworkContext The network context containing the TCP socket
  * handle.

--- a/FreeRTOS-Plus/Source/Application-Protocols/network_transport/freertos_plus_tcp/using_plaintext/using_plaintext.h
+++ b/FreeRTOS-Plus/Source/Application-Protocols/network_transport/freertos_plus_tcp/using_plaintext/using_plaintext.h
@@ -117,7 +117,9 @@ PlaintextTransportStatus_t Plaintext_FreeRTOS_Connect( NetworkContext_t * pNetwo
 PlaintextTransportStatus_t Plaintext_FreeRTOS_Disconnect( const NetworkContext_t * pNetworkContext );
 
 /**
- * @brief Receives data from an established TCP connection.
+ * @brief Receives data from an established TCP connection. When the number of
+ * bytes to read is 1, the TCP socket’s Rx stream is checked for available bytes
+ * to read. If there are none, the function immediately returns.
  *
  * @param[in] pNetworkContext The network context containing the TCP socket
  * handle.

--- a/FreeRTOS-Plus/Source/Utilities/mbedtls_freertos/mbedtls_error.c
+++ b/FreeRTOS-Plus/Source/Utilities/mbedtls_freertos/mbedtls_error.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Error Code Stringification utilies for mbed TLS v2.16.0
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
@@ -18,6 +18,10 @@
  * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
  * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * https://www.FreeRTOS.org
+ * https://github.com/FreeRTOS
+ *
  */
 
 /**

--- a/FreeRTOS-Plus/Source/Utilities/mbedtls_freertos/mbedtls_error.h
+++ b/FreeRTOS-Plus/Source/Utilities/mbedtls_freertos/mbedtls_error.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Error Code Stringification utilities for mbed TLS v2.16.0
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
@@ -18,6 +18,10 @@
  * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
  * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * https://www.FreeRTOS.org
+ * https://github.com/FreeRTOS
+ *
  */
 
 /**

--- a/FreeRTOS-Plus/Source/Utilities/mbedtls_freertos/mbedtls_freertos_port.c
+++ b/FreeRTOS-Plus/Source/Utilities/mbedtls_freertos/mbedtls_freertos_port.c
@@ -163,7 +163,7 @@ int mbedtls_platform_recv( void * ctx,
                            size_t len )
 {
     Socket_t socket;
-    BaseType_t recvStatus = 0, recvCount = 0;
+    BaseType_t recvStatus = 0;
     int returnStatus = -1;
 
     configASSERT( ctx != NULL );
@@ -171,17 +171,7 @@ int mbedtls_platform_recv( void * ctx,
 
     socket = ( Socket_t ) ctx;
 
-    /* When attempting to read a TLS record header and there is no data to receive,
-     * this function will immediately return MBEDTLS_ERR_SSL_WANT_READ without blocking. */
-    if( ( len != TLS_RECORD_HEADER_BYTE_LENGTH ) ||
-        ( recvCount = FreeRTOS_recvcount( socket ) > 0 ) )
-    {
-        recvStatus = FreeRTOS_recv( socket, buf, len, 0 );
-    }
-    else
-    {
-        recvStatus = recvCount;
-    }
+    recvStatus = FreeRTOS_recv( socket, buf, len, 0 );
 
     switch( recvStatus )
     {

--- a/FreeRTOS-Plus/Source/Utilities/mbedtls_freertos/mbedtls_freertos_port.c
+++ b/FreeRTOS-Plus/Source/Utilities/mbedtls_freertos/mbedtls_freertos_port.c
@@ -101,16 +101,16 @@ int mbedtls_platform_send( void * ctx,
                            size_t len )
 {
     Socket_t socket;
-    BaseType_t recvStatus;
+    BaseType_t sendStatus;
     int returnStatus = -1;
 
     configASSERT( ctx != NULL );
     configASSERT( buf != NULL );
 
     socket = ( Socket_t ) ctx;
-    recvStatus = FreeRTOS_send( socket, buf, len, 0 );
+    sendStatus = FreeRTOS_send( socket, buf, len, 0 );
 
-    switch( recvStatus )
+    switch( sendStatus )
     {
         /* Socket was closed or just got closed. */
         case -pdFREERTOS_ERRNO_ENOTCONN:
@@ -129,7 +129,7 @@ int mbedtls_platform_send( void * ctx,
             break;
 
         default:
-            returnStatus = ( int ) recvStatus;
+            returnStatus = ( int ) sendStatus;
             break;
     }
 
@@ -171,12 +171,10 @@ int mbedtls_platform_recv( void * ctx,
         case -pdFREERTOS_ERRNO_EINVAL:
             returnStatus = MBEDTLS_ERR_SSL_INTERNAL_ERROR;
             break;
-
-        /* A timeout occurred before any data could be sent. */
-        case -pdFREERTOS_ERRNO_ENOSPC:
+        /* A timeout occurred before any data could be received. */
+        case 0:
             returnStatus = MBEDTLS_ERR_SSL_TIMEOUT;
             break;
-
         default:
             returnStatus = ( int ) recvStatus;
             break;

--- a/FreeRTOS-Plus/Source/Utilities/mbedtls_freertos/mbedtls_freertos_port.c
+++ b/FreeRTOS-Plus/Source/Utilities/mbedtls_freertos/mbedtls_freertos_port.c
@@ -98,7 +98,7 @@ int mbedtls_platform_send( void * ctx,
 {
     Socket_t socket;
     BaseType_t recvStatus;
-    int ret = -1;
+    int returnStatus = -1;
 
     configASSERT( ctx != NULL );
     configASSERT( buf != NULL );

--- a/FreeRTOS-Plus/Source/Utilities/mbedtls_freertos/mbedtls_freertos_port.c
+++ b/FreeRTOS-Plus/Source/Utilities/mbedtls_freertos/mbedtls_freertos_port.c
@@ -1,23 +1,27 @@
 /*
+ * FreeRTOS V202011.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
  *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * https://www.FreeRTOS.org
+ * https://github.com/FreeRTOS
+ *
  */
 
 /**

--- a/FreeRTOS-Plus/Source/Utilities/mbedtls_freertos/mbedtls_freertos_port.c
+++ b/FreeRTOS-Plus/Source/Utilities/mbedtls_freertos/mbedtls_freertos_port.c
@@ -171,8 +171,8 @@ int mbedtls_platform_recv( void * ctx,
 
     socket = ( Socket_t ) ctx;
 
-    /* When attempting to read a TLS record header and there is no data
-     * to receive, this function will immediately return 0 without blocking. */
+    /* When attempting to read a TLS record header and there is no data to receive,
+     * this function will immediately return MBEDTLS_ERR_SSL_WANT_READ without blocking. */
     if( ( len != TLS_RECORD_HEADER_BYTE_LENGTH ) ||
         ( recvCount = FreeRTOS_recvcount( socket ) > 0 ) )
     {

--- a/FreeRTOS-Plus/Source/Utilities/mbedtls_freertos/mbedtls_freertos_port.c
+++ b/FreeRTOS-Plus/Source/Utilities/mbedtls_freertos/mbedtls_freertos_port.c
@@ -129,7 +129,7 @@ int mbedtls_platform_send( void * ctx,
             break;
     }
 
-    return recvStatus;
+    return returnStatus;
 }
 
 /*-----------------------------------------------------------*/


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->
From the FreeRTOS documentation, pdFREERTOS_ERRNO_ENOSPC means that timeout occurred before any data could be sent or received.
- In the plaintext transport-interface implementation, we would directly return `-pdFREERTOS_ERRNO_ENOSPC`. However, an error like this can occur when the TCP buffer is full, so this ought to be retriable. Libraries that consume the transport interface interpret a return value of 0 to mean that send/recv can be invoked again to get the data. As such, we should appropriately set the return value as 0 when the status is `-pdFREERTOS_ERRNO_ENOSPC`.
- In the mbedTLS port, we would directly return whatever `FreeRTOS_send` or `FreeRTOS_recv` returns. However, sometimes, the return value can be an error. In such cases, we ought to map an error from FreeRTOS+TCP to an equivalent error in mbedTLS. In the case of `-pdFREERTOS_ERRNO_ENOSPC`, we map that to `MBEDTLS_ERR_SSL_TIMEOUT`. When the mbedTLS transport-interface send/recv wrapper sees that value, it appropriately returns 0, so that the library can retry the send/recv. I've verified that when the mbedTLS port returns an error, that same error is returned by `mbedtls_ssl_write` & `mbedtls_ssl_read`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
