### PR TITLE
Fix infinite loop due to TEST_PROTECT usage in message buffer and stream buffer unit tests

### DIFF
--- a/FreeRTOS/Test/CMock/message_buffer/message_buffer_utest.c
+++ b/FreeRTOS/Test/CMock/message_buffer/message_buffer_utest.c
@@ -340,7 +340,7 @@ void test_xMessageBufferCreate_integer_overflow( void )
 }
 
 /**
- * @breif API should fail and return null if the malloc fails.
+ * @brief API should fail and return null if the malloc fails.
  */
 void test_xMessageBufferCreate_malloc_fail( void )
 {

--- a/FreeRTOS/Test/CMock/message_buffer/message_buffer_utest.c
+++ b/FreeRTOS/Test/CMock/message_buffer/message_buffer_utest.c
@@ -69,7 +69,7 @@
 
 /**
  * @brief Ticks to wait from tests if the message buffer is full while sending data or
- * below trigger level while receiveing data.
+ * below trigger level while receiving data.
  */
 #define TEST_MESSAGE_BUFFER_WAIT_TICKS       ( 1000U )
 
@@ -79,23 +79,25 @@
 #define configASSERT_E                       0xAA101
 
 /**
- * @brief Expect a configASSERT from the funciton called.
+ * @brief Expect a configASSERT from the function called.
  *  Break out of the called function when this occurs.
- * @details Use this macro when the call passsed in as a parameter is expected
+ * @details Use this macro when the call passed in as a parameter is expected
  * to cause invalid memory access.
  */
-#define EXPECT_ASSERT_BREAK( call )             \
-    do                                          \
-    {                                           \
-        shouldAbortOnAssertion = true;          \
-        CEXCEPTION_T e = CEXCEPTION_NONE;       \
-        Try                                     \
-        {                                       \
-            call;                               \
-            TEST_FAIL();                        \
-        }                                       \
-        Catch( e )                              \
-        TEST_ASSERT_EQUAL( configASSERT_E, e ); \
+#define EXPECT_ASSERT_BREAK( call )                 \
+    do                                              \
+    {                                               \
+        shouldAbortOnAssertion = true;              \
+        CEXCEPTION_T e = CEXCEPTION_NONE;           \
+        Try                                         \
+        {                                           \
+            call;                                   \
+            TEST_FAIL();                            \
+        }                                           \
+        Catch( e )                                  \
+        {                                           \
+            TEST_ASSERT_EQUAL( configASSERT_E, e ); \
+        }                                           \
     } while ( 0 )
 
 /* ============================  GLOBAL VARIABLES =========================== */
@@ -274,7 +276,7 @@ void setUp( void )
     UnityMalloc_StartTest();
 }
 
-/*! called before each testcase */
+/*! called before each test case */
 void tearDown( void )
 {
     TEST_ASSERT_EQUAL_MESSAGE( 0, assertionFailed, "Assertion check failed in code." );
@@ -360,7 +362,7 @@ void test_xMessageBufferCreate_zero_size( void )
 }
 
 /**
- * @brief Should assert if the size passed is less than the minimum size requried to store metadata size.
+ * @brief Should assert if the size passed is less than the minimum size required to store metadata size.
  */
 void test_xMessageBufferCreate_invalid_size( void )
 {
@@ -422,7 +424,7 @@ void test_xMessageBufferCreateStatic_null_struct( void )
 }
 
 /**
- * @brief Validates message buffer create assert if the size passed is less than the minimum size requried to store metadata size.
+ * @brief Validates message buffer create assert if the size passed is less than the minimum size required to store metadata size.
  */
 void test_xMessageBufferCreateStatic_invalid_size( void )
 {
@@ -650,7 +652,7 @@ void test_xMessageBufferReceive_null_input_message( void )
     xMessageBuffer = xMessageBufferCreate( TEST_MESSAGE_BUFFER_SIZE );
     TEST_ASSERT_NOT_NULL( xMessageBuffer );
 
-    /* Should assert if a null input mssage is passed. */
+    /* Should assert if a null input message is passed. */
     EXPECT_ASSERT_BREAK( ( void ) xMessageBufferReceive( xMessageBuffer, NULL, TEST_MAX_MESSAGE_SIZE, TEST_MESSAGE_BUFFER_WAIT_TICKS ) );
 
     validate_and_clear_assertions();

--- a/FreeRTOS/Test/CMock/stream_buffer/stream_buffer_utest.c
+++ b/FreeRTOS/Test/CMock/stream_buffer/stream_buffer_utest.c
@@ -70,7 +70,7 @@
 
 /**
  * @brief Wait ticks passed into from tests if the stream buffer is full while sending data or
- * empty while receiveing data.
+ * empty while receiving data.
  */
 #define TEST_STREAM_BUFFER_WAIT_TICKS       ( 1000U )
 
@@ -80,23 +80,25 @@
 #define configASSERT_E                      0xAA101
 
 /**
- * @brief Expect a configASSERT from the funciton called.
+ * @brief Expect a configASSERT from the function called.
  *  Break out of the called function when this occurs.
- * @details Use this macro when the call passsed in as a parameter is expected
+ * @details Use this macro when the call passed in as a parameter is expected
  * to cause invalid memory access.
  */
-#define EXPECT_ASSERT_BREAK( call )             \
-    do                                          \
-    {                                           \
-        shouldAbortOnAssertion = true;          \
-        CEXCEPTION_T e = CEXCEPTION_NONE;       \
-        Try                                     \
-        {                                       \
-            call;                               \
-            TEST_FAIL();                        \
-        }                                       \
-        Catch( e )                              \
-        TEST_ASSERT_EQUAL( configASSERT_E, e ); \
+#define EXPECT_ASSERT_BREAK( call )                 \
+    do                                              \
+    {                                               \
+        shouldAbortOnAssertion = true;              \
+        CEXCEPTION_T e = CEXCEPTION_NONE;           \
+        Try                                         \
+        {                                           \
+            call;                                   \
+            TEST_FAIL();                            \
+        }                                           \
+        Catch( e )                                  \
+        {                                           \
+            TEST_ASSERT_EQUAL( configASSERT_E, e ); \
+        }                                           \
     } while ( 0 )
 
 
@@ -399,7 +401,7 @@ void setUp( void )
     UnityMalloc_StartTest();
 }
 
-/*! called before each testcase */
+/*! called before each test case */
 void tearDown( void )
 {
     TEST_ASSERT_EQUAL_MESSAGE( 0, assertionFailed, "Assertion check failed in code." );
@@ -443,7 +445,7 @@ static void validate_and_clear_assertions( void )
 /* ==============================  Test Cases  ============================== */
 
 /**
- * @brief Validates that stream buffer of sample size is created succesfully.
+ * @brief Validates that stream buffer of sample size is created successfully.
  */
 void test_xStreamBufferCreate_success( void )
 {
@@ -776,7 +778,7 @@ void test_xStreamBufferReceive_success( void )
 }
 
 /**
- * @brief Validates receiving from an empty stream buffer will block untill atleast trigger level bytes are
+ * @brief Validates receiving from an empty stream buffer will block until at least trigger level bytes are
  * sent to the buffer.
  */
 void test_xStreamBufferReceive_blocking( void )
@@ -808,7 +810,7 @@ void test_xStreamBufferReceive_blocking( void )
     TEST_ASSERT_EQUAL( 0, receivedBytes );
 
     /*
-     * Sending atleast trigger level bytes, should notify and wake up the receiver task.
+     * Sending at least trigger level bytes, should notify and wake up the receiver task.
      */
     xTaskGenericNotifyWait_StubWithCallback( streamBufferSendCallback );
     xTaskCheckForTimeOut_IgnoreAndReturn( pdFALSE );
@@ -818,7 +820,7 @@ void test_xStreamBufferReceive_blocking( void )
     TEST_ASSERT_EQUAL( 0, xStreamBufferBytesAvailable( xStreamBuffer ) );
 
     /*
-     * Sending atleast trigger level bytes from ISR, should notify and wake up the receiver task.
+     * Sending at least trigger level bytes from ISR, should notify and wake up the receiver task.
      */
     xTaskGenericNotifyWait_StubWithCallback( streamBufferSendFromISRCallback );
     xTaskGenericNotifyFromISR_StubWithCallback( receiverTaskNotificationFromISRCallback );
@@ -890,7 +892,7 @@ void test_xStreamBufferReceiveFromISR_success( void )
     TEST_ASSERT_NOT_NULL( xStreamBuffer );
     TEST_ASSERT_EQUAL( TEST_STREAM_BUFFER_SIZE, xStreamBufferSpacesAvailable( xStreamBuffer ) );
 
-    /* Send data of atmost capacity to the stream buffer. */
+    /* Send data to fill the stream buffer to maximum capacity. */
     sentBytes = xStreamBufferSend( xStreamBuffer, data, TEST_STREAM_BUFFER_SIZE, TEST_STREAM_BUFFER_WAIT_TICKS );
     TEST_ASSERT_EQUAL( TEST_STREAM_BUFFER_SIZE, sentBytes );
     TEST_ASSERT_EQUAL( TEST_STREAM_BUFFER_SIZE, xStreamBufferBytesAvailable( xStreamBuffer ) );
@@ -1194,7 +1196,7 @@ void test_xStreamBufferBytesAvailable_null_stream_buffer( void )
 }
 
 /**
- * @brief Checking if strem buffer is full for a null stream buffer should fail assertion.
+ * @brief Checking if stream buffer is full for a null stream buffer should fail assertion.
  */
 void test_xStreamBufferIsFull_null_stream_buffer( void )
 {
@@ -1203,7 +1205,7 @@ void test_xStreamBufferIsFull_null_stream_buffer( void )
 }
 
 /**
- * @brief Checking if strem buffer is empty for a null stream buffer should fail assertion.
+ * @brief Checking if stream buffer is empty for a null stream buffer should fail assertion.
  */
 void test_xStreamBufferIsEmpty_null_stream_buffer( void )
 {

--- a/FreeRTOS/Test/CMock/stream_buffer/stream_buffer_utest.c
+++ b/FreeRTOS/Test/CMock/stream_buffer/stream_buffer_utest.c
@@ -628,7 +628,8 @@ void test_xStreamBufferSend_more_than_buffer_size( void )
 }
 
 /**
- * @brief Sending zero bytes to stream buffer should fail assertion.
+ * @brief Sending zero bytes to stream buffer should return write nothing to the
+ * buffer and return 0.
  */
 void test_xStreamBufferSend_zero_bytes( void )
 {

--- a/FreeRTOS/Test/CMock/stream_buffer/stream_buffer_utest.c
+++ b/FreeRTOS/Test/CMock/stream_buffer/stream_buffer_utest.c
@@ -29,7 +29,7 @@
 #include <stdlib.h>
 #include <stdbool.h>
 
-/* Queue includes */
+/* Stream Buffer includes */
 #include "FreeRTOS.h"
 #include "FreeRTOSConfig.h"
 #include "stream_buffer.h"
@@ -37,6 +37,7 @@
 /* Test includes. */
 #include "unity.h"
 #include "unity_memory.h"
+#include "CException.h"
 
 /* Mock includes. */
 #include "mock_task.h"
@@ -72,6 +73,32 @@
  * empty while receiveing data.
  */
 #define TEST_STREAM_BUFFER_WAIT_TICKS       ( 1000U )
+
+/**
+ * @brief CException code for when a configASSERT should be intercepted.
+ */
+#define configASSERT_E                      0xAA101
+
+/**
+ * @brief Expect a configASSERT from the funciton called.
+ *  Break out of the called function when this occurs.
+ * @details Use this macro when the call passsed in as a parameter is expected
+ * to cause invalid memory access.
+ */
+#define EXPECT_ASSERT_BREAK( call )             \
+    do                                          \
+    {                                           \
+        shouldAbortOnAssertion = true;          \
+        CEXCEPTION_T e = CEXCEPTION_NONE;       \
+        Try                                     \
+        {                                       \
+            call;                               \
+            TEST_FAIL();                        \
+        }                                       \
+        Catch( e )                              \
+        TEST_ASSERT_EQUAL( configASSERT_E, e ); \
+    } while ( 0 )
+
 
 /* ============================  GLOBAL VARIABLES =========================== */
 
@@ -138,7 +165,7 @@ static void vFakeAssertStub( bool x,
 
         if( shouldAbortOnAssertion == pdTRUE )
         {
-            TEST_ABORT();
+            Throw( configASSERT_E );
         }
     }
 }
@@ -459,11 +486,7 @@ void test_xStreamBufferCreate_malloc_fail( void )
  */
 void test_xStreamBufferCreate_zero_buffer_size( void )
 {
-
-    if( TEST_PROTECT() )
-    {
-        ( void ) xStreamBufferCreate( 0, TEST_STREAM_BUFFER_TRIGGER_LEVEL );
-    }
+    EXPECT_ASSERT_BREAK( ( void ) xStreamBufferCreate( 0, TEST_STREAM_BUFFER_TRIGGER_LEVEL ) );
     validate_and_clear_assertions();
 }
 
@@ -472,10 +495,7 @@ void test_xStreamBufferCreate_zero_buffer_size( void )
  */
 void test_xStreamBufferCreate_invalid_trigger_level( void )
 {
-    if( TEST_PROTECT() )
-    {
-        ( void ) xStreamBufferCreate( TEST_STREAM_BUFFER_SIZE, ( TEST_STREAM_BUFFER_SIZE + 1 ) );
-    }
+    EXPECT_ASSERT_BREAK( ( void ) xStreamBufferCreate( TEST_STREAM_BUFFER_SIZE, ( TEST_STREAM_BUFFER_SIZE + 1 ) ) );
     validate_and_clear_assertions();
 }
 
@@ -484,10 +504,7 @@ void test_xStreamBufferCreate_invalid_trigger_level( void )
  */
 void test_xStreamBufferDelete_null_stream_buffer( void )
 {
-    if( TEST_PROTECT() )
-    {
-        vStreamBufferDelete( NULL );
-    }
+    EXPECT_ASSERT_BREAK( vStreamBufferDelete( NULL ) );
     validate_and_clear_assertions();
 }
 
@@ -554,10 +571,7 @@ void test_xStreamBufferCreateStatic_invalid_trigger_level( void )
     /* The size of stream buffer array should be one greater than the required size of stream buffer. */
     uint8_t streamBufferArray[ TEST_STREAM_BUFFER_SIZE + 1 ] = { 0 };
 
-    if( TEST_PROTECT() )
-    {
-        ( void ) xStreamBufferCreateStatic( sizeof( streamBufferArray ), TEST_STREAM_BUFFER_SIZE + 2, streamBufferArray, &streamBufferStruct );
-    }
+    EXPECT_ASSERT_BREAK( ( void ) xStreamBufferCreateStatic( sizeof( streamBufferArray ), TEST_STREAM_BUFFER_SIZE + 2, streamBufferArray, &streamBufferStruct ) );
 
     validate_and_clear_assertions();
 }
@@ -629,11 +643,7 @@ void test_xStreamBufferSend_zero_bytes( void )
     TEST_ASSERT_NOT_NULL( xStreamBuffer );
     TEST_ASSERT_EQUAL( TEST_STREAM_BUFFER_SIZE, xStreamBufferSpacesAvailable( xStreamBuffer ) );
 
-    if( TEST_PROTECT() )
-    {
-        ( void ) xStreamBufferSend( xStreamBuffer, data, 0U, TEST_STREAM_BUFFER_WAIT_TICKS );
-    }
-    validate_and_clear_assertions();
+    TEST_ASSERT_EQUAL( pdFALSE, xStreamBufferSend( xStreamBuffer, data, 0U, TEST_STREAM_BUFFER_WAIT_TICKS ) );
 
     vStreamBufferDelete( xStreamBuffer );
 }
