### PR TITLE
Moved definition of ucBufferStorage out of if macro. 

### DIFF
--- a/FreeRTOS/Demo/Common/Minimal/StreamBufferDemo.c
+++ b/FreeRTOS/Demo/Common/Minimal/StreamBufferDemo.c
@@ -19,10 +19,9 @@
  * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  *
- * http://www.FreeRTOS.org
- * http://aws.amazon.com/freertos
+ * https://www.FreeRTOS.org
+ * https://github.com/FreeRTOS
  *
- * 1 tab == 4 spaces!
  */
 
 /* Standard includes. */

--- a/FreeRTOS/Demo/Common/Minimal/StreamBufferDemo.c
+++ b/FreeRTOS/Demo/Common/Minimal/StreamBufferDemo.c
@@ -124,15 +124,15 @@ static void prvInterruptTriggerLevelTest( void *pvParameters );
 	static void prvSenderTask( void *pvParameters );
 
 	static StaticStreamBuffer_t xStaticStreamBuffers[ sbNUMBER_OF_ECHO_CLIENTS ];
-
-	/* The +1 is to make the test logic easier as the function that calculates the
-	free space will return one less than the actual free space - adding a 1 to the
-	actual length makes it appear to the tests as if the free space is returned as
-	it might logically be expected.  Returning 1 less than the actual free space is
-	fine as it can never result in an overrun. */
-	static uint8_t ucBufferStorage[ sbNUMBER_OF_SENDER_TASKS ][ sbSTREAM_BUFFER_LENGTH_BYTES + 1 ];
 	static uint32_t ulSenderLoopCounters[ sbNUMBER_OF_SENDER_TASKS ] = { 0 };
 #endif /* configSUPPORT_STATIC_ALLOCATION */
+
+/* The +1 is to make the test logic easier as the function that calculates the
+free space will return one less than the actual free space - adding a 1 to the
+actual length makes it appear to the tests as if the free space is returned as
+it might logically be expected.  Returning 1 less than the actual free space is
+fine as it can never result in an overrun. */
+static uint8_t ucBufferStorage[ sbNUMBER_OF_SENDER_TASKS ][ sbSTREAM_BUFFER_LENGTH_BYTES + 1 ];
 
 /*-----------------------------------------------------------*/
 
@@ -1240,4 +1240,3 @@ BaseType_t x;
 	return xErrorStatus;
 }
 /*-----------------------------------------------------------*/
-


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->
Compilation of the StreamBufferDemo will fail currently if configSUPPORT_STATIC_ALLOCATION was set to 0 or left undefined (because it will default to 0, as mentioned in the documentation). 
This is because the variable ucBufferStorage is only defined, if configSUPPORT_STATIC_ALLOCATION is set to 1 (see line 119 of StreamBufferDemo.c) but will be used without any further checks in line 232 and in some other places in StreamBufferDemo.c.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->
Compile StreamBufferDemo without defining configSUPPORT_STATIC_ALLOCATION. For me the error occurred when compiling the "RISC-V_Renode_Emulator_SoftConsole" demo (configSUPPORT_STATIC_ALLOCATION not defined in FreeRTOSConfig.h)  with Release FreeRTOSv202011.00.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
