### PR TITLE
Update win32 demo to exercise configRUN_TIME_COUNTER_TYPE

### DIFF
--- a/FreeRTOS/Demo/WIN32-MSVC/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/WIN32-MSVC/FreeRTOSConfig.h
@@ -47,7 +47,7 @@
 #define configUSE_DAEMON_TASK_STARTUP_HOOK		1
 #define configTICK_RATE_HZ						( 1000 ) /* In this non-real time simulated environment the tick frequency has to be at least a multiple of the Win32 tick frequency, and therefore very slow. */
 #define configMINIMAL_STACK_SIZE				( ( unsigned short ) 70 ) /* In this simulated case, the stack only has to hold one small structure as the real stack is part of the win32 thread. */
-#define configTOTAL_HEAP_SIZE					( ( size_t ) ( 52 * 1024 ) )
+#define configTOTAL_HEAP_SIZE					( ( size_t ) ( 52 * 1024 ) ) /* This demo tests heap_5 so places multiple blocks within this total heap size.  See mainREGION_1_SIZE to mainREGION_3_SIZE definitions in main.c. */
 #define configMAX_TASK_NAME_LEN					( 12 )
 #define configUSE_TRACE_FACILITY				1
 #define configUSE_16_BIT_TICKS					0
@@ -76,7 +76,8 @@
 #define configMAX_PRIORITIES					( 7 )
 
 /* Run time stats gathering configuration options. */
-unsigned long ulGetRunTimeCounterValue( void ); /* Prototype of function that returns run time counter. */
+#define configRUN_TIME_COUNTER_TYPE				uint64_t
+configRUN_TIME_COUNTER_TYPE ulGetRunTimeCounterValue( void ); /* Prototype of function that returns run time counter. */
 void vConfigureTimerForRunTimeStats( void );	/* Prototype of function that initialises the run time counter. */
 #define configGENERATE_RUN_TIME_STATS			1
 #define portCONFIGURE_TIMER_FOR_RUN_TIME_STATS() vConfigureTimerForRunTimeStats()

--- a/FreeRTOS/Demo/WIN32-MSVC/Run-time-stats-utils.c
+++ b/FreeRTOS/Demo/WIN32-MSVC/Run-time-stats-utils.c
@@ -72,10 +72,10 @@ LARGE_INTEGER liPerformanceCounterFrequency, liInitialRunTimeValue;
 }
 /*-----------------------------------------------------------*/
 
-unsigned long ulGetRunTimeCounterValue( void )
+configRUN_TIME_COUNTER_TYPE ulGetRunTimeCounterValue( void )
 {
 LARGE_INTEGER liCurrentCount;
-unsigned long ulReturn;
+configRUN_TIME_COUNTER_TYPE ulReturn;
 
 	/* What is the performance counter value now? */
 	QueryPerformanceCounter( &liCurrentCount );
@@ -91,7 +91,7 @@ unsigned long ulReturn;
 	}
 	else
 	{
-		ulReturn = ( unsigned long ) ( ( liCurrentCount.QuadPart - llInitialRunTimeCounterValue ) / llTicksPerHundedthMillisecond );
+		ulReturn = ( configRUN_TIME_COUNTER_TYPE ) ( ( liCurrentCount.QuadPart - llInitialRunTimeCounterValue ) / llTicksPerHundedthMillisecond );
 	}
 
 	return ulReturn;

--- a/FreeRTOS/Demo/WIN32-MSVC/main.c
+++ b/FreeRTOS/Demo/WIN32-MSVC/main.c
@@ -71,7 +71,7 @@ The blinky demo is implemented and described in main_blinky.c.
 If mainCREATE_SIMPLE_BLINKY_DEMO_ONLY is not 1 then the comprehensive test and
 demo application will be built.  The comprehensive test and demo application is
 implemented and described in main_full.c. */
-#define mainCREATE_SIMPLE_BLINKY_DEMO_ONLY	0
+#define mainCREATE_SIMPLE_BLINKY_DEMO_ONLY	1
 
 /* This demo uses heap_5.c, and these constants define the sizes of the regions
 that make up the total heap.  heap_5 is only used for test and example purposes
@@ -79,7 +79,7 @@ as this demo could easily create one large heap region instead of multiple
 smaller heap regions - in which case heap_4.c would be the more appropriate
 choice.  See http://www.freertos.org/a00111.html for an explanation. */
 #define mainREGION_1_SIZE	8201
-#define mainREGION_2_SIZE	29905
+#define mainREGION_2_SIZE	31905
 #define mainREGION_3_SIZE	7807
 
 /*-----------------------------------------------------------*/

--- a/FreeRTOS/Demo/WIN32-MSVC/main_blinky.c
+++ b/FreeRTOS/Demo/WIN32-MSVC/main_blinky.c
@@ -246,7 +246,7 @@ uint32_t ulReceivedValue;
 		console output) from a FreeRTOS task. */
 		if( ulReceivedValue == mainVALUE_SENT_FROM_TASK )
 		{
-			printf( "Message received from task\r\n" );
+			printf( "Message received from task - idle time %llu%%\r\n", ulTaskGetIdleRunTimePercent() );
 		}
 		else if( ulReceivedValue == mainVALUE_SENT_FROM_TIMER )
 		{

--- a/FreeRTOS/Demo/WIN32-MSVC/main_full.c
+++ b/FreeRTOS/Demo/WIN32-MSVC/main_full.c
@@ -390,12 +390,13 @@ HeapStats_t xHeapStats;
 		configASSERT( xHeapStats.xAvailableHeapSpaceInBytes == xPortGetFreeHeapSize() );
 		configASSERT( xHeapStats.xMinimumEverFreeBytesRemaining == xPortGetMinimumEverFreeHeapSize() );
 
-		printf( "%s - tick count %zu - free heap %zu - min free heap %zu - largest free block %zu \r\n",
+		printf( "%s - tick count %zu - free heap %zu - min free heap %zu - largest free block %zu - idle time %llu%%\r\n",
 			pcStatusMessage,
 			xTaskGetTickCount(),
 			xHeapStats.xAvailableHeapSpaceInBytes,
 			xHeapStats.xMinimumEverFreeBytesRemaining,
-			xHeapStats.xSizeOfLargestFreeBlockInBytes );
+			xHeapStats.xSizeOfLargestFreeBlockInBytes,
+			ulTaskGetIdleRunTimePercent() );
 	}
 }
 /*-----------------------------------------------------------*/

--- a/lexicon.txt
+++ b/lexicon.txt
@@ -2550,6 +2550,7 @@ ulstartingperiodms
 ulstatsoverflowcount
 ulstringlength
 ultaskendtrace
+ultaskgetidleruntimepercent
 ultasknotifytake
 ultasknotifytakeindexed
 ultasknotifyvalueclearindexed


### PR DESCRIPTION
Description
-----------
PR https://github.com/FreeRTOS/FreeRTOS-Kernel/pull/350 introduced configRUN_TIME_COUNTER_TYPE and ulTaskGetIdleRunTimePercent().  This PR updates the Win32 demo to exercise both additions.

Must be merged after https://github.com/FreeRTOS/FreeRTOS-Kernel/pull/350


Test Steps
-----------
Run the full Win32 demo.
Used new MPU function in STM32 MPU port.

Related Issue
-----------
https://github.com/FreeRTOS/FreeRTOS-Kernel/pull/350


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
