### PR TITLE
Force a branch in the definition of configASSERT in the default CMock FreeRTOSConfig.h file

### DIFF
--- a/FreeRTOS/Test/CMock/config/FreeRTOSConfig.h
+++ b/FreeRTOS/Test/CMock/config/FreeRTOSConfig.h
@@ -115,13 +115,17 @@ void vConfigureTimerForRunTimeStats( void );    /* Prototype of function that in
 
 /* It is a good idea to define configASSERT() while developing.  configASSERT()
  * uses the same semantics as the standard C assert() macro. */
-#define configASSERT( x )                         \
-    do                                            \
-    {                                             \
-        if( x )                                   \
-        vFakeAssert( true, __FILE__, __LINE__ );  \
-        else                                      \
-        vFakeAssert( false, __FILE__, __LINE__ ); \
+#define configASSERT( x )                             \
+    do                                                \
+    {                                                 \
+        if( x )                                       \
+        {                                             \
+            vFakeAssert( true, __FILE__, __LINE__ );  \
+        }                                             \
+        else                                          \
+        {                                             \
+            vFakeAssert( false, __FILE__, __LINE__ ); \
+        }                                             \
     } while ( 0 );
 
 #define mtCOVERAGE_TEST_MARKER()    __asm volatile ( "NOP" )

--- a/FreeRTOS/Test/CMock/config/FreeRTOSConfig.h
+++ b/FreeRTOS/Test/CMock/config/FreeRTOSConfig.h
@@ -31,99 +31,105 @@
 #include "fake_assert.h"
 
 /*-----------------------------------------------------------
- * Application specific definitions.
- *
- * These definitions should be adjusted for your particular hardware and
- * application requirements.
- *
- * THESE PARAMETERS ARE DESCRIBED WITHIN THE 'CONFIGURATION' SECTION OF THE
- * FreeRTOS API DOCUMENTATION AVAILABLE ON THE FreeRTOS.org WEB SITE.  See
- * http://www.freertos.org/a00110.html
- *----------------------------------------------------------*/
+* Application specific definitions.
+*
+* These definitions should be adjusted for your particular hardware and
+* application requirements.
+*
+* THESE PARAMETERS ARE DESCRIBED WITHIN THE 'CONFIGURATION' SECTION OF THE
+* FreeRTOS API DOCUMENTATION AVAILABLE ON THE FreeRTOS.org WEB SITE.  See
+* http://www.freertos.org/a00110.html
+*----------------------------------------------------------*/
 
-#define configUSE_PREEMPTION					1
-#define configUSE_PORT_OPTIMISED_TASK_SELECTION	1
-#define configUSE_IDLE_HOOK						1
-#define configUSE_TICK_HOOK						1
-#define configUSE_DAEMON_TASK_STARTUP_HOOK		1
-#define configTICK_RATE_HZ						( 1000 ) /* In this non-real time simulated environment the tick frequency has to be at least a multiple of the Win32 tick frequency, and therefore very slow. */
-#define configMINIMAL_STACK_SIZE				( ( unsigned short ) 70 ) /* In this simulated case, the stack only has to hold one small structure as the real stack is part of the win32 thread. */
-#define configTOTAL_HEAP_SIZE					( ( size_t ) ( 52 * 1024 ) )
-#define configMAX_TASK_NAME_LEN					( 12 )
-#define configUSE_TRACE_FACILITY				1
-#define configUSE_16_BIT_TICKS					0
-#define configIDLE_SHOULD_YIELD					1
-#define configUSE_MUTEXES						1
-#define configCHECK_FOR_STACK_OVERFLOW			0
-#define configUSE_RECURSIVE_MUTEXES				1
-#define configQUEUE_REGISTRY_SIZE				20
-#define configUSE_MALLOC_FAILED_HOOK			1
-#define configUSE_APPLICATION_TASK_TAG			1
-#define configUSE_COUNTING_SEMAPHORES			1
-#define configUSE_ALTERNATIVE_API				0
-#define configUSE_QUEUE_SETS					1
-#define configUSE_TASK_NOTIFICATIONS			1
-#define configTASK_NOTIFICATION_ARRAY_ENTRIES		5
-#define configSUPPORT_STATIC_ALLOCATION			1
-#define configINITIAL_TICK_COUNT				( ( TickType_t ) 0 ) /* For test. */
-#define configSTREAM_BUFFER_TRIGGER_LEVEL_TEST_MARGIN 1 /* As there are a lot of tasks running. */
+#define configUSE_PREEMPTION                             1
+#define configUSE_PORT_OPTIMISED_TASK_SELECTION          1
+#define configUSE_IDLE_HOOK                              1
+#define configUSE_TICK_HOOK                              1
+#define configUSE_DAEMON_TASK_STARTUP_HOOK               1
+#define configTICK_RATE_HZ                               ( 1000 )                  /* In this non-real time simulated environment the tick frequency has to be at least a multiple of the Win32 tick frequency, and therefore very slow. */
+#define configMINIMAL_STACK_SIZE                         ( ( unsigned short ) 70 ) /* In this simulated case, the stack only has to hold one small structure as the real stack is part of the win32 thread. */
+#define configTOTAL_HEAP_SIZE                            ( ( size_t ) ( 52 * 1024 ) )
+#define configMAX_TASK_NAME_LEN                          ( 12 )
+#define configUSE_TRACE_FACILITY                         1
+#define configUSE_16_BIT_TICKS                           0
+#define configIDLE_SHOULD_YIELD                          1
+#define configUSE_MUTEXES                                1
+#define configCHECK_FOR_STACK_OVERFLOW                   0
+#define configUSE_RECURSIVE_MUTEXES                      1
+#define configQUEUE_REGISTRY_SIZE                        20
+#define configUSE_MALLOC_FAILED_HOOK                     1
+#define configUSE_APPLICATION_TASK_TAG                   1
+#define configUSE_COUNTING_SEMAPHORES                    1
+#define configUSE_ALTERNATIVE_API                        0
+#define configUSE_QUEUE_SETS                             1
+#define configUSE_TASK_NOTIFICATIONS                     1
+#define configTASK_NOTIFICATION_ARRAY_ENTRIES            5
+#define configSUPPORT_STATIC_ALLOCATION                  1
+#define configINITIAL_TICK_COUNT                         ( ( TickType_t ) 0 ) /* For test. */
+#define configSTREAM_BUFFER_TRIGGER_LEVEL_TEST_MARGIN    1                    /* As there are a lot of tasks running. */
 
 /* Software timer related configuration options. */
-#define configUSE_TIMERS						1
-#define configTIMER_TASK_PRIORITY				( configMAX_PRIORITIES - 1 )
-#define configTIMER_QUEUE_LENGTH				20
-#define configTIMER_TASK_STACK_DEPTH			( configMINIMAL_STACK_SIZE * 2 )
+#define configUSE_TIMERS                                 1
+#define configTIMER_TASK_PRIORITY                        ( configMAX_PRIORITIES - 1 )
+#define configTIMER_QUEUE_LENGTH                         20
+#define configTIMER_TASK_STACK_DEPTH                     ( configMINIMAL_STACK_SIZE * 2 )
 
-#define configMAX_PRIORITIES					( 7 )
+#define configMAX_PRIORITIES                             ( 7 )
 
 /* Run time stats gathering configuration options. */
 unsigned long ulGetRunTimeCounterValue( void ); /* Prototype of function that returns run time counter. */
-void vConfigureTimerForRunTimeStats( void );	/* Prototype of function that initialises the run time counter. */
-#define configGENERATE_RUN_TIME_STATS			1
-#define portCONFIGURE_TIMER_FOR_RUN_TIME_STATS() vConfigureTimerForRunTimeStats()
-#define portGET_RUN_TIME_COUNTER_VALUE() ulGetRunTimeCounterValue()
+void vConfigureTimerForRunTimeStats( void );    /* Prototype of function that initialises the run time counter. */
+#define configGENERATE_RUN_TIME_STATS    1
+#define portCONFIGURE_TIMER_FOR_RUN_TIME_STATS()    vConfigureTimerForRunTimeStats()
+#define portGET_RUN_TIME_COUNTER_VALUE()            ulGetRunTimeCounterValue()
 
 /* Co-routine related configuration options. */
-#define configUSE_CO_ROUTINES 					0
-#define configMAX_CO_ROUTINE_PRIORITIES			( 2 )
+#define configUSE_CO_ROUTINES                     0
+#define configMAX_CO_ROUTINE_PRIORITIES           ( 2 )
 
 /* This demo makes use of one or more example stats formatting functions.  These
-format the raw data provided by the uxTaskGetSystemState() function in to human
-readable ASCII form.  See the notes in the implementation of vTaskList() within
-FreeRTOS/Source/tasks.c for limitations. */
-#define configUSE_STATS_FORMATTING_FUNCTIONS	1
+ * format the raw data provided by the uxTaskGetSystemState() function in to human
+ * readable ASCII form.  See the notes in the implementation of vTaskList() within
+ * FreeRTOS/Source/tasks.c for limitations. */
+#define configUSE_STATS_FORMATTING_FUNCTIONS      1
 
 /* Set the following definitions to 1 to include the API function, or zero
-to exclude the API function.  In most cases the linker will remove unused
-functions anyway. */
-#define INCLUDE_vTaskPrioritySet				1
-#define INCLUDE_uxTaskPriorityGet				1
-#define INCLUDE_vTaskDelete						1
-#define INCLUDE_vTaskCleanUpResources			0
-#define INCLUDE_vTaskSuspend					1
-#define INCLUDE_vTaskDelayUntil					1
-#define INCLUDE_vTaskDelay						1
-#define INCLUDE_uxTaskGetStackHighWaterMark		1
-#define INCLUDE_xTaskGetSchedulerState			1
-#define INCLUDE_xTimerGetTimerDaemonTaskHandle	1
-#define INCLUDE_xTaskGetIdleTaskHandle			1
-#define INCLUDE_xTaskGetHandle					1
-#define INCLUDE_eTaskGetState					1
-#define INCLUDE_xSemaphoreGetMutexHolder		1
-#define INCLUDE_xTimerPendFunctionCall			1
-#define INCLUDE_xTaskAbortDelay					1
+ * to exclude the API function.  In most cases the linker will remove unused
+ * functions anyway. */
+#define INCLUDE_vTaskPrioritySet                  1
+#define INCLUDE_uxTaskPriorityGet                 1
+#define INCLUDE_vTaskDelete                       1
+#define INCLUDE_vTaskCleanUpResources             0
+#define INCLUDE_vTaskSuspend                      1
+#define INCLUDE_vTaskDelayUntil                   1
+#define INCLUDE_vTaskDelay                        1
+#define INCLUDE_uxTaskGetStackHighWaterMark       1
+#define INCLUDE_xTaskGetSchedulerState            1
+#define INCLUDE_xTimerGetTimerDaemonTaskHandle    1
+#define INCLUDE_xTaskGetIdleTaskHandle            1
+#define INCLUDE_xTaskGetHandle                    1
+#define INCLUDE_eTaskGetState                     1
+#define INCLUDE_xSemaphoreGetMutexHolder          1
+#define INCLUDE_xTimerPendFunctionCall            1
+#define INCLUDE_xTaskAbortDelay                   1
 
 /* It is a good idea to define configASSERT() while developing.  configASSERT()
-uses the same semantics as the standard C assert() macro. */
-#define configASSERT( x ) \
-        vFakeAssert( (bool) ( x ), __FILE__, __LINE__)
+ * uses the same semantics as the standard C assert() macro. */
+#define configASSERT( x )                         \
+    do                                            \
+    {                                             \
+        if( x )                                   \
+        vFakeAssert( true, __FILE__, __LINE__ );  \
+        else                                      \
+        vFakeAssert( false, __FILE__, __LINE__ ); \
+    } while ( 0 );
 
-#define mtCOVERAGE_TEST_MARKER() __asm volatile( "NOP" )
+#define mtCOVERAGE_TEST_MARKER()    __asm volatile ( "NOP" )
 
-#define configINCLUDE_MESSAGE_BUFFER_AMP_DEMO	0
+#define configINCLUDE_MESSAGE_BUFFER_AMP_DEMO    0
 #if ( configINCLUDE_MESSAGE_BUFFER_AMP_DEMO == 1 )
-	extern void vGenerateCoreBInterrupt( void * xUpdatedMessageBuffer );
-	#define sbSEND_COMPLETED( pxStreamBuffer ) vGenerateCoreBInterrupt( pxStreamBuffer )
+    extern void vGenerateCoreBInterrupt( void * xUpdatedMessageBuffer );
+    #define sbSEND_COMPLETED( pxStreamBuffer )    vGenerateCoreBInterrupt( pxStreamBuffer )
 #endif /* configINCLUDE_MESSAGE_BUFFER_AMP_DEMO */
 
 #endif /* FREERTOS_CONFIG_H */


### PR DESCRIPTION
Description
-----------
Force a branch in the definition of configASSERT in the default CMock FreeRTOSConfig.h file

This ensures that coverage data and coverage reports show a branch wherever configASSERT is called.

Also run uncrustify on FreeRTOSConfig.h.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
