### PR TITLE
Reintroduce quarantined CBMC test

### DIFF
--- a/FreeRTOS/Test/CBMC/proofs/Task/TaskResumeAll/Configurations.json
+++ b/FreeRTOS/Test/CBMC/proofs/Task/TaskResumeAll/Configurations.json
@@ -30,6 +30,15 @@
   "ENTRY": "TaskResumeAll",
   "DEF":
   [
+    { "default":
+      [
+        "FREERTOS_MODULE_TEST",
+        "PENDED_TICKS=1",
+        "'mtCOVERAGE_TEST_MARKER()=__CPROVER_assert(1, \"Coverage marker\")'",
+        "configUSE_TRACE_FACILITY=0",
+        "configGENERATE_RUN_TIME_STATS=0"
+      ]
+    },
     { "useTickHook1":
       [
         "FREERTOS_MODULE_TEST",


### PR DESCRIPTION
 Reintroduce quarantined CBMC test #516 

Description
-----------
This CBMC test would go over the memory limit of most hosts, causing the
kernel to kill the process. With larger memory capabilities, this can be
re-enabled.

Test Steps
-----------
Run the TaskResume proofs.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
