### PR TITLE
Add prvExerciseTaskHeapAllocationStats() to the MSVN Win32 and MPS2 Q…

### DIFF
--- a/FreeRTOS/Demo/CORTEX_MPS2_QEMU_IAR/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_MPS2_QEMU_IAR/FreeRTOSConfig.h
@@ -40,14 +40,14 @@
  *----------------------------------------------------------*/
 
 #define configUSE_PREEMPTION			1
-#define configUSE_IDLE_HOOK				0
+#define configUSE_IDLE_HOOK				1
 #define configUSE_TICK_HOOK				1
 #define configCPU_CLOCK_HZ				( ( unsigned long ) 25000000 )
 #define configTICK_RATE_HZ				( ( TickType_t ) 1000 )
 #define configMINIMAL_STACK_SIZE		( ( unsigned short ) 80 )
 #define configTOTAL_HEAP_SIZE			( ( size_t ) ( 50 * 1024 ) )
 #define configMAX_TASK_NAME_LEN			( 12 )
-#define configUSE_TRACE_FACILITY		0
+#define configUSE_TRACE_FACILITY		1
 #define configUSE_16_BIT_TICKS			0
 #define configIDLE_SHOULD_YIELD			0
 #define configUSE_CO_ROUTINES 			0
@@ -92,11 +92,9 @@ to exclude the API function. */
 #define INCLUDE_xTaskAbortDelay					1
 #define INCLUDE_xTaskGetHandle					1
 
