### PR TITLE
POSIX Simulator: let vAssertCalled() produce some logging to stdout

### DIFF
--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Echo_Posix/main.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Echo_Posix/main.c
@@ -243,14 +243,14 @@ void vAssertCalled( const char * const pcFileName,
 {
 static BaseType_t xPrinted = pdFALSE;
 volatile uint32_t ulSetToNonZeroInDebuggerToContinue = 0;
+/* Copy the parameters to local volatile variables, just for debugging */
+volatile char * pcFile = ( volatile char * ) pcFileName;
+volatile uint32_t ulLineNumber = ulLine;
 
     /* Called if an assertion passed to configASSERT() fails.  See
     http://www.freertos.org/a00110.html#configASSERT for more information. */
 
-    /* Parameters are not used. */
-    ( void ) ulLine;
-    ( void ) pcFileName;
-
+	printf( "vAssertCalled( %s, %u )\n", pcFileName, ulLine );
 
     taskENTER_CRITICAL();
     {


### PR DESCRIPTION
Description
-----------
[Grant Edwards](https://forums.freertos.org/u/Grant_Edwards) reported on the [FreeRTOS forum](https://forums.freertos.org/t/freertos-tcp-simulator-on-linux-64bit-requires-ipconfigbuffer-padding-14/12576) that the use of `configASSERT()` can be confusing in the **POSIX demo project**.

This PR will add some logging:
~~~c
    printf( "vAssertCalled( %s, %u )\n", pcFileName, ulLine );
~~~

Test Steps
-----------
At this moment, I do not have a set-up for the POSIX project, can anyone please test it?

Related Issue
-----------
Without this patch, when `configASSERT()` is called, the application seems just dead.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