@@ -899,37 +909,31 @@ void test_xStreamBufferReceiveFromISR_success( void )
 }
 
 /**
- * @brief Assertion fails if a null stream buffer is passed. 
+ * @brief Assertion fails if a null stream buffer is passed.
  */
 void test_xStreamBufferReceiveFromISR_null_stream_buffer( void )
 {
     uint8_t data[ TEST_STREAM_BUFFER_SIZE ] = { 0xAA };
     BaseType_t xHighPriorityTaskWoken = pdFALSE;
-    
-    if( TEST_PROTECT() )
-    {
-        ( void ) xStreamBufferReceiveFromISR( NULL, data, TEST_STREAM_BUFFER_SIZE, &xHighPriorityTaskWoken );
-    }
+
+    EXPECT_ASSERT_BREAK( ( void ) xStreamBufferReceiveFromISR( NULL, data, TEST_STREAM_BUFFER_SIZE, &xHighPriorityTaskWoken ) );
 
     validate_and_clear_assertions();
 }
 
 /**
- * @brief Assertion fails if a null message is passed. 
+ * @brief Assertion fails if a null message is passed.
  */
 void test_xStreamBufferReceiveFromISR_null_buffer( void )
 {
     BaseType_t xHighPriorityTaskWoken = pdFALSE;
-    
+
     /* Create a stream buffer of sample size. */
     xStreamBuffer = xStreamBufferCreate( TEST_STREAM_BUFFER_SIZE, TEST_STREAM_BUFFER_TRIGGER_LEVEL );
     TEST_ASSERT_NOT_NULL( xStreamBuffer );
     TEST_ASSERT_EQUAL( TEST_STREAM_BUFFER_SIZE, xStreamBufferSpacesAvailable( xStreamBuffer ) );
-    
-    if( TEST_PROTECT() )
-    {
-        ( void ) xStreamBufferReceiveFromISR( xStreamBuffer, NULL, TEST_STREAM_BUFFER_SIZE, &xHighPriorityTaskWoken );
-    }
+
+    EXPECT_ASSERT_BREAK( ( void ) xStreamBufferReceiveFromISR( xStreamBuffer, NULL, TEST_STREAM_BUFFER_SIZE, &xHighPriorityTaskWoken ) );
 
     validate_and_clear_assertions();
 
@@ -975,37 +979,31 @@ void test_xStreamBufferSendFromISR_success( void )
 }
 
 /**
- * @brief Assertion fails if a null stream buffer is passed. 
+ * @brief Assertion fails if a null stream buffer is passed.
  */
 void test_xStreamBufferSendFromISR_null_stream_buffer( void )
 {
     uint8_t data[ TEST_STREAM_BUFFER_SIZE ] = { 0xAA };
     BaseType_t xHighPriorityTaskWoken = pdFALSE;
-    
-    if( TEST_PROTECT() )
-    {
-        ( void ) xStreamBufferSendFromISR( NULL, data, TEST_STREAM_BUFFER_SIZE, &xHighPriorityTaskWoken );
-    }
+
+    EXPECT_ASSERT_BREAK( ( void ) xStreamBufferSendFromISR( NULL, data, TEST_STREAM_BUFFER_SIZE, &xHighPriorityTaskWoken ) );
 
     validate_and_clear_assertions();
 }
 
 /**
- * @brief Assertion fails if a null message is passed. 
+ * @brief Assertion fails if a null message is passed.
  */
 void test_xStreamBufferSendFromISR_null_message( void )
 {
     BaseType_t xHighPriorityTaskWoken = pdFALSE;
-    
+
     /* Create a stream buffer of sample size. */
     xStreamBuffer = xStreamBufferCreate( TEST_STREAM_BUFFER_SIZE, TEST_STREAM_BUFFER_TRIGGER_LEVEL );
     TEST_ASSERT_NOT_NULL( xStreamBuffer );
     TEST_ASSERT_EQUAL( TEST_STREAM_BUFFER_SIZE, xStreamBufferSpacesAvailable( xStreamBuffer ) );
-    
-    if( TEST_PROTECT() )
-    {
-        ( void ) xStreamBufferSendFromISR( xStreamBuffer, NULL, TEST_STREAM_BUFFER_SIZE, &xHighPriorityTaskWoken );
-    }
+
+    EXPECT_ASSERT_BREAK( ( void ) xStreamBufferSendFromISR( xStreamBuffer, NULL, TEST_STREAM_BUFFER_SIZE, &xHighPriorityTaskWoken ) );
 
     validate_and_clear_assertions();
 
@@ -1058,10 +1056,7 @@ void test_xStreamBufferReset_null_stream_buffer( void )
     vTaskSuspendAll_Ignore();
     xTaskResumeAll_IgnoreAndReturn( pdTRUE );
 
-    if( TEST_PROTECT() )
-    {
-        ( void ) xStreamBufferReset( NULL );
-    }
+    EXPECT_ASSERT_BREAK( ( void ) xStreamBufferReset( NULL ) );
     validate_and_clear_assertions();
 }
 
