### PR TITLE
Fix versioning of header checks

### DIFF
--- a/.github/scripts/versioning.py
+++ b/.github/scripts/versioning.py
@@ -104,9 +104,9 @@ def extract_version_number_from_file(file_path):
         match = re.search('\s*\*\s*(Amazon FreeRTOS.*V(.*))', content, re.MULTILINE)
         # Is it a kernel file?
         if match is None:
-            match = re.search('\s*\*\s*(FreeRTOS Kernel.*V(.*))', content, re.MULTILINE)
+            match = re.search('\s*\*\s*(FreeRTOS Kernel.*V([0-9]*\.[0-9]*\.[0-9]*))', content, re.MULTILINE)
         if match is None:
-            match = re.search('\s*\*\s*(FreeRTOS V(.*\..*))', content, re.MULTILINE)
+            match = re.search('\s*\*\s*(FreeRTOS V([0-9]*\.[0-9]*))', content, re.MULTILINE)
         # Is it s FreeRTOS+TCP file?
         if match is None:
             match = re.search('\s*\*\s*(FreeRTOS\+TCP.*V(.*))', content, re.MULTILINE)


### PR DESCRIPTION
Description
-----------
Adjusts regex pattern so it doesn't replace formatting in the header checks.

Test Steps
-----------
Run test release on your fork, verify that `core-checker.py` has appropriate versioning done.

`python3 release.py <your-git-username> --new-core-version=<test-version> --use-git-ssh --core-repo-branch=main`

`python3 release.py <your-git-username> --new-kernel-version=<test-version> --use-git-ssh --core-repo-branch=main`

Related Issue
-----------
n/a


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
