### PR TITLE
QEMU CORTEX_M3_MPS2_QEMU_GCC Demo Failure Counter

### DIFF
--- a/FreeRTOS/Demo/CORTEX_M3_MPS2_QEMU_GCC/gdbinit
+++ b/FreeRTOS/Demo/CORTEX_M3_MPS2_QEMU_GCC/gdbinit
@@ -1,0 +1,29 @@
+target remote :1234
+set pagination off
+p xTaskGetTickCount()
+p ullSuccesfulIterations
+p ullTimerDemoTaskFailures
+p ullStreamBufferTaskFailures
+p ullMessageBufferFailures
+p ullTaskNotificationFailures
+p ullInterruptSemaphoreFailures
+p ullEventGroupTaskFailures
+p ullIntegerMathsFailures
+p ullGenericQueueFailures
+p ullQueuePeekFailures
+p ullBlockingQueueFailures
+p ullSemaphoreTaskFailures
+p ullPollingQueueFailures
+p ullMathsFailures
+p ullRecursiveMutexFailures
+p ullCountingSemaphoreFailures
+p ullCreateTaskFailures
+p ullDynamicPriorityFailures
+p ullQueueOverwriteFailures
+p ullBlockTimeFailures
+p ullAbortDelayFailures
+p ullInterruptStreamBufferFailures
+p ullMessageBufferAMPFailures
+p ullStaticAllocationFailures
+quit
+

--- a/FreeRTOS/Demo/CORTEX_M3_MPS2_QEMU_GCC/main_full.c
+++ b/FreeRTOS/Demo/CORTEX_M3_MPS2_QEMU_GCC/main_full.c
@@ -189,6 +189,40 @@ static char *pcStatusMessage = "OK: No errors";
 semaphore tracing API functions.  It has no other purpose. */
 static SemaphoreHandle_t xMutexToDelete = NULL;
 
+/* Counters for task failures. */
+long long unsigned ullSuccesfulIterations = 0;
+#if( configUSE_PREEMPTION != 0 )
+long long unsigned ullTimerDemoTaskFailures = 0;
+#endif
+long long unsigned ullStreamBufferTaskFailures = 0;
+long long unsigned ullMessageBufferFailures = 0;
+long long unsigned ullTaskNotificationFailures = 0;
+long long unsigned ullInterruptSemaphoreFailures = 0;
+long long unsigned ullEventGroupTaskFailures = 0;
+long long unsigned ullIntegerMathsFailures = 0;
+long long unsigned ullGenericQueueFailures = 0;
+long long unsigned ullQueuePeekFailures = 0;
+long long unsigned ullBlockingQueueFailures = 0;
+long long unsigned ullSemaphoreTaskFailures = 0;
+long long unsigned ullPollingQueueFailures = 0;
+long long unsigned ullMathsFailures = 0;
+long long unsigned ullRecursiveMutexFailures = 0;
+long long unsigned ullCountingSemaphoreFailures = 0;
+long long unsigned ullCreateTaskFailures = 0;
+long long unsigned ullDynamicPriorityFailures = 0;
+long long unsigned ullQueueOverwriteFailures = 0;
+long long unsigned ullBlockTimeFailures = 0;
+long long unsigned ullAbortDelayFailures = 0;
+long long unsigned ullInterruptStreamBufferFailures = 0;
+long long unsigned ullMessageBufferAMPFailures = 0;
+#if( configUSE_QUEUE_SETS == 1 )
+long long unsigned ullQueueSetFailures = 0;
+long long unsigned ullQueueSetPollFailures = 0;
+#endif
+#if( configSUPPORT_STATIC_ALLOCATION == 1 )
+long long unsigned ullStaticAllocationFailures = 0;
+#endif
+
 /*-----------------------------------------------------------*/
 
 int main_full( void )
@@ -285,6 +319,7 @@ HeapStats_t xHeapStats;
 			/* These tasks are only created when preemption is used. */
 			if( xAreTimerDemoTasksStillRunning( xCycleFrequency ) != pdTRUE )
 			{
+				ullTimerDemoTaskFailures++;
 				pcStatusMessage = "Error: TimerDemo";
 			}
 		}
@@ -292,14 +327,17 @@ HeapStats_t xHeapStats;
 
 		if( xAreStreamBufferTasksStillRunning() != pdTRUE )
 		{
+			ullStreamBufferTaskFailures++;
 			pcStatusMessage = "Error:  StreamBuffer";
 		}
 		else if( xAreMessageBufferTasksStillRunning() != pdTRUE )
 		{
+			ullMessageBufferFailures++;
 			pcStatusMessage = "Error:  MessageBuffer";
 		}
 		else if( xAreTaskNotificationTasksStillRunning() != pdTRUE )
 		{
+			ullTaskNotificationFailures++;
 			pcStatusMessage = "Error:  Notification";
 		}
 		// else if( xAreTaskNotificationArrayTasksStillRunning() != pdTRUE )