@@ -1184,10 +1179,7 @@ void test_xStreamBufferSetTrigerLevel_zero( void )
  */
 void test_xStreamBufferSetTriggerLevel_null_stream_buffer( void )
 {
-    if( TEST_PROTECT() )
-    {
-        ( void ) xStreamBufferSetTriggerLevel( NULL, TEST_STREAM_BUFFER_TRIGGER_LEVEL );
-    }
+    EXPECT_ASSERT_BREAK( ( void ) xStreamBufferSetTriggerLevel( NULL, TEST_STREAM_BUFFER_TRIGGER_LEVEL ) );
     validate_and_clear_assertions();
 }
 
@@ -1196,10 +1188,7 @@ void test_xStreamBufferSetTriggerLevel_null_stream_buffer( void )
  */
 void test_xStreamBufferBytesAvailable_null_stream_buffer( void )
 {
-    if( TEST_PROTECT() )
-    {
-        ( void ) xStreamBufferBytesAvailable( NULL );
-    }
+    EXPECT_ASSERT_BREAK( ( void ) xStreamBufferBytesAvailable( NULL ) );
     validate_and_clear_assertions();
 }
 
@@ -1208,10 +1197,7 @@ void test_xStreamBufferBytesAvailable_null_stream_buffer( void )
  */
 void test_xStreamBufferIsFull_null_stream_buffer( void )
 {
-    if( TEST_PROTECT() )
-    {
-        ( void ) xStreamBufferIsFull( NULL );
-    }
+    EXPECT_ASSERT_BREAK( ( void ) xStreamBufferIsFull( NULL ) );
     validate_and_clear_assertions();
 }
 
