### PR TITLE
Work around gcov json output bug

### DIFF
--- a/FreeRTOS/Test/CMock/tools/filtercov.py
+++ b/FreeRTOS/Test/CMock/tools/filtercov.py
@@ -308,7 +308,7 @@ def convert_to_lcov_info(args, covdata, outfile):
             # Handle branch data
             for target_branch in target_line["branches"]:
                 branch_count = "-"
-                if target_line["unexecuted_block"] or target_line["count"] == 0:
+                if target_line["unexecuted_block"] and target_line["count"] == 0:
                     branch_count = "-"
                 elif "count" in target_branch:
                     branch_count = target_branch["count"]


### PR DESCRIPTION
Work around gcov json output bug

Description
-----------
When gcov outputs into it's intermediate json format, sometimes it marks blocks as unexecuted but also sets an execution count != 0. In this case, the "count" field is correct, but the "unexecuted_block" field is incorrect.

When outputting lcov formatted coverage data in filtercov.py, only output a branch coverage data lines (BRDA) with a "-" for the "taken" field when both count==0 and unexecuted_block==true in the input gcov json intermediate file.

This results in many configASSERT calls that should have coverage but erroneously have no coverage shown in the lcov files, html output or summary.

Steps to Reproduce the issue
-----------
1. Remove all coverage tags from an affected _utest.c file and generate coverage data normally with the "make lcov" target. 
Copy the resulting .info coverage data file to somewhere safe.

2. Next, modify the testdir.mk file to use lcov to gather coverage directly. 

3. Comment out the following lines:
```
    # Gather coverage into a json.gz file
    gcov $(GCOV_OPTS) $(foreach src,$(PROJECT_SRC),$(PROJ_DIR)/$(src:.c=.gcda)) \
         --json-format --stdout | gzip > $(subst .info,.json.gz,$@)

    # Filter coverage based on tags in unit test file
    $(TOOLS_DIR)/filtercov.py --in $(subst .info,.json.gz,$@)   \
                              --map $(PROJ_DIR)/callgraph.json  \
                              --test $(SUITE_DIR)/$*_utest.c    \
                              --format lcov                     \
                              --out $@
```

4. Replace with this line:
```
lcov $(LCOV_OPTS) --capture --directory $(PROJ_DIR) -o $@
```

5. Run "make clean" and "make lcov".

6. Diff the resulting .info file with the .info file from step 1. Note that some BRDA lines that lcov has marked as covered were not marked as covered in the info file generated by filtercov.py.

Verifying the Fix
-----------
1. Check out this branch and re-run the make lcov target on an affected utest.c file.
2. Diff the resulting coverage data .info file with the one generated directly with lcov in the repro steps above.
3. Note that all relevant BRDA lines are the same between the two files.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