@@ -308,84 +346,104 @@ HeapStats_t xHeapStats;
 		// }
 		else if( xAreInterruptSemaphoreTasksStillRunning() != pdTRUE )
 		{
+			ullInterruptSemaphoreFailures++;
 			pcStatusMessage = "Error: IntSem";
 		}
 		else if( xAreEventGroupTasksStillRunning() != pdTRUE )
 		{
+			ullEventGroupTaskFailures++;
 			pcStatusMessage = "Error: EventGroup";
 		}
 		else if( xAreIntegerMathsTaskStillRunning() != pdTRUE )
 		{
+			ullIntegerMathsFailures++;
 			pcStatusMessage = "Error: IntMath";
 		}
 		else if( xAreGenericQueueTasksStillRunning() != pdTRUE )
 		{
+			ullGenericQueueFailures++;
 			pcStatusMessage = "Error: GenQueue";
 		}
 		else if( xAreQueuePeekTasksStillRunning() != pdTRUE )
 		{
+			ullQueuePeekFailures++;
 			pcStatusMessage = "Error: QueuePeek";
 		}
 		else if( xAreBlockingQueuesStillRunning() != pdTRUE )
 		{
+			ullBlockingQueueFailures++;
 			pcStatusMessage = "Error: BlockQueue";
 		}
 		else if( xAreSemaphoreTasksStillRunning() != pdTRUE )
 		{
+			ullSemaphoreTaskFailures++;
 			pcStatusMessage = "Error: SemTest";
 		}
 		else if( xArePollingQueuesStillRunning() != pdTRUE )
 		{
+			ullPollingQueueFailures++;
 			pcStatusMessage = "Error: PollQueue";
 		}
 		else if( xAreMathsTaskStillRunning() != pdPASS )
 		{
+			ullMathsFailures++;
 			pcStatusMessage = "Error: Flop";
 		}
 		else if( xAreRecursiveMutexTasksStillRunning() != pdTRUE )
 		{
+			ullRecursiveMutexFailures++;
 			pcStatusMessage = "Error: RecMutex";
 		}
 		else if( xAreCountingSemaphoreTasksStillRunning() != pdTRUE )
 		{
+			ullCountingSemaphoreFailures++;
 			pcStatusMessage = "Error: CountSem";
 		}
 		else if( xIsCreateTaskStillRunning() != pdTRUE )
 		{
+			ullCreateTaskFailures++;
 			pcStatusMessage = "Error: Death";
 		}
 		else if( xAreDynamicPriorityTasksStillRunning() != pdPASS )
 		{
+			ullDynamicPriorityFailures++;
 			pcStatusMessage = "Error: Dynamic";
 		}
 		else if( xIsQueueOverwriteTaskStillRunning() != pdPASS )
 		{
+			ullQueueOverwriteFailures++;
 			pcStatusMessage = "Error: Queue overwrite";
 		}
 		else if( xAreBlockTimeTestTasksStillRunning() != pdPASS )
 		{
+			ullBlockTimeFailures++;
 			pcStatusMessage = "Error: Block time";
 		}
 		else if( xAreAbortDelayTestTasksStillRunning() != pdPASS )
 		{
+			ullAbortDelayFailures++;
 			pcStatusMessage = "Error: Abort delay";
 		}
 		else if( xIsInterruptStreamBufferDemoStillRunning() != pdPASS )
 		{
+			ullInterruptStreamBufferFailures++;
 			pcStatusMessage = "Error: Stream buffer interrupt";
 		}
 		else if( xAreMessageBufferAMPTasksStillRunning() != pdPASS )
 		{
+			ullMessageBufferAMPFailures++;
 			pcStatusMessage = "Error: Message buffer AMP";
 		}
 
 		#if( configUSE_QUEUE_SETS == 1 )
 			else if( xAreQueueSetTasksStillRunning() != pdPASS )
 			{
+				ullQueueSetFailures++;
 				pcStatusMessage = "Error: Queue set";
 			}
 			else if( xAreQueueSetPollTasksStillRunning() != pdPASS )
 			{
+				ullQueueSetPollFailures++;
 				pcStatusMessage = "Error: Queue set polling";
 			}
 		#endif
@@ -393,9 +451,14 @@ HeapStats_t xHeapStats;
 		#if( configSUPPORT_STATIC_ALLOCATION == 1 )
 			else if( xAreStaticAllocationTasksStillRunning() != pdPASS )
 			{
+				ullStaticAllocationFailures++;
 				pcStatusMessage = "Error: Static allocation";
 			}
 		#endif /* configSUPPORT_STATIC_ALLOCATION */
+		else
+		{
+			ullSuccesfulIterations++;
+		}
 
 		printf( "%s - tick count %u \r\n",
 					pcStatusMessage,


### PR DESCRIPTION
Add failure counters to QEMU CORTEX_M3_MPS2_QEMU_GCC Full Demo and GDB script to count failures.

Description
-----------
Add failure counters to QEMU CORTEX_M3_MPS2_QEMU_GCC Full Demo and GDB script to count failures. The updated variables store how many times a task has faltered, and a GDB script is provided that can be used to extract the failures when QEMU is running with no serial.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
