### PR TITLE
Fix send zero bytes stream buffer unit test

### DIFF
--- a/FreeRTOS/Test/CMock/stream_buffer/stream_buffer_utest.c
+++ b/FreeRTOS/Test/CMock/stream_buffer/stream_buffer_utest.c
@@ -619,6 +619,7 @@ void test_xStreamBufferSend_more_than_buffer_size( void )
 void test_xStreamBufferSend_zero_bytes( void )
 {
     uint8_t data[ TEST_STREAM_BUFFER_SIZE + 1 ] = { 0 };
+    size_t bytesWritten;
 
     vTaskSetTimeOutState_Ignore();
     vTaskSuspendAll_Ignore();
@@ -629,11 +630,8 @@ void test_xStreamBufferSend_zero_bytes( void )
     TEST_ASSERT_NOT_NULL( xStreamBuffer );
     TEST_ASSERT_EQUAL( TEST_STREAM_BUFFER_SIZE, xStreamBufferSpacesAvailable( xStreamBuffer ) );
 
-    if( TEST_PROTECT() )
-    {
-        ( void ) xStreamBufferSend( xStreamBuffer, data, 0U, TEST_STREAM_BUFFER_WAIT_TICKS );
-    }
-    validate_and_clear_assertions();
+    bytesWritten = xStreamBufferSend( xStreamBuffer, data, 0U, TEST_STREAM_BUFFER_WAIT_TICKS );
+    TEST_ASSERT_EQUAL( 0, bytesWritten );
 
     vStreamBufferDelete( xStreamBuffer );
 }

--- a/FreeRTOS/Test/CMock/stream_buffer/stream_buffer_utest.c
+++ b/FreeRTOS/Test/CMock/stream_buffer/stream_buffer_utest.c
@@ -614,7 +614,8 @@ void test_xStreamBufferSend_more_than_buffer_size( void )
 }
 
 /**
- * @brief Sending zero bytes to stream buffer should fail assertion.
+ * @brief Sending zero bytes to stream buffer should return write nothing to the
+ * buffer and return 0.
  */
 void test_xStreamBufferSend_zero_bytes( void )
 {


### PR DESCRIPTION
Description
-----------
The change in https://github.com/FreeRTOS/FreeRTOS-Kernel/pull/264 updated `prvWriteMessageToBuffer` in a way that it no longer calls `prvWriteBytesToBuffer` for messages of zero size (`prvWriteBytesToBuffer` triggers an assert for messages of zero size). As a result, a zero byte send to a stream buffer no longer results in assert failure but instead returns 0. This change updates the zero byte send test to check for 0 return value.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