-/* This demo makes use of one or more example stats formatting functions.  These
-format the raw data provided by the uxTaskGetSystemState() function in to human
-readable ASCII form.  See the notes in the implementation of vTaskList() within
-FreeRTOS/Source/tasks.c for limitations. */
-#define configUSE_STATS_FORMATTING_FUNCTIONS	1
+/* This demo checks the operation of the functions that track memory allocated
+by tasks calling pvPortMalloc() and vPortFree. */
+#define configTRACK_TASK_MEMORY_ALLOCATIONS		1
 
 #define configKERNEL_INTERRUPT_PRIORITY 		( 255 )	/* All eight bits as QEMU doesn't model the priority bits. */
 /* !!!! configMAX_SYSCALL_INTERRUPT_PRIORITY must not be set to zero !!!!

--- a/FreeRTOS/Demo/CORTEX_MPS2_QEMU_IAR/RTOSDemo.ewd
+++ b/FreeRTOS/Demo/CORTEX_MPS2_QEMU_IAR/RTOSDemo.ewd
@@ -88,7 +88,7 @@
                 </option>
                 <option>
                     <name>OCLastSavedByProductVersion</name>
-                    <state>8.42.1.23869</state>
+                    <state>8.50.6.28950</state>
                 </option>
                 <option>
                     <name>UseFlashLoader</name>
@@ -1007,7 +1007,7 @@
             <name>STLINK_ID</name>
             <archiveVersion>2</archiveVersion>
             <data>
-                <version>6</version>
+                <version>7</version>
                 <wantNonLocal>1</wantNonLocal>
                 <debug>1</debug>
                 <option>

--- a/FreeRTOS/Demo/CORTEX_MPS2_QEMU_IAR/RTOSDemo.ewp
+++ b/FreeRTOS/Demo/CORTEX_MPS2_QEMU_IAR/RTOSDemo.ewp
@@ -66,7 +66,7 @@
                 </option>
                 <option>
                     <name>OGLastSavedByProductVersion</name>
-                    <state>8.42.1.23869</state>
+                    <state>8.50.6.28950</state>
                 </option>
                 <option>
                     <name>GeneralEnableMisra</name>
@@ -285,7 +285,7 @@
                 <option>
                     <name>CCAllowList</name>
                     <version>1</version>
-                    <state>11111110</state>
+                    <state>00000000</state>
                 </option>
                 <option>
                     <name>CCDebugInfo</name>
@@ -369,7 +369,7 @@
                 </option>
                 <option>
                     <name>CCOptLevel</name>
-                    <state>3</state>
+                    <state>0</state>
                 </option>
                 <option>
                     <name>CCOptStrategy</name>
@@ -378,7 +378,7 @@
                 </option>
                 <option>
                     <name>CCOptLevelSlave</name>
-                    <state>3</state>
+                    <state>0</state>
                 </option>
                 <option>
                     <name>CompilerMisraRules98</name>

--- a/FreeRTOS/Demo/CORTEX_MPS2_QEMU_IAR/RTOSDemo.ewt
+++ b/FreeRTOS/Demo/CORTEX_MPS2_QEMU_IAR/RTOSDemo.ewt
@@ -9,9 +9,9 @@
         <debug>1</debug>
         <settings>
             <name>C-STAT</name>
-            <archiveVersion>262</archiveVersion>
+            <archiveVersion>264</archiveVersion>
             <data>
-                <version>262</version>
+                <version>264</version>
                 <cstatargs>
                     <useExtraArgs>0</useExtraArgs>
                     <extraArgs></extraArgs>
@@ -24,1084 +24,1318 @@
                     <messagesLimit>100</messagesLimit>
                 </cstatargs>
                 <cstat_settings>
-                    <cstat_version>1.6.2</cstat_version>
+                    <cstat_version>1.8.1</cstat_version>
                     <checks_tree>
-                        <package name="STDCHECKS" enabled="true">
+                        <package enabled="true" name="STDCHECKS">
                             <group enabled="true" name="ARR">
-                                <check name="ARR-inv-index-pos" enabled="true" />
-                                <check name="ARR-inv-index-ptr-pos" enabled="true" />
-                                <check name="ARR-inv-index-ptr" enabled="true" />
-                                <check name="ARR-inv-index" enabled="true" />
-                                <check name="ARR-neg-index" enabled="true" />
-                                <check name="ARR-uninit-index" enabled="true" />
+                                <check enabled="true" name="ARR-inv-index-pos" />
+                                <check enabled="true" name="ARR-inv-index-ptr-pos" />
+                                <check enabled="true" name="ARR-inv-index-ptr" />
+                                <check enabled="true" name="ARR-inv-index" />
+                                <check enabled="true" name="ARR-neg-index" />
+                                <check enabled="true" name="ARR-uninit-index" />
                             </group>
                             <group enabled="true" name="ATH">
-                                <check name="ATH-cmp-float" enabled="true" />
-                                <check name="ATH-cmp-unsign-neg" enabled="true" />
-                                <check name="ATH-cmp-unsign-pos" enabled="true" />
-                                <check name="ATH-div-0-assign" enabled="true" />
-                                <check name="ATH-div-0-cmp-aft" enabled="false" />
-                                <check name="ATH-div-0-cmp-bef" enabled="true" />
-                                <check name="ATH-div-0-interval" enabled="true" />
-                                <check name="ATH-div-0-pos" enabled="true" />
-                                <check name="ATH-div-0-unchk-global" enabled="true" />
-                                <check name="ATH-div-0-unchk-local" enabled="true" />
-                                <check name="ATH-div-0-unchk-param" enabled="true" />
-                                <check name="ATH-div-0" enabled="true" />
-                                <check name="ATH-inc-bool" enabled="true" />
-                                <check name="ATH-malloc-overrun" enabled="true" />
-                                <check name="ATH-neg-check-nonneg" enabled="true" />
-                                <check name="ATH-neg-check-pos" enabled="true" />
-                                <check name="ATH-new-overrun" enabled="true" />
-                                <check name="ATH-overflow-cast" enabled="false" />
-                                <check name="ATH-overflow" enabled="true" />
-                                <check name="ATH-shift-bounds" enabled="true" />
-                                <check name="ATH-shift-neg" enabled="true" />
-                                <check name="ATH-sizeof-by-sizeof" enabled="true" />
+                                <check enabled="true" name="ATH-cmp-float" />
+                                <check enabled="true" name="ATH-cmp-unsign-neg" />
+                                <check enabled="true" name="ATH-cmp-unsign-pos" />
+                                <check enabled="true" name="ATH-div-0-assign" />
+                                <check enabled="false" name="ATH-div-0-cmp-aft" />
+                                <check enabled="true" name="ATH-div-0-cmp-bef" />
+                                <check enabled="true" name="ATH-div-0-interval" />
+                                <check enabled="true" name="ATH-div-0-pos" />
+                                <check enabled="true" name="ATH-div-0-unchk-global" />
+                                <check enabled="true" name="ATH-div-0-unchk-local" />
+                                <check enabled="true" name="ATH-div-0-unchk-param" />
+                                <check enabled="true" name="ATH-div-0" />
+                                <check enabled="true" name="ATH-inc-bool" />
+                                <check enabled="true" name="ATH-malloc-overrun" />
+                                <check enabled="true" name="ATH-neg-check-nonneg" />
+                                <check enabled="true" name="ATH-neg-check-pos" />
+                                <check enabled="true" name="ATH-new-overrun" />
+                                <check enabled="false" name="ATH-overflow-cast" />
+                                <check enabled="true" name="ATH-overflow" />
+                                <check enabled="true" name="ATH-shift-bounds" />
+                                <check enabled="true" name="ATH-shift-neg" />
+                                <check enabled="true" name="ATH-sizeof-by-sizeof" />
                             </group>
                             <group enabled="true" name="CAST">
-                                <check name="CAST-old-style" enabled="false" />
+                                <check enabled="false" name="CAST-old-style" />
                             </group>
                             <group enabled="true" name="CATCH">
-                                <check name="CATCH-object-slicing" enabled="true" />
-                                <check name="CATCH-xtor-bad-member" enabled="false" />
+                                <check enabled="true" name="CATCH-object-slicing" />
+                                <check enabled="false" name="CATCH-xtor-bad-member" />
                             </group>
                             <group enabled="true" name="COMMA">
-                                <check name="COMMA-overload" enabled="false" />
+                                <check enabled="false" name="COMMA-overload" />
                             </group>
                             <group enabled="true" name="COMMENT">
-                                <check name="COMMENT-nested" enabled="true" />
+                                <check enabled="true" name="COMMENT-nested" />
                             </group>
                             <group enabled="true" name="CONST">
-                                <check name="CONST-member-ret" enabled="true" />
+                                <check enabled="true" name="CONST-member-ret" />
                             </group>
                             <group enabled="true" name="COP">
-                                <check name="COP-alloc-ctor" enabled="false" />
-                                <check name="COP-assign-op-ret" enabled="true" />
-                                <check name="COP-assign-op-self" enabled="true" />
-                                <check name="COP-assign-op" enabled="true" />
-                                <check name="COP-copy-ctor" enabled="true" />
-                                <check name="COP-dealloc-dtor" enabled="false" />
-                                <check name="COP-dtor-throw" enabled="true" />
-                                <check name="COP-dtor" enabled="true" />
-                                <check name="COP-init-order" enabled="true" />
-                                <check name="COP-init-uninit" enabled="true" />
-                                <check name="COP-member-uninit" enabled="true" />
+                                <check enabled="false" name="COP-alloc-ctor" />
+                                <check enabled="true" name="COP-assign-op-ret" />
+                                <check enabled="true" name="COP-assign-op-self" />
+                                <check enabled="true" name="COP-assign-op" />
+                                <check enabled="true" name="COP-copy-ctor" />
+                                <check enabled="false" name="COP-dealloc-dtor" />
+                                <check enabled="true" name="COP-dtor-throw" />
+                                <check enabled="true" name="COP-dtor" />
+                                <check enabled="true" name="COP-init-order" />
+                                <check enabled="true" name="COP-init-uninit" />
+                                <check enabled="true" name="COP-member-uninit" />
                             </group>
                             <group enabled="true" name="CPU">
-                                <check name="CPU-ctor-call-virt" enabled="true" />
-                                <check name="CPU-ctor-implicit" enabled="false" />
-                                <check name="CPU-delete-throw" enabled="true" />
-                                <check name="CPU-delete-void" enabled="true" />
-                                <check name="CPU-dtor-call-virt" enabled="true" />
-                                <check name="CPU-malloc-class" enabled="true" />
-                                <check name="CPU-nonvirt-dtor" enabled="true" />
-                                <check name="CPU-return-ref-to-class-data" enabled="true" />
+                                <check enabled="true" name="CPU-ctor-call-virt" />
+                                <check enabled="false" name="CPU-ctor-implicit" />
+                                <check enabled="true" name="CPU-delete-throw" />
+                                <check enabled="true" name="CPU-delete-void" />
+                                <check enabled="true" name="CPU-dtor-call-virt" />
+                                <check enabled="true" name="CPU-malloc-class" />
+                                <check enabled="true" name="CPU-nonvirt-dtor" />
+                                <check enabled="true" name="CPU-return-ref-to-class-data" />
                             </group>
                             <group enabled="true" name="DECL">
-                                <check name="DECL-implicit-int" enabled="false" />
+                                <check enabled="false" name="DECL-implicit-int" />
                             </group>
                             <group enabled="true" name="DEFINE">
-                                <check name="DEFINE-hash-multiple" enabled="true" />
+                                <check enabled="true" name="DEFINE-hash-multiple" />
                             </group>
                             <group enabled="true" name="ENUM">
-                                <check name="ENUM-bounds" enabled="false" />
+                                <check enabled="false" name="ENUM-bounds" />
                             </group>
                             <group enabled="true" name="EXP">
-                                <check name="EXP-cond-assign" enabled="true" />
-                                <check name="EXP-dangling-else" enabled="true" />
-                                <check name="EXP-loop-exit" enabled="true" />
-                                <check name="EXP-main-ret-int" enabled="false" />
-                                <check name="EXP-null-stmt" enabled="false" />
-                                <check name="EXP-stray-semicolon" enabled="false" />
+                                <check enabled="true" name="EXP-cond-assign" />
+                                <check enabled="true" name="EXP-dangling-else" />
+                                <check enabled="true" name="EXP-loop-exit" />
+                                <check enabled="false" name="EXP-main-ret-int" />
+                                <check enabled="false" name="EXP-null-stmt" />
+                                <check enabled="false" name="EXP-stray-semicolon" />
                             </group>
                             <group enabled="true" name="EXPR">
-                                <check name="EXPR-const-overflow" enabled="true" />
+                                <check enabled="true" name="EXPR-const-overflow" />
                             </group>
                             <group enabled="true" name="FPT">
-                                <check name="FPT-cmp-null" enabled="true" />
-                                <check name="FPT-literal" enabled="false" />
-                                <check name="FPT-misuse" enabled="true" />
+                                <check enabled="true" name="FPT-cmp-null" />
+                                <check enabled="false" name="FPT-literal" />
+                                <check enabled="true" name="FPT-misuse" />
                             </group>
                             <group enabled="true" name="FUNC">
-                                <check name="FUNC-implicit-decl" enabled="false" />
-                                <check name="FUNC-unprototyped-all" enabled="false" />
-                                <check name="FUNC-unprototyped-used" enabled="true" />
+                                <check enabled="false" name="FUNC-implicit-decl" />
+                                <check enabled="false" name="FUNC-unprototyped-all" />
+                                <check enabled="true" name="FUNC-unprototyped-used" />
                             </group>
                             <group enabled="true" name="INCLUDE">
-                                <check name="INCLUDE-c-file" enabled="false" />
+                                <check enabled="false" name="INCLUDE-c-file" />
                             </group>
                             <group enabled="true" name="INT">
-                                <check name="INT-use-signed-as-unsigned-pos" enabled="false" />
-                                <check name="INT-use-signed-as-unsigned" enabled="true" />
+                                <check enabled="false" name="INT-use-signed-as-unsigned-pos" />
+                                <check enabled="true" name="INT-use-signed-as-unsigned" />
                             </group>
                             <group enabled="true" name="ITR">
-                                <check name="ITR-end-cmp-aft" enabled="true" />
-                                <check name="ITR-end-cmp-bef" enabled="true" />
-                                <check name="ITR-invalidated" enabled="true" />
-                                <check name="ITR-mismatch-alg" enabled="false" />
-                                <check name="ITR-store" enabled="false" />
-                                <check name="ITR-uninit" enabled="true" />
+                                <check enabled="true" name="ITR-end-cmp-aft" />
+                                <check enabled="true" name="ITR-end-cmp-bef" />
+                                <check enabled="true" name="ITR-invalidated" />
+                                <check enabled="false" name="ITR-mismatch-alg" />
+                                <check enabled="false" name="ITR-store" />
+                                <check enabled="true" name="ITR-uninit" />
                             </group>
                             <group enabled="true" name="LIB">
-                                <check name="LIB-bsearch-overrun-pos" enabled="false" />
-                                <check name="LIB-bsearch-overrun" enabled="false" />
-                                <check name="LIB-fn-unsafe" enabled="false" />
-                                <check name="LIB-fread-overrun-pos" enabled="false" />
-                                <check name="LIB-fread-overrun" enabled="true" />
-                                <check name="LIB-memchr-overrun-pos" enabled="false" />
-                                <check name="LIB-memchr-overrun" enabled="true" />
-                                <check name="LIB-memcpy-overrun-pos" enabled="false" />
-                                <check name="LIB-memcpy-overrun" enabled="true" />
-                                <check name="LIB-memset-overrun-pos" enabled="false" />
-                                <check name="LIB-memset-overrun" enabled="true" />
-                                <check name="LIB-putenv" enabled="false" />
-                                <check name="LIB-qsort-overrun-pos" enabled="false" />
-                                <check name="LIB-qsort-overrun" enabled="false" />
-                                <check name="LIB-return-const" enabled="true" />
-                                <check name="LIB-return-error" enabled="true" />
-                                <check name="LIB-return-leak" enabled="true" />
-                                <check name="LIB-return-neg" enabled="true" />
-                                <check name="LIB-return-null" enabled="true" />
-                                <check name="LIB-sprintf-overrun" enabled="false" />
-                                <check name="LIB-std-sort-overrun-pos" enabled="false" />
-                                <check name="LIB-std-sort-overrun" enabled="true" />
-                                <check name="LIB-strcat-overrun-pos" enabled="false" />
-                                <check name="LIB-strcat-overrun" enabled="true" />
-                                <check name="LIB-strcpy-overrun-pos" enabled="false" />
-                                <check name="LIB-strcpy-overrun" enabled="true" />
-                                <check name="LIB-strncat-overrun-pos" enabled="false" />
-                                <check name="LIB-strncat-overrun" enabled="true" />
-                                <check name="LIB-strncmp-overrun-pos" enabled="false" />
-                                <check name="LIB-strncmp-overrun" enabled="true" />
-                                <check name="LIB-strncpy-overrun-pos" enabled="false" />
-                                <check name="LIB-strncpy-overrun" enabled="true" />
+                                <check enabled="false" name="LIB-bsearch-overrun-pos" />
+                                <check enabled="false" name="LIB-bsearch-overrun" />
+                                <check enabled="false" name="LIB-fn-unsafe" />
+                                <check enabled="false" name="LIB-fread-overrun-pos" />
+                                <check enabled="true" name="LIB-fread-overrun" />
+                                <check enabled="false" name="LIB-memchr-overrun-pos" />
+                                <check enabled="true" name="LIB-memchr-overrun" />
+                                <check enabled="false" name="LIB-memcpy-overrun-pos" />
+                                <check enabled="true" name="LIB-memcpy-overrun" />
+                                <check enabled="false" name="LIB-memset-overrun-pos" />
+                                <check enabled="true" name="LIB-memset-overrun" />
+                                <check enabled="false" name="LIB-putenv" />
+                                <check enabled="false" name="LIB-qsort-overrun-pos" />
+                                <check enabled="false" name="LIB-qsort-overrun" />
+                                <check enabled="true" name="LIB-return-const" />
+                                <check enabled="true" name="LIB-return-error" />
+                                <check enabled="true" name="LIB-return-leak" />
+                                <check enabled="true" name="LIB-return-neg" />
+                                <check enabled="true" name="LIB-return-null" />
+                                <check enabled="false" name="LIB-sprintf-overrun" />
+                                <check enabled="false" name="LIB-std-sort-overrun-pos" />
+                                <check enabled="true" name="LIB-std-sort-overrun" />
+                                <check enabled="false" name="LIB-strcat-overrun-pos" />
+                                <check enabled="true" name="LIB-strcat-overrun" />
+                                <check enabled="false" name="LIB-strcpy-overrun-pos" />
+                                <check enabled="true" name="LIB-strcpy-overrun" />
+                                <check enabled="false" name="LIB-strncat-overrun-pos" />
+                                <check enabled="true" name="LIB-strncat-overrun" />
+                                <check enabled="false" name="LIB-strncmp-overrun-pos" />
+                                <check enabled="true" name="LIB-strncmp-overrun" />
+                                <check enabled="false" name="LIB-strncpy-overrun-pos" />
+                                <check enabled="true" name="LIB-strncpy-overrun" />
                             </group>
                             <group enabled="true" name="LOGIC">
-                                <check name="LOGIC-overload" enabled="false" />
+                                <check enabled="false" name="LOGIC-overload" />
                             </group>
                             <group enabled="true" name="MEM">
-                                <check name="MEM-delete-array-op" enabled="true" />
-                                <check name="MEM-delete-op" enabled="true" />
-                                <check name="MEM-double-free-alias" enabled="true" />
-                                <check name="MEM-double-free-some" enabled="true" />
-                                <check name="MEM-double-free" enabled="true" />
-                                <check name="MEM-free-field" enabled="true" />
-                                <check name="MEM-free-fptr" enabled="true" />
-                                <check name="MEM-free-no-alloc-struct" enabled="false" />
-                                <check name="MEM-free-no-alloc" enabled="false" />
-                                <check name="MEM-free-no-use" enabled="true" />
-                                <check name="MEM-free-op" enabled="true" />
-                                <check name="MEM-free-struct-field" enabled="true" />
-                                <check name="MEM-free-variable-alias" enabled="true" />
-                                <check name="MEM-free-variable" enabled="true" />
-                                <check name="MEM-leak-alias" enabled="true" />
-                                <check name="MEM-leak" enabled="false" />
-                                <check name="MEM-malloc-arith" enabled="false" />
-                                <check name="MEM-malloc-diff-type" enabled="true" />
-                                <check name="MEM-malloc-sizeof-ptr" enabled="true" />
-                                <check name="MEM-malloc-sizeof" enabled="true" />
-                                <check name="MEM-malloc-strlen" enabled="false" />
-                                <check name="MEM-realloc-diff-type" enabled="true" />
-                                <check name="MEM-return-free" enabled="true" />
-                                <check name="MEM-return-no-assign" enabled="true" />
-                                <check name="MEM-stack-global-field" enabled="true" />
-                                <check name="MEM-stack-global" enabled="true" />
-                                <check name="MEM-stack-param-ref" enabled="true" />
-                                <check name="MEM-stack-param" enabled="true" />
-                                <check name="MEM-stack-pos" enabled="true" />
-                                <check name="MEM-stack-ref" enabled="true" />
-                                <check name="MEM-stack" enabled="true" />
-                                <check name="MEM-use-free-all" enabled="true" />
-                                <check name="MEM-use-free-some" enabled="true" />
+                                <check enabled="true" name="MEM-delete-array-op" />
+                                <check enabled="true" name="MEM-delete-op" />
+                                <check enabled="true" name="MEM-double-free-alias" />
+                                <check enabled="true" name="MEM-double-free-some" />
+                                <check enabled="true" name="MEM-double-free" />
+                                <check enabled="true" name="MEM-free-field" />
+                                <check enabled="true" name="MEM-free-fptr" />
+                                <check enabled="false" name="MEM-free-no-alloc-struct" />
+                                <check enabled="false" name="MEM-free-no-alloc" />
+                                <check enabled="true" name="MEM-free-no-use" />
+                                <check enabled="true" name="MEM-free-op" />
+                                <check enabled="true" name="MEM-free-struct-field" />
+                                <check enabled="true" name="MEM-free-variable-alias" />
+                                <check enabled="true" name="MEM-free-variable" />
+                                <check enabled="true" name="MEM-leak-alias" />
+                                <check enabled="false" name="MEM-leak" />
+                                <check enabled="false" name="MEM-malloc-arith" />
+                                <check enabled="true" name="MEM-malloc-diff-type" />
+                                <check enabled="true" name="MEM-malloc-sizeof-ptr" />
+                                <check enabled="true" name="MEM-malloc-sizeof" />
+                                <check enabled="false" name="MEM-malloc-strlen" />
+                                <check enabled="true" name="MEM-realloc-diff-type" />
+                                <check enabled="true" name="MEM-return-free" />
+                                <check enabled="true" name="MEM-return-no-assign" />
+                                <check enabled="true" name="MEM-stack-global-field" />
+                                <check enabled="true" name="MEM-stack-global" />
+                                <check enabled="true" name="MEM-stack-param-ref" />
+                                <check enabled="true" name="MEM-stack-param" />
+                                <check enabled="true" name="MEM-stack-pos" />
+                                <check enabled="true" name="MEM-stack-ref" />
+                                <check enabled="true" name="MEM-stack" />
+                                <check enabled="true" name="MEM-use-free-all" />
+                                <check enabled="true" name="MEM-use-free-some" />
                             </group>
                             <group enabled="true" name="PTR">
-                                <check name="PTR-arith-field" enabled="true" />
-                                <check name="PTR-arith-stack" enabled="true" />
-                                <check name="PTR-arith-var" enabled="true" />
-                                <check name="PTR-cmp-str-lit" enabled="true" />
-                                <check name="PTR-null-assign-fun-pos" enabled="false" />
-                                <check name="PTR-null-assign-pos" enabled="false" />
-                                <check name="PTR-null-assign" enabled="true" />
-                                <check name="PTR-null-cmp-aft" enabled="true" />
-                                <check name="PTR-null-cmp-bef-fun" enabled="true" />
-                                <check name="PTR-null-cmp-bef" enabled="true" />
-                                <check name="PTR-null-fun-pos" enabled="true" />
-                                <check name="PTR-null-literal-pos" enabled="false" />
-                                <check name="PTR-overload" enabled="false" />
-                                <check name="PTR-singleton-arith-pos" enabled="false" />
-                                <check name="PTR-singleton-arith" enabled="true" />
-                                <check name="PTR-unchk-param-some" enabled="true" />
-                                <check name="PTR-unchk-param" enabled="false" />
-                                <check name="PTR-uninit-pos" enabled="false" />
-                                <check name="PTR-uninit" enabled="true" />
+                                <check enabled="true" name="PTR-arith-field" />
+                                <check enabled="true" name="PTR-arith-stack" />
+                                <check enabled="true" name="PTR-arith-var" />
+                                <check enabled="true" name="PTR-cmp-str-lit" />
+                                <check enabled="false" name="PTR-null-assign-fun-pos" />
+                                <check enabled="false" name="PTR-null-assign-pos" />
+                                <check enabled="true" name="PTR-null-assign" />
+                                <check enabled="true" name="PTR-null-cmp-aft" />
+                                <check enabled="true" name="PTR-null-cmp-bef-fun" />
+                                <check enabled="true" name="PTR-null-cmp-bef" />
+                                <check enabled="true" name="PTR-null-fun-pos" />
+                                <check enabled="false" name="PTR-null-literal-pos" />
+                                <check enabled="false" name="PTR-overload" />
+                                <check enabled="false" name="PTR-singleton-arith-pos" />
+                                <check enabled="true" name="PTR-singleton-arith" />
+                                <check enabled="true" name="PTR-unchk-param-some" />
+                                <check enabled="false" name="PTR-unchk-param" />
+                                <check enabled="false" name="PTR-uninit-pos" />
+                                <check enabled="true" name="PTR-uninit" />
                             </group>
                             <group enabled="true" name="RED">
-                                <check name="RED-alloc-zero-bytes" enabled="false" />
-                                <check name="RED-case-reach" enabled="false" />
-                                <check name="RED-cmp-always" enabled="false" />
-                                <check name="RED-cmp-never" enabled="false" />
-                                <check name="RED-cond-always" enabled="false" />
-                                <check name="RED-cond-const-assign" enabled="true" />
-                                <check name="RED-cond-const-expr" enabled="false" />
-                                <check name="RED-cond-const" enabled="false" />
-                                <check name="RED-cond-never" enabled="false" />
-                                <check name="RED-dead" enabled="true" />
-                                <check name="RED-expr" enabled="false" />
-                                <check name="RED-func-no-effect" enabled="false" />
-                                <check name="RED-local-hides-global" enabled="true" />
-                                <check name="RED-local-hides-local" enabled="false" />
-                                <check name="RED-local-hides-member" enabled="false" />
-                                <check name="RED-local-hides-param" enabled="true" />
-                                <check name="RED-no-effect" enabled="false" />
-                                <check name="RED-self-assign" enabled="true" />
-                                <check name="RED-unused-assign" enabled="true" />
-                                <check name="RED-unused-param" enabled="false" />
-                                <check name="RED-unused-return-val" enabled="false" />
-                                <check name="RED-unused-val" enabled="false" />
-                                <check name="RED-unused-var-all" enabled="true" />
+                                <check enabled="false" name="RED-alloc-zero-bytes" />
+                                <check enabled="false" name="RED-case-reach" />
+                                <check enabled="false" name="RED-cmp-always" />
+                                <check enabled="false" name="RED-cmp-never" />
+                                <check enabled="false" name="RED-cond-always" />
+                                <check enabled="true" name="RED-cond-const-assign" />
+                                <check enabled="false" name="RED-cond-const-expr" />
+                                <check enabled="false" name="RED-cond-const" />
+                                <check enabled="false" name="RED-cond-never" />
+                                <check enabled="true" name="RED-dead" />
+                                <check enabled="false" name="RED-expr" />
+                                <check enabled="false" name="RED-func-no-effect" />
+                                <check enabled="true" name="RED-local-hides-global" />
+                                <check enabled="false" name="RED-local-hides-local" />
+                                <check enabled="false" name="RED-local-hides-member" />
+                                <check enabled="true" name="RED-local-hides-param" />
+                                <check enabled="false" name="RED-no-effect" />
+                                <check enabled="true" name="RED-self-assign" />
+                                <check enabled="true" name="RED-unused-assign" />
+                                <check enabled="false" name="RED-unused-param" />
+                                <check enabled="false" name="RED-unused-return-val" />
+                                <check enabled="false" name="RED-unused-val" />
+                                <check enabled="true" name="RED-unused-var-all" />
                             </group>
                             <group enabled="true" name="RESOURCE">
-                                <check name="RESOURCE-deref-file" enabled="false" />
-                                <check name="RESOURCE-double-close" enabled="true" />
-                                <check name="RESOURCE-file-no-close-all" enabled="true" />
-                                <check name="RESOURCE-file-pos-neg" enabled="false" />
-                                <check name="RESOURCE-file-use-after-close" enabled="true" />
-                                <check name="RESOURCE-implicit-deref-file" enabled="false" />
-                                <check name="RESOURCE-write-ronly-file" enabled="true" />
+                                <check enabled="false" name="RESOURCE-deref-file" />
+                                <check enabled="true" name="RESOURCE-double-close" />
+                                <check enabled="true" name="RESOURCE-file-no-close-all" />
+                                <check enabled="false" name="RESOURCE-file-pos-neg" />
+                                <check enabled="true" name="RESOURCE-file-use-after-close" />
+                                <check enabled="false" name="RESOURCE-implicit-deref-file" />
+                                <check enabled="true" name="RESOURCE-write-ronly-file" />
                             </group>
                             <group enabled="true" name="SIZEOF">
-                                <check name="SIZEOF-side-effect" enabled="true" />
+                                <check enabled="true" name="SIZEOF-side-effect" />
                             </group>
                             <group enabled="true" name="SPC">
-                                <check name="SPC-order" enabled="true" />
-                                <check name="SPC-uninit-arr-all" enabled="false" />
-                                <check name="SPC-uninit-struct-field-heap" enabled="true" />
-                                <check name="SPC-uninit-struct-field" enabled="false" />
-                                <check name="SPC-uninit-struct" enabled="true" />
-                                <check name="SPC-uninit-var-all" enabled="true" />
-                                <check name="SPC-uninit-var-some" enabled="true" />
-                                <check name="SPC-volatile-reads" enabled="false" />
-                                <check name="SPC-volatile-writes" enabled="false" />
+                                <check enabled="true" name="SPC-order" />
+                                <check enabled="false" name="SPC-uninit-arr-all" />
+                                <check enabled="true" name="SPC-uninit-struct-field-heap" />
+                                <check enabled="false" name="SPC-uninit-struct-field" />
+                                <check enabled="true" name="SPC-uninit-struct" />
+                                <check enabled="true" name="SPC-uninit-var-all" />
+                                <check enabled="true" name="SPC-uninit-var-some" />
+                                <check enabled="false" name="SPC-volatile-reads" />
+                                <check enabled="false" name="SPC-volatile-writes" />
                             </group>
                             <group enabled="true" name="STRUCT">
-                                <check name="STRUCT-signed-bit" enabled="false" />
+                                <check enabled="false" name="STRUCT-signed-bit" />
                             </group>
                             <group enabled="true" name="SWITCH">
-                                <check name="SWITCH-fall-through" enabled="true" />
+                                <check enabled="true" name="SWITCH-fall-through" />
                             </group>
                             <group enabled="true" name="THROW">
-                                <check name="THROW-empty" enabled="false" />
-                                <check name="THROW-main" enabled="false" />
-                                <check name="THROW-null" enabled="true" />
-                                <check name="THROW-ptr" enabled="true" />
-                                <check name="THROW-static" enabled="true" />
-                                <check name="THROW-unhandled" enabled="true" />
+                                <check enabled="false" name="THROW-empty" />
+                                <check enabled="false" name="THROW-main" />
+                                <check enabled="true" name="THROW-null" />
+                                <check enabled="true" name="THROW-ptr" />
+                                <check enabled="true" name="THROW-static" />
+                                <check enabled="true" name="THROW-unhandled" />
                             </group>
                             <group enabled="true" name="UNION">
-                                <check name="UNION-overlap-assign" enabled="true" />
-                                <check name="UNION-type-punning" enabled="true" />
+                                <check enabled="true" name="UNION-overlap-assign" />
+                                <check enabled="true" name="UNION-type-punning" />
                             </group>
                         </package>
-                        <package name="CERT" enabled="false">
+                        <package enabled="false" name="CERT">
+                            <group enabled="true" name="CERT-ARR">
+                                <check enabled="true" name="CERT-ARR30-C_a" />
+                                <check enabled="true" name="CERT-ARR30-C_b" />
+                                <check enabled="true" name="CERT-ARR30-C_c" />
+                                <check enabled="true" name="CERT-ARR30-C_d" />
+                                <check enabled="true" name="CERT-ARR30-C_e" />
+                                <check enabled="true" name="CERT-ARR30-C_f" />
+                                <check enabled="true" name="CERT-ARR30-C_g" />
+                                <check enabled="true" name="CERT-ARR30-C_h" />
+                                <check enabled="true" name="CERT-ARR30-C_i" />
+                                <check enabled="true" name="CERT-ARR30-C_j" />
+                                <check enabled="true" name="CERT-ARR32-C" />
+                                <check enabled="true" name="CERT-ARR36-C_a" />
+                                <check enabled="true" name="CERT-ARR36-C_b" />
+                                <check enabled="true" name="CERT-ARR37-C" />
+                                <check enabled="true" name="CERT-ARR38-C_a" />
+                                <check enabled="true" name="CERT-ARR38-C_b" />
+                                <check enabled="true" name="CERT-ARR38-C_c" />
+                                <check enabled="true" name="CERT-ARR38-C_d" />
+                                <check enabled="true" name="CERT-ARR38-C_e" />
+                                <check enabled="true" name="CERT-ARR38-C_f" />
+                                <check enabled="true" name="CERT-ARR39-C" />
+                            </group>
+                            <group enabled="true" name="CERT-DCL">
+                                <check enabled="true" name="CERT-DCL30-C_a" />
+                                <check enabled="true" name="CERT-DCL30-C_b" />
+                                <check enabled="true" name="CERT-DCL30-C_c" />
+                                <check enabled="true" name="CERT-DCL30-C_d" />
+                                <check enabled="true" name="CERT-DCL30-C_e" />
+                                <check enabled="true" name="CERT-DCL31-C" />
+                                <check enabled="true" name="CERT-DCL36-C" />
+                                <check enabled="true" name="CERT-DCL37-C_a" />
+                                <check enabled="true" name="CERT-DCL37-C_b" />
+                                <check enabled="false" name="CERT-DCL37-C_c" />
+                                <check enabled="true" name="CERT-DCL38-C" />
+                                <check enabled="true" name="CERT-DCL39-C" />
+                                <check enabled="true" name="CERT-DCL40-C" />
+                                <check enabled="true" name="CERT-DCL41-C" />
+                            </group>
+                            <group enabled="true" name="CERT-ENV">
+                                <check enabled="true" name="CERT-ENV30-C" />
+                                <check enabled="true" name="CERT-ENV31-C" />
+                                <check enabled="true" name="CERT-ENV32-C" />
+                                <check enabled="true" name="CERT-ENV33-C" />
+                                <check enabled="true" name="CERT-ENV34-C" />
+                            </group>
+                            <group enabled="true" name="CERT-ERR">
+                                <check enabled="true" name="CERT-ERR30-C_a" />
+                                <check enabled="true" name="CERT-ERR30-C_b" />
+                                <check enabled="true" name="CERT-ERR30-C_c" />
+                                <check enabled="true" name="CERT-ERR30-C_d" />
+                                <check enabled="true" name="CERT-ERR32-C" />
+                                <check enabled="true" name="CERT-ERR33-C_a" />
+                                <check enabled="true" name="CERT-ERR33-C_b" />
+                                <check enabled="true" name="CERT-ERR33-C_c" />
+                                <check enabled="true" name="CERT-ERR33-C_d" />
+                                <check enabled="true" name="CERT-ERR34-C_a" />
+                                <check enabled="true" name="CERT-ERR34-C_b" />
+                            </group>
                             <group enabled="true" name="CERT-EXP">
-                                <check name="CERT-EXP19-C" enabled="true" />
+                                <check enabled="true" name="CERT-EXP19-C" />
+                                <check enabled="true" name="CERT-EXP30-C_a" />
+                                <check enabled="true" name="CERT-EXP30-C_b" />
+                                <check enabled="true" name="CERT-EXP32-C" />
+                                <check enabled="true" name="CERT-EXP33-C_a" />
+                                <check enabled="true" name="CERT-EXP33-C_b" />
+                                <check enabled="true" name="CERT-EXP33-C_c" />
+                                <check enabled="true" name="CERT-EXP33-C_d" />
+                                <check enabled="true" name="CERT-EXP33-C_e" />
+                                <check enabled="true" name="CERT-EXP33-C_f" />
+                                <check enabled="true" name="CERT-EXP34-C_a" />
+                                <check enabled="true" name="CERT-EXP34-C_b" />
+                                <check enabled="true" name="CERT-EXP34-C_c" />
+                                <check enabled="true" name="CERT-EXP34-C_d" />
+                                <check enabled="true" name="CERT-EXP34-C_e" />
+                                <check enabled="true" name="CERT-EXP34-C_f" />
+                                <check enabled="true" name="CERT-EXP34-C_g" />
+                                <check enabled="true" name="CERT-EXP35-C" />
+                                <check enabled="true" name="CERT-EXP36-C_a" />
+                                <check enabled="true" name="CERT-EXP36-C_b" />
+                                <check enabled="true" name="CERT-EXP37-C_a" />
+                                <check enabled="true" name="CERT-EXP37-C_b" />
+                                <check enabled="true" name="CERT-EXP37-C_c" />
+                                <check enabled="true" name="CERT-EXP39-C_a" />
+                                <check enabled="true" name="CERT-EXP39-C_b" />
+                                <check enabled="true" name="CERT-EXP39-C_c" />
+                                <check enabled="true" name="CERT-EXP39-C_d" />
+                                <check enabled="true" name="CERT-EXP39-C_e" />
+                                <check enabled="true" name="CERT-EXP40-C_a" />
+                                <check enabled="true" name="CERT-EXP40-C_b" />
+                                <check enabled="true" name="CERT-EXP42-C" />
+                                <check enabled="true" name="CERT-EXP43-C_a" />
+                                <check enabled="true" name="CERT-EXP43-C_b" />
+                                <check enabled="true" name="CERT-EXP43-C_c" />
+                                <check enabled="true" name="CERT-EXP43-C_d" />
+                                <check enabled="true" name="CERT-EXP44-C" />
+                                <check enabled="true" name="CERT-EXP45-C" />
+                                <check enabled="true" name="CERT-EXP46-C" />
+                                <check enabled="true" name="CERT-EXP47-C_a" />
+                                <check enabled="true" name="CERT-EXP47-C_b" />
                             </group>
                             <group enabled="true" name="CERT-FIO">
-                                <check name="CERT-FIO37-C" enabled="true" />
-                                <check name="CERT-FIO38-C" enabled="true" />
+                                <check enabled="true" name="CERT-FIO30-C" />
+                                <check enabled="true" name="CERT-FIO32-C" />
+                                <check enabled="true" name="CERT-FIO34-C" />
+                                <check enabled="true" name="CERT-FIO37-C" />
+                                <check enabled="true" name="CERT-FIO38-C" />
+                                <check enabled="true" name="CERT-FIO39-C" />
+                                <check enabled="true" name="CERT-FIO40-C" />
+                                <check enabled="true" name="CERT-FIO41-C" />
+                                <check enabled="true" name="CERT-FIO42-C_a" />
+                                <check enabled="false" name="CERT-FIO42-C_b" />
+                                <check enabled="true" name="CERT-FIO44-C" />
+                                <check enabled="true" name="CERT-FIO45-C" />
+                                <check enabled="true" name="CERT-FIO46-C_a" />
+                                <check enabled="true" name="CERT-FIO46-C_b" />
+                                <check enabled="true" name="CERT-FIO46-C_c" />
+                                <check enabled="true" name="CERT-FIO47-C_a" />
+                                <check enabled="true" name="CERT-FIO47-C_b" />
+                                <check enabled="true" name="CERT-FIO47-C_c" />
+                            </group>
+                            <group enabled="true" name="CERT-FLP">
+                                <check enabled="true" name="CERT-FLP30-C_a" />
+                                <check enabled="true" name="CERT-FLP30-C_b" />
+                                <check enabled="true" name="CERT-FLP32-C_a" />
+                                <check enabled="true" name="CERT-FLP32-C_b" />
+                                <check enabled="true" name="CERT-FLP34-C" />
+                                <check enabled="true" name="CERT-FLP36-C" />
+                                <check enabled="true" name="CERT-FLP37-C" />
+                            </group>
+                            <group enabled="true" name="CERT-INT">
+                                <check enabled="true" name="CERT-INT30-C_a" />
+                                <check enabled="false" name="CERT-INT30-C_b" />
+                                <check enabled="true" name="CERT-INT31-C_a" />
+                                <check enabled="true" name="CERT-INT31-C_b" />
+                                <check enabled="true" name="CERT-INT31-C_c" />
+                                <check enabled="true" name="CERT-INT32-C_a" />
+                                <check enabled="false" name="CERT-INT32-C_b" />
+                                <check enabled="true" name="CERT-INT33-C_a" />
+                                <check enabled="true" name="CERT-INT33-C_b" />
+                                <check enabled="true" name="CERT-INT33-C_c" />
+                                <check enabled="true" name="CERT-INT33-C_d" />
+                                <check enabled="true" name="CERT-INT33-C_e" />
+                                <check enabled="true" name="CERT-INT33-C_f" />
+                                <check enabled="true" name="CERT-INT33-C_g" />
+                                <check enabled="true" name="CERT-INT33-C_h" />
+                                <check enabled="true" name="CERT-INT33-C_i" />
+                                <check enabled="true" name="CERT-INT34-C_a" />
+                                <check enabled="true" name="CERT-INT34-C_b" />
+                                <check enabled="true" name="CERT-INT34-C_c" />
+                                <check enabled="true" name="CERT-INT35-C" />
+                                <check enabled="true" name="CERT-INT36-C" />
+                            </group>
+                            <group enabled="true" name="CERT-MEM">
+                                <check enabled="true" name="CERT-MEM30-C_a" />
+                                <check enabled="true" name="CERT-MEM30-C_b" />
+                                <check enabled="true" name="CERT-MEM30-C_c" />
+                                <check enabled="true" name="CERT-MEM31-C" />
+                                <check enabled="true" name="CERT-MEM33-C_a" />
+                                <check enabled="true" name="CERT-MEM33-C_b" />
+                                <check enabled="true" name="CERT-MEM34-C_a" />
+                                <check enabled="true" name="CERT-MEM34-C_b" />
+                                <check enabled="true" name="CERT-MEM34-C_c" />
+                                <check enabled="true" name="CERT-MEM35-C_a" />
+                                <check enabled="true" name="CERT-MEM35-C_b" />
+                                <check enabled="true" name="CERT-MEM35-C_c" />
+                                <check enabled="true" name="CERT-MEM36-C" />
+                            </group>
+                            <group enabled="true" name="CERT-MSC">
+                                <check enabled="true" name="CERT-MSC30-C" />
+                                <check enabled="true" name="CERT-MSC32-C" />
+                                <check enabled="false" name="CERT-MSC33-C" />
+                                <check enabled="true" name="CERT-MSC37-C" />
+                                <check enabled="true" name="CERT-MSC38-C" />
+                                <check enabled="true" name="CERT-MSC39-C" />
+                                <check enabled="true" name="CERT-MSC40-C_a" />
+                                <check enabled="true" name="CERT-MSC40-C_b" />
+                                <check enabled="true" name="CERT-MSC40-C_c" />
+                                <check enabled="true" name="CERT-MSC40-C_d" />
+                                <check enabled="false" name="CERT-MSC40-C_e" />
+                                <check enabled="true" name="CERT-MSC41-C_a" />
+                                <check enabled="true" name="CERT-MSC41-C_b" />
+                                <check enabled="true" name="CERT-MSC41-C_c" />
+                            </group>
+                            <group enabled="true" name="CERT-PRE">
+                                <check enabled="true" name="CERT-PRE31-C" />
+                                <check enabled="true" name="CERT-PRE32-C_a" />
+                                <check enabled="true" name="CERT-PRE32-C_b" />
                             </group>
                             <group enabled="true" name="CERT-SIG">
-                                <check name="CERT-SIG31-C" enabled="true" />
+                                <check enabled="true" name="CERT-SIG30-C" />
+                                <check enabled="true" name="CERT-SIG31-C" />
+                                <check enabled="true" name="CERT-SIG34-C" />
+                                <check enabled="true" name="CERT-SIG35-C" />
+                            </group>
+                            <group enabled="true" name="CERT-STR">
+                                <check enabled="true" name="CERT-STR30-C" />
+                                <check enabled="true" name="CERT-STR31-C_a" />
+                                <check enabled="true" name="CERT-STR31-C_b" />
+                                <check enabled="true" name="CERT-STR31-C_c" />
+                                <check enabled="true" name="CERT-STR31-C_d" />
+                                <check enabled="true" name="CERT-STR31-C_e" />
+                                <check enabled="true" name="CERT-STR31-C_f" />
+                                <check enabled="true" name="CERT-STR31-C_g" />
+                                <check enabled="true" name="CERT-STR31-C_h" />
+                                <check enabled="true" name="CERT-STR32-C" />
+                                <check enabled="true" name="CERT-STR34-C" />
+                                <check enabled="true" name="CERT-STR37-C" />
                             </group>
                         </package>
-                        <package name="SECURITY" enabled="false">
+                        <package enabled="false" name="SECURITY">
                             <group enabled="true" name="SEC-BUFFER">
-                                <check name="SEC-BUFFER-memory-leak-alias" enabled="true" />
-                                <check name="SEC-BUFFER-memory-leak" enabled="false" />
-                                <check name="SEC-BUFFER-memset-overrun-pos" enabled="false" />
-                                <check name="SEC-BUFFER-memset-overrun" enabled="true" />
-                                <check name="SEC-BUFFER-qsort-overrun-pos" enabled="false" />
-                                <check name="SEC-BUFFER-qsort-overrun" enabled="true" />
-                                <check name="SEC-BUFFER-sprintf-overrun" enabled="true" />
-                                <check name="SEC-BUFFER-std-sort-overrun-pos" enabled="false" />
-                                <check name="SEC-BUFFER-std-sort-overrun" enabled="true" />
-                                <check name="SEC-BUFFER-strcat-overrun-pos" enabled="false" />
-                                <check name="SEC-BUFFER-strcat-overrun" enabled="true" />
-                                <check name="SEC-BUFFER-strcpy-overrun-pos" enabled="false" />
-                                <check name="SEC-BUFFER-strcpy-overrun" enabled="true" />
-                                <check name="SEC-BUFFER-strncat-overrun-pos" enabled="false" />
-                                <check name="SEC-BUFFER-strncat-overrun" enabled="true" />
-                                <check name="SEC-BUFFER-strncmp-overrun-pos" enabled="false" />
-                                <check name="SEC-BUFFER-strncmp-overrun" enabled="true" />
-                                <check name="SEC-BUFFER-strncpy-overrun-pos" enabled="false" />
-                                <check name="SEC-BUFFER-strncpy-overrun" enabled="true" />
-                                <check name="SEC-BUFFER-tainted-alloc-size" enabled="true" />
-                                <check name="SEC-BUFFER-tainted-copy-length" enabled="true" />
-                                <check name="SEC-BUFFER-tainted-copy" enabled="true" />
-                                <check name="SEC-BUFFER-tainted-index" enabled="true" />
-                                <check name="SEC-BUFFER-tainted-offset" enabled="true" />
-                                <check name="SEC-BUFFER-use-after-free-all" enabled="true" />
-                                <check name="SEC-BUFFER-use-after-free-some" enabled="true" />
+                                <check enabled="true" name="SEC-BUFFER-memory-leak-alias" />
+                                <check enabled="false" name="SEC-BUFFER-memory-leak" />
+                                <check enabled="false" name="SEC-BUFFER-memset-overrun-pos" />
+                                <check enabled="true" name="SEC-BUFFER-memset-overrun" />
+                                <check enabled="false" name="SEC-BUFFER-qsort-overrun-pos" />
+                                <check enabled="true" name="SEC-BUFFER-qsort-overrun" />
+                                <check enabled="true" name="SEC-BUFFER-sprintf-overrun" />
+                                <check enabled="false" name="SEC-BUFFER-std-sort-overrun-pos" />
+                                <check enabled="true" name="SEC-BUFFER-std-sort-overrun" />
+                                <check enabled="false" name="SEC-BUFFER-strcat-overrun-pos" />
+                                <check enabled="true" name="SEC-BUFFER-strcat-overrun" />
+                                <check enabled="false" name="SEC-BUFFER-strcpy-overrun-pos" />
+                                <check enabled="true" name="SEC-BUFFER-strcpy-overrun" />
+                                <check enabled="false" name="SEC-BUFFER-strncat-overrun-pos" />
+                                <check enabled="true" name="SEC-BUFFER-strncat-overrun" />
+                                <check enabled="false" name="SEC-BUFFER-strncmp-overrun-pos" />
+                                <check enabled="true" name="SEC-BUFFER-strncmp-overrun" />
+                                <check enabled="false" name="SEC-BUFFER-strncpy-overrun-pos" />
+                                <check enabled="true" name="SEC-BUFFER-strncpy-overrun" />
+                                <check enabled="true" name="SEC-BUFFER-tainted-alloc-size" />
+                                <check enabled="true" name="SEC-BUFFER-tainted-copy-length" />
+                                <check enabled="true" name="SEC-BUFFER-tainted-copy" />
+                                <check enabled="true" name="SEC-BUFFER-tainted-index" />
+                                <check enabled="true" name="SEC-BUFFER-tainted-offset" />
+                                <check enabled="true" name="SEC-BUFFER-use-after-free-all" />
+                                <check enabled="true" name="SEC-BUFFER-use-after-free-some" />
                             </group>
                             <group enabled="true" name="SEC-DIV-0">
-                                <check name="SEC-DIV-0-compare-after" enabled="true" />
-                                <check name="SEC-DIV-0-compare-before" enabled="true" />
-                                <check name="SEC-DIV-0-tainted" enabled="true" />
+                                <check enabled="true" name="SEC-DIV-0-compare-after" />
+                                <check enabled="true" name="SEC-DIV-0-compare-before" />
+                                <check enabled="true" name="SEC-DIV-0-tainted" />
                             </group>
                             <group enabled="true" name="SEC-FILEOP">
-                                <check name="SEC-FILEOP-open-no-close" enabled="true" />
-                                <check name="SEC-FILEOP-path-traversal" enabled="false" />
-                                <check name="SEC-FILEOP-use-after-close" enabled="true" />
+                                <check enabled="true" name="SEC-FILEOP-open-no-close" />
+                                <check enabled="false" name="SEC-FILEOP-path-traversal" />
+                                <check enabled="true" name="SEC-FILEOP-use-after-close" />
                             </group>
                             <group enabled="true" name="SEC-INJECTION">
-                                <check name="SEC-INJECTION-sql" enabled="false" />
-                                <check name="SEC-INJECTION-xpath" enabled="false" />
+                                <check enabled="false" name="SEC-INJECTION-sql" />
+                                <check enabled="false" name="SEC-INJECTION-xpath" />
                             </group>
                             <group enabled="true" name="SEC-LOOP">
-                                <check name="SEC-LOOP-tainted-bound" enabled="true" />
+                                <check enabled="true" name="SEC-LOOP-tainted-bound" />
                             </group>
                             <group enabled="true" name="SEC-NULL">
-                                <check name="SEC-NULL-assignment-fun-pos" enabled="false" />
-                                <check name="SEC-NULL-assignment" enabled="true" />
-                                <check name="SEC-NULL-cmp-aft" enabled="true" />
-                                <check name="SEC-NULL-cmp-bef-fun" enabled="true" />
-                                <check name="SEC-NULL-cmp-bef" enabled="true" />
-                                <check name="SEC-NULL-literal-pos" enabled="false" />
+                                <check enabled="false" name="SEC-NULL-assignment-fun-pos" />
+                                <check enabled="true" name="SEC-NULL-assignment" />
+                                <check enabled="true" name="SEC-NULL-cmp-aft" />
+                                <check enabled="true" name="SEC-NULL-cmp-bef-fun" />
+                                <check enabled="true" name="SEC-NULL-cmp-bef" />
+                                <check enabled="false" name="SEC-NULL-literal-pos" />
                             </group>
                             <group enabled="true" name="SEC-STRING">
-                                <check name="SEC-STRING-format-string" enabled="true" />
-                                <check name="SEC-STRING-hard-coded-credentials" enabled="false" />
+                                <check enabled="true" name="SEC-STRING-format-string" />
+                                <check enabled="false" name="SEC-STRING-hard-coded-credentials" />
                             </group>
                         </package>
-                        <package name="MISRAC2004" enabled="false">
+                        <package enabled="false" name="MISRAC2004">
                             <group enabled="true" name="MISRAC2004-1">
-                                <check name="MISRAC2004-1.1" enabled="true" />
-                                <check name="MISRAC2004-1.2_a" enabled="true" />
-                                <check name="MISRAC2004-1.2_b" enabled="true" />
-                                <check name="MISRAC2004-1.2_c" enabled="true" />
-                                <check name="MISRAC2004-1.2_d" enabled="true" />
-                                <check name="MISRAC2004-1.2_e" enabled="true" />
-                                <check name="MISRAC2004-1.2_f" enabled="true" />
-                                <check name="MISRAC2004-1.2_g" enabled="true" />
-                                <check name="MISRAC2004-1.2_h" enabled="true" />
-                                <check name="MISRAC2004-1.2_i" enabled="true" />
-                                <check name="MISRAC2004-1.2_j" enabled="true" />
+                                <check enabled="true" name="MISRAC2004-1.1" />
+                                <check enabled="true" name="MISRAC2004-1.2_a" />
+                                <check enabled="true" name="MISRAC2004-1.2_b" />
+                                <check enabled="true" name="MISRAC2004-1.2_c" />
+                                <check enabled="true" name="MISRAC2004-1.2_d" />
+                                <check enabled="true" name="MISRAC2004-1.2_e" />
+                                <check enabled="true" name="MISRAC2004-1.2_f" />
+                                <check enabled="true" name="MISRAC2004-1.2_g" />
+                                <check enabled="true" name="MISRAC2004-1.2_h" />
+                                <check enabled="true" name="MISRAC2004-1.2_i" />
+                                <check enabled="true" name="MISRAC2004-1.2_j" />
                             </group>
                             <group enabled="true" name="MISRAC2004-2">
-                                <check name="MISRAC2004-2.1" enabled="true" />
-                                <check name="MISRAC2004-2.2" enabled="true" />
-                                <check name="MISRAC2004-2.3" enabled="true" />
-                                <check name="MISRAC2004-2.4" enabled="false" />
+                                <check enabled="true" name="MISRAC2004-2.1" />
+                                <check enabled="true" name="MISRAC2004-2.2" />
+                                <check enabled="true" name="MISRAC2004-2.3" />
+                                <check enabled="false" name="MISRAC2004-2.4" />
                             </group>
                             <group enabled="true" name="MISRAC2004-5">
-                                <check name="MISRAC2004-5.1" enabled="true" />
-                                <check name="MISRAC2004-5.2" enabled="true" />
-                                <check name="MISRAC2004-5.3" enabled="true" />
-                                <check name="MISRAC2004-5.4" enabled="true" />
-                                <check name="MISRAC2004-5.5" enabled="false" />
-                                <check name="MISRAC2004-5.6" enabled="false" />
-                                <check name="MISRAC2004-5.7" enabled="false" />
+                                <check enabled="true" name="MISRAC2004-5.1" />
+                                <check enabled="true" name="MISRAC2004-5.2" />
+                                <check enabled="true" name="MISRAC2004-5.3" />
+                                <check enabled="true" name="MISRAC2004-5.4" />
+                                <check enabled="false" name="MISRAC2004-5.5" />
+                                <check enabled="false" name="MISRAC2004-5.6" />
+                                <check enabled="false" name="MISRAC2004-5.7" />
                             </group>
                             <group enabled="true" name="MISRAC2004-6">
-                                <check name="MISRAC2004-6.1" enabled="true" />
-                                <check name="MISRAC2004-6.2" enabled="true" />
-                                <check name="MISRAC2004-6.3" enabled="false" />
-                                <check name="MISRAC2004-6.4" enabled="true" />
-                                <check name="MISRAC2004-6.5" enabled="true" />
+                                <check enabled="true" name="MISRAC2004-6.1" />
+                                <check enabled="true" name="MISRAC2004-6.2" />
+                                <check enabled="false" name="MISRAC2004-6.3" />
+                                <check enabled="true" name="MISRAC2004-6.4" />
+                                <check enabled="true" name="MISRAC2004-6.5" />
                             </group>
                             <group enabled="true" name="MISRAC2004-7">
-                                <check name="MISRAC2004-7.1" enabled="true" />
+                                <check enabled="true" name="MISRAC2004-7.1" />
                             </group>
                             <group enabled="true" name="MISRAC2004-8">
-                                <check name="MISRAC2004-8.1" enabled="true" />
-                                <check name="MISRAC2004-8.2" enabled="true" />
-                                <check name="MISRAC2004-8.3" enabled="true" />
-                                <check name="MISRAC2004-8.5_a" enabled="true" />
-                                <check name="MISRAC2004-8.5_b" enabled="true" />
-                                <check name="MISRAC2004-8.6" enabled="true" />
-                                <check name="MISRAC2004-8.7" enabled="true" />
-                                <check name="MISRAC2004-8.8_a" enabled="true" />
-                                <check name="MISRAC2004-8.8_b" enabled="true" />
-                                <check name="MISRAC2004-8.10" enabled="true" />
-                                <check name="MISRAC2004-8.12" enabled="true" />
+                                <check enabled="true" name="MISRAC2004-8.1" />
+                                <check enabled="true" name="MISRAC2004-8.2" />
+                                <check enabled="true" name="MISRAC2004-8.3" />
+                                <check enabled="true" name="MISRAC2004-8.5_a" />
+                                <check enabled="true" name="MISRAC2004-8.5_b" />
+                                <check enabled="true" name="MISRAC2004-8.6" />
+                                <check enabled="true" name="MISRAC2004-8.7" />
+                                <check enabled="true" name="MISRAC2004-8.8_a" />
+                                <check enabled="true" name="MISRAC2004-8.8_b" />
+                                <check enabled="true" name="MISRAC2004-8.10" />
+                                <check enabled="true" name="MISRAC2004-8.12" />
                             </group>
                             <group enabled="true" name="MISRAC2004-9">
-                                <check name="MISRAC2004-9.1_a" enabled="true" />
-                                <check name="MISRAC2004-9.1_b" enabled="true" />
-                                <check name="MISRAC2004-9.1_c" enabled="true" />
-                                <check name="MISRAC2004-9.2" enabled="true" />
-                                <check name="MISRAC2004-9.3" enabled="true" />
+                                <check enabled="true" name="MISRAC2004-9.1_a" />
+                                <check enabled="true" name="MISRAC2004-9.1_b" />
+                                <check enabled="true" name="MISRAC2004-9.1_c" />
+                                <check enabled="true" name="MISRAC2004-9.2" />
+                                <check enabled="true" name="MISRAC2004-9.3" />
                             </group>
                             <group enabled="true" name="MISRAC2004-10">
-                                <check name="MISRAC2004-10.1_a" enabled="true" />
-                                <check name="MISRAC2004-10.1_b" enabled="true" />
-                                <check name="MISRAC2004-10.1_c" enabled="true" />
-                                <check name="MISRAC2004-10.1_d" enabled="true" />
-                                <check name="MISRAC2004-10.2_a" enabled="true" />
-                                <check name="MISRAC2004-10.2_b" enabled="true" />
-                                <check name="MISRAC2004-10.2_c" enabled="true" />
-                                <check name="MISRAC2004-10.2_d" enabled="true" />
-                                <check name="MISRAC2004-10.3" enabled="true" />
-                                <check name="MISRAC2004-10.4" enabled="true" />
-                                <check name="MISRAC2004-10.5" enabled="true" />
-                                <check name="MISRAC2004-10.6" enabled="true" />
+                                <check enabled="true" name="MISRAC2004-10.1_a" />
+                                <check enabled="true" name="MISRAC2004-10.1_b" />
+                                <check enabled="true" name="MISRAC2004-10.1_c" />
+                                <check enabled="true" name="MISRAC2004-10.1_d" />
+                                <check enabled="true" name="MISRAC2004-10.2_a" />
+                                <check enabled="true" name="MISRAC2004-10.2_b" />
+                                <check enabled="true" name="MISRAC2004-10.2_c" />
+                                <check enabled="true" name="MISRAC2004-10.2_d" />
+                                <check enabled="true" name="MISRAC2004-10.3" />
+                                <check enabled="true" name="MISRAC2004-10.4" />
+                                <check enabled="true" name="MISRAC2004-10.5" />
+                                <check enabled="true" name="MISRAC2004-10.6" />
                             </group>
                             <group enabled="true" name="MISRAC2004-11">
-                                <check name="MISRAC2004-11.1" enabled="true" />
-                                <check name="MISRAC2004-11.3" enabled="false" />
-                                <check name="MISRAC2004-11.4" enabled="false" />
-                                <check name="MISRAC2004-11.5" enabled="true" />
+                                <check enabled="true" name="MISRAC2004-11.1" />
+                                <check enabled="false" name="MISRAC2004-11.3" />
+                                <check enabled="false" name="MISRAC2004-11.4" />
+                                <check enabled="true" name="MISRAC2004-11.5" />
                             </group>
                             <group enabled="true" name="MISRAC2004-12">
-                                <check name="MISRAC2004-12.1" enabled="false" />
-                                <check name="MISRAC2004-12.2_a" enabled="true" />
-                                <check name="MISRAC2004-12.2_b" enabled="true" />
-                                <check name="MISRAC2004-12.2_c" enabled="true" />
-                                <check name="MISRAC2004-12.3" enabled="true" />
-                                <check name="MISRAC2004-12.4" enabled="true" />
-                                <check name="MISRAC2004-12.5" enabled="true" />
-                                <check name="MISRAC2004-12.6_a" enabled="false" />
-                                <check name="MISRAC2004-12.6_b" enabled="false" />
-                                <check name="MISRAC2004-12.7" enabled="true" />
-                                <check name="MISRAC2004-12.8" enabled="true" />
-                                <check name="MISRAC2004-12.9" enabled="true" />
-                                <check name="MISRAC2004-12.10" enabled="true" />
-                                <check name="MISRAC2004-12.11" enabled="false" />
-                                <check name="MISRAC2004-12.12_a" enabled="true" />
-                                <check name="MISRAC2004-12.12_b" enabled="true" />
-                                <check name="MISRAC2004-12.13" enabled="false" />
+                                <check enabled="false" name="MISRAC2004-12.1" />
+                                <check enabled="true" name="MISRAC2004-12.2_a" />
+                                <check enabled="true" name="MISRAC2004-12.2_b" />
+                                <check enabled="true" name="MISRAC2004-12.2_c" />
+                                <check enabled="true" name="MISRAC2004-12.3" />
+                                <check enabled="true" name="MISRAC2004-12.4" />
+                                <check enabled="true" name="MISRAC2004-12.5" />
+                                <check enabled="false" name="MISRAC2004-12.6_a" />
+                                <check enabled="false" name="MISRAC2004-12.6_b" />
+                                <check enabled="true" name="MISRAC2004-12.7" />
+                                <check enabled="true" name="MISRAC2004-12.8" />
+                                <check enabled="true" name="MISRAC2004-12.9" />
+                                <check enabled="true" name="MISRAC2004-12.10" />
+                                <check enabled="false" name="MISRAC2004-12.11" />
+                                <check enabled="true" name="MISRAC2004-12.12_a" />
+                                <check enabled="true" name="MISRAC2004-12.12_b" />
+                                <check enabled="false" name="MISRAC2004-12.13" />
                             </group>
                             <group enabled="true" name="MISRAC2004-13">
-                                <check name="MISRAC2004-13.1" enabled="true" />
-                                <check name="MISRAC2004-13.2_a" enabled="false" />
-                                <check name="MISRAC2004-13.2_b" enabled="false" />
-                                <check name="MISRAC2004-13.2_c" enabled="false" />
-                                <check name="MISRAC2004-13.2_d" enabled="false" />
-                                <check name="MISRAC2004-13.2_e" enabled="false" />
-                                <check name="MISRAC2004-13.3" enabled="true" />
-                                <check name="MISRAC2004-13.4" enabled="true" />
-                                <check name="MISRAC2004-13.5" enabled="true" />
-                                <check name="MISRAC2004-13.6" enabled="true" />
-                                <check name="MISRAC2004-13.7_a" enabled="true" />
-                                <check name="MISRAC2004-13.7_b" enabled="true" />
+                                <check enabled="true" name="MISRAC2004-13.1" />
+                                <check enabled="false" name="MISRAC2004-13.2_a" />
+                                <check enabled="false" name="MISRAC2004-13.2_b" />
+                                <check enabled="false" name="MISRAC2004-13.2_c" />
+                                <check enabled="false" name="MISRAC2004-13.2_d" />
+                                <check enabled="false" name="MISRAC2004-13.2_e" />
+                                <check enabled="true" name="MISRAC2004-13.3" />
+                                <check enabled="true" name="MISRAC2004-13.4" />
+                                <check enabled="true" name="MISRAC2004-13.5" />
+                                <check enabled="true" name="MISRAC2004-13.6" />
+                                <check enabled="true" name="MISRAC2004-13.7_a" />
+                                <check enabled="true" name="MISRAC2004-13.7_b" />
                             </group>
                             <group enabled="true" name="MISRAC2004-14">
-                                <check name="MISRAC2004-14.1" enabled="true" />
-                                <check name="MISRAC2004-14.2" enabled="true" />
-                                <check name="MISRAC2004-14.3" enabled="true" />
-                                <check name="MISRAC2004-14.4" enabled="true" />
-                                <check name="MISRAC2004-14.5" enabled="true" />
-                                <check name="MISRAC2004-14.6" enabled="true" />
-                                <check name="MISRAC2004-14.7" enabled="true" />
-                                <check name="MISRAC2004-14.8_a" enabled="true" />
-                                <check name="MISRAC2004-14.8_b" enabled="true" />
-                                <check name="MISRAC2004-14.8_c" enabled="true" />
-                                <check name="MISRAC2004-14.8_d" enabled="true" />
-                                <check name="MISRAC2004-14.9" enabled="true" />
-                                <check name="MISRAC2004-14.10" enabled="true" />
+                                <check enabled="true" name="MISRAC2004-14.1" />
+                                <check enabled="true" name="MISRAC2004-14.2" />
+                                <check enabled="true" name="MISRAC2004-14.3" />
+                                <check enabled="true" name="MISRAC2004-14.4" />
+                                <check enabled="true" name="MISRAC2004-14.5" />
+                                <check enabled="true" name="MISRAC2004-14.6" />
+                                <check enabled="true" name="MISRAC2004-14.7" />
+                                <check enabled="true" name="MISRAC2004-14.8_a" />
+                                <check enabled="true" name="MISRAC2004-14.8_b" />
+                                <check enabled="true" name="MISRAC2004-14.8_c" />
+                                <check enabled="true" name="MISRAC2004-14.8_d" />
+                                <check enabled="true" name="MISRAC2004-14.9" />
+                                <check enabled="true" name="MISRAC2004-14.10" />
                             </group>
                             <group enabled="true" name="MISRAC2004-15">
-                                <check name="MISRAC2004-15.0" enabled="true" />
-                                <check name="MISRAC2004-15.1" enabled="true" />
-                                <check name="MISRAC2004-15.2" enabled="true" />
-                                <check name="MISRAC2004-15.3" enabled="true" />
-                                <check name="MISRAC2004-15.4" enabled="true" />
-                                <check name="MISRAC2004-15.5" enabled="true" />
+                                <check enabled="true" name="MISRAC2004-15.0" />
+                                <check enabled="true" name="MISRAC2004-15.1" />
+                                <check enabled="true" name="MISRAC2004-15.2" />
+                                <check enabled="true" name="MISRAC2004-15.3" />
+                                <check enabled="true" name="MISRAC2004-15.4" />
+                                <check enabled="true" name="MISRAC2004-15.5" />
                             </group>
                             <group enabled="true" name="MISRAC2004-16">
-                                <check name="MISRAC2004-16.1" enabled="true" />
-                                <check name="MISRAC2004-16.2_a" enabled="true" />
-                                <check name="MISRAC2004-16.2_b" enabled="true" />
-                                <check name="MISRAC2004-16.3" enabled="true" />
-                                <check name="MISRAC2004-16.4" enabled="true" />
-                                <check name="MISRAC2004-16.5" enabled="true" />
-                                <check name="MISRAC2004-16.7" enabled="true" />
-                                <check name="MISRAC2004-16.8" enabled="true" />
-                                <check name="MISRAC2004-16.9" enabled="true" />
-                                <check name="MISRAC2004-16.10" enabled="true" />
+                                <check enabled="true" name="MISRAC2004-16.1" />
+                                <check enabled="true" name="MISRAC2004-16.2_a" />
+                                <check enabled="true" name="MISRAC2004-16.2_b" />
+                                <check enabled="true" name="MISRAC2004-16.3" />
+                                <check enabled="true" name="MISRAC2004-16.4" />
+                                <check enabled="true" name="MISRAC2004-16.5" />
+                                <check enabled="true" name="MISRAC2004-16.7" />
+                                <check enabled="true" name="MISRAC2004-16.8" />
+                                <check enabled="true" name="MISRAC2004-16.9" />
+                                <check enabled="true" name="MISRAC2004-16.10" />
                             </group>
                             <group enabled="true" name="MISRAC2004-17">
-                                <check name="MISRAC2004-17.1_a" enabled="true" />
-                                <check name="MISRAC2004-17.1_b" enabled="true" />
-                                <check name="MISRAC2004-17.1_c" enabled="true" />
-                                <check name="MISRAC2004-17.2" enabled="true" />
-                                <check name="MISRAC2004-17.3" enabled="true" />
-                                <check name="MISRAC2004-17.4_a" enabled="true" />
-                                <check name="MISRAC2004-17.4_b" enabled="true" />
-                                <check name="MISRAC2004-17.5" enabled="true" />
-                                <check name="MISRAC2004-17.6_a" enabled="true" />
-                                <check name="MISRAC2004-17.6_b" enabled="true" />
-                                <check name="MISRAC2004-17.6_c" enabled="true" />
-                                <check name="MISRAC2004-17.6_d" enabled="true" />
+                                <check enabled="true" name="MISRAC2004-17.1_a" />
+                                <check enabled="true" name="MISRAC2004-17.1_b" />
+                                <check enabled="true" name="MISRAC2004-17.1_c" />
+                                <check enabled="true" name="MISRAC2004-17.2" />
+                                <check enabled="true" name="MISRAC2004-17.3" />
+                                <check enabled="true" name="MISRAC2004-17.4_a" />
+                                <check enabled="true" name="MISRAC2004-17.4_b" />
+                                <check enabled="true" name="MISRAC2004-17.5" />
+                                <check enabled="true" name="MISRAC2004-17.6_a" />
+                                <check enabled="true" name="MISRAC2004-17.6_b" />
+                                <check enabled="true" name="MISRAC2004-17.6_c" />
+                                <check enabled="true" name="MISRAC2004-17.6_d" />
                             </group>
                             <group enabled="true" name="MISRAC2004-18">
-                                <check name="MISRAC2004-18.1" enabled="true" />
-                                <check name="MISRAC2004-18.2" enabled="true" />
-                                <check name="MISRAC2004-18.4" enabled="true" />
+                                <check enabled="true" name="MISRAC2004-18.1" />
+                                <check enabled="true" name="MISRAC2004-18.2" />
+                                <check enabled="true" name="MISRAC2004-18.4" />
                             </group>
                             <group enabled="true" name="MISRAC2004-19">
-                                <check name="MISRAC2004-19.1" enabled="false" />
-                                <check name="MISRAC2004-19.2" enabled="false" />
-                                <check name="MISRAC2004-19.4" enabled="true" />
-                                <check name="MISRAC2004-19.5" enabled="true" />
-                                <check name="MISRAC2004-19.6" enabled="true" />
-                                <check name="MISRAC2004-19.7" enabled="false" />
-                                <check name="MISRAC2004-19.10" enabled="true" />
-                                <check name="MISRAC2004-19.12" enabled="true" />
-                                <check name="MISRAC2004-19.13" enabled="false" />
-                                <check name="MISRAC2004-19.15" enabled="true" />
+                                <check enabled="false" name="MISRAC2004-19.1" />
+                                <check enabled="false" name="MISRAC2004-19.2" />
+                                <check enabled="true" name="MISRAC2004-19.4" />
+                                <check enabled="true" name="MISRAC2004-19.5" />
+                                <check enabled="true" name="MISRAC2004-19.6" />
+                                <check enabled="false" name="MISRAC2004-19.7" />
+                                <check enabled="true" name="MISRAC2004-19.10" />
+                                <check enabled="true" name="MISRAC2004-19.12" />
+                                <check enabled="false" name="MISRAC2004-19.13" />
+                                <check enabled="true" name="MISRAC2004-19.15" />
                             </group>
                             <group enabled="true" name="MISRAC2004-20">
-                                <check name="MISRAC2004-20.1" enabled="true" />
-                                <check name="MISRAC2004-20.2" enabled="true" />
-                                <check name="MISRAC2004-20.3_a" enabled="true" />
-                                <check name="MISRAC2004-20.3_b" enabled="true" />
-                                <check name="MISRAC2004-20.3_c" enabled="true" />
-                                <check name="MISRAC2004-20.3_d" enabled="true" />
-                                <check name="MISRAC2004-20.3_e" enabled="true" />
-                                <check name="MISRAC2004-20.3_f" enabled="true" />
-                                <check name="MISRAC2004-20.3_g" enabled="true" />
-                                <check name="MISRAC2004-20.3_h" enabled="true" />
-                                <check name="MISRAC2004-20.3_i" enabled="true" />
-                                <check name="MISRAC2004-20.4" enabled="true" />
-                                <check name="MISRAC2004-20.5" enabled="true" />
-                                <check name="MISRAC2004-20.6" enabled="true" />
-                                <check name="MISRAC2004-20.7" enabled="true" />
-                                <check name="MISRAC2004-20.8" enabled="true" />
-                                <check name="MISRAC2004-20.9" enabled="true" />
-                                <check name="MISRAC2004-20.10" enabled="true" />
-                                <check name="MISRAC2004-20.11" enabled="true" />
-                                <check name="MISRAC2004-20.12" enabled="true" />
+                                <check enabled="true" name="MISRAC2004-20.1" />
+                                <check enabled="true" name="MISRAC2004-20.2" />
+                                <check enabled="true" name="MISRAC2004-20.3_a" />
+                                <check enabled="true" name="MISRAC2004-20.3_b" />
+                                <check enabled="true" name="MISRAC2004-20.3_c" />
+                                <check enabled="true" name="MISRAC2004-20.3_d" />
+                                <check enabled="true" name="MISRAC2004-20.3_e" />
+                                <check enabled="true" name="MISRAC2004-20.3_f" />
+                                <check enabled="true" name="MISRAC2004-20.3_g" />
+                                <check enabled="true" name="MISRAC2004-20.3_h" />
+                                <check enabled="true" name="MISRAC2004-20.3_i" />
+                                <check enabled="true" name="MISRAC2004-20.4" />
+                                <check enabled="true" name="MISRAC2004-20.5" />
+                                <check enabled="true" name="MISRAC2004-20.6" />
+                                <check enabled="true" name="MISRAC2004-20.7" />
+                                <check enabled="true" name="MISRAC2004-20.8" />
+                                <check enabled="true" name="MISRAC2004-20.9" />
+                                <check enabled="true" name="MISRAC2004-20.10" />
+                                <check enabled="true" name="MISRAC2004-20.11" />
+                                <check enabled="true" name="MISRAC2004-20.12" />
                             </group>
                         </package>
-                        <package name="MISRAC2012" enabled="false">
+                        <package enabled="false" name="MISRAC2012">
                             <group enabled="true" name="MISRAC2012-Dir-4">
-                                <check name="MISRAC2012-Dir-4.3" enabled="true" />
-                                <check name="MISRAC2012-Dir-4.4" enabled="false" />
-                                <check name="MISRAC2012-Dir-4.5" enabled="false" />
-                                <check name="MISRAC2012-Dir-4.6_a" enabled="false" />
-                                <check name="MISRAC2012-Dir-4.6_b" enabled="false" />
-                                <check name="MISRAC2012-Dir-4.7_a" enabled="false" />
-                                <check name="MISRAC2012-Dir-4.7_b" enabled="false" />
-                                <check name="MISRAC2012-Dir-4.7_c" enabled="false" />
-                                <check name="MISRAC2012-Dir-4.8" enabled="false" />
-                                <check name="MISRAC2012-Dir-4.9" enabled="false" />
-                                <check name="MISRAC2012-Dir-4.10" enabled="true" />
-                                <check name="MISRAC2012-Dir-4.11_a" enabled="false" />
-                                <check name="MISRAC2012-Dir-4.11_b" enabled="false" />
-                                <check name="MISRAC2012-Dir-4.11_c" enabled="false" />
-                                <check name="MISRAC2012-Dir-4.11_d" enabled="false" />
-                                <check name="MISRAC2012-Dir-4.11_e" enabled="false" />
-                                <check name="MISRAC2012-Dir-4.11_f" enabled="false" />
-                                <check name="MISRAC2012-Dir-4.11_g" enabled="false" />
-                                <check name="MISRAC2012-Dir-4.11_h" enabled="false" />
-                                <check name="MISRAC2012-Dir-4.11_i" enabled="false" />
-                                <check name="MISRAC2012-Dir-4.12" enabled="false" />
-                                <check name="MISRAC2012-Dir-4.13_b" enabled="true" />
-                                <check name="MISRAC2012-Dir-4.13_c" enabled="true" />
-                                <check name="MISRAC2012-Dir-4.13_d" enabled="true" />
-                                <check name="MISRAC2012-Dir-4.13_e" enabled="true" />
-                                <check name="MISRAC2012-Dir-4.13_f" enabled="true" />
-                                <check name="MISRAC2012-Dir-4.13_g" enabled="true" />
-                                <check name="MISRAC2012-Dir-4.13_h" enabled="false" />
+                                <check enabled="true" name="MISRAC2012-Dir-4.3" />
+                                <check enabled="false" name="MISRAC2012-Dir-4.4" />
+                                <check enabled="false" name="MISRAC2012-Dir-4.5" />
+                                <check enabled="false" name="MISRAC2012-Dir-4.6_a" />
+                                <check enabled="false" name="MISRAC2012-Dir-4.6_b" />
+                                <check enabled="false" name="MISRAC2012-Dir-4.7_a" />
+                                <check enabled="false" name="MISRAC2012-Dir-4.7_b" />
+                                <check enabled="false" name="MISRAC2012-Dir-4.7_c" />
+                                <check enabled="false" name="MISRAC2012-Dir-4.8" />
+                                <check enabled="false" name="MISRAC2012-Dir-4.9" />
+                                <check enabled="true" name="MISRAC2012-Dir-4.10" />
+                                <check enabled="false" name="MISRAC2012-Dir-4.11_a" />
+                                <check enabled="false" name="MISRAC2012-Dir-4.11_b" />
+                                <check enabled="false" name="MISRAC2012-Dir-4.11_c" />
+                                <check enabled="false" name="MISRAC2012-Dir-4.11_d" />
+                                <check enabled="false" name="MISRAC2012-Dir-4.11_e" />
+                                <check enabled="false" name="MISRAC2012-Dir-4.11_f" />
+                                <check enabled="false" name="MISRAC2012-Dir-4.11_g" />
+                                <check enabled="false" name="MISRAC2012-Dir-4.11_h" />
+                                <check enabled="false" name="MISRAC2012-Dir-4.11_i" />
+                                <check enabled="false" name="MISRAC2012-Dir-4.12" />
+                                <check enabled="true" name="MISRAC2012-Dir-4.13_b" />
+                                <check enabled="true" name="MISRAC2012-Dir-4.13_c" />
+                                <check enabled="true" name="MISRAC2012-Dir-4.13_d" />
+                                <check enabled="true" name="MISRAC2012-Dir-4.13_e" />
+                                <check enabled="true" name="MISRAC2012-Dir-4.13_f" />
+                                <check enabled="true" name="MISRAC2012-Dir-4.13_g" />
+                                <check enabled="false" name="MISRAC2012-Dir-4.13_h" />
+                                <check enabled="true" name="MISRAC2012-Dir-4.14_a" />
+                                <check enabled="true" name="MISRAC2012-Dir-4.14_b" />
+                                <check enabled="true" name="MISRAC2012-Dir-4.14_c" />
+                                <check enabled="true" name="MISRAC2012-Dir-4.14_d" />
+                                <check enabled="true" name="MISRAC2012-Dir-4.14_e" />
+                                <check enabled="true" name="MISRAC2012-Dir-4.14_f" />
+                                <check enabled="true" name="MISRAC2012-Dir-4.14_g" />
+                                <check enabled="true" name="MISRAC2012-Dir-4.14_h" />
+                                <check enabled="true" name="MISRAC2012-Dir-4.14_i" />
+                                <check enabled="true" name="MISRAC2012-Dir-4.14_j" />
+                                <check enabled="true" name="MISRAC2012-Dir-4.14_l" />
+                                <check enabled="true" name="MISRAC2012-Dir-4.14_m" />
                             </group>
                             <group enabled="true" name="MISRAC2012-Rule-1">
-                                <check name="MISRAC2012-Rule-1.3_a" enabled="true" />
-                                <check name="MISRAC2012-Rule-1.3_b" enabled="true" />
-                                <check name="MISRAC2012-Rule-1.3_c" enabled="true" />
-                                <check name="MISRAC2012-Rule-1.3_d" enabled="true" />
-                                <check name="MISRAC2012-Rule-1.3_e" enabled="true" />
-                                <check name="MISRAC2012-Rule-1.3_f" enabled="true" />
-                                <check name="MISRAC2012-Rule-1.3_g" enabled="true" />
-                                <check name="MISRAC2012-Rule-1.3_h" enabled="true" />
-                                <check name="MISRAC2012-Rule-1.3_i" enabled="true" />
-                                <check name="MISRAC2012-Rule-1.3_j" enabled="true" />
-                                <check name="MISRAC2012-Rule-1.3_k" enabled="true" />
-                                <check name="MISRAC2012-Rule-1.3_m" enabled="true" />
-                                <check name="MISRAC2012-Rule-1.3_n" enabled="true" />
-                                <check name="MISRAC2012-Rule-1.3_o" enabled="true" />
-                                <check name="MISRAC2012-Rule-1.3_p" enabled="true" />
-                                <check name="MISRAC2012-Rule-1.3_q" enabled="true" />
-                                <check name="MISRAC2012-Rule-1.3_r" enabled="true" />
-                                <check name="MISRAC2012-Rule-1.3_s" enabled="true" />
-                                <check name="MISRAC2012-Rule-1.3_t" enabled="true" />
-                                <check name="MISRAC2012-Rule-1.3_u" enabled="true" />
-                                <check name="MISRAC2012-Rule-1.3_v" enabled="true" />
-                                <check name="MISRAC2012-Rule-1.3_w" enabled="true" />
+                                <check enabled="true" name="MISRAC2012-Rule-1.3_a" />
+                                <check enabled="true" name="MISRAC2012-Rule-1.3_b" />
+                                <check enabled="true" name="MISRAC2012-Rule-1.3_c" />
+                                <check enabled="true" name="MISRAC2012-Rule-1.3_d" />
+                                <check enabled="true" name="MISRAC2012-Rule-1.3_e" />
+                                <check enabled="true" name="MISRAC2012-Rule-1.3_f" />
+                                <check enabled="true" name="MISRAC2012-Rule-1.3_g" />
+                                <check enabled="true" name="MISRAC2012-Rule-1.3_h" />
+                                <check enabled="true" name="MISRAC2012-Rule-1.3_i" />
+                                <check enabled="true" name="MISRAC2012-Rule-1.3_j" />
+                                <check enabled="true" name="MISRAC2012-Rule-1.3_k" />
+                                <check enabled="true" name="MISRAC2012-Rule-1.3_m" />
+                                <check enabled="true" name="MISRAC2012-Rule-1.3_n" />
+                                <check enabled="true" name="MISRAC2012-Rule-1.3_o" />
+                                <check enabled="true" name="MISRAC2012-Rule-1.3_p" />
+                                <check enabled="true" name="MISRAC2012-Rule-1.3_q" />
+                                <check enabled="true" name="MISRAC2012-Rule-1.3_r" />
+                                <check enabled="true" name="MISRAC2012-Rule-1.3_s" />
+                                <check enabled="true" name="MISRAC2012-Rule-1.3_t" />
+                                <check enabled="true" name="MISRAC2012-Rule-1.3_u" />
+                                <check enabled="true" name="MISRAC2012-Rule-1.3_v" />
+                                <check enabled="true" name="MISRAC2012-Rule-1.3_w" />
                             </group>
                             <group enabled="true" name="MISRAC2012-Rule-2">
-                                <check name="MISRAC2012-Rule-2.1_a" enabled="true" />
-                                <check name="MISRAC2012-Rule-2.1_b" enabled="true" />
-                                <check name="MISRAC2012-Rule-2.2_a" enabled="true" />
-                                <check name="MISRAC2012-Rule-2.2_b" enabled="true" />
-                                <check name="MISRAC2012-Rule-2.2_c" enabled="true" />
-                                <check name="MISRAC2012-Rule-2.3" enabled="false" />
-                                <check name="MISRAC2012-Rule-2.4" enabled="false" />
-                                <check name="MISRAC2012-Rule-2.5" enabled="false" />
-                                <check name="MISRAC2012-Rule-2.6" enabled="false" />
-                                <check name="MISRAC2012-Rule-2.7" enabled="false" />
+                                <check enabled="true" name="MISRAC2012-Rule-2.1_a" />
+                                <check enabled="true" name="MISRAC2012-Rule-2.1_b" />
+                                <check enabled="true" name="MISRAC2012-Rule-2.2_a" />
+                                <check enabled="true" name="MISRAC2012-Rule-2.2_b" />
+                                <check enabled="true" name="MISRAC2012-Rule-2.2_c" />
+                                <check enabled="false" name="MISRAC2012-Rule-2.3" />
+                                <check enabled="false" name="MISRAC2012-Rule-2.4" />
+                                <check enabled="false" name="MISRAC2012-Rule-2.5" />
+                                <check enabled="false" name="MISRAC2012-Rule-2.6" />
+                                <check enabled="false" name="MISRAC2012-Rule-2.7" />
                             </group>
                             <group enabled="true" name="MISRAC2012-Rule-3">
-                                <check name="MISRAC2012-Rule-3.1" enabled="true" />
-                                <check name="MISRAC2012-Rule-3.2" enabled="true" />
+                                <check enabled="true" name="MISRAC2012-Rule-3.1" />
+                                <check enabled="true" name="MISRAC2012-Rule-3.2" />
                             </group>
                             <group enabled="true" name="MISRAC2012-Rule-5">
-                                <check name="MISRAC2012-Rule-5.1" enabled="true" />
-                                <check name="MISRAC2012-Rule-5.2_c89" enabled="true" />
-                                <check name="MISRAC2012-Rule-5.2_c99" enabled="true" />
-                                <check name="MISRAC2012-Rule-5.3_c89" enabled="true" />
-                                <check name="MISRAC2012-Rule-5.3_c99" enabled="true" />
-                                <check name="MISRAC2012-Rule-5.4_c89" enabled="true" />
-                                <check name="MISRAC2012-Rule-5.4_c99" enabled="true" />
-                                <check name="MISRAC2012-Rule-5.5_c89" enabled="true" />
-                                <check name="MISRAC2012-Rule-5.5_c99" enabled="true" />
-                                <check name="MISRAC2012-Rule-5.6" enabled="true" />
-                                <check name="MISRAC2012-Rule-5.7" enabled="true" />
-                                <check name="MISRAC2012-Rule-5.8" enabled="true" />
-                                <check name="MISRAC2012-Rule-5.9" enabled="false" />
+                                <check enabled="true" name="MISRAC2012-Rule-5.1" />
+                                <check enabled="true" name="MISRAC2012-Rule-5.2_c89" />
+                                <check enabled="true" name="MISRAC2012-Rule-5.2_c99" />
+                                <check enabled="true" name="MISRAC2012-Rule-5.3_c89" />
+                                <check enabled="true" name="MISRAC2012-Rule-5.3_c99" />
+                                <check enabled="true" name="MISRAC2012-Rule-5.4_c89" />
+                                <check enabled="true" name="MISRAC2012-Rule-5.4_c99" />
+                                <check enabled="true" name="MISRAC2012-Rule-5.5_c89" />
+                                <check enabled="true" name="MISRAC2012-Rule-5.5_c99" />
+                                <check enabled="true" name="MISRAC2012-Rule-5.6" />
+                                <check enabled="true" name="MISRAC2012-Rule-5.7" />
+                                <check enabled="true" name="MISRAC2012-Rule-5.8" />
+                                <check enabled="false" name="MISRAC2012-Rule-5.9" />
                             </group>
                             <group enabled="true" name="MISRAC2012-Rule-6">
-                                <check name="MISRAC2012-Rule-6.1" enabled="true" />
-                                <check name="MISRAC2012-Rule-6.2" enabled="true" />
+                                <check enabled="true" name="MISRAC2012-Rule-6.1" />
+                                <check enabled="true" name="MISRAC2012-Rule-6.2" />
                             </group>
                             <group enabled="true" name="MISRAC2012-Rule-7">
-                                <check name="MISRAC2012-Rule-7.1" enabled="true" />
-                                <check name="MISRAC2012-Rule-7.2" enabled="true" />
-                                <check name="MISRAC2012-Rule-7.3" enabled="true" />
-                                <check name="MISRAC2012-Rule-7.4_a" enabled="true" />
-                                <check name="MISRAC2012-Rule-7.4_b" enabled="true" />
+                                <check enabled="true" name="MISRAC2012-Rule-7.1" />
+                                <check enabled="true" name="MISRAC2012-Rule-7.2" />
+                                <check enabled="true" name="MISRAC2012-Rule-7.3" />
+                                <check enabled="true" name="MISRAC2012-Rule-7.4_a" />
+                                <check enabled="true" name="MISRAC2012-Rule-7.4_b" />
                             </group>
                             <group enabled="true" name="MISRAC2012-Rule-8">
-                                <check name="MISRAC2012-Rule-8.1" enabled="true" />
-                                <check name="MISRAC2012-Rule-8.2_a" enabled="true" />
-                                <check name="MISRAC2012-Rule-8.2_b" enabled="true" />
-                                <check name="MISRAC2012-Rule-8.3_b" enabled="true" />
-                                <check name="MISRAC2012-Rule-8.4" enabled="true" />
-                                <check name="MISRAC2012-Rule-8.5_a" enabled="true" />
-                                <check name="MISRAC2012-Rule-8.5_b" enabled="true" />
-                                <check name="MISRAC2012-Rule-8.7" enabled="false" />
-                                <check name="MISRAC2012-Rule-8.9_a" enabled="false" />
-                                <check name="MISRAC2012-Rule-8.9_b" enabled="false" />
-                                <check name="MISRAC2012-Rule-8.10" enabled="true" />
-                                <check name="MISRAC2012-Rule-8.11" enabled="false" />
-                                <check name="MISRAC2012-Rule-8.12" enabled="true" />
-                                <check name="MISRAC2012-Rule-8.13" enabled="false" />
-                                <check name="MISRAC2012-Rule-8.14" enabled="true" />
+                                <check enabled="true" name="MISRAC2012-Rule-8.1" />
+                                <check enabled="true" name="MISRAC2012-Rule-8.2_a" />
+                                <check enabled="true" name="MISRAC2012-Rule-8.2_b" />
+                                <check enabled="true" name="MISRAC2012-Rule-8.3" />
+                                <check enabled="true" name="MISRAC2012-Rule-8.4" />
+                                <check enabled="true" name="MISRAC2012-Rule-8.5_a" />
+                                <check enabled="true" name="MISRAC2012-Rule-8.5_b" />
+                                <check enabled="false" name="MISRAC2012-Rule-8.7" />
+                                <check enabled="false" name="MISRAC2012-Rule-8.9_a" />
+                                <check enabled="false" name="MISRAC2012-Rule-8.9_b" />
+                                <check enabled="true" name="MISRAC2012-Rule-8.10" />
+                                <check enabled="false" name="MISRAC2012-Rule-8.11" />
+                                <check enabled="true" name="MISRAC2012-Rule-8.12" />
+                                <check enabled="false" name="MISRAC2012-Rule-8.13" />
+                                <check enabled="true" name="MISRAC2012-Rule-8.14" />
                             </group>
                             <group enabled="true" name="MISRAC2012-Rule-9">
-                                <check name="MISRAC2012-Rule-9.1_a" enabled="true" />
-                                <check name="MISRAC2012-Rule-9.1_b" enabled="true" />
-                                <check name="MISRAC2012-Rule-9.1_c" enabled="true" />
-                                <check name="MISRAC2012-Rule-9.1_d" enabled="true" />
-                                <check name="MISRAC2012-Rule-9.1_e" enabled="true" />
-                                <check name="MISRAC2012-Rule-9.1_f" enabled="true" />
-                                <check name="MISRAC2012-Rule-9.2" enabled="true" />
-                                <check name="MISRAC2012-Rule-9.3" enabled="true" />
-                                <check name="MISRAC2012-Rule-9.4" enabled="true" />
-                                <check name="MISRAC2012-Rule-9.5_a" enabled="true" />
-                                <check name="MISRAC2012-Rule-9.5_b" enabled="true" />
+                                <check enabled="true" name="MISRAC2012-Rule-9.1_a" />
+                                <check enabled="true" name="MISRAC2012-Rule-9.1_b" />
+                                <check enabled="true" name="MISRAC2012-Rule-9.1_c" />
+                                <check enabled="true" name="MISRAC2012-Rule-9.1_d" />
+                                <check enabled="true" name="MISRAC2012-Rule-9.1_e" />
+                                <check enabled="true" name="MISRAC2012-Rule-9.1_f" />
+                                <check enabled="true" name="MISRAC2012-Rule-9.2" />
+                                <check enabled="true" name="MISRAC2012-Rule-9.3" />
+                                <check enabled="true" name="MISRAC2012-Rule-9.4" />
+                                <check enabled="true" name="MISRAC2012-Rule-9.5_a" />
+                                <check enabled="true" name="MISRAC2012-Rule-9.5_b" />
                             </group>
                             <group enabled="true" name="MISRAC2012-Rule-10">
-                                <check name="MISRAC2012-Rule-10.1_R2" enabled="true" />
-                                <check name="MISRAC2012-Rule-10.1_R3" enabled="true" />
-                                <check name="MISRAC2012-Rule-10.1_R4" enabled="true" />
-                                <check name="MISRAC2012-Rule-10.1_R5" enabled="true" />
-                                <check name="MISRAC2012-Rule-10.1_R6" enabled="true" />
-                                <check name="MISRAC2012-Rule-10.1_R7" enabled="true" />
-                                <check name="MISRAC2012-Rule-10.1_R8" enabled="true" />
-                                <check name="MISRAC2012-Rule-10.2" enabled="true" />
-                                <check name="MISRAC2012-Rule-10.3" enabled="true" />
-                                <check name="MISRAC2012-Rule-10.4_a" enabled="true" />
-                                <check name="MISRAC2012-Rule-10.4_b" enabled="true" />
-                                <check name="MISRAC2012-Rule-10.5" enabled="false" />
-                                <check name="MISRAC2012-Rule-10.6" enabled="true" />
-                                <check name="MISRAC2012-Rule-10.7" enabled="true" />
-                                <check name="MISRAC2012-Rule-10.8" enabled="true" />
+                                <check enabled="true" name="MISRAC2012-Rule-10.1_R2" />
+                                <check enabled="true" name="MISRAC2012-Rule-10.1_R3" />
+                                <check enabled="true" name="MISRAC2012-Rule-10.1_R4" />
+                                <check enabled="true" name="MISRAC2012-Rule-10.1_R5" />
+                                <check enabled="true" name="MISRAC2012-Rule-10.1_R6" />
+                                <check enabled="true" name="MISRAC2012-Rule-10.1_R7" />
+                                <check enabled="true" name="MISRAC2012-Rule-10.1_R8" />
+                                <check enabled="true" name="MISRAC2012-Rule-10.2" />
+                                <check enabled="true" name="MISRAC2012-Rule-10.3" />
+                                <check enabled="true" name="MISRAC2012-Rule-10.4_a" />
+                                <check enabled="true" name="MISRAC2012-Rule-10.4_b" />
+                                <check enabled="false" name="MISRAC2012-Rule-10.5" />
+                                <check enabled="true" name="MISRAC2012-Rule-10.6" />
+                                <check enabled="true" name="MISRAC2012-Rule-10.7" />
+                                <check enabled="true" name="MISRAC2012-Rule-10.8" />
                             </group>
                             <group enabled="true" name="MISRAC2012-Rule-11">
-                                <check name="MISRAC2012-Rule-11.1" enabled="true" />
-                                <check name="MISRAC2012-Rule-11.2" enabled="true" />
-                                <check name="MISRAC2012-Rule-11.3" enabled="true" />
-                                <check name="MISRAC2012-Rule-11.4" enabled="false" />
-                                <check name="MISRAC2012-Rule-11.5" enabled="false" />
-                                <check name="MISRAC2012-Rule-11.6" enabled="true" />
-                                <check name="MISRAC2012-Rule-11.7" enabled="true" />
-                                <check name="MISRAC2012-Rule-11.8" enabled="true" />
-                                <check name="MISRAC2012-Rule-11.9" enabled="true" />
+                                <check enabled="true" name="MISRAC2012-Rule-11.1" />
+                                <check enabled="true" name="MISRAC2012-Rule-11.2" />
+                                <check enabled="true" name="MISRAC2012-Rule-11.3" />
+                                <check enabled="false" name="MISRAC2012-Rule-11.4" />
+                                <check enabled="false" name="MISRAC2012-Rule-11.5" />
+                                <check enabled="true" name="MISRAC2012-Rule-11.6" />
+                                <check enabled="true" name="MISRAC2012-Rule-11.7" />
+                                <check enabled="true" name="MISRAC2012-Rule-11.8" />
+                                <check enabled="true" name="MISRAC2012-Rule-11.9" />
                             </group>
                             <group enabled="true" name="MISRAC2012-Rule-12">
-                                <check name="MISRAC2012-Rule-12.1" enabled="false" />
-                                <check name="MISRAC2012-Rule-12.2" enabled="true" />
-                                <check name="MISRAC2012-Rule-12.3" enabled="false" />
+                                <check enabled="false" name="MISRAC2012-Rule-12.1" />
+                                <check enabled="true" name="MISRAC2012-Rule-12.2" />
+                                <check enabled="false" name="MISRAC2012-Rule-12.3" />
+                                <check enabled="true" name="MISRAC2012-Rule-12.5" />
                             </group>
                             <group enabled="true" name="MISRAC2012-Rule-13">
-                                <check name="MISRAC2012-Rule-13.1" enabled="true" />
-                                <check name="MISRAC2012-Rule-13.2_a" enabled="true" />
-                                <check name="MISRAC2012-Rule-13.2_b" enabled="true" />
-                                <check name="MISRAC2012-Rule-13.2_c" enabled="true" />
-                                <check name="MISRAC2012-Rule-13.3" enabled="false" />
-                                <check name="MISRAC2012-Rule-13.4_a" enabled="false" />
-                                <check name="MISRAC2012-Rule-13.4_b" enabled="false" />
-                                <check name="MISRAC2012-Rule-13.5" enabled="true" />
-                                <check name="MISRAC2012-Rule-13.6" enabled="true" />
+                                <check enabled="true" name="MISRAC2012-Rule-13.1" />
+                                <check enabled="true" name="MISRAC2012-Rule-13.2_a" />
+                                <check enabled="true" name="MISRAC2012-Rule-13.2_b" />
+                                <check enabled="true" name="MISRAC2012-Rule-13.2_c" />
+                                <check enabled="false" name="MISRAC2012-Rule-13.3" />
+                                <check enabled="false" name="MISRAC2012-Rule-13.4_a" />
+                                <check enabled="false" name="MISRAC2012-Rule-13.4_b" />
+                                <check enabled="true" name="MISRAC2012-Rule-13.5" />
+                                <check enabled="true" name="MISRAC2012-Rule-13.6" />
                             </group>
                             <group enabled="true" name="MISRAC2012-Rule-14">
-                                <check name="MISRAC2012-Rule-14.1_a" enabled="true" />
-                                <check name="MISRAC2012-Rule-14.1_b" enabled="true" />
-                                <check name="MISRAC2012-Rule-14.2" enabled="true" />
-                                <check name="MISRAC2012-Rule-14.3_a" enabled="true" />
-                                <check name="MISRAC2012-Rule-14.3_b" enabled="true" />
-                                <check name="MISRAC2012-Rule-14.4_a" enabled="true" />
-                                <check name="MISRAC2012-Rule-14.4_b" enabled="true" />
-                                <check name="MISRAC2012-Rule-14.4_c" enabled="true" />
-                                <check name="MISRAC2012-Rule-14.4_d" enabled="true" />
+                                <check enabled="true" name="MISRAC2012-Rule-14.1_a" />
+                                <check enabled="true" name="MISRAC2012-Rule-14.1_b" />
+                                <check enabled="true" name="MISRAC2012-Rule-14.2" />
+                                <check enabled="true" name="MISRAC2012-Rule-14.3_a" />
+                                <check enabled="true" name="MISRAC2012-Rule-14.3_b" />
+                                <check enabled="true" name="MISRAC2012-Rule-14.4_a" />
+                                <check enabled="true" name="MISRAC2012-Rule-14.4_b" />
+                                <check enabled="true" name="MISRAC2012-Rule-14.4_c" />
+                                <check enabled="true" name="MISRAC2012-Rule-14.4_d" />
                             </group>
                             <group enabled="true" name="MISRAC2012-Rule-15">
-                                <check name="MISRAC2012-Rule-15.1" enabled="false" />
-                                <check name="MISRAC2012-Rule-15.2" enabled="true" />
-                                <check name="MISRAC2012-Rule-15.3" enabled="true" />
-                                <check name="MISRAC2012-Rule-15.4" enabled="false" />
-                                <check name="MISRAC2012-Rule-15.5" enabled="false" />
-                                <check name="MISRAC2012-Rule-15.6_a" enabled="true" />
-                                <check name="MISRAC2012-Rule-15.6_b" enabled="true" />
-                                <check name="MISRAC2012-Rule-15.6_c" enabled="true" />
-                                <check name="MISRAC2012-Rule-15.6_d" enabled="true" />
-                                <check name="MISRAC2012-Rule-15.6_e" enabled="true" />
-                                <check name="MISRAC2012-Rule-15.7" enabled="true" />
+                                <check enabled="false" name="MISRAC2012-Rule-15.1" />
+                                <check enabled="true" name="MISRAC2012-Rule-15.2" />
+                                <check enabled="true" name="MISRAC2012-Rule-15.3" />
+                                <check enabled="false" name="MISRAC2012-Rule-15.4" />
+                                <check enabled="false" name="MISRAC2012-Rule-15.5" />
+                                <check enabled="true" name="MISRAC2012-Rule-15.6_a" />
+                                <check enabled="true" name="MISRAC2012-Rule-15.6_b" />
+                                <check enabled="true" name="MISRAC2012-Rule-15.6_c" />
+                                <check enabled="true" name="MISRAC2012-Rule-15.6_d" />
+                                <check enabled="true" name="MISRAC2012-Rule-15.6_e" />
+                                <check enabled="true" name="MISRAC2012-Rule-15.7" />
                             </group>
                             <group enabled="true" name="MISRAC2012-Rule-16">
-                                <check name="MISRAC2012-Rule-16.1" enabled="true" />
-                                <check name="MISRAC2012-Rule-16.2" enabled="true" />
-                                <check name="MISRAC2012-Rule-16.3" enabled="true" />
-                                <check name="MISRAC2012-Rule-16.4" enabled="true" />
-                                <check name="MISRAC2012-Rule-16.5" enabled="true" />
-                                <check name="MISRAC2012-Rule-16.6" enabled="true" />
-                                <check name="MISRAC2012-Rule-16.7" enabled="true" />
+                                <check enabled="true" name="MISRAC2012-Rule-16.1" />
+                                <check enabled="true" name="MISRAC2012-Rule-16.2" />
+                                <check enabled="true" name="MISRAC2012-Rule-16.3" />
+                                <check enabled="true" name="MISRAC2012-Rule-16.4" />
+                                <check enabled="true" name="MISRAC2012-Rule-16.5" />
+                                <check enabled="true" name="MISRAC2012-Rule-16.6" />
+                                <check enabled="true" name="MISRAC2012-Rule-16.7" />
                             </group>
                             <group enabled="true" name="MISRAC2012-Rule-17">
-                                <check name="MISRAC2012-Rule-17.1" enabled="true" />
-                                <check name="MISRAC2012-Rule-17.2_a" enabled="true" />
-                                <check name="MISRAC2012-Rule-17.2_b" enabled="true" />
-                                <check name="MISRAC2012-Rule-17.3" enabled="true" />
-                                <check name="MISRAC2012-Rule-17.4" enabled="true" />
-                                <check name="MISRAC2012-Rule-17.5" enabled="false" />
-                                <check name="MISRAC2012-Rule-17.6" enabled="true" />
-                                <check name="MISRAC2012-Rule-17.7" enabled="true" />
-                                <check name="MISRAC2012-Rule-17.8" enabled="false" />
+                                <check enabled="true" name="MISRAC2012-Rule-17.1" />
+                                <check enabled="true" name="MISRAC2012-Rule-17.2_a" />
+                                <check enabled="true" name="MISRAC2012-Rule-17.2_b" />
+                                <check enabled="true" name="MISRAC2012-Rule-17.3" />
+                                <check enabled="true" name="MISRAC2012-Rule-17.4" />
+                                <check enabled="false" name="MISRAC2012-Rule-17.5" />
+                                <check enabled="true" name="MISRAC2012-Rule-17.6" />
+                                <check enabled="true" name="MISRAC2012-Rule-17.7" />
+                                <check enabled="false" name="MISRAC2012-Rule-17.8" />
                             </group>
                             <group enabled="true" name="MISRAC2012-Rule-18">
-                                <check name="MISRAC2012-Rule-18.1_a" enabled="true" />
-                                <check name="MISRAC2012-Rule-18.1_b" enabled="true" />
-                                <check name="MISRAC2012-Rule-18.1_c" enabled="true" />
-                                <check name="MISRAC2012-Rule-18.1_d" enabled="true" />
-                                <check name="MISRAC2012-Rule-18.2" enabled="true" />
-                                <check name="MISRAC2012-Rule-18.3" enabled="true" />
-                                <check name="MISRAC2012-Rule-18.4" enabled="true" />
-                                <check name="MISRAC2012-Rule-18.5" enabled="false" />
-                                <check name="MISRAC2012-Rule-18.6_a" enabled="true" />
-                                <check name="MISRAC2012-Rule-18.6_b" enabled="true" />
-                                <check name="MISRAC2012-Rule-18.6_c" enabled="true" />
-                                <check name="MISRAC2012-Rule-18.6_d" enabled="true" />
-                                <check name="MISRAC2012-Rule-18.7" enabled="true" />
-                                <check name="MISRAC2012-Rule-18.8" enabled="true" />
+                                <check enabled="true" name="MISRAC2012-Rule-18.1_a" />
+                                <check enabled="true" name="MISRAC2012-Rule-18.1_b" />
+                                <check enabled="true" name="MISRAC2012-Rule-18.1_c" />
+                                <check enabled="true" name="MISRAC2012-Rule-18.1_d" />
+                                <check enabled="true" name="MISRAC2012-Rule-18.2" />
+                                <check enabled="true" name="MISRAC2012-Rule-18.3" />
+                                <check enabled="true" name="MISRAC2012-Rule-18.4" />
+                                <check enabled="false" name="MISRAC2012-Rule-18.5" />
+                                <check enabled="true" name="MISRAC2012-Rule-18.6_a" />
+                                <check enabled="true" name="MISRAC2012-Rule-18.6_b" />
+                                <check enabled="true" name="MISRAC2012-Rule-18.6_c" />
+                                <check enabled="true" name="MISRAC2012-Rule-18.6_d" />
+                                <check enabled="true" name="MISRAC2012-Rule-18.7" />
+                                <check enabled="true" name="MISRAC2012-Rule-18.8" />
                             </group>
                             <group enabled="true" name="MISRAC2012-Rule-19">
-                                <check name="MISRAC2012-Rule-19.1" enabled="true" />
-                                <check name="MISRAC2012-Rule-19.2" enabled="false" />
+                                <check enabled="true" name="MISRAC2012-Rule-19.1" />
+                                <check enabled="false" name="MISRAC2012-Rule-19.2" />
                             </group>
                             <group enabled="true" name="MISRAC2012-Rule-20">
-                                <check name="MISRAC2012-Rule-20.1" enabled="false" />
-                                <check name="MISRAC2012-Rule-20.2" enabled="true" />
-                                <check name="MISRAC2012-Rule-20.4_c89" enabled="true" />
-                                <check name="MISRAC2012-Rule-20.4_c99" enabled="true" />
-                                <check name="MISRAC2012-Rule-20.5" enabled="false" />
-                                <check name="MISRAC2012-Rule-20.7" enabled="true" />
-                                <check name="MISRAC2012-Rule-20.10" enabled="false" />
+                                <check enabled="false" name="MISRAC2012-Rule-20.1" />
+                                <check enabled="true" name="MISRAC2012-Rule-20.2" />
+                                <check enabled="true" name="MISRAC2012-Rule-20.4_c89" />
+                                <check enabled="true" name="MISRAC2012-Rule-20.4_c99" />
+                                <check enabled="false" name="MISRAC2012-Rule-20.5" />
+                                <check enabled="true" name="MISRAC2012-Rule-20.6_a" />
+                                <check enabled="true" name="MISRAC2012-Rule-20.6_b" />
+                                <check enabled="true" name="MISRAC2012-Rule-20.7" />
+                                <check enabled="false" name="MISRAC2012-Rule-20.10" />
                             </group>
                             <group enabled="true" name="MISRAC2012-Rule-21">
-                                <check name="MISRAC2012-Rule-21.1" enabled="true" />
-                                <check name="MISRAC2012-Rule-21.2" enabled="true" />
-                                <check name="MISRAC2012-Rule-21.3" enabled="true" />
-                                <check name="MISRAC2012-Rule-21.4" enabled="true" />
-                                <check name="MISRAC2012-Rule-21.5" enabled="true" />
-                                <check name="MISRAC2012-Rule-21.6" enabled="true" />
-                                <check name="MISRAC2012-Rule-21.7" enabled="true" />
-                                <check name="MISRAC2012-Rule-21.8" enabled="true" />
-                                <check name="MISRAC2012-Rule-21.9" enabled="true" />
-                                <check name="MISRAC2012-Rule-21.10" enabled="true" />
-                                <check name="MISRAC2012-Rule-21.11" enabled="true" />
-                                <check name="MISRAC2012-Rule-21.12_a" enabled="false" />
-                                <check name="MISRAC2012-Rule-21.12_b" enabled="false" />
+                                <check enabled="true" name="MISRAC2012-Rule-21.1" />
+                                <check enabled="true" name="MISRAC2012-Rule-21.2" />
+                                <check enabled="true" name="MISRAC2012-Rule-21.3" />
+                                <check enabled="true" name="MISRAC2012-Rule-21.4" />
+                                <check enabled="true" name="MISRAC2012-Rule-21.5" />
+                                <check enabled="true" name="MISRAC2012-Rule-21.6" />
+                                <check enabled="true" name="MISRAC2012-Rule-21.7" />
+                                <check enabled="true" name="MISRAC2012-Rule-21.8" />
+                                <check enabled="true" name="MISRAC2012-Rule-21.9" />
+                                <check enabled="true" name="MISRAC2012-Rule-21.10" />
+                                <check enabled="true" name="MISRAC2012-Rule-21.11" />
+                                <check enabled="false" name="MISRAC2012-Rule-21.12_a" />
+                                <check enabled="false" name="MISRAC2012-Rule-21.12_b" />
+                                <check enabled="true" name="MISRAC2012-Rule-21.13" />
+                                <check enabled="true" name="MISRAC2012-Rule-21.14" />
+                                <check enabled="true" name="MISRAC2012-Rule-21.15" />
+                                <check enabled="true" name="MISRAC2012-Rule-21.16" />
+                                <check enabled="true" name="MISRAC2012-Rule-21.17_a" />
+                                <check enabled="true" name="MISRAC2012-Rule-21.17_b" />
+                                <check enabled="true" name="MISRAC2012-Rule-21.17_c" />
+                                <check enabled="true" name="MISRAC2012-Rule-21.17_d" />
+                                <check enabled="true" name="MISRAC2012-Rule-21.17_e" />
+                                <check enabled="true" name="MISRAC2012-Rule-21.17_f" />
+                                <check enabled="true" name="MISRAC2012-Rule-21.18_a" />
+                                <check enabled="true" name="MISRAC2012-Rule-21.18_b" />
+                                <check enabled="true" name="MISRAC2012-Rule-21.19_a" />
+                                <check enabled="true" name="MISRAC2012-Rule-21.19_b" />
+                                <check enabled="true" name="MISRAC2012-Rule-21.20" />
                             </group>
                             <group enabled="true" name="MISRAC2012-Rule-22">
-                                <check name="MISRAC2012-Rule-22.1_a" enabled="true" />
-                                <check name="MISRAC2012-Rule-22.1_b" enabled="true" />
-                                <check name="MISRAC2012-Rule-22.2_a" enabled="true" />
-                                <check name="MISRAC2012-Rule-22.2_b" enabled="true" />
-                                <check name="MISRAC2012-Rule-22.2_c" enabled="true" />
-                                <check name="MISRAC2012-Rule-22.3" enabled="true" />
-                                <check name="MISRAC2012-Rule-22.4" enabled="true" />
-                                <check name="MISRAC2012-Rule-22.5_a" enabled="true" />
-                                <check name="MISRAC2012-Rule-22.5_b" enabled="true" />
-                                <check name="MISRAC2012-Rule-22.6" enabled="true" />
+                                <check enabled="true" name="MISRAC2012-Rule-22.1_a" />
+                                <check enabled="true" name="MISRAC2012-Rule-22.1_b" />
+                                <check enabled="true" name="MISRAC2012-Rule-22.2_a" />
+                                <check enabled="true" name="MISRAC2012-Rule-22.2_b" />
+                                <check enabled="true" name="MISRAC2012-Rule-22.2_c" />
+                                <check enabled="true" name="MISRAC2012-Rule-22.3" />
+                                <check enabled="true" name="MISRAC2012-Rule-22.4" />
+                                <check enabled="true" name="MISRAC2012-Rule-22.5_a" />
+                                <check enabled="true" name="MISRAC2012-Rule-22.5_b" />
+                                <check enabled="true" name="MISRAC2012-Rule-22.6" />
+                                <check enabled="true" name="MISRAC2012-Rule-22.7_a" />
+                                <check enabled="true" name="MISRAC2012-Rule-22.7_b" />
+                                <check enabled="true" name="MISRAC2012-Rule-22.8" />
+                                <check enabled="true" name="MISRAC2012-Rule-22.9" />
+                                <check enabled="true" name="MISRAC2012-Rule-22.10" />
                             </group>
                         </package>
-                        <package name="MISRAC++2008" enabled="false">
+                        <package enabled="false" name="MISRAC++2008">
                             <group enabled="true" name="MISRAC++2008-0-1">
-                                <check name="MISRAC++2008-0-1-1" enabled="true" />
-                                <check name="MISRAC++2008-0-1-2_a" enabled="true" />
-                                <check name="MISRAC++2008-0-1-2_b" enabled="true" />
-                                <check name="MISRAC++2008-0-1-2_c" enabled="true" />
-                                <check name="MISRAC++2008-0-1-3" enabled="true" />
-                                <check name="MISRAC++2008-0-1-4_a" enabled="true" />
-                                <check name="MISRAC++2008-0-1-4_b" enabled="true" />
-                                <check name="MISRAC++2008-0-1-6" enabled="true" />
-                                <check name="MISRAC++2008-0-1-7" enabled="true" />
-                                <check name="MISRAC++2008-0-1-8" enabled="false" />
-                                <check name="MISRAC++2008-0-1-9" enabled="true" />
-                                <check name="MISRAC++2008-0-1-11" enabled="true" />
+                                <check enabled="true" name="MISRAC++2008-0-1-1" />
+                                <check enabled="true" name="MISRAC++2008-0-1-2_a" />
+                                <check enabled="true" name="MISRAC++2008-0-1-2_b" />
+                                <check enabled="true" name="MISRAC++2008-0-1-2_c" />
+                                <check enabled="true" name="MISRAC++2008-0-1-3" />
+                                <check enabled="true" name="MISRAC++2008-0-1-4_a" />
+                                <check enabled="true" name="MISRAC++2008-0-1-4_b" />
+                                <check enabled="true" name="MISRAC++2008-0-1-6" />
+                                <check enabled="true" name="MISRAC++2008-0-1-7" />
+                                <check enabled="false" name="MISRAC++2008-0-1-8" />
+                                <check enabled="true" name="MISRAC++2008-0-1-9" />
+                                <check enabled="true" name="MISRAC++2008-0-1-11" />
                             </group>
                             <group enabled="true" name="MISRAC++2008-0-2">
-                                <check name="MISRAC++2008-0-2-1" enabled="true" />
+                                <check enabled="true" name="MISRAC++2008-0-2-1" />
                             </group>
                             <group enabled="true" name="MISRAC++2008-0-3">
-                                <check name="MISRAC++2008-0-3-2" enabled="true" />
+                                <check enabled="true" name="MISRAC++2008-0-3-2" />
                             </group>
                             <group enabled="true" name="MISRAC++2008-2-7">
-                                <check name="MISRAC++2008-2-7-1" enabled="true" />
-                                <check name="MISRAC++2008-2-7-2" enabled="true" />
-                                <check name="MISRAC++2008-2-7-3" enabled="false" />
+                                <check enabled="true" name="MISRAC++2008-2-7-1" />
+                                <check enabled="true" name="MISRAC++2008-2-7-2" />
+                                <check enabled="false" name="MISRAC++2008-2-7-3" />
                             </group>
                             <group enabled="true" name="MISRAC++2008-2-10">
-                                <check name="MISRAC++2008-2-10-1" enabled="true" />
-                                <check name="MISRAC++2008-2-10-2" enabled="true" />
-                                <check name="MISRAC++2008-2-10-3" enabled="true" />
-                                <check name="MISRAC++2008-2-10-4" enabled="true" />
-                                <check name="MISRAC++2008-2-10-5" enabled="false" />
-                                <check name="MISRAC++2008-2-10-6" enabled="true" />
+                                <check enabled="true" name="MISRAC++2008-2-10-1" />
+                                <check enabled="true" name="MISRAC++2008-2-10-2" />
+                                <check enabled="true" name="MISRAC++2008-2-10-3" />
+                                <check enabled="true" name="MISRAC++2008-2-10-4" />
+                                <check enabled="false" name="MISRAC++2008-2-10-5" />
+                                <check enabled="true" name="MISRAC++2008-2-10-6" />
                             </group>
                             <group enabled="true" name="MISRAC++2008-2-13">
-                                <check name="MISRAC++2008-2-13-2" enabled="true" />
-                                <check name="MISRAC++2008-2-13-3" enabled="true" />
-                                <check name="MISRAC++2008-2-13-4_a" enabled="true" />
-                                <check name="MISRAC++2008-2-13-4_b" enabled="true" />
+                                <check enabled="true" name="MISRAC++2008-2-13-2" />
+                                <check enabled="true" name="MISRAC++2008-2-13-3" />
+                                <check enabled="true" name="MISRAC++2008-2-13-4_a" />
+                                <check enabled="true" name="MISRAC++2008-2-13-4_b" />
                             </group>
                             <group enabled="true" name="MISRAC++2008-3-1">
-                                <check name="MISRAC++2008-3-1-1" enabled="true" />
-                                <check name="MISRAC++2008-3-1-3" enabled="true" />
+                                <check enabled="true" name="MISRAC++2008-3-1-1" />
+                                <check enabled="true" name="MISRAC++2008-3-1-3" />
                             </group>
                             <group enabled="true" name="MISRAC++2008-3-9">
-                                <check name="MISRAC++2008-3-9-2" enabled="false" />
-                                <check name="MISRAC++2008-3-9-3" enabled="true" />
+                                <check enabled="false" name="MISRAC++2008-3-9-2" />
+                                <check enabled="true" name="MISRAC++2008-3-9-3" />
                             </group>
                             <group enabled="true" name="MISRAC++2008-4-5">
-                                <check name="MISRAC++2008-4-5-1" enabled="true" />
-                                <check name="MISRAC++2008-4-5-2" enabled="true" />
-                                <check name="MISRAC++2008-4-5-3" enabled="true" />
+                                <check enabled="true" name="MISRAC++2008-4-5-1" />
+                                <check enabled="true" name="MISRAC++2008-4-5-2" />
+                                <check enabled="true" name="MISRAC++2008-4-5-3" />
                             </group>
                             <group enabled="true" name="MISRAC++2008-5-0">
-                                <check name="MISRAC++2008-5-0-1_a" enabled="true" />
-                                <check name="MISRAC++2008-5-0-1_b" enabled="true" />
-                                <check name="MISRAC++2008-5-0-1_c" enabled="true" />
-                                <check name="MISRAC++2008-5-0-2" enabled="false" />
-                                <check name="MISRAC++2008-5-0-3" enabled="true" />
-                                <check name="MISRAC++2008-5-0-4" enabled="true" />
-                                <check name="MISRAC++2008-5-0-5" enabled="true" />
-                                <check name="MISRAC++2008-5-0-6" enabled="true" />
-                                <check name="MISRAC++2008-5-0-7" enabled="true" />
-                                <check name="MISRAC++2008-5-0-8" enabled="true" />
-                                <check name="MISRAC++2008-5-0-9" enabled="true" />
-                                <check name="MISRAC++2008-5-0-10" enabled="true" />
-                                <check name="MISRAC++2008-5-0-13_a" enabled="true" />
-                                <check name="MISRAC++2008-5-0-13_b" enabled="true" />
-                                <check name="MISRAC++2008-5-0-13_c" enabled="true" />
-                                <check name="MISRAC++2008-5-0-13_d" enabled="true" />
-                                <check name="MISRAC++2008-5-0-14" enabled="true" />
-                                <check name="MISRAC++2008-5-0-15_a" enabled="true" />
-                                <check name="MISRAC++2008-5-0-15_b" enabled="true" />
-                                <check name="MISRAC++2008-5-0-16_a" enabled="true" />
-                                <check name="MISRAC++2008-5-0-16_b" enabled="true" />
-                                <check name="MISRAC++2008-5-0-16_c" enabled="true" />
-                                <check name="MISRAC++2008-5-0-16_d" enabled="true" />
-                                <check name="MISRAC++2008-5-0-16_e" enabled="true" />
-                                <check name="MISRAC++2008-5-0-16_f" enabled="true" />
-                                <check name="MISRAC++2008-5-0-19" enabled="true" />
-                                <check name="MISRAC++2008-5-0-21" enabled="true" />
+                                <check enabled="true" name="MISRAC++2008-5-0-1_a" />
+                                <check enabled="true" name="MISRAC++2008-5-0-1_b" />
+                                <check enabled="true" name="MISRAC++2008-5-0-1_c" />
+                                <check enabled="false" name="MISRAC++2008-5-0-2" />
+                                <check enabled="true" name="MISRAC++2008-5-0-3" />
+                                <check enabled="true" name="MISRAC++2008-5-0-4" />
+                                <check enabled="true" name="MISRAC++2008-5-0-5" />
+                                <check enabled="true" name="MISRAC++2008-5-0-6" />
+                                <check enabled="true" name="MISRAC++2008-5-0-7" />
+                                <check enabled="true" name="MISRAC++2008-5-0-8" />
+                                <check enabled="true" name="MISRAC++2008-5-0-9" />
+                                <check enabled="true" name="MISRAC++2008-5-0-10" />
+                                <check enabled="true" name="MISRAC++2008-5-0-13_a" />
+                                <check enabled="true" name="MISRAC++2008-5-0-13_b" />
+                                <check enabled="true" name="MISRAC++2008-5-0-13_c" />
+                                <check enabled="true" name="MISRAC++2008-5-0-13_d" />
+                                <check enabled="true" name="MISRAC++2008-5-0-14" />
+                                <check enabled="true" name="MISRAC++2008-5-0-15_a" />
+                                <check enabled="true" name="MISRAC++2008-5-0-15_b" />
+                                <check enabled="true" name="MISRAC++2008-5-0-16_a" />
+                                <check enabled="true" name="MISRAC++2008-5-0-16_b" />
+                                <check enabled="true" name="MISRAC++2008-5-0-16_c" />
+                                <check enabled="true" name="MISRAC++2008-5-0-16_d" />
+                                <check enabled="true" name="MISRAC++2008-5-0-16_e" />
+                                <check enabled="true" name="MISRAC++2008-5-0-16_f" />
+                                <check enabled="true" name="MISRAC++2008-5-0-19" />
+                                <check enabled="true" name="MISRAC++2008-5-0-21" />
                             </group>
                             <group enabled="true" name="MISRAC++2008-5-2">
-                                <check name="MISRAC++2008-5-2-4" enabled="true" />
-                                <check name="MISRAC++2008-5-2-5" enabled="true" />
-                                <check name="MISRAC++2008-5-2-6" enabled="true" />
-                                <check name="MISRAC++2008-5-2-7" enabled="true" />
-                                <check name="MISRAC++2008-5-2-9" enabled="false" />
-                                <check name="MISRAC++2008-5-2-10" enabled="false" />
-                                <check name="MISRAC++2008-5-2-11_a" enabled="true" />
-                                <check name="MISRAC++2008-5-2-11_b" enabled="true" />
+                                <check enabled="true" name="MISRAC++2008-5-2-4" />
+                                <check enabled="true" name="MISRAC++2008-5-2-5" />
+                                <check enabled="true" name="MISRAC++2008-5-2-6" />
+                                <check enabled="true" name="MISRAC++2008-5-2-7" />
+                                <check enabled="false" name="MISRAC++2008-5-2-9" />
+                                <check enabled="false" name="MISRAC++2008-5-2-10" />
+                                <check enabled="true" name="MISRAC++2008-5-2-11_a" />
+                                <check enabled="true" name="MISRAC++2008-5-2-11_b" />
                             </group>
                             <group enabled="true" name="MISRAC++2008-5-3">
-                                <check name="MISRAC++2008-5-3-1" enabled="true" />
-                                <check name="MISRAC++2008-5-3-2_a" enabled="true" />
-                                <check name="MISRAC++2008-5-3-2_b" enabled="true" />
-                                <check name="MISRAC++2008-5-3-3" enabled="true" />
-                                <check name="MISRAC++2008-5-3-4" enabled="true" />
+                                <check enabled="true" name="MISRAC++2008-5-3-1" />
+                                <check enabled="true" name="MISRAC++2008-5-3-2_a" />
+                                <check enabled="true" name="MISRAC++2008-5-3-2_b" />
+                                <check enabled="true" name="MISRAC++2008-5-3-3" />
+                                <check enabled="true" name="MISRAC++2008-5-3-4" />
                             </group>
                             <group enabled="true" name="MISRAC++2008-5-8">
-                                <check name="MISRAC++2008-5-8-1" enabled="true" />
+                                <check enabled="true" name="MISRAC++2008-5-8-1" />
                             </group>
                             <group enabled="true" name="MISRAC++2008-5-14">
-                                <check name="MISRAC++2008-5-14-1" enabled="true" />
+                                <check enabled="true" name="MISRAC++2008-5-14-1" />
                             </group>
                             <group enabled="true" name="MISRAC++2008-5-18">
-                                <check name="MISRAC++2008-5-18-1" enabled="true" />
+                                <check enabled="true" name="MISRAC++2008-5-18-1" />
                             </group>
                             <group enabled="true" name="MISRAC++2008-5-19">
-                                <check name="MISRAC++2008-5-19-1" enabled="false" />
+                                <check enabled="false" name="MISRAC++2008-5-19-1" />
                             </group>
                             <group enabled="true" name="MISRAC++2008-6-2">
-                                <check name="MISRAC++2008-6-2-1" enabled="true" />
-                                <check name="MISRAC++2008-6-2-2" enabled="true" />
-                                <check name="MISRAC++2008-6-2-3" enabled="false" />
+                                <check enabled="true" name="MISRAC++2008-6-2-1" />
+                                <check enabled="true" name="MISRAC++2008-6-2-2" />
+                                <check enabled="false" name="MISRAC++2008-6-2-3" />
                             </group>
                             <group enabled="true" name="MISRAC++2008-6-3">
-                                <check name="MISRAC++2008-6-3-1_a" enabled="true" />
-                                <check name="MISRAC++2008-6-3-1_b" enabled="true" />
-                                <check name="MISRAC++2008-6-3-1_c" enabled="true" />
-                                <check name="MISRAC++2008-6-3-1_d" enabled="true" />
+                                <check enabled="true" name="MISRAC++2008-6-3-1_a" />
+                                <check enabled="true" name="MISRAC++2008-6-3-1_b" />
+                                <check enabled="true" name="MISRAC++2008-6-3-1_c" />
+                                <check enabled="true" name="MISRAC++2008-6-3-1_d" />
                             </group>
                             <group enabled="true" name="MISRAC++2008-6-4">
-                                <check name="MISRAC++2008-6-4-1" enabled="true" />
-                                <check name="MISRAC++2008-6-4-2" enabled="true" />
-                                <check name="MISRAC++2008-6-4-3" enabled="true" />
-                                <check name="MISRAC++2008-6-4-4" enabled="true" />
-                                <check name="MISRAC++2008-6-4-5" enabled="true" />
-                                <check name="MISRAC++2008-6-4-6" enabled="true" />
-                                <check name="MISRAC++2008-6-4-7" enabled="true" />
-                                <check name="MISRAC++2008-6-4-8" enabled="true" />
+                                <check enabled="true" name="MISRAC++2008-6-4-1" />
+                                <check enabled="true" name="MISRAC++2008-6-4-2" />
+                                <check enabled="true" name="MISRAC++2008-6-4-3" />
+                                <check enabled="true" name="MISRAC++2008-6-4-4" />
+                                <check enabled="true" name="MISRAC++2008-6-4-5" />
+                                <check enabled="true" name="MISRAC++2008-6-4-6" />
+                                <check enabled="true" name="MISRAC++2008-6-4-7" />
+                                <check enabled="true" name="MISRAC++2008-6-4-8" />
                             </group>
                             <group enabled="true" name="MISRAC++2008-6-5">
-                                <check name="MISRAC++2008-6-5-1_a" enabled="true" />
-                                <check name="MISRAC++2008-6-5-1_b" enabled="true" />
-                                <check name="MISRAC++2008-6-5-2" enabled="true" />
-                                <check name="MISRAC++2008-6-5-3" enabled="true" />
-                                <check name="MISRAC++2008-6-5-4" enabled="true" />
-                                <check name="MISRAC++2008-6-5-5" enabled="true" />
-                                <check name="MISRAC++2008-6-5-6" enabled="true" />
+                                <check enabled="true" name="MISRAC++2008-6-5-1_a" />
+                                <check enabled="true" name="MISRAC++2008-6-5-1_b" />
+                                <check enabled="true" name="MISRAC++2008-6-5-2" />
+                                <check enabled="true" name="MISRAC++2008-6-5-3" />
+                                <check enabled="true" name="MISRAC++2008-6-5-4" />
+                                <check enabled="true" name="MISRAC++2008-6-5-5" />
+                                <check enabled="true" name="MISRAC++2008-6-5-6" />
                             </group>
                             <group enabled="true" name="MISRAC++2008-6-6">
-                                <check name="MISRAC++2008-6-6-1" enabled="true" />
-                                <check name="MISRAC++2008-6-6-2" enabled="true" />
-                                <check name="MISRAC++2008-6-6-4" enabled="true" />
-                                <check name="MISRAC++2008-6-6-5" enabled="true" />
+                                <check enabled="true" name="MISRAC++2008-6-6-1" />
+                                <check enabled="true" name="MISRAC++2008-6-6-2" />
+                                <check enabled="true" name="MISRAC++2008-6-6-4" />
+                                <check enabled="true" name="MISRAC++2008-6-6-5" />
                             </group>
                             <group enabled="true" name="MISRAC++2008-7-1">
-                                <check name="MISRAC++2008-7-1-1" enabled="true" />
-                                <check name="MISRAC++2008-7-1-2" enabled="true" />
+                                <check enabled="true" name="MISRAC++2008-7-1-1" />
+                                <check enabled="true" name="MISRAC++2008-7-1-2" />
                             </group>
                             <group enabled="true" name="MISRAC++2008-7-2">
-                                <check name="MISRAC++2008-7-2-1" enabled="true" />
+                                <check enabled="true" name="MISRAC++2008-7-2-1" />
                             </group>
                             <group enabled="true" name="MISRAC++2008-7-4">
-                                <check name="MISRAC++2008-7-4-3" enabled="true" />
+                                <check enabled="true" name="MISRAC++2008-7-4-3" />
                             </group>
                             <group enabled="true" name="MISRAC++2008-7-5">
-                                <check name="MISRAC++2008-7-5-1_a" enabled="true" />
-                                <check name="MISRAC++2008-7-5-1_b" enabled="true" />
-                                <check name="MISRAC++2008-7-5-2_a" enabled="true" />
-                                <check name="MISRAC++2008-7-5-2_b" enabled="true" />
-                                <check name="MISRAC++2008-7-5-2_c" enabled="true" />
-                                <check name="MISRAC++2008-7-5-2_d" enabled="true" />
-                                <check name="MISRAC++2008-7-5-4_a" enabled="false" />
-                                <check name="MISRAC++2008-7-5-4_b" enabled="false" />
+                                <check enabled="true" name="MISRAC++2008-7-5-1_a" />
+                                <check enabled="true" name="MISRAC++2008-7-5-1_b" />
+                                <check enabled="true" name="MISRAC++2008-7-5-2_a" />
+                                <check enabled="true" name="MISRAC++2008-7-5-2_b" />
+                                <check enabled="true" name="MISRAC++2008-7-5-2_c" />
+                                <check enabled="true" name="MISRAC++2008-7-5-2_d" />
+                                <check enabled="false" name="MISRAC++2008-7-5-4_a" />
+                                <check enabled="false" name="MISRAC++2008-7-5-4_b" />
                             </group>
                             <group enabled="true" name="MISRAC++2008-8-0">
-                                <check name="MISRAC++2008-8-0-1" enabled="true" />
+                                <check enabled="true" name="MISRAC++2008-8-0-1" />
                             </group>
                             <group enabled="true" name="MISRAC++2008-8-4">
-                                <check name="MISRAC++2008-8-4-1" enabled="true" />
-                                <check name="MISRAC++2008-8-4-3" enabled="true" />
-                                <check name="MISRAC++2008-8-4-4" enabled="true" />
+                                <check enabled="true" name="MISRAC++2008-8-4-1" />
+                                <check enabled="true" name="MISRAC++2008-8-4-3" />
+                                <check enabled="true" name="MISRAC++2008-8-4-4" />
                             </group>
                             <group enabled="true" name="MISRAC++2008-8-5">
-                                <check name="MISRAC++2008-8-5-1_a" enabled="true" />
-                                <check name="MISRAC++2008-8-5-1_b" enabled="true" />
-                                <check name="MISRAC++2008-8-5-1_c" enabled="true" />
-                                <check name="MISRAC++2008-8-5-2" enabled="true" />
+                                <check enabled="true" name="MISRAC++2008-8-5-1_a" />
+                                <check enabled="true" name="MISRAC++2008-8-5-1_b" />
+                                <check enabled="true" name="MISRAC++2008-8-5-1_c" />
+                                <check enabled="true" name="MISRAC++2008-8-5-2" />
                             </group>
                             <group enabled="true" name="MISRAC++2008-9-3">
-                                <check name="MISRAC++2008-9-3-1" enabled="true" />
-                                <check name="MISRAC++2008-9-3-2" enabled="true" />
+                                <check enabled="true" name="MISRAC++2008-9-3-1" />
+                                <check enabled="true" name="MISRAC++2008-9-3-2" />
                             </group>
                             <group enabled="true" name="MISRAC++2008-9-5">
-                                <check name="MISRAC++2008-9-5-1" enabled="true" />
+                                <check enabled="true" name="MISRAC++2008-9-5-1" />
                             </group>
                             <group enabled="true" name="MISRAC++2008-9-6">
-                                <check name="MISRAC++2008-9-6-2" enabled="true" />
-                                <check name="MISRAC++2008-9-6-3" enabled="true" />
-                                <check name="MISRAC++2008-9-6-4" enabled="true" />
+                                <check enabled="true" name="MISRAC++2008-9-6-2" />
+                                <check enabled="true" name="MISRAC++2008-9-6-3" />
+                                <check enabled="true" name="MISRAC++2008-9-6-4" />
                             </group>
                             <group enabled="true" name="MISRAC++2008-12-1">
-                                <check name="MISRAC++2008-12-1-1_a" enabled="true" />
-                                <check name="MISRAC++2008-12-1-1_b" enabled="true" />
-                                <check name="MISRAC++2008-12-1-3" enabled="true" />
+                                <check enabled="true" name="MISRAC++2008-12-1-1_a" />
+                                <check enabled="true" name="MISRAC++2008-12-1-1_b" />
+                                <check enabled="true" name="MISRAC++2008-12-1-3" />
                             </group>
                             <group enabled="true" name="MISRAC++2008-15-0">
-                                <check name="MISRAC++2008-15-0-2" enabled="false" />
+                                <check enabled="false" name="MISRAC++2008-15-0-2" />
                             </group>
                             <group enabled="true" name="MISRAC++2008-15-1">
-                                <check name="MISRAC++2008-15-1-2" enabled="true" />
-                                <check name="MISRAC++2008-15-1-3" enabled="true" />
+                                <check enabled="true" name="MISRAC++2008-15-1-2" />
+                                <check enabled="true" name="MISRAC++2008-15-1-3" />
                             </group>
                             <group enabled="true" name="MISRAC++2008-15-3">
-                                <check name="MISRAC++2008-15-3-1" enabled="true" />
-                                <check name="MISRAC++2008-15-3-2" enabled="false" />
-                                <check name="MISRAC++2008-15-3-3" enabled="true" />
-                                <check name="MISRAC++2008-15-3-4" enabled="true" />
-                                <check name="MISRAC++2008-15-3-5" enabled="true" />
+                                <check enabled="true" name="MISRAC++2008-15-3-1" />
+                                <check enabled="false" name="MISRAC++2008-15-3-2" />
+                                <check enabled="true" name="MISRAC++2008-15-3-3" />
+                                <check enabled="true" name="MISRAC++2008-15-3-4" />
+                                <check enabled="true" name="MISRAC++2008-15-3-5" />
                             </group>
                             <group enabled="true" name="MISRAC++2008-15-5">
-                                <check name="MISRAC++2008-15-5-1" enabled="true" />
+                                <check enabled="true" name="MISRAC++2008-15-5-1" />
                             </group>
                             <group enabled="true" name="MISRAC++2008-16-0">
-                                <check name="MISRAC++2008-16-0-3" enabled="true" />
-                                <check name="MISRAC++2008-16-0-4" enabled="true" />
+                                <check enabled="true" name="MISRAC++2008-16-0-3" />
+                                <check enabled="true" name="MISRAC++2008-16-0-4" />
                             </group>
                             <group enabled="true" name="MISRAC++2008-16-2">
-                                <check name="MISRAC++2008-16-2-2" enabled="true" />
-                                <check name="MISRAC++2008-16-2-3" enabled="true" />
-                                <check name="MISRAC++2008-16-2-4" enabled="true" />
-                                <check name="MISRAC++2008-16-2-5" enabled="false" />
+                                <check enabled="true" name="MISRAC++2008-16-2-2" />
+                                <check enabled="true" name="MISRAC++2008-16-2-3" />
+                                <check enabled="true" name="MISRAC++2008-16-2-4" />
+                                <check enabled="false" name="MISRAC++2008-16-2-5" />
                             </group>
                             <group enabled="true" name="MISRAC++2008-16-3">
-                                <check name="MISRAC++2008-16-3-1" enabled="true" />
-                                <check name="MISRAC++2008-16-3-2" enabled="false" />
+                                <check enabled="true" name="MISRAC++2008-16-3-1" />
+                                <check enabled="false" name="MISRAC++2008-16-3-2" />
                             </group>
                             <group enabled="true" name="MISRAC++2008-17-0">
-                                <check name="MISRAC++2008-17-0-1" enabled="true" />
-                                <check name="MISRAC++2008-17-0-3" enabled="true" />
-                                <check name="MISRAC++2008-17-0-5" enabled="true" />
+                                <check enabled="true" name="MISRAC++2008-17-0-1" />
+                                <check enabled="true" name="MISRAC++2008-17-0-3" />
+                                <check enabled="true" name="MISRAC++2008-17-0-5" />
                             </group>
                             <group enabled="true" name="MISRAC++2008-18-0">
-                                <check name="MISRAC++2008-18-0-1" enabled="true" />
-                                <check name="MISRAC++2008-18-0-2" enabled="true" />
-                                <check name="MISRAC++2008-18-0-3" enabled="true" />
-                                <check name="MISRAC++2008-18-0-4" enabled="true" />
-                                <check name="MISRAC++2008-18-0-5" enabled="true" />
+                                <check enabled="true" name="MISRAC++2008-18-0-1" />
+                                <check enabled="true" name="MISRAC++2008-18-0-2" />
+                                <check enabled="true" name="MISRAC++2008-18-0-3" />
+                                <check enabled="true" name="MISRAC++2008-18-0-4" />
+                                <check enabled="true" name="MISRAC++2008-18-0-5" />
                             </group>
                             <group enabled="true" name="MISRAC++2008-18-2">
-                                <check name="MISRAC++2008-18-2-1" enabled="true" />
+                                <check enabled="true" name="MISRAC++2008-18-2-1" />
                             </group>
                             <group enabled="true" name="MISRAC++2008-18-4">
-                                <check name="MISRAC++2008-18-4-1" enabled="true" />
+                                <check enabled="true" name="MISRAC++2008-18-4-1" />
                             </group>
                             <group enabled="true" name="MISRAC++2008-18-7">
-                                <check name="MISRAC++2008-18-7-1" enabled="true" />
+                                <check enabled="true" name="MISRAC++2008-18-7-1" />
                             </group>
                             <group enabled="true" name="MISRAC++2008-19-3">
-                                <check name="MISRAC++2008-19-3-1" enabled="true" />
+                                <check enabled="true" name="MISRAC++2008-19-3-1" />
                             </group>
                             <group enabled="true" name="MISRAC++2008-27-0">
-                                <check name="MISRAC++2008-27-0-1" enabled="true" />
+                                <check enabled="true" name="MISRAC++2008-27-0-1" />
                             </group>
                         </package>
                     </checks_tree>

--- a/FreeRTOS/Demo/CORTEX_MPS2_QEMU_IAR/main.c
+++ b/FreeRTOS/Demo/CORTEX_MPS2_QEMU_IAR/main.c
@@ -141,6 +141,13 @@ void vApplicationIdleHook( void )
 	that vApplicationIdleHook() is permitted to return to its calling function,
 	because it is the responsibility of the idle task to clean up memory
 	allocated by the kernel to any task that has since deleted itself. */
