### PR TITLE
Kernel UT: Enable preprocessor when running cflow in callgraph.py

### DIFF
--- a/FreeRTOS/Test/CMock/testdir.mk
+++ b/FreeRTOS/Test/CMock/testdir.mk
@@ -120,7 +120,7 @@ $(MOCK_HDR_LIST) $(MOCK_SRC_LIST) : $(PROJECT_DIR)/$(PROJECT).yml $(MOCK_FILES_F
 # Generate callgraph for coverage filtering
 $(PROJ_DIR)/callgraph.json : $(PROJ_SRC_LIST)
     mkdir -p $(PROJ_DIR)
-    python3 $(UT_ROOT_DIR)/tools/callgraph.py $^ > $@
+    python3 $(UT_ROOT_DIR)/tools/callgraph.py --out $@ $^
 
 # preprocess proj files to expand macros for coverage
 $(PROJ_DIR)/%.i : $(KERNEL_DIR)/%.c

--- a/FreeRTOS/Test/CMock/tools/callgraph.py
+++ b/FreeRTOS/Test/CMock/tools/callgraph.py
@@ -38,6 +38,13 @@ for f in target_files:
         print("ERROR: Input file {} does not exist.".format(f))
         exit(1)
 
+includes = ""
+# Get INCLUDE_DIR from envrionment
+if "INCLUDE_DIR" in os.environ:
+    includes = os.environ["INCLUDE_DIR"]
+else:
+    print("WARNING: INCLUDE_DIR variable was not found in the envrionment.")
+
 ret = subprocess.run(
     [
         "cflow",
@@ -46,6 +53,7 @@ ret = subprocess.run(
         "--omit-arguments",
         "--omit-symbol-names",
         "--all",
+        includes,
     ]
     + target_files,
     capture_output=True,


### PR DESCRIPTION
Kernel UT: Enable preprocessor when running cflow in callgraph.py

Description
-----------
Pass include paths when calling cflow so that it can exclude functions that are disabled by the relevant FreeRTOS config item.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
