### PR TITLE
Update release scripts to handle new "<DEVELOPMENT BRANCH>" version tags.

### DIFF
--- a/.github/scripts/release.py
+++ b/.github/scripts/release.py
@@ -200,7 +200,7 @@ class BaseRelease:
         return False
 
     def restorePriorToRelease(self):
-        info('Restoring "master" to just before autorelease:%s' % self.version)
+        info('Restoring "main" to just before autorelease:%s' % self.version)
 
         self.deleteGitRelease()
         self.rollbackAutoCommits()
@@ -209,12 +209,13 @@ class BaseRelease:
 
 
 class KernelRelease(BaseRelease):
-    def __init__(self, mGit, version, commit='HEAD', git_ssh=False, git_org='FreeRTOS', repo_path=None, branch='main'):
+    def __init__(self, mGit, version, commit='HEAD', git_ssh=False, git_org='FreeRTOS', repo_path=None, branch='main', main_br_version=''):
         super().__init__(mGit, version, commit=commit, git_ssh=git_ssh, git_org=git_org, repo_path=repo_path, branch=branch)
 
         self.repo_name = '%s/FreeRTOS-Kernel' % self.git_org
         self.repo = mGit.get_repo(self.repo_name)
         self.tag = 'V%s' % version
+        self.main_br_version = main_br_version
 
         # Parent ctor configures local_repo if caller chooses to source local repo from repo_path.
         if self.repo_path is None:
@@ -232,14 +233,14 @@ class KernelRelease(BaseRelease):
 
         print()
 
+    def updateVersionMacros(self, version_str):
+        info('Updating version macros in task.h for "%s"' % version_str)
 
-    def updateVersionMacros(self):
-        info('Updating version macros in task.h for "%s"' % self.version)
+        # Strip out any non-numeric or '.' characters before setting major / minor / build
+        (major, minor, build) = re.sub("[^0-9.]", "", version_str).split('.')
+        update_freertos_version_macros(os.path.join(self.repo_path, 'include', 'task.h'), version_str, major, minor, build)
 