+	#if ( mainCREATE_SIMPLE_BLINKY_DEMO_ONLY == 0 )
+	{
+		extern void vFullDemoIdleHookFunction( void );
+
+		vFullDemoIdleHookFunction();
+	}
+	#endif
 }
 /*-----------------------------------------------------------*/
 

--- a/FreeRTOS/Demo/CORTEX_MPS2_QEMU_IAR/main_full.c
+++ b/FreeRTOS/Demo/CORTEX_MPS2_QEMU_IAR/main_full.c
@@ -110,6 +110,23 @@
  * described at the top of this file. */
 static void prvCheckTask( void *pvParameters );
 
+/*
+ * Called by the Idle task hook function.
+ */
+void vFullDemoIdleHook( void );
+
+/*
+ * Indirectly exercises the xTaskMemoryAllocated() and xTaskMemoryFreed()
+ * functions.
+ */
+static void prvExerciseTaskHeapAllocationStats( void );
+
+/*-----------------------------------------------------------*/
+
+/* Holds the string that is output by the check task.  Initialised to pass, but
+ * updated to hold an error message if an error is detected. */
+static const char * volatile pcStatusMessage = "PASS";
+
 /*-----------------------------------------------------------*/
 
 void main_full( void )
@@ -160,7 +177,6 @@ void main_full( void )
 /* See the comments at the top of this file. */
 static void prvCheckTask( void *pvParameters )
 {
-static const char * pcMessage = "PASS";
 const TickType_t xTaskPeriod = pdMS_TO_TICKS( 5000UL );
 TickType_t xPreviousWakeTime;
 extern uint32_t ulNestCount;
@@ -174,104 +190,104 @@ extern uint32_t ulNestCount;
 		/* Has an error been found in any task? */
 		if( xAreStreamBufferTasksStillRunning() != pdTRUE )
 		{
-			pcMessage = "xAreStreamBufferTasksStillRunning() returned false";
+			pcStatusMessage = "xAreStreamBufferTasksStillRunning() returned false";
 		}
 		else if( xAreMessageBufferTasksStillRunning() != pdTRUE )
 		{
-			pcMessage = "xAreMessageBufferTasksStillRunning() returned false";
+			pcStatusMessage = "xAreMessageBufferTasksStillRunning() returned false";
 		}
 		if( xAreGenericQueueTasksStillRunning() != pdTRUE )
 		{
-			pcMessage = "xAreGenericQueueTasksStillRunning() returned false";
+			pcStatusMessage = "xAreGenericQueueTasksStillRunning() returned false";
 		}
 	    else if( xIsCreateTaskStillRunning() != pdTRUE )
 	    {
-	        pcMessage = "xIsCreateTaskStillRunning() returned false";
+	        pcStatusMessage = "xIsCreateTaskStillRunning() returned false";
 	    }
 		else if( xAreIntQueueTasksStillRunning() != pdTRUE )
 		{
-			pcMessage = "xAreIntQueueTasksStillRunning() returned false";
+			pcStatusMessage = "xAreIntQueueTasksStillRunning() returned false";
 		}
 		else if( xAreBlockTimeTestTasksStillRunning() != pdTRUE )
 		{
-			pcMessage = "xAreBlockTimeTestTasksStillRunning() returned false";
+			pcStatusMessage = "xAreBlockTimeTestTasksStillRunning() returned false";
 		}
 		else if( xAreSemaphoreTasksStillRunning() != pdTRUE )
 		{
-			pcMessage = "xAreSemaphoreTasksStillRunning() returned false";
+			pcStatusMessage = "xAreSemaphoreTasksStillRunning() returned false";
 		}
 		else if( xArePollingQueuesStillRunning() != pdTRUE )
 		{
-			pcMessage = "xArePollingQueuesStillRunning() returned false";
+			pcStatusMessage = "xArePollingQueuesStillRunning() returned false";
 		}
 		else if( xAreQueuePeekTasksStillRunning() != pdTRUE )
 		{
-			pcMessage = "xAreQueuePeekTasksStillRunning() returned false";
+			pcStatusMessage = "xAreQueuePeekTasksStillRunning() returned false";
 		}
 		else if( xAreRecursiveMutexTasksStillRunning() != pdTRUE )
 		{
-			pcMessage = "xAreRecursiveMutexTasksStillRunning() returned false";
+			pcStatusMessage = "xAreRecursiveMutexTasksStillRunning() returned false";
 		}
 		else if( xAreQueueSetTasksStillRunning() != pdPASS )
 		{
-			pcMessage = "xAreQueueSetTasksStillRunning() returned false";
+			pcStatusMessage = "xAreQueueSetTasksStillRunning() returned false";
 		}
 		else if( xAreEventGroupTasksStillRunning() != pdTRUE )
 		{
-			pcMessage = "xAreEventGroupTasksStillRunning() returned false";
+			pcStatusMessage = "xAreEventGroupTasksStillRunning() returned false";
 		}
 		else if( xAreAbortDelayTestTasksStillRunning() != pdTRUE )
 		{
-			pcMessage = "xAreAbortDelayTestTasksStillRunning() returned false";
+			pcStatusMessage = "xAreAbortDelayTestTasksStillRunning() returned false";
 		}
 		else if( xAreCountingSemaphoreTasksStillRunning() != pdTRUE )
 		{
-			pcMessage = "xAreCountingSemaphoreTasksStillRunning() returned false";
+			pcStatusMessage = "xAreCountingSemaphoreTasksStillRunning() returned false";
 		}
 		else if( xAreDynamicPriorityTasksStillRunning() != pdTRUE )
 		{
-			pcMessage = "xAreDynamicPriorityTasksStillRunning() returned false";
+			pcStatusMessage = "xAreDynamicPriorityTasksStillRunning() returned false";
 		}
 		else if( xAreMessageBufferAMPTasksStillRunning() != pdTRUE )
 		{
-			pcMessage = "xAreMessageBufferAMPTasksStillRunning() returned false";
+			pcStatusMessage = "xAreMessageBufferAMPTasksStillRunning() returned false";
 		}
 		else if( xIsQueueOverwriteTaskStillRunning() != pdTRUE )
 		{
-			pcMessage = "xIsQueueOverwriteTaskStillRunning() returned false";
+			pcStatusMessage = "xIsQueueOverwriteTaskStillRunning() returned false";
 		}
 		else if( xAreQueueSetPollTasksStillRunning() != pdTRUE )
 		{
-			pcMessage = "xAreQueueSetPollTasksStillRunning() returned false";
+			pcStatusMessage = "xAreQueueSetPollTasksStillRunning() returned false";
 		}
 		else if( xAreStaticAllocationTasksStillRunning() != pdTRUE )
 		{
-			pcMessage = "xAreStaticAllocationTasksStillRunning() returned false";
+			pcStatusMessage = "xAreStaticAllocationTasksStillRunning() returned false";
 		}
 		else if( xAreTaskNotificationTasksStillRunning() != pdTRUE )
 		{
-			pcMessage = "xAreTaskNotificationTasksStillRunning() returned false";
+			pcStatusMessage = "xAreTaskNotificationTasksStillRunning() returned false";
 		}
 		else if( xAreTaskNotificationArrayTasksStillRunning() != pdTRUE )
 		{
-			pcMessage = "xAreTaskNotificationArrayTasksStillRunning() returned false";
+			pcStatusMessage = "xAreTaskNotificationArrayTasksStillRunning() returned false";
 		}
 		else if( xAreTimerDemoTasksStillRunning( xTaskPeriod ) != pdTRUE )
 		{
-			pcMessage = "xAreTimerDemoTasksStillRunning() returned false";
+			pcStatusMessage = "xAreTimerDemoTasksStillRunning() returned false";
 		}
 		else if( xIsInterruptStreamBufferDemoStillRunning() != pdTRUE )
 		{
-			pcMessage = "xIsInterruptStreamBufferDemoStillRunning() returned false";
+			pcStatusMessage = "xIsInterruptStreamBufferDemoStillRunning() returned false";
 		}
 		else if( xAreInterruptSemaphoreTasksStillRunning() != pdTRUE )
 		{
-			pcMessage = "xAreInterruptSemaphoreTasksStillRunning() returned false";
+			pcStatusMessage = "xAreInterruptSemaphoreTasksStillRunning() returned false";
 		}
 
 		/* It is normally not good to call printf() from an embedded system,
 		although it is ok in this simulated case. */
-		printf( "%s : %d (%d)\r\n", pcMessage, (int) xTaskGetTickCount(), ulNestCount );
+		printf( "%s : %d (%d)\r\n", pcStatusMessage, (int) xTaskGetTickCount(), ulNestCount );
 	}
 }
 /*-----------------------------------------------------------*/