@@ -1220,10 +1206,7 @@ void test_xStreamBufferIsFull_null_stream_buffer( void )
  */
 void test_xStreamBufferIsEmpty_null_stream_buffer( void )
 {
-    if( TEST_PROTECT() )
-    {
-        ( void ) xStreamBufferIsEmpty( NULL );
-    }
+    EXPECT_ASSERT_BREAK( ( void ) xStreamBufferIsEmpty( NULL ) );
     validate_and_clear_assertions();
 }
 
@@ -1232,10 +1215,7 @@ void test_xStreamBufferIsEmpty_null_stream_buffer( void )
  */
 void test_xStreamBufferSpacesAvailable_null_stream_buffer( void )
 {
-    if( TEST_PROTECT() )
-    {
-        ( void ) xStreamBufferSpacesAvailable( NULL );
-    }
+    EXPECT_ASSERT_BREAK( ( void ) xStreamBufferSpacesAvailable( NULL ) );
     validate_and_clear_assertions();
 }
 
@@ -1245,10 +1225,7 @@ void test_xStreamBufferSpacesAvailable_null_stream_buffer( void )
  */
 void test_xStreamBufferNextMessageLengthBytes_null_stream_buffer( void )
 {
-    if( TEST_PROTECT() )
-    {
-        ( void ) xStreamBufferNextMessageLengthBytes( NULL );
-    }
+    EXPECT_ASSERT_BREAK( ( void ) xStreamBufferNextMessageLengthBytes( NULL ) );
     validate_and_clear_assertions();
 }
 
