### PR TITLE
Small RISC-V spike demo improvements

### DIFF
--- a/FreeRTOS/Demo/RISC-V-spike-htif_GCC/Makefile
+++ b/FreeRTOS/Demo/RISC-V-spike-htif_GCC/Makefile
@@ -62,17 +62,17 @@ SRCS = main.c main_blinky.c riscv-virt.c htif.c \
 ASMS = start.S \
 	$(RTOS_SOURCE_DIR)/portable/GCC/RISC-V/portASM.S
 
-OBJS = $(SRCS:%.c=$(BUILD_DIR)/%.o) $(ASMS:%.S=$(BUILD_DIR)/%.o)
-DEPS = $(SRCS:%.c=$(BUILD_DIR)/%.d) $(ASMS:%.S=$(BUILD_DIR)/%.d)
+OBJS = $(SRCS:%.c=$(BUILD_DIR)/%$(XLEN).o) $(ASMS:%.S=$(BUILD_DIR)/%$(XLEN).o)
+DEPS = $(SRCS:%.c=$(BUILD_DIR)/%$(XLEN).d) $(ASMS:%.S=$(BUILD_DIR)/%$(XLEN).d)
 
-$(BUILD_DIR)/RTOSDemo.axf: $(OBJS) fake_rom.lds Makefile
+$(BUILD_DIR)/RTOSDemo$(XLEN).axf: $(OBJS) fake_rom.lds Makefile
 	$(CC) $(LDFLAGS) $(OBJS) -o $@
 
-$(BUILD_DIR)/%.o: %.c Makefile
+$(BUILD_DIR)/%$(XLEN).o: %.c Makefile
 	@mkdir -p $(@D)
 	$(CC) $(CPPFLAGS) $(CFLAGS) -MMD -MP -c $< -o $@
 
-$(BUILD_DIR)/%.o: %.S Makefile
+$(BUILD_DIR)/%$(XLEN).o: %.S Makefile
 	@mkdir -p $(@D)
 	$(CC) $(CPPFLAGS) $(ASFLAGS) -MMD -MP -c $< -o $@
 

--- a/FreeRTOS/Demo/RISC-V-spike-htif_GCC/Makefile
+++ b/FreeRTOS/Demo/RISC-V-spike-htif_GCC/Makefile
@@ -1,9 +1,11 @@
 XLEN ?= 32
 CROSS   = riscv$(XLEN)-unknown-elf-
 CC      = $(CROSS)gcc
+CPP     = $(CROSS)cpp
 OBJCOPY = $(CROSS)objcopy
 ARCH    = $(CROSS)ar
 DEBUG ?= 0
+BASE_ADDRESS ?= 0x80000000
 
 ifeq ($(XLEN), 64)
     MARCH = rv64ima
@@ -33,7 +35,7 @@ CFLAGS  = -march=$(MARCH) -mabi=$(MABI) -mcmodel=medany \
 	-fdata-sections \
 	-fno-builtin-printf
 ASFLAGS = -march=$(MARCH) -mabi=$(MABI) -mcmodel=medany
-LDFLAGS = -nostartfiles -Tfake_rom.lds \
+LDFLAGS = -nostartfiles \
 	-Xlinker --gc-sections \
 	-Xlinker --defsym=__stack_size=$(STACK_SIZE)
 
@@ -65,8 +67,8 @@ ASMS = start.S \
 OBJS = $(SRCS:%.c=$(BUILD_DIR)/%$(XLEN).o) $(ASMS:%.S=$(BUILD_DIR)/%$(XLEN).o)
 DEPS = $(SRCS:%.c=$(BUILD_DIR)/%$(XLEN).d) $(ASMS:%.S=$(BUILD_DIR)/%$(XLEN).d)
 
-$(BUILD_DIR)/RTOSDemo$(XLEN).axf: $(OBJS) fake_rom.lds Makefile
-	$(CC) $(LDFLAGS) $(OBJS) -o $@
+$(BUILD_DIR)/RTOSDemo$(XLEN).axf: $(OBJS) $(BUILD_DIR)/fake_rom$(BASE_ADDRESS).lds Makefile
+	$(CC) $(LDFLAGS) $(OBJS) -T$(BUILD_DIR)/fake_rom$(BASE_ADDRESS).lds -o $@
 
 $(BUILD_DIR)/%$(XLEN).o: %.c Makefile
 	@mkdir -p $(@D)