@@ -309,3 +325,97 @@ void vFullDemoTickHookFunction( void )
 }
 /*-----------------------------------------------------------*/
 
+void vFullDemoIdleHookFunction( void )
+{
+	prvExerciseTaskHeapAllocationStats();
+}
+/*-----------------------------------------------------------*/
+
+static void prvExerciseTaskHeapAllocationStats( void )
+{
+TaskStatus_t xTaskInfo;
+uint32_t ulOriginalNumberOfAllocations, ulOriginalNumberOfFrees;
+size_t xOriginalHighWaterMark;
+const size_t xBytesToAllocate = ( size_t ) 100;
+void *pvAllocatedMemory;
+TaskHandle_t xIdleTaskHandle;
+static uint32_t ulCallCount = 0UL;
+const uint32_t ulMaxCallCount = 0xfffffff0UL;
+
+	/* Test will fail once the number of allocations and frees cannot be
+	 * incremented without resulting in an overflow. */
+	if( ulCallCount < ulMaxCallCount )
+	{
+		xIdleTaskHandle = xTaskGetCurrentTaskHandle();
+
+		vTaskGetInfo( xIdleTaskHandle,	/* The task being queried. */
+						  &xTaskInfo,	/* The structure into which information on the task will be written. */
+						  pdTRUE,		/* Include the task's high watermark in the structure. */
+						  eInvalid );	/* Include the task state in the structure. */
+
+		/* The idle task does not otherwise allocate any memory. */
+		if( ( xTaskInfo.eCurrentState != eRunning )								||
+			( xTaskInfo.xHeapBytesCurrentlyHeld != ( size_t ) 0 ) )
+		{
+			pcStatusMessage = "Error:  vTaskGetInfo() returned incorrect information about heap allocated by idle task.\r\n";
+		}
+
+		/* Remember the current heap stats for the idle task, allocate some memory,
+		 * then ensure the heap stats are updated as expected. */
+		ulOriginalNumberOfAllocations = xTaskInfo.ulNumberOfHeapAllocations;
+		ulOriginalNumberOfFrees = xTaskInfo.ulNumberOfHeapFrees;
+		xOriginalHighWaterMark = xTaskInfo.xMaxHeapBytesEverHeld;
+
+		pvAllocatedMemory = pvPortMalloc( xBytesToAllocate );
+		configASSERT( pvAllocatedMemory );
+
+		vTaskGetInfo( xIdleTaskHandle,	/* The task being queried. */
+						  &xTaskInfo,	/* The structure into which information on the task will be written. */
+						  pdTRUE,		/* Include the task's high watermark in the structure. */
+						  eInvalid );	/* Include the task state in the structure. */
+
+		if( ( xTaskInfo.ulNumberOfHeapAllocations != ( ulOriginalNumberOfAllocations + 1UL ) ||
+			( xTaskInfo.ulNumberOfHeapFrees != ulOriginalNumberOfFrees ) ||
+			( xTaskInfo.xHeapBytesCurrentlyHeld != xBytesToAllocate ) ) )
+		{
+			pcStatusMessage = "Error:  vTaskGetInfo() returned incorrect information after allocating memory in the idle task.\r\n";
+		}
+
+		/* If this is the first time through the high water mark should have
+		 * increased by the amount of memory allocated, otherwise it should have
+		 * stayed the same. */
+		if( ulCallCount == 0 )
+		{
+			if( xTaskInfo.xMaxHeapBytesEverHeld != xBytesToAllocate )
+			{
+				pcStatusMessage = "Error:  vTaskGetInfo() returned incorrect heap allocation high water mark for the idle task, first pass.\r\n";
+			}
+		}
+		else
+		{
+			if( xTaskInfo.xMaxHeapBytesEverHeld != xOriginalHighWaterMark )
+			{
+				pcStatusMessage = "Error:  vTaskGetInfo() returned incorrect heap allocation high water mark for the idle task, not first pass.\r\n";
+			}
+		}
+
+		/* Likewise free the memory just allocated and double check the task's heap
+		 * stats once more. */
+		vPortFree( pvAllocatedMemory );
+
+		vTaskGetInfo( xIdleTaskHandle,	/* The task being queried. */
+						  &xTaskInfo,	/* The structure into which information on the task will be written. */
+						  pdTRUE,		/* Include the task's high watermark in the structure. */
+						  eInvalid );	/* Include the task state in the structure. */
+
+		if( ( xTaskInfo.ulNumberOfHeapAllocations != ( ulOriginalNumberOfAllocations + 1UL ) ||
+			( xTaskInfo.ulNumberOfHeapFrees != ( ulOriginalNumberOfFrees + 1 ) ) ||
+			( xTaskInfo.xHeapBytesCurrentlyHeld != ( size_t ) 0 ) ) )
+		{
+			pcStatusMessage = "Error:  vTaskGetInfo() returned incorrect information after freeing memory in the idle task.\r\n";
+		}
+
+		ulCallCount++;
+	}
+}
+/*-----------------------------------------------------------*/

