### PR TITLE
Allow pip to determine the correct version of colorama and requests

### DIFF
--- a/.github/scripts/common/requirements.txt
+++ b/.github/scripts/common/requirements.txt
@@ -1,6 +1,6 @@
 certifi==2020.12.5
 chardet==4.0.0
-colorama==0.4.4
+colorama
 Deprecated==1.2.10
 gitdb==4.0.5
 GitPython==3.1.11
@@ -8,7 +8,7 @@ idna==2.10
 PyGithub==1.54
 PyJWT==1.7.1
 PyYAML==5.4
-requests==2.25.1
+requests
 smmap==3.0.4
 urllib3==1.26.3
 wrapt==1.12.1


### PR DESCRIPTION
Description
-----------
Fix issue with dependencies by allowing pip to install the best suited versions of the colorama and requests libraries.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
