### PR TITLE
Make the address sanitizer optional for CMock kernel unit tests

### DIFF
--- a/FreeRTOS/Test/CMock/Readme.md
+++ b/FreeRTOS/Test/CMock/Readme.md
@@ -60,6 +60,11 @@ $ make coverage
 Would build all unit tests, runs them one after the other, then generates html code
 coverage and places them in build/coverage with initial file index.html
 
+## Runing tests with Address Sanitizer enabled ##
+The GCC address sanitizer can be enabled by passing in "ENABLE_SANITIZER=1" when calling make.
+
+Note: Enabling the address sanitizer will introduce additional branches that may not be possible to get test coverage of. For this reason, the address sanitizer is not enabled by default. It is recommended that developers enable the address sanitizer when modifying or developing new test cases.
+
 ## Running individual tests
 From each test directory, you can build, run the test, and generate gcov coverage with the default "all" target like so:
 ```

--- a/FreeRTOS/Test/CMock/makefile.in
+++ b/FreeRTOS/Test/CMock/makefile.in
@@ -41,20 +41,24 @@ CPPFLAGS    :=
 
 # Compiler flags
 CFLAGS              :=  $(INCLUDE_DIR)  -O0 -ggdb -pthread  --std=c99 -Werror -Wall
-CFLAGS              +=  -fsanitize=address,undefined -fsanitize-recover=address
 CFLAGS              +=  -fstack-protector-all
 CFLAGS              +=  -Wformat -Werror=format-security -Werror=array-bounds
 CFLAGS              +=  -D_FORTIFY_SOURCE=2
+ifdef ENABLE_SANITIZER
+    CFLAGS          +=  -fsanitize=address,undefined -fsanitize-recover=address
+endif
 
 # Linker flags
 LDFLAGS             :=  -L$(LIB_DIR) -Wl,-rpath,$(LIB_DIR)
-LDFLAGS             +=  -fsanitize=address,undefined
 LDFLAGS             +=  -pthread
 LDFLAGS             +=  -lunity
 LDFLAGS             +=  -lunitymemory
 LDFLAGS             +=  -lcexception
 LDFLAGS             +=  -lcmock
 LDFLAGS             +=  -lgcov
+ifdef ENABLE_SANITIZER
+    LDFLAGS         +=  -fsanitize=address,undefined
+endif
 
 # Shared libraries
 LIBS                :=  libunity

--- a/FreeRTOS/Test/CMock/makefile.in
+++ b/FreeRTOS/Test/CMock/makefile.in
@@ -44,7 +44,7 @@ CFLAGS              :=  $(INCLUDE_DIR)  -O0 -ggdb -pthread  --std=c99 -Werror -W
 CFLAGS              +=  -fstack-protector-all
 CFLAGS              +=  -Wformat -Werror=format-security -Werror=array-bounds
 CFLAGS              +=  -D_FORTIFY_SOURCE=2
-ifdef ENABLE_SANITIZER
+ifeq ($(ENABLE_SANITIZER),1)
     CFLAGS          +=  -fsanitize=address,undefined -fsanitize-recover=address
 endif
 
@@ -56,7 +56,7 @@ LDFLAGS             +=  -lunitymemory
 LDFLAGS             +=  -lcexception
 LDFLAGS             +=  -lcmock
 LDFLAGS             +=  -lgcov
-ifdef ENABLE_SANITIZER
+ifeq ($(ENABLE_SANITIZER),1)
     LDFLAGS         +=  -fsanitize=address,undefined
 endif
 


### PR DESCRIPTION
Make the address sanitizer optional

Description
-----------
The address sanitizer is now disabled by default for CMock tests because it introduces additional branches into the compiled code. When make is run with the ENABLE_SANITIZER=1 argument, the address sanitizer is enabled and coverage data may not be accurate.


Test Steps
-----------
N/A

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