@@ -75,6 +77,11 @@ $(BUILD_DIR)/%$(XLEN).o: %.c Makefile
 $(BUILD_DIR)/%$(XLEN).o: %.S Makefile
 	@mkdir -p $(@D)
 	$(CC) $(CPPFLAGS) $(ASFLAGS) -MMD -MP -c $< -o $@
+
+# Run lds through the C preprocessor, to replace BASE_ADDRESS with the actual
+# value. It might be simpler to use sed instead.
+$(BUILD_DIR)/%$(BASE_ADDRESS).lds: fake_rom.lds Makefile
+	$(CPP) $(CPPFLAGS) -DBASE_ADDRESS=$(BASE_ADDRESS) $< | grep -v '^#' > $@
 
 clean:
 	rm -rf $(BUILD_DIR)

--- a/FreeRTOS/Demo/RISC-V-spike-htif_GCC/README.md
+++ b/FreeRTOS/Demo/RISC-V-spike-htif_GCC/README.md
@@ -67,20 +67,20 @@ $ export PATH=~/x-tools/riscv64-unknown-elf/bin:$PATH
 To build, simply run `make`. If you want a debug build, pass `DEBUG=1`. If
 you want an RV64 build, pass `XLEN=64`.
 
-The resulting executable file is ./build/RTOSDemo.axf.
+The resulting executable file is ./build/RTOSDemo32.axf or ./build/RTOSDemo64.axf.
 
 ## How to run
 
 RV32:
 ```
 $ spike -p1 --isa RV32IMA -m0x80000000:0x10000000 --rbb-port 9824 \
-        ./build/RTOSDemo.axf
+        ./build/RTOSDemo32.axf
 ```
 
 RV64:
 ```
 $ spike -p1 --isa RV64IMA -m0x80000000:0x10000000 --rbb-port 9824 \
-        ./build/RTOSDemo.axf
+        ./build/RTOSDemo64.axf
 ```
 
 ## How to debug with gdb

--- a/FreeRTOS/Demo/RISC-V-spike-htif_GCC/fake_rom.lds
+++ b/FreeRTOS/Demo/RISC-V-spike-htif_GCC/fake_rom.lds
@@ -4,8 +4,9 @@ ENTRY( _start )
 MEMORY
 {
 	/* Fake ROM area */
-	rom (rxa) : ORIGIN = 0x80000000, LENGTH = 512K
-	ram (wxa) : ORIGIN = 0x80080000, LENGTH = 512K
+        /* BASE_ADDRESS is replaced with the real value by the Makefile. */
+	rom (rxa) : ORIGIN = BASE_ADDRESS, LENGTH = 512K
+	ram (wxa) : ORIGIN = BASE_ADDRESS + 512K, LENGTH = 512K
 }
 
 SECTIONS

--- a/FreeRTOS/Demo/RISC-V-spike-htif_GCC/riscv-virt.c
+++ b/FreeRTOS/Demo/RISC-V-spike-htif_GCC/riscv-virt.c
@@ -33,22 +33,28 @@
 
 int xGetCoreID( void )
 {
-int id;
+	int id;
 
 	__asm ("csrr %0, mhartid" : "=r" ( id ) );
 
 	return id;
 }
 
+/* Use a debugger to set this to 0 if this binary was loaded through gdb instead
+ * of spike's ELF loader. HTIF only works if spike's ELF loader was used. */
+volatile int use_htif = 1;
+
 void vSendString( const char *s )
 {
 	portENTER_CRITICAL();
 
-	while (*s) {
-		htif_putc(*s);
-		s++;
+	if (use_htif) {
+		while (*s) {
+			htif_putc(*s);
+			s++;
+		}
+		htif_putc('\n');
 	}
-	htif_putc('\n');
 
 	portEXIT_CRITICAL();
 }


### PR DESCRIPTION
Small RISC-V spike demo improvements

Description
-----------
* Put XLEN into .o files. This makes it easier to work on RV32 and RV64 binaries side-by-side.
* Let the debugger disable HTIF use by making its use conditional on a global volatile int.
* Makefile now links the binary at BASE_ADDRESS. I need this so I can easily generate the appropriate binaries for riscv-tests/debug. Unfortunately there doesn't seem to be any good mechanism to externally define values for lds files, so I'm running it through the C preprocessor.

Test Steps
-----------
Tested RV32 and RV64 against spike as part of riscv-tests/debug. (Those changes have not yet been submitted.)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
