### PR TITLE
Run kernel unit tests on pull requests and pushes.

### DIFF
--- a/.github/workflows/kernel-unit-tests.yml
+++ b/.github/workflows/kernel-unit-tests.yml
@@ -1,8 +1,5 @@
 name: Kernel Unit Tests
-on:
-  push:
-    paths:
-    - 'FreeRTOS/Test/CMock/**'
+on: [push, pull_request]
 
 jobs:
   run:


### PR DESCRIPTION
Run kernel unit tests on pull requests and pushes.

Description
-----------
Previously, kernel unit tests would only run as a github action on a "push" event and will not show up in a PR.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
