### PR TITLE
Skip filtering of coverage if no @coverage tags are found in a _utest.c file

### DIFF
--- a/FreeRTOS/Test/CMock/tools/filtercov.py
+++ b/FreeRTOS/Test/CMock/tools/filtercov.py
@@ -79,10 +79,12 @@ def main():
         print("The test file path does not exist.", file=sys.stderr)
         sys.exit(1)
 
+    skip_target_filtering = False
     tagged_functions = get_tagged_functions_in_file(args.test)
     if len(tagged_functions) == 0:
-        print("No target functions found in test file.")
-        sys.exit(1)
+        print("WARNING: No target functions found in test file.")
+        skip_target_filtering = True
+
     print("Target functions from UT: " + str(tagged_functions), file=sys.stderr)
 
     cov_functions_deps = get_function_deps(args.map, tagged_functions)
@@ -94,7 +96,13 @@ def main():
         covfile_handle = gzip.open(vars(args)["in"], "rb")
     else:
         covfile_handle = open(vars(args)["in"], "r")
-    covdata_out = filter_coverage_file(covfile_handle, cov_functions_deps)
+
+    if skip_target_filtering:
+        print("WARNING: Skipping coverage filtering.")
+        covdata_out = json.load(covfile_handle)
+    else:
+        covdata_out = filter_coverage_file(covfile_handle, cov_functions_deps)
+
     covfile_handle.close()
 
     filter_excluded_lines(covdata_out)


### PR DESCRIPTION
Skip filtering of coverage if no @ coverage tags are found in a _utest.c file

Description
-----------
Skip coverage filtering when a unit test does not contain any @coverage tags.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