-        (major, minor, build) = self.version.split('.')
-        update_freertos_version_macros(os.path.join(self.repo_path, 'include', 'task.h'), major, minor, build)
-
-        self.commitChanges(self.commit_msg_prefix + 'Bump task.h version macros to "%s"' % self.version)
+        self.commitChanges(self.commit_msg_prefix + 'Bump task.h version macros to "%s"' % version_str)
 
     def createGitRelease(self):
         '''
@@ -264,16 +265,33 @@ class KernelRelease(BaseRelease):
     def autoRelease(self):
         info('Auto-releasing FreeRTOS Kernel V%s' % self.version)
 
-        self.updateFileHeaderVersions(['FreeRTOS Kernel V'], 'FreeRTOS Kernel V%s' % self.version)
-        self.updateVersionMacros()
+        # Determine if we need to set a separate version macros for the main branch
+        if (self.commit == 'HEAD') and len(self.main_br_version) > 0 and (self.main_br_version != self.version):
+            # Update version macros for main branch
+            self.updateVersionMacros(self.main_br_version)
 
-        # When baselining off a non-HEAD commit, master is left unchanged by tagging a detached HEAD,
-        # applying the autocommits, tagging, and pushing the new tag data to remote.
-        # However in the detached HEAD state we don't have a branch to push to, so we skip
-        if self.commit == 'HEAD':
+            # Push the branch
             self.pushLocalCommits()
 
+            # Revert the last commit in our working git repo
+            self.local_repo.git.reset('--hard','HEAD^')
+
+        # Update the version macros
+        self.updateVersionMacros(self.version)
+
+        if (self.commit == 'HEAD') and (self.main_br_version == self.version):
+            # Share a task.h version number commit for main branch and release tag)
+            self.pushLocalCommits()
+
+        # When baselining off a non-HEAD commit, main is left unchanged by tagging a detached HEAD,
+        # applying the autocommits, tagging, and pushing the new tag data to remote.
+        # However in the detached HEAD state we don't have a branch to push to, so we skip
+
+        # Update the header in each c/assembly file
+        self.updateFileHeaderVersions(['FreeRTOS Kernel V','FreeRTOS Kernel <DEVELOPMENT BRANCH>'], 'FreeRTOS Kernel V%s' % self.version)
+
         self.pushTag()
+
         self.createGitRelease()
 
         info('Kernel release done.')
@@ -410,9 +428,9 @@ class FreertosRelease(BaseRelease):
     def autoRelease(self):
         info('Auto-releasing FreeRTOS V%s' % self.version)
 
-        self.updateFileHeaderVersions(['FreeRTOS Kernel V', 'FreeRTOS V'], 'FreeRTOS V%s' % self.version)
+        self.updateFileHeaderVersions(['FreeRTOS Kernel V', 'FreeRTOS V', 'FreeRTOS Kernel <DEVELOPMENT BRANCH>', 'FreeRTOS <DEVELOPMENT BRANCH>'], 'FreeRTOS V%s' % self.version)
         self.updateSubmodulePointers()
-        # When baselining off a non-HEAD commit, master is left unchanged by tagging a detached HEAD,
+        # When baselining off a non-HEAD commit, main is left unchanged by tagging a detached HEAD,
         # applying the autocommits, tagging, and pushing the new tag data to remote.
         # However in the detached HEAD state we don't have a branch to push to, so we skip
         if self.commit == 'HEAD':
@@ -446,7 +464,7 @@ def configure_argparser():
     parser.add_argument('--rollback-core-version',
                         default=None,
                         required=False,
-                        help='Reset "master" to state prior to autorelease of given core version')
+                        help='Reset "main" to state prior to autorelease of given core version')
 
     parser.add_argument('--core-repo-path',
                         type=str,
@@ -463,7 +481,12 @@ def configure_argparser():
     parser.add_argument('--new-kernel-version',
                         default=None,
                         required=False,
-                        help='Reset "master" to just before the autorelease for the specified kernel version")')
+                        help='Reset "main" to just before the autorelease for the specified kernel version")')
+
+    parser.add_argument('--new-kernel-main-br-version',
+                        default='',
+                        required=False,
+                        help='Set the version in task.h on the kernel main branch to the specified value.')
 
     parser.add_argument('--kernel-commit',
                         default='HEAD',
@@ -474,7 +497,7 @@ def configure_argparser():
     parser.add_argument('--rollback-kernel-version',
                         default=None,
                         required=False,
-                        help='Reset "master" to state prior to autorelease of the given kernel version')
+                        help='Reset "main" to state prior to autorelease of the given kernel version')
 
     parser.add_argument('--kernel-repo-path',
                         type=str,
@@ -517,7 +540,8 @@ def main():
         info('Starting kernel release...')
         logIndentPush()
         rel_kernel = KernelRelease(mGit, args.new_kernel_version, args.kernel_commit, git_ssh=args.use_git_ssh,
-                                   git_org=args.git_org, repo_path=args.kernel_repo_path, branch=args.kernel_repo_branch)
+                                   git_org=args.git_org, repo_path=args.kernel_repo_path, branch=args.kernel_repo_branch,
+                                   main_br_version=args.new_kernel_main_br_version)
         rel_kernel.autoRelease()
         logIndentPop()
 

--- a/.github/scripts/versioning.py
+++ b/.github/scripts/versioning.py
@@ -104,12 +104,12 @@ def extract_version_number_from_file(file_path):
         match = re.search('\s*\*\s*(Amazon FreeRTOS.*V(.*))', content, re.MULTILINE)
         # Is it a kernel file?
         if match is None:
-            match = re.search('\s*\*\s*(FreeRTOS Kernel.*V([0-9]*\.[0-9]*\.[0-9]*))', content, re.MULTILINE)
+            match = re.search('\s*\*\s*(FreeRTOS Kernel.*V?([0-9]*\.[0-9]*\.[0-9]*|<DEVELOPMENT BRANCH>))', content, re.MULTILINE)
         if match is None:
-            match = re.search('\s*\*\s*(FreeRTOS V([0-9]*\.[0-9]*))', content, re.MULTILINE)
+            match = re.search('\s*\*\s*(FreeRTOS V?([0-9]*\.[0-9]*|<DEVELOPMENT BRANCH>))', content, re.MULTILINE)
         # Is it s FreeRTOS+TCP file?
         if match is None:
-            match = re.search('\s*\*\s*(FreeRTOS\+TCP.*V(.*))', content, re.MULTILINE)
+            match = re.search('\s*\*\s*(FreeRTOS\+TCP.*V?(.*|<DEVELOPMENT BRANCH>))', content, re.MULTILINE)
         # AWS library from C SDK
         if match is None:
             match = re.search('\s*\*\s*(AWS IoT.*V(.*))', content, re.MULTILINE)
@@ -196,7 +196,7 @@ def process_components(root_dir, components, exclude_dirs=[]):
         if wanna_update_version == 'yes':
             update_version_number_in_a_component(c, root_dir, exclude_dirs=exclude_dirs)
 
-def update_freertos_version_macros(path_macrofile, major, minor, build):
+def update_freertos_version_macros(path_macrofile, version_str, major, minor, build):
     with open(path_macrofile, encoding='utf-8', errors='ignore', newline='') as macro_file:
         macro_file_content = macro_file.read()
         match_version = re.search(r'(^.*#define *tskKERNEL_VERSION_NUMBER *(".*")$)', macro_file_content, re.MULTILINE)
@@ -206,7 +206,7 @@ def update_freertos_version_macros(path_macrofile, major, minor, build):
 
         if match_version.groups() and match_major.groups() and match_minor.groups() and match_build.groups():
             (old_version_string, old_version_number) = match_version.groups()
-            new_version_string = old_version_string.replace(old_version_number, '"V%s.%s.%s"' % (major, minor, build))
+            new_version_string = old_version_string.replace(old_version_number, '"V%s"' % version_str)
             macro_file_content = macro_file_content.replace(old_version_string, new_version_string)
 
             (old_major_string, old_major_number) = match_major.groups()
@@ -309,7 +309,7 @@ def main():
         print('FreeRTOS Code:\n    %s' % freertos_path)
         print('Old Version:\n    %s' % args.freertos_old_version)
         print('New Version:\n    %s' % args.freertos_new_version)
-        process_freertos_components(freertos_path, _FREERTOS_COMPONENTS, args.freertos_old_version.strip(), args.freertos_new_version.strip(), verbose=args.verbose)            
+        process_freertos_components(freertos_path, _FREERTOS_COMPONENTS, args.freertos_old_version.strip(), args.freertos_new_version.strip(), verbose=args.verbose)
 
     if not afr_path and not freertos_path:
         parser.print_help()


### PR DESCRIPTION
Description
-----------
Update release scripts to handle new "<DEVELOPMENT BRANCH>" version tags.

Add support for setting the main branch version number in task.h from within the github auto release workflow.


Test Steps
-----------
Tested the auto release script on my personal fork of the FreeRTOS/FreeRTOS and FreeRTOS/FreeRTOS-Kernel repositories.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
