### PR TITLE
Add comment about certificate migration to S3 demo configs

### DIFF
--- a/FreeRTOS-Plus/Demo/coreHTTP_Windows_Simulator/HTTP_S3_Download/demo_config.h
+++ b/FreeRTOS-Plus/Demo/coreHTTP_Windows_Simulator/HTTP_S3_Download/demo_config.h
@@ -79,8 +79,13 @@ extern void vLoggingPrintf( const char * pcFormatString,
 /**
  * @brief Server's root CA certificate for TLS authentication with S3.
  *
- * The Baltimore Cybertrust Root CA Certificate should be pasted below using the
- * following format:
+ * The Baltimore Cybertrust root CA certificate is often used for authentication
+ * with S3. It can be found at:
+ * https://baltimore-cybertrust-root.chain-demos.digicert.com/info/index.html.
+ *
+ * S3 has started migrating certificates to Amazon Trust Services. If
+ * authentication errors persist, re-attempt the connection with an Amazon root
+ * CA certificate: https://www.amazontrust.com/repository.
  *
  * @note This certificate should be PEM-encoded.
  *

--- a/FreeRTOS-Plus/Demo/coreHTTP_Windows_Simulator/HTTP_S3_Download_Multithreaded/demo_config.h
+++ b/FreeRTOS-Plus/Demo/coreHTTP_Windows_Simulator/HTTP_S3_Download_Multithreaded/demo_config.h
@@ -79,8 +79,13 @@ extern void vLoggingPrintf( const char * pcFormatString,
 /**
  * @brief Server's root CA certificate for TLS authentication with S3.
  *
- * The Baltimore Cybertrust Root CA Certificate should be pasted below using the
- * following format:
+ * The Baltimore Cybertrust root CA certificate is often used for authentication
+ * with S3. It can be found at:
+ * https://baltimore-cybertrust-root.chain-demos.digicert.com/info/index.html.
+ *
+ * S3 has started migrating certificates to Amazon Trust Services. If
+ * authentication errors persist, re-attempt the connection with an Amazon root
+ * CA certificate: https://www.amazontrust.com/repository.
  *
  * @note This certificate should be PEM-encoded.
  *

--- a/FreeRTOS-Plus/Demo/coreHTTP_Windows_Simulator/HTTP_S3_Upload/demo_config.h
+++ b/FreeRTOS-Plus/Demo/coreHTTP_Windows_Simulator/HTTP_S3_Upload/demo_config.h
@@ -79,8 +79,13 @@ extern void vLoggingPrintf( const char * pcFormatString,
 /**
  * @brief Server's root CA certificate for TLS authentication with S3.
  *
- * The Baltimore Cybertrust Root CA Certificate should be pasted below using the
- * following format:
+ * The Baltimore Cybertrust root CA certificate is often used for authentication
+ * with S3. It can be found at:
+ * https://baltimore-cybertrust-root.chain-demos.digicert.com/info/index.html.
+ *
+ * S3 has started migrating certificates to Amazon Trust Services. If
+ * authentication errors persist, re-attempt the connection with an Amazon root
+ * CA certificate: https://www.amazontrust.com/repository.
  *
  * @note This certificate should be PEM-encoded.
  *


### PR DESCRIPTION
Update comment description for `democonfigROOT_CA_PEM` to highlight S3's recent [certificate migration](https://aws.amazon.com/blogs/storage/reminder-amazon-s3-and-amazon-cloudfront-migrating-service-certificates-to-amazon-trust-services-starting-march-23-2021).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
