### PR TITLE
Unit Test/timer[0]

### DIFF
--- a/FreeRTOS/Test/CMock/Makefile
+++ b/FreeRTOS/Test/CMock/Makefile
@@ -1,8 +1,8 @@
 # Change to match installed location
-export CC=/usr/local/bin/gcc
-export LD=/usr/local/bin/ld
+export CC ?= /usr/local/bin/gcc
+export LD ?= /usr/local/bin/ld
 # Add units here when adding a new unit test directory with the same name
-UNITS := queue list
+UNITS := queue list timers
 
 include makefile.in
 

--- a/FreeRTOS/Test/CMock/timers/Makefile
+++ b/FreeRTOS/Test/CMock/timers/Makefile
@@ -1,0 +1,75 @@
+# Change according to what your  unit test directory is.
+# For example if testing queue.c your directory should be called queue
+# and the project name should be queue
+# if testing list.c your directory should be called list
+# and the project name should be list
+PROJECT          :=   timers
+
+# List the dependency files you wish to mock
+MOCK_FILES_FP    :=  $(KERNEL_DIR)/include/task.h
+MOCK_FILES_FP    +=  $(KERNEL_DIR)/include/queue.h
+MOCK_FILES_FP    +=  $(KERNEL_DIR)/include/list.h
+
+# List the options the compilation would need
+CPPFLAGS         +=   -DconfigSUPPORT_DYNAMIC_ALLOCATION=1
+CPPFLAGS         +=   -DconfigSUPPORT_STATIC_ALLOCATION=1
+
+
+# Try not to edit beyond this line
+MOCK_FILES       :=   $(notdir $(MOCK_FILES_FP))
+MOCK_OBJ         :=   $(addprefix mock_,$(MOCK_FILES:.h=.o))
+MOCK_SRC         :=   $(addprefix mock_,$(MOCK_FILES:.h=.c))
+EXEC             :=   $(PROJECT)_utest
+PROJECT_DIR      :=   $(abspath .)
+SCRATCH_DIR      :=   $(GENERATED_DIR)/$(PROJECT)
+PROJ_LIB_DIR     :=   $(SCRATCH_DIR)/lib
+MOCK_OBJ_LIST    :=   $(addprefix $(PROJ_LIB_DIR)/,$(MOCK_OBJ))
+MOCKS_DIR        :=   $(SCRATCH_DIR)/mocks
+MOCK_SRC_LIST    :=   $(addprefix $(MOCKS_DIR)/,$(MOCK_SRC))
+CFLAGS           +=   -I$(MOCKS_DIR)
+COVERAGE_OPTS    := -fprofile-arcs -ftest-coverage -fprofile-generate
+
+ifeq ($(MOCK_FILES_FP),)
+     $(shell mkdir -p  $(MOCKS_DIR))
+     $(shell touch -a $(MOCKS_DIR)/mock_dummy.c)
+endif
+
+$(MOCKS_DIR)/mock_%.c : Makefile $(PROJECT_DIR)/$(PROJECT).yml | directories
+	cd $(SCRATCH_DIR) &&                                                \
+	    ruby $(CMOCK_EXEC_DIR)/cmock.rb -o$(PROJECT_DIR)/$(PROJECT).yml \
+	    $(MOCK_FILES_FP)
+
+$(PROJ_LIB_DIR)/mock_%.o : $(MOCKS_DIR)/mock_%.c
+	$(CC) -c $< -fPIC $(CFLAGS) -o $@
+
+$(BIN_DIR)/$(EXEC) : $(SCRATCH_DIR)/test_runner.o                           \
+		    $(SCRATCH_DIR)/$(PROJECT).o                             \
+		    $(SCRATCH_DIR)/$(PROJECT)_utest.o                       \
+		    $(MOCK_OBJ_LIST)
+	$(CC) $+ $(LDFLAGS) -o $@
+
+$(SCRATCH_DIR)/test_runner.o : $(SCRATCH_DIR)/test_runner.c                 \
+                               $(SCRATCH_DIR)/$(PROJECT).o
+	$(CC) -c $< $(CPPFLAGS)  $(CFLAGS) -o $@
+
+$(SCRATCH_DIR)/$(PROJECT)_utest.o : $(PROJECT_DIR)/$(PROJECT)_utest.c       \
+                                    $(MOCKS_DIR)/mock_*.c                   \
+                                    | directories
+	$(CC) -c $< $(CPPFLAGS)  $(CFLAGS) -o $@
+
+$(SCRATCH_DIR)/$(PROJECT).o : $(KERNEL_DIR)/$(PROJECT).c
+	$(CC) -c $< $(CPPFLAGS)  $(CFLAGS) $(COVERAGE_OPTS) -o $@
+
+$(SCRATCH_DIR)/test_runner.c : $(SCRATCH_DIR)/$(PROJECT)_utest.o            \
+                               Makefile | directories
+	ruby $(UNITY_BIN_DIR)/generate_test_runner.rb $(EXEC).c             \
+		$(PROJECT_DIR)/$(PROJECT).yml $@
+
+.PHONY: directories
+directories :
+	-mkdir  $(SCRATCH_DIR)
+	-mkdir  $(MOCKS_DIR)
+	-mkdir  $(PROJ_LIB_DIR)
+
+# prevent deletion by chain of implicit rules
+NO_DELETE: $(MOCK_SRC_LIST)