--- a/FreeRTOS/Demo/WIN32-MSVC/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/WIN32-MSVC/FreeRTOSConfig.h
@@ -81,6 +81,8 @@ void vConfigureTimerForRunTimeStats( void );	/* Prototype of function that initi
 #define configGENERATE_RUN_TIME_STATS			1
 #define portCONFIGURE_TIMER_FOR_RUN_TIME_STATS() vConfigureTimerForRunTimeStats()
 #define portGET_RUN_TIME_COUNTER_VALUE() ulGetRunTimeCounterValue()
+#define configTRACK_TASK_MEMORY_ALLOCATIONS		1
+
 
 /* Co-routine related configuration options. */
 #define configUSE_CO_ROUTINES 					1

--- a/FreeRTOS/Demo/WIN32-MSVC/main.c
+++ b/FreeRTOS/Demo/WIN32-MSVC/main.c
@@ -78,9 +78,9 @@ that make up the total heap.  heap_5 is only used for test and example purposes
 as this demo could easily create one large heap region instead of multiple
 smaller heap regions - in which case heap_4.c would be the more appropriate
 choice.  See http://www.freertos.org/a00111.html for an explanation. */
-#define mainREGION_1_SIZE	8201
-#define mainREGION_2_SIZE	29905
-#define mainREGION_3_SIZE	7807
+#define mainREGION_1_SIZE	9801
+#define mainREGION_2_SIZE	32000
+#define mainREGION_3_SIZE	10000
 
 /*-----------------------------------------------------------*/
 


### PR DESCRIPTION
Description
-----------
Add prvExerciseTaskHeapAllocationStats() to the MSVN Win32 and MPS2 QEMU IAR demos to exercise the function that track memory allocations on a task by task basis as introduced by https://github.com/FreeRTOS/FreeRTOS-Kernel/pull/353.

Test Steps
-----------
Run "full" build of the MSVN Win32 demo and MPS2 QEMU IAR demos.

Related Issue
-----------
https://github.com/FreeRTOS/FreeRTOS-Kernel/pull/353


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
