### PR TITLE
Add new demo submodules to manifest.yml

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -109,12 +109,14 @@ dependencies:
       path: "FreeRTOS-Plus/Source/Application-Protocols/coreSNTP"
 
   - name: "FreeRTOS-Community-Supported-Demos"
+    version: "e21b617"
     repository:
       type: "git"
       url: "https://github.com/FreeRTOS/FreeRTOS-Community-Supported-Demos"
       path: "FreeRTOS/Demo/ThirdParty/Community-Supported-Demos"
 
   - name: "FreeRTOS-Partner-Supported-Demos"
+    version: "109ef4d"
     repository:
       type: "git"
       url: "https://github.com/FreeRTOS/FreeRTOS-Partner-Supported-Demos"

--- a/manifest.yml
+++ b/manifest.yml
@@ -108,4 +108,16 @@ dependencies:
       url: "https://github.com/FreeRTOS/coreSNTP"
       path: "FreeRTOS-Plus/Source/Application-Protocols/coreSNTP"
 
+  - name: "FreeRTOS-Community-Supported-Demos"
+    repository:
+      type: "git"
+      url: "https://github.com/FreeRTOS/FreeRTOS-Community-Supported-Demos"
+      path: "FreeRTOS/Demo/ThirdParty/Community-Supported-Demos"
+
+  - name: "FreeRTOS-Partner-Supported-Demos"
+    repository:
+      type: "git"
+      url: "https://github.com/FreeRTOS/FreeRTOS-Partner-Supported-Demos"
+      path: "FreeRTOS/Demo/ThirdParty/Partner-Supported-Demos"
+
 license: "MIT"


### PR DESCRIPTION
Description
-----------
Adds FreeRTOS-Community-Supported-Demos and FreeRTOS-Partner-Supported-Demos to the manifest.yml file.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