--- a/FreeRTOS/Test/CMock/timers/timers.yml
+++ b/FreeRTOS/Test/CMock/timers/timers.yml
@@ -1,0 +1,32 @@
+:cmock:
+  :mock_prefix: mock_
+  :when_no_prototypes: :warn
+  :treat_externs: :include
+  :enforce_strict_ordering: TRUE
+  :plugins:
+    - :ignore
+    - :ignore_arg
+    - :expect_any_args
+    - :array
+    - :callback
+    - :return_thru_ptr
+  :callback_include_count: true # include a count arg when calling the callback
+  :callback_after_arg_check: false # check arguments before calling the callback
+  :treat_as:
+    uint8:    HEX8
+    uint16:   HEX16
+    uint32:   UINT32
+    int8:     INT8
+    bool:     UINT8
+  :includes:        # This will add these includes to each mock.
+    - <stdbool.h>
+    - "FreeRTOS.h"
+  :treat_externs: :exclude  # Now the extern-ed functions will be mocked.
+  :weak: __attribute__((weak))
+  :verbosity: 3
+  :attributes:
+    - PRIVILEGED_FUNCTION
+  :strippables:
+    - PRIVILEGED_FUNCTION
+    - portDONT_DISCARD
+  :treat_externs: :include

--- a/FreeRTOS/Test/CMock/timers/timers_utest.c
+++ b/FreeRTOS/Test/CMock/timers/timers_utest.c
@@ -1,0 +1,123 @@
+/*
+ * FreeRTOS V202012.00
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * https://www.FreeRTOS.org
+ * https://github.com/FreeRTOS
+ *
+ */
+/*! @file timers_utest.c */
+
+/* C runtime includes. */
+#include <stdlib.h>
+#include <stdbool.h>
+
+/* Test includes. */
+#include "FreeRTOS.h"
+#include "FreeRTOSConfig.h"
+#include "timers.h"
+#include "unity.h"
+
+/* Mock includes. */
+#include "mock_queue.h"
+#include "mock_list.h"
+
+
+/* ============================  GLOBAL VARIABLES =========================== */
+static uint16_t usMallocFreeCalls = 0;
+
+/* ==========================  CALLBACK FUNCTIONS =========================== */
+
+void * pvPortMalloc( size_t xSize )
+{
+    return malloc( xSize );
+}
+void vPortFree( void * pv )
+{
+    return free( pv );
+}
+
+/*******************************************************************************
+ * Unity fixtures
+ ******************************************************************************/
+void setUp( void )
+{
+}
+
+/*! called before each testcase */
+void tearDown( void )
+{
+    TEST_ASSERT_EQUAL_INT_MESSAGE( 0, usMallocFreeCalls,
+                                   "free is not called the same number of times as malloc,"
+                                   "you might have a memory leak!!" );
+    usMallocFreeCalls = 0;
+}
+
+/*! called at the beginning of the whole suite */
+void suiteSetUp()
+{
+}
+
+/*! called at the end of the whole suite */
+int suiteTearDown( int numFailures )
+{
+    return numFailures;
+}
+
+
+static void _xCallback_Test( TimerHandle_t xTimer )
+{}
+
+/**
+ * @brief xTimerCreate happy path
+ * 
+ */
+void test_xTimerCreate_Success( void )
+{
+    uint32_t ulID = 0; 
+    TimerHandle_t xTimer = NULL;
+
+    vListInitialise_Ignore();
+    xQueueGenericCreateStatic_IgnoreAndReturn( (QueueHandle_t)1 );
+    vQueueAddToRegistry_Ignore();
+    vListInitialiseItem_Ignore();
+
+    xTimer = xTimerCreate( "ut-timer",
+                            pdMS_TO_TICKS(1000),
+                            pdTRUE,
+                            &ulID,
+                            _xCallback_Test );
+
+    TEST_ASSERT_NOT_EQUAL( NULL, xTimer );
+}
+
+void vApplicationGetTimerTaskMemory( StaticTask_t ** ppxTimerTaskTCBBuffer,
+                                     StackType_t ** ppxTimerTaskStackBuffer,
+                                     uint32_t * pulTimerTaskStackSize )
+{
+    static StaticTask_t xTimerTaskTCB;
+    static StackType_t uxTimerTaskStack[ configTIMER_TASK_STACK_DEPTH ];
+    *ppxTimerTaskTCBBuffer = &xTimerTaskTCB;
+    *ppxTimerTaskStackBuffer = uxTimerTaskStack;
+    *pulTimerTaskStackSize = configTIMER_TASK_STACK_DEPTH;
+}
+
+void vApplicationDaemonTaskStartupHook( void )
+{}


### PR DESCRIPTION
Description
-----------
Initial iteration. Only includes happy path test for `xTimerCreate`. Realized I really wanted an integration test which I'll be writing elsewhere, but made this along the way.

Also make CC/LD assignment conditional and only set in Makefile if not already set, so users like myself can specify CC/LD without updating the Makefile.


Test Steps
-----------
Read `FreeRTOS/Test/Cmock/ReadMe.md`.
```
make timers run
```

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
