### PR TITLE
Re-enable list, message_buffer, and stream_buffers unit tests

### DIFF
--- a/FreeRTOS/Test/CMock/Makefile
+++ b/FreeRTOS/Test/CMock/Makefile
@@ -7,11 +7,11 @@ export CC ?= /usr/local/bin/gcc
 export LD ?= /usr/local/bin/ld
 
 # Add units here when adding a new unit test directory with the same name
-#UNITS       +=  list
+UNITS       +=  list
 #UNITS       +=  queue
 #UNITS       +=  timers
-#UNITS       +=  stream_buffer
-#UNITS       +=  message_buffer
+UNITS       +=  stream_buffer
+UNITS       +=  message_buffer
 UNITS       +=  event_groups
 
 COVINFO     :=  $(BUILD_DIR)/cmock_test.info


### PR DESCRIPTION
Re-enable list, message_buffer, and stream_buffers unit tests

Description
-----------
These unit tests were mistakenly disabled in a previous PR.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
