### PR TITLE
Update Plaintext_FreeRTOS_send to check -pdFREERTOS_ERRNO_ENOSPC

### DIFF
--- a/FreeRTOS-Plus/Source/Application-Protocols/network_transport/freertos_plus_tcp/using_plaintext/using_plaintext.c
+++ b/FreeRTOS-Plus/Source/Application-Protocols/network_transport/freertos_plus_tcp/using_plaintext/using_plaintext.c
@@ -149,5 +149,13 @@ int32_t Plaintext_FreeRTOS_send( NetworkContext_t * pNetworkContext,
                                   bytesToSend,
                                   0 );
 
+    if( socketStatus == -pdFREERTOS_ERRNO_ENOSPC )
+    {
+        /* The TCP buffers could not accept any more bytes so zero bytes were sent
+         * but this is not necessarily an error that should cause a disconnect
+         * unless it persists. */
+        socketStatus = 0;
+    }
+
     return socketStatus;
 }

--- a/FreeRTOS-Plus/Source/Application-Protocols/network_transport/freertos_plus_tcp/using_plaintext/using_plaintext.c
+++ b/FreeRTOS-Plus/Source/Application-Protocols/network_transport/freertos_plus_tcp/using_plaintext/using_plaintext.c
@@ -151,9 +151,9 @@ int32_t Plaintext_FreeRTOS_send( NetworkContext_t * pNetworkContext,
 
     if( socketStatus == -pdFREERTOS_ERRNO_ENOSPC )
     {
-        /* The TCP buffers could not accept any more bytes so zero bytes were sent
-         * but this is not necessarily an error that should cause a disconnect
-         * unless it persists. */
+        /* The TCP buffers could not accept any more bytes so zero bytes were sent.
+         * This is not necessarily an error that should cause a disconnect, unless it
+         * persists. */
         socketStatus = 0;
     }
 


### PR DESCRIPTION
<!--- Title -->

Description
-----------
`-pdFREERTOS_ERRNO_ENOSPC` is returned by `FreeRTOS_send` when the TCP buffers are full. This updates `Plaintext_FreeRTOS_send` to check for it and treat as a non-fatal error.  

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
