### PR TITLE
Add comment about handling S3 request limits to S3 download demos

### DIFF
--- a/FreeRTOS-Plus/Demo/coreHTTP_Windows_Simulator/HTTP_S3_Download/DemoTasks/S3DownloadHTTPExample.c
+++ b/FreeRTOS-Plus/Demo/coreHTTP_Windows_Simulator/HTTP_S3_Download/DemoTasks/S3DownloadHTTPExample.c
@@ -36,10 +36,17 @@
  * requests, filling up the response buffer each time until all parts are
  * downloaded). If any request fails, an error code is returned.
  *
- * @Note: This demo requires user-generated pre-signed URLs to be pasted into
+ * @note This demo requires user-generated pre-signed URLs to be pasted into
  * demo_config.h. Please use the provided script "presigned_urls_gen.py"
  * (located in located in coreHTTP_Windows_Simulator/Common) to generate these
  * URLs. For detailed instructions, see the accompanied README.md.
+ *
+ * @note If your file requires more than 99 range requests to S3 (depending on the
+ * size of the file and the length specified in democonfigRANGE_REQUEST_LENGTH),
+ * your connection may be dropped by S3. In this case, either increase the
+ * buffer size and range request length (if feasible), to reduce the number of
+ * requests required, or re-establish the connection with S3 after receiving a
+ * "Connection: close" response header.
  */
 
 /**
@@ -279,7 +286,7 @@ void vStartSimpleHTTPDemo( void )
  * requests, filling up the response buffer each time until all parts are
  * downloaded). If any request fails, an error code is returned.
  *
- * @Note: This demo requires user-generated pre-signed URLs to be pasted into
+ * @note This demo requires user-generated pre-signed URLs to be pasted into
  * demo_config.h. Please use the provided script "presigned_urls_gen.py"
  * (located in located in coreHTTP_Windows_Simulator/Common) to generate these
  * URLs. For detailed instructions, see the accompanied README.md.

--- a/FreeRTOS-Plus/Demo/coreHTTP_Windows_Simulator/HTTP_S3_Download/FreeRTOSIPConfig.h
+++ b/FreeRTOS-Plus/Demo/coreHTTP_Windows_Simulator/HTTP_S3_Download/FreeRTOSIPConfig.h
@@ -287,7 +287,7 @@ extern UBaseType_t uxRand();
 
 /* Each TCP socket has a circular buffers for Rx and Tx, which have a fixed
  * maximum size.  Define the size of Rx buffer for TCP sockets. */
-#define ipconfigTCP_RX_BUFFER_LENGTH                          ( 1000 )
+#define ipconfigTCP_RX_BUFFER_LENGTH                          ( 5000 )
 
 /* Define the size of Tx buffer for TCP sockets. */
 #define ipconfigTCP_TX_BUFFER_LENGTH                          ( 1000 )

--- a/FreeRTOS-Plus/Demo/coreHTTP_Windows_Simulator/HTTP_S3_Download_Multithreaded/DemoTasks/S3DownloadMultithreadedHTTPExample.c
+++ b/FreeRTOS-Plus/Demo/coreHTTP_Windows_Simulator/HTTP_S3_Download_Multithreaded/DemoTasks/S3DownloadMultithreadedHTTPExample.c
@@ -56,6 +56,13 @@
  * demo_config.h. Please use the provided script "presigned_urls_gen.py"
  * (located in located in coreHTTP_Windows_Simulator/Common) to generate these
  * URLs. For detailed instructions, see the accompanied README.md.
+ *
+ * @note If your file requires more than 99 range requests to S3 (depending on the
+ * size of the file and the length specified in democonfigRANGE_REQUEST_LENGTH),
+ * your connection may be dropped by S3. In this case, either increase the
+ * buffer size and range request length (if feasible), to reduce the number of
+ * requests required, or re-establish the connection with S3 after receiving a
+ * "Connection: close" response header.
  */
 
 /**

--- a/FreeRTOS-Plus/Demo/coreHTTP_Windows_Simulator/HTTP_S3_Download_Multithreaded/FreeRTOSIPConfig.h
+++ b/FreeRTOS-Plus/Demo/coreHTTP_Windows_Simulator/HTTP_S3_Download_Multithreaded/FreeRTOSIPConfig.h
@@ -287,7 +287,7 @@ extern UBaseType_t uxRand();
 
 /* Each TCP socket has a circular buffers for Rx and Tx, which have a fixed
  * maximum size.  Define the size of Rx buffer for TCP sockets. */
-#define ipconfigTCP_RX_BUFFER_LENGTH                          ( 1000 )
+#define ipconfigTCP_RX_BUFFER_LENGTH                          ( 5000 )
 
 /* Define the size of Tx buffer for TCP sockets. */
 #define ipconfigTCP_TX_BUFFER_LENGTH                          ( 1000 )

--- a/FreeRTOS-Plus/Demo/coreHTTP_Windows_Simulator/HTTP_S3_Upload/DemoTasks/S3UploadHTTPExample.c
+++ b/FreeRTOS-Plus/Demo/coreHTTP_Windows_Simulator/HTTP_S3_Upload/DemoTasks/S3UploadHTTPExample.c
@@ -36,7 +36,7 @@
  * request, and verify the file was uploaded using a GET request. If any request
  * fails, an error code is returned.
  *
- * @Note: This demo requires user-generated pre-signed URLs to be pasted into
+ * @note This demo requires user-generated pre-signed URLs to be pasted into
  * demo_config.h. Please use the provided script "presigned_urls_gen.py"
  * (located in coreHTTP_Windows_Simulator/Common) to generate these URLs. For
  * detailed instructions, see the accompanied README.md.


### PR DESCRIPTION
Adding a comment to the top of S3 download and multi-threaded download demo source code files, to explain how to handle S3 request limits. This is done to prevent users from treating this case as a bug. This PR also updates `ipconfigTCP_RX_BUFFER_LENGTH`, as was done recently for other demos.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