@@ -1296,10 +1273,7 @@ void test_xStreamBufferSendCompletedFromISR_null_stream_buffer( void )
     BaseType_t highPriorityTaskWoken = pdFALSE;
 
     /* Send completed from ISR without receiver task waiting. */
-    if( TEST_PROTECT() )
-    {
-        ( void ) xStreamBufferSendCompletedFromISR( NULL, &highPriorityTaskWoken );
-    }
+    EXPECT_ASSERT_BREAK( ( void ) xStreamBufferSendCompletedFromISR( NULL, &highPriorityTaskWoken ) );
     validate_and_clear_assertions();
 }
 
@@ -1354,10 +1328,7 @@ void test_xStreamBufferReceiveCompletedFromISR_null_stream_buffer( void )
     BaseType_t highPriorityTaskWoken = pdFALSE;
 
     /* Send completed from ISR without receiver task waiting. */
-    if( TEST_PROTECT() )
-    {
-        ( void ) xStreamBufferReceiveCompletedFromISR( NULL, &highPriorityTaskWoken );
-    }
+    EXPECT_ASSERT_BREAK( ( void ) xStreamBufferReceiveCompletedFromISR( NULL, &highPriorityTaskWoken ) );
     validate_and_clear_assertions();
 }
 


### PR DESCRIPTION
Fix infinite loop due to TEST_PROTECT usage in message buffer and stream buffer unit tests

Description
-----------
Replace TEST_PROTECT usage with a try/catch/throw using the CException library.

Issue repro steps
-----------
To reproduce the problem, remove a configASSERT that is expected by one of the two unit tests and note that the relevant test case enters an infinite loop.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
