### PR TITLE
Blocklist certificate files in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,7 @@
 # Python Tools for Visual Studio (PTVS)
 __pycache__/
 *.pyc
+
+# Ignore certificate files.
+*.pem
+*.crt


### PR DESCRIPTION
Add certificate file extensions to **.gitignore** to prevent certificate files from being accidentally checked in the repository.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
