### PR TITLE
Run kernel unit tests against FreeRTOS-Kernel repository main branch and the current submodule version.

### DIFF
--- a/.github/workflows/kernel-unit-tests.yml
+++ b/.github/workflows/kernel-unit-tests.yml
@@ -2,7 +2,8 @@ name: Kernel Unit Tests
 on: [push, pull_request]
 
 jobs:
-  run:
+  run-submodule:
+    name: FreeRTOS/Source Submodule Revision
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repository
@@ -10,6 +11,47 @@ jobs:
       with:
         submodules: 'recursive'
         fetch-depth: 5
+    - name: Setup Python
+      uses: actions/setup-python@master
+      with:
+        python-version: 3.8
+    - name: Install packages
+      run: |
+          sudo apt-get install lcov cflow ruby doxygen build-essential unifdef
+    - name: Run Unit Tests with ENABLE_SANITIZER=1
+      run: |
+          make -C FreeRTOS/Test/CMock clean
+          make -C FreeRTOS/Test/CMock ENABLE_SANITIZER=1 run_col_formatted
+    - name: Run Unit Tests for coverage
+      run: |
+          make -C FreeRTOS/Test/CMock clean
+          make -C FreeRTOS/Test/CMock lcovhtml
+          lcov --config-file FreeRTOS/Test/CMock/lcovrc --summary FreeRTOS/Test/CMock/build/cmock_test.info > FreeRTOS/Test/CMock/build/cmock_test_summary.txt
+    - name: Archive code coverage data
+      uses: actions/upload-artifact@v2
+      with:
+        name: coverage-data
+        path: FreeRTOS/Test/CMock/build/cmock_test*
+    - name: Archive code coverage html report
+      uses: actions/upload-artifact@v2
+      with:
+        name: coverage-report
+        path: FreeRTOS/Test/CMock/build/coverage
+  run-upstream:
+    name: FreeRTOS-Kernel Main Branch
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v2
+      with:
+        submodules: 'recursive'
+        fetch-depth: 5
+    - name: Checkout the main branch from the FreeRTOS-Kernel repository
+      uses: actions/checkout@v2
+      with:
+        path: ./FreeRTOS/Source
+        ref: main
+        repository: FreeRTOS/FreeRTOS-Kernel
     - name: Setup Python
       uses: actions/setup-python@master
       with:


### PR DESCRIPTION
Run kernel unit tests against FreeRTOS-Kernel repository main branch and the current submodule version.

Description
-----------
When running PR unit test checks, run the tests against both the current revision of the FreeRTOS/Source submodule and the main branch in the FreeRTOS-Kernel repository.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
