### PR TITLE
Qemu Mps2 network interrupt

### DIFF
--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Echo_Qemu_mps2/FreeRTOSConfig.h
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Echo_Qemu_mps2/FreeRTOSConfig.h
@@ -81,10 +81,10 @@ to exclude the API function. */
 #define INCLUDE_vTaskDelay              1
 
 
-#define configKERNEL_INTERRUPT_PRIORITY         255
+#define configKERNEL_INTERRUPT_PRIORITY         252
 /* !!!! configMAX_SYSCALL_INTERRUPT_PRIORITY must not be set to zero !!!!
 See http://www.FreeRTOS.org/RTOS-Cortex-M3-M4.html. */
-#define configMAX_SYSCALL_INTERRUPT_PRIORITY    191 /* equivalent to 0xa0, or priority 5. */
+#define configMAX_SYSCALL_INTERRUPT_PRIORITY    5 /* equivalent to 0xa0, or priority 5. */
 #define configMAC_INTERRUPT_PRIORITY 5
 
 
@@ -99,10 +99,10 @@ tasks.
 http://www.freertos.org/FreeRTOS-Plus/FreeRTOS_Plus_TCP/TCP_Echo_Clients.html
 http://www.freertos.org/FreeRTOS-Plus/FreeRTOS_Plus_TCP/UDP_Echo_Clients.html */
 
-#define configECHO_SERVER_ADDR0 192
-#define configECHO_SERVER_ADDR1 168
-#define configECHO_SERVER_ADDR2 1
-#define configECHO_SERVER_ADDR3 201
+#define configECHO_SERVER_ADDR0 10
+#define configECHO_SERVER_ADDR1 136
+#define configECHO_SERVER_ADDR2 206
+#define configECHO_SERVER_ADDR3 133
 
 /* Default MAC address configuration.  The demo creates a virtual network
 connection that uses this MAC address by accessing the raw Ethernet/WiFi data
@@ -123,7 +123,7 @@ ipconfigUSE_DNS is set to 1 but a DNS server cannot be contacted. */
 #define configIP_ADDR0      10
 #define configIP_ADDR1      211
 #define configIP_ADDR2      55
-#define configIP_ADDR3      250
+#define configIP_ADDR3      5
 
 /* Default gateway IP address configuration.  Used in ipconfigUSE_DNS is set to
 0, or ipconfigUSE_DNS is set to 1 but a DNS server cannot be contacted. */

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Echo_Qemu_mps2/FreeRTOSConfig.h
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Echo_Qemu_mps2/FreeRTOSConfig.h
@@ -85,7 +85,7 @@ to exclude the API function. */
 /* !!!! configMAX_SYSCALL_INTERRUPT_PRIORITY must not be set to zero !!!!
 See http://www.FreeRTOS.org/RTOS-Cortex-M3-M4.html. */
 #define configMAX_SYSCALL_INTERRUPT_PRIORITY    5 /* equivalent to 0xa0, or priority 5. */
-#define configMAC_INTERRUPT_PRIORITY 5
+#define configMAC_INTERRUPT_PRIORITY 2
 
 
 /* networking definitions */

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Echo_Qemu_mps2/Readme.md
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Echo_Qemu_mps2/Readme.md
@@ -95,7 +95,7 @@ $ sudo ufw disable
 $ sudo ufw status
 ```
 5. Setup the local machine
-Run the following commands replacing the values  and interface names
+Run the following commands replacing the values and interface names
 that conform to your system
 ```
 sudo ip link add virbr0 type bridge

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Echo_Qemu_mps2/init/startup.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Echo_Qemu_mps2/init/startup.c
@@ -150,36 +150,35 @@ void Default_Handler6(void)
 const uint32_t* isr_vector[] __attribute__((section(".isr_vector"))) =
 {
     (uint32_t*)&_estack,
-    (uint32_t*)&Reset_Handler,    // Reset                -15
-    (uint32_t*)&Default_Handler,  // NMI_Handler          -14
-    (uint32_t*)&Default_Handler2, // HardFault_Handler    -13
-    (uint32_t*)&Default_Handler3, // MemManage_Handler    -12
-    (uint32_t*)&Default_Handler4, // BusFault_Handler     -11
-    (uint32_t*)&Default_Handler5, // UsageFault_Handler   -10
-    0, // reserved
-    0, // reserved
-    0, // reserved
-    0, // reserved   -6
-    (uint32_t*)&vPortSVCHandler,  // SVC_Handler              -5
-    (uint32_t*)&Default_Handler6, // DebugMon_Handler         -4
-    0, // reserved
-    (uint32_t*)&xPortPendSVHandler,      // PendSV handler    -2
-    (uint32_t*)&xPortSysTickHandler,     // SysTick_Handler   -1
-    0,                    // uart0 receive 0
-    0,                    // uart0 transmit
-    0,                    // uart1 receive
-    0,                    // uart1 transmit
-    0,                    // uart 2 receive
-    0,                    // uart 2 transmit
-    0,                    // GPIO 0 combined interrupt
-    0,                    // GPIO 2 combined interrupt
-    0,                    // Timer 0
-    0,                    // Timer 1
-    0,                    // Dial Timer
-    0,                    // SPI0 SPI1
-    0,                    // uart overflow 1, 2,3
-    0,                    // Ethernet   13
-
+    (uint32_t*)&Reset_Handler,           // Reset                -15
+    (uint32_t*)&Default_Handler,         // NMI_Handler          -14
+    (uint32_t*)&Default_Handler2,        // HardFault_Handler    -13
+    (uint32_t*)&Default_Handler3,        // MemManage_Handler    -12
+    (uint32_t*)&Default_Handler4,        // BusFault_Handler     -11
+    (uint32_t*)&Default_Handler5,        // UsageFault_Handler   -10
+    0,                                   // reserved
+    0,                                   // reserved
+    0,                                   // reserved
+    0,                                   // reserved             -6
+    (uint32_t*)&vPortSVCHandler,         // SVC_Handler          -5
+    (uint32_t*)&Default_Handler6,        // DebugMon_Handler     -4
+    0,                                   // reserved
+    (uint32_t*)&xPortPendSVHandler,      // PendSV handler       -2
+    (uint32_t*)&xPortSysTickHandler,     // SysTick_Handler      -1
+    0,                                   // uart0 receive         0
+    0,                                   // uart0 transmit
+    0,                                   // uart1 receive
+    0,                                   // uart1 transmit
+    0,                                   // uart 2 receive
+    0,                                   // uart 2 transmit
+    0,                                   // GPIO 0 combined interrupt
+    0,                                   // GPIO 2 combined interrupt
+    0,                                   // Timer 0
+    0,                                   // Timer 1
+    0,                                   // Dial Timer
+    0,                                   // SPI0 SPI1
+    0,                                   // uart overflow 1 2,3   12
+    (uint32_t*)&EthernetISR,             // Ethernet              13
 };
 
 void _start(void)


### PR DESCRIPTION
Qemu Mps2 network interrupt

Description
-----------
- Change the way mps2 port under qemu reads data from the network from polling to using interrupts 
Networking changes are in: https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/pull/141
- Changing interrupt priorities 

Test Steps
-----------
manual testing

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
