### PR TITLE
Prevent optimization in reset handler for QEMU MPS2

### DIFF
--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Echo_Qemu_mps2/init/startup.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Echo_Qemu_mps2/init/startup.c
@@ -41,7 +41,10 @@ void __attribute__((weak)) EthernetISR (void);
 
 extern uint32_t _estack, _sidata, _sdata, _edata, _sbss, _ebss;
 
-__attribute__((naked)) void Reset_Handler(void)
+/* Prevent optimization so gcc does not replace code with memcpy */
+__attribute__((optimize("O0")))
+__attribute__((naked))
+void Reset_Handler(void)
  {
     // set stack pointer
     __asm volatile ("ldr r0, =_estack");

--- a/FreeRTOS/Demo/CORTEX_M3_MPS2_QEMU_GCC/init/startup.c
+++ b/FreeRTOS/Demo/CORTEX_M3_MPS2_QEMU_GCC/init/startup.c
@@ -41,8 +41,11 @@ void __attribute__((weak)) EthernetISR (void);
 
 extern uint32_t _estack, _sidata, _sdata, _edata, _sbss, _ebss;
 
-__attribute__((naked)) void Reset_Handler(void)
- {
+/* Prevent optimization so gcc does not replace code with memcpy */
+__attribute__((optimize("O0")))
+__attribute__((naked))
+void Reset_Handler(void)
+{
     // set stack pointer
     __asm volatile ("ldr r0, =_estack");
     __asm volatile ("mov sp, r0");


### PR DESCRIPTION
Prevent optimization in reset handler for QEMU MPS2

Description
-----------
The reset handler is a naked function means it doesn't have a stack, when optimization is turned on gcc is substituting the code with memcpy and memset which is causing issues since they use the stack
The change turns off optimization for the reset handler to prevent gcc from substituting the code with memcpy and memset

Test Steps
-----------
1- with the modified code
```
00000080 <Reset_Handler>:
      80:       4835            ldr     r0, [pc, #212]  ; (158 <end+0x4>)
      82:       4685            mov     sp, r0
      84:       4d0b            ldr     r5, [pc, #44]   ; (b4 <Reset_Handler+0x34>)
      86:       4c0c            ldr     r4, [pc, #48]   ; (b8 <Reset_Handler+0x38>)
      88:       e005            b.n     96 <Reset_Handler+0x16>
      8a:       462a            mov     r2, r5
      8c:       1d15            adds    r5, r2, #4
      8e:       4623            mov     r3, r4
      90:       1d1c            adds    r4, r3, #4
      92:       6812            ldr     r2, [r2, #0]
      94:       601a            str     r2, [r3, #0]
      96:       4b09            ldr     r3, [pc, #36]   ; (bc <Reset_Handler+0x3c>)
      98:       429c            cmp     r4, r3
      9a:       d3f6            bcc.n   8a <Reset_Handler+0xa>
      9c:       4c08            ldr     r4, [pc, #32]   ; (c0 <Reset_Handler+0x40>)
      9e:       e003            b.n     a8 <Reset_Handler+0x28>
      a0:       4623            mov     r3, r4
      a2:       1d1c            adds    r4, r3, #4
      a4:       2200            movs    r2, #0
      a6:       601a            str     r2, [r3, #0]
      a8:       4b06            ldr     r3, [pc, #24]   ; (c4 <Reset_Handler+0x44>)
      aa:       429c            cmp     r4, r3
      ac:       d3f8            bcc.n   a0 <Reset_Handler+0x20>
      ae:       f000 f83f       bl      130 <_start>
      b2:       bf00            nop
      b4:       00010cc4        andeq   r0, r1, r4, asr #25
      b8:       20000100        andcs   r0, r0, r0, lsl #2
      bc:       200001a0        andcs   r0, r0, r0, lsr #3
      c0:       200001a0        andcs   r0, r0, r0, lsr #3
      c4:       2000170c        andcs   r1, r0, ip, lsl #14
```
2 - Without the modification
```
0000010c <Reset_Handler>:
     10c:       4813            ldr     r0, [pc, #76]   ; (15c <Reset_Handler+0x50>)
     10e:       4685            mov     sp, r0
     110:       480c            ldr     r0, [pc, #48]   ; (144 <Reset_Handler+0x38>)
     112:       4a0d            ldr     r2, [pc, #52]   ; (148 <Reset_Handler+0x3c>)
     114:       4290            cmp     r0, r2
     116:       d207            bcs.n   128 <Reset_Handler+0x1c>
     118:       3a01            subs    r2, #1
     11a:       1a12            subs    r2, r2, r0
     11c:       f022 0203       bic.w   r2, r2, #3
     120:       490a            ldr     r1, [pc, #40]   ; (14c <Reset_Handler+0x40>)
     122:       3204            adds    r2, #4
     124:       f00c fc0a       bl      c93c <memcpy>                                    <------------------
     128:       4809            ldr     r0, [pc, #36]   ; (150 <Reset_Handler+0x44>)
     12a:       4a0a            ldr     r2, [pc, #40]   ; (154 <Reset_Handler+0x48>)
     12c:       4290            cmp     r0, r2
     12e:       d207            bcs.n   140 <Reset_Handler+0x34>
     130:       3a01            subs    r2, #1
     132:       1a12            subs    r2, r2, r0
     134:       f022 0203       bic.w   r2, r2, #3
     138:       2100            movs    r1, #0
     13a:       3204            adds    r2, #4
     13c:       f00c fc26       bl      c98c <memset>                                   <----------------
     140:       f7ff ffda       bl      f8 <_start>
     144:       20000100        andcs   r0, r0, r0, lsl #2
     148:       200001a0        andcs   r0, r0, r0, lsr #3
     14c:       00010cc4        andeq   r0, r1, r4, asr #25
     150:       200001a0        andcs   r0, r0, r0, lsr #3
     154:       2000170c        andcs   r1, r0, ip, lsl #14
     158:       00020026        andeq   r0, r2, r6, lsr #32
     15c:       20400000        subcs   r0, r0, r0
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
