### PR TITLE
Generate JUnit style report for kernel unit test

### DIFF
--- a/FreeRTOS/Test/CMock/Makefile
+++ b/FreeRTOS/Test/CMock/Makefile
@@ -54,7 +54,7 @@ $(LIB_DIR)/libunity.so : ${UNITY_SRC_DIR}/unity.c     \
 
 run : $(UNITS) zero_coverage | directories
 	for f in $(BIN_DIR)/*; do \
-	  $${f}; done 
+	  $${f}; done
 
 run_col : $(UNITS) zero_coverage | directories
 	for f in $(BIN_DIR)/*; do \
@@ -64,7 +64,7 @@ run_formatted :  $(UNITS) zero_coverage | directories
 	for f in $(BIN_DIR)/*; do \
 	  $${f} > $(BUILD_DIR)/output; \
 	  ruby  $(UNITY_BIN_DIR)/parse_output.rb $(BUILD_DIR)/output ; \
-	  done 
+	  done
 
 run_col_formatted :  $(UNITS) zero_coverage | directories
 	for f in $(BIN_DIR)/*; do \
@@ -81,4 +81,10 @@ coverage : run_col
 	    --rc genhtml_branch_coverage=1  -o $(BUILD_DIR)/cmock_test.info
 	genhtml $(BUILD_DIR)/cmock_test.info --branch-coverage               \
 	    --output-directory $(COVERAGE_DIR)
+
+run_report : $(UNITS) directories
+	-rm $(BUILD_DIR)/unit_test_report.txt
+	for f in $(BIN_DIR)/*; do \
+	  $${f} >> $(BUILD_DIR)/unit_test_report.txt ; done
+	  ruby $(UNITY_BIN_DIR)/parse_output.rb $(BUILD_DIR)/unit_test_report.txt
 

--- a/FreeRTOS/Test/CMock/Makefile
+++ b/FreeRTOS/Test/CMock/Makefile
@@ -1,6 +1,6 @@
 # Change to match installed location
-export CC ?= /usr/local/bin/gcc
-export LD ?= /usr/local/bin/ld
+export CC := /usr/local/bin/gcc
+export LD := /usr/local/bin/ld
 # Add units here when adding a new unit test directory with the same name
 UNITS := queue list timers
 
@@ -14,7 +14,7 @@ execs: $(UNITS) | directories
 
 
 $(UNITS) : ${LIB_DIR}/libcmock.so  ${LIB_DIR}/libunity.so | directories
-	$(MAKE) -C $@ 
+	$(MAKE) -C $@
 
 doc: | directories
 	$(MAKE) -C doc all
@@ -50,15 +50,18 @@ $(LIB_DIR)/libcmock.so : ${CMOCK_SRC_DIR}/cmock.c     \
 $(LIB_DIR)/libunity.so : ${UNITY_SRC_DIR}/unity.c     \
 			 ${UNITY_SRC_DIR}/unity.h     \
 			 Makefile | directories
-	${CC} -o $@ -shared -fPIC  $< 
+	${CC} -o $@ -shared -fPIC  $<
 
-run : $(UNITS) zero_coverage | directories
-	for f in $(BIN_DIR)/*; do \
-	  $${f}; done
+run : $(UNITS) directories
+	-rm $(BUILD_DIR)/unit_test_report.txt
+	for f in $(BIN_DIR)/*; do                                              \
+	  $${f} | tee -a $(BUILD_DIR)/unit_test_report.txt ; done
+	  cd $(BUILD_DIR) &&                                                   \
+	      ruby $(UNITY_BIN_DIR)/parse_output.rb -xml $(BUILD_DIR)/unit_test_report.txt
 
 run_col : $(UNITS) zero_coverage | directories
 	for f in $(BIN_DIR)/*; do \
-	  ruby -r $(UNITY_BIN_DIR)/colour_reporter.rb  -e "report('`$${f}`')"; done 
+	  ruby -r $(UNITY_BIN_DIR)/colour_reporter.rb  -e "report('`$${f}`')"; done
 
 run_formatted :  $(UNITS) zero_coverage | directories
 	for f in $(BIN_DIR)/*; do \
@@ -72,7 +75,7 @@ run_col_formatted :  $(UNITS) zero_coverage | directories
 	  ruby -r $(UNITY_BIN_DIR)/colour_reporter.rb  \
 		-e "report('$$(ruby $(UNITY_BIN_DIR)/parse_output.rb \
 		 $(BUILD_DIR)/output)')"; \
-	  done 
+	  done
 
 zero_coverage :
 	lcov --zerocounters --directory $(BUILD_DIR)
@@ -82,9 +85,4 @@ coverage : run_col
 	genhtml $(BUILD_DIR)/cmock_test.info --branch-coverage               \
 	    --output-directory $(COVERAGE_DIR)
 
-run_report : $(UNITS) directories
-	-rm $(BUILD_DIR)/unit_test_report.txt
-	for f in $(BIN_DIR)/*; do \
-	  $${f} >> $(BUILD_DIR)/unit_test_report.txt ; done
-	  ruby $(UNITY_BIN_DIR)/parse_output.rb $(BUILD_DIR)/unit_test_report.txt
 

--- a/FreeRTOS/Test/CMock/Makefile
+++ b/FreeRTOS/Test/CMock/Makefile
@@ -1,6 +1,6 @@
 # Change to match installed location
-export CC := /usr/local/bin/gcc
-export LD := /usr/local/bin/ld
+export CC ?= /usr/local/bin/gcc
+export LD ?= /usr/local/bin/ld
 # Add units here when adding a new unit test directory with the same name
 UNITS := queue list timers
 


### PR DESCRIPTION
Generate JUnit style report for kernel Unit Test

Description
-----------
Generating an xml file containing JUnit style report to display on capable CI's

Test Steps
-----------
```
$ make run
```
two new files will be generated in build report.xml(containing xml JUnit output) and unit_test_report.txt (containing unity output)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
