### PR TITLE
Update coreSNTP submodule and coreSNTP demo

### DIFF
--- a/FreeRTOS-Plus/Demo/coreSNTP_Windows_Simulator/DemoTasks/SNTPClientTask.c
+++ b/FreeRTOS-Plus/Demo/coreSNTP_Windows_Simulator/DemoTasks/SNTPClientTask.c
@@ -106,11 +106,11 @@
 #endif
 
 #ifndef democonfigSEND_TIME_REQUEST_TIMEOUT_MS
-    #define democonfigSERVER_RESPONSE_TIMEOUT_MS    ( 50 )
+    #define democonfigSEND_TIME_REQUEST_TIMEOUT_MS    ( 50 )
 #endif
 
 #ifndef democonfigRECEIVE_SERVER_RESPONSE_BLOCK_TIME_MS
-    #define democonfigSERVER_RESPONSE_TIMEOUT_MS    ( 200 )
+    #define democonfigRECEIVE_SERVER_RESPONSE_BLOCK_TIME_MS    ( 200 )
 #endif
 
 /**

--- a/FreeRTOS-Plus/Demo/coreSNTP_Windows_Simulator/demo_config.h
+++ b/FreeRTOS-Plus/Demo/coreSNTP_Windows_Simulator/demo_config.h
@@ -150,19 +150,19 @@ extern void vLoggingPrintf( const char * pcFormatString,
  *     OR
  *  * Using the same firmware baked-in starting time of device for every boot-up.
  */
-#define democonfigSYSTEM_START_YEAR               ( 2021 )
+#define democonfigSYSTEM_START_YEAR                        ( 2021 )
 
 /**
  * @brief The timeout (in milliseconds) for the time response to a time request made to a
  * time server.
  */
-#define democonfigSERVER_RESPONSE_TIMEOUT_MS      ( 5000 )
+#define democonfigSERVER_RESPONSE_TIMEOUT_MS               ( 5000 )
 
 /**
  * @brief The maximum block time (in milliseconds) for an attempt to send time request over the network
  * to a time server when through the Sntp_SendTimeRequest API.
  */
-#define democonfigSEND_TIME_REQUEST_TIMEOUT_MS    ( 50 )
+#define democonfigSEND_TIME_REQUEST_TIMEOUT_MS             ( 50 )
 
 /**
  * @brief The maximum block time (in milliseconds) for an attempt to read server response (to a time request)
@@ -174,7 +174,7 @@ extern void vLoggingPrintf( const char * pcFormatString,
  * that is orders of degree shorter than the response timeout value) to check whether an expected server response
  * has been received as well as performing other application logic in the same thread context.
  */
-#define democonfigSERVER_RESPONSE_TIMEOUT_MS      ( 200 )
+#define democonfigRECEIVE_SERVER_RESPONSE_BLOCK_TIME_MS    ( 200 )
 
 /**
  * @brief Set the stack size of the main demo task.
@@ -182,7 +182,7 @@ extern void vLoggingPrintf( const char * pcFormatString,
  * In the Windows port, this stack only holds a structure. The actual
  * stack is created by an operating system thread.
  */
-#define democonfigDEMO_STACKSIZE                  configMINIMAL_STACK_SIZE
+#define democonfigDEMO_STACKSIZE                           configMINIMAL_STACK_SIZE
 
 
 #endif /* DEMO_CONFIG_H */

--- a/FreeRTOS-Plus/Demo/coreSNTP_Windows_Simulator/demo_config.h
+++ b/FreeRTOS-Plus/Demo/coreSNTP_Windows_Simulator/demo_config.h
@@ -150,13 +150,31 @@ extern void vLoggingPrintf( const char * pcFormatString,
  *     OR
  *  * Using the same firmware baked-in starting time of device for every boot-up.
  */
-#define democonfigSYSTEM_START_YEAR             ( 2021 )
+#define democonfigSYSTEM_START_YEAR               ( 2021 )
 
 /**
  * @brief The timeout (in milliseconds) for the time response to a time request made to a
  * time server.
  */
-#define democonfigSERVER_RESPONSE_TIMEOUT_MS    ( 5000 )
+#define democonfigSERVER_RESPONSE_TIMEOUT_MS      ( 5000 )
+
+/**
+ * @brief The maximum block time (in milliseconds) for an attempt to send time request over the network
+ * to a time server when through the Sntp_SendTimeRequest API.
+ */
+#define democonfigSEND_TIME_REQUEST_TIMEOUT_MS    ( 50 )
+
+/**
+ * @brief The maximum block time (in milliseconds) for an attempt to read server response (to a time request)
+ * from the network through the Sntp_ReceiveTimeResponse API.
+ *
+ * @note This value MAY BE less than the server response timeout (configured in democonfigSERVER_RESPONSE_TIMEOUT_MS)
+ * to support use-cases when application DOES NOT want to block for the entire server response timeout period.
+ * In such a case, the Sntp_ReceiveTimeResponse API can be called multiple times (with block time duration
+ * that is orders of degree shorter than the response timeout value) to check whether an expected server response
+ * has been received as well as performing other application logic in the same thread context.
+ */
+#define democonfigSERVER_RESPONSE_TIMEOUT_MS      ( 200 )
 
 /**
  * @brief Set the stack size of the main demo task.
@@ -164,6 +182,7 @@ extern void vLoggingPrintf( const char * pcFormatString,
  * In the Windows port, this stack only holds a structure. The actual
  * stack is created by an operating system thread.
  */
-#define democonfigDEMO_STACKSIZE                configMINIMAL_STACK_SIZE
+#define democonfigDEMO_STACKSIZE                  configMINIMAL_STACK_SIZE
+
 
 #endif /* DEMO_CONFIG_H */

--- a/lexicon.txt
+++ b/lexicon.txt
@@ -162,9 +162,9 @@ busfault
 buttonisr
 bvic
 bytesreceived
-bytesreceived 
+bytesreceived
 bytessent
-bytessent 
+bytessent
 bytestorecv
 bytestosend
 bytestring
@@ -243,6 +243,7 @@ cliprocesscommand
 clk
 clkdiv
 clksel
+clockoffsetms
 clocksource
 closesession
 cmac
@@ -792,6 +793,7 @@ gmon
 gnd
 gnuc
 googleapis
+gov
 gpio
 gpioa
 gpiob
@@ -1010,6 +1012,7 @@ js
 json
 jtag
 jtvic
+june
 juse
 katy
 kbhit
@@ -1044,6 +1047,7 @@ ldi
 ldo
 ldr
 le
+leapsecondinfo
 ledflash
 ledio
 leds
@@ -1297,6 +1301,7 @@ networkcredentials
 nextjobexecutionchanged
 nic
 nirq
+nist
 nmemb
 nmi
 nnnn
@@ -1547,6 +1552,7 @@ pllon
 plls
 pm
 pmc
+pml
 pmp
 pmqttagentcontext
 pmsg
@@ -1824,6 +1830,7 @@ pscheckvariable
 psel
 pserver
 pserverinfo
+pservertime
 psignature
 psl
 pslotlist


### PR DESCRIPTION
Update the `coreSNTP` submodule to the latest commit. Also, make updates to the coreSNTP demo for the new changes in the SNTP library which include the following: 
1. Update to the type for packet size from `size_t` to `uint16_t` for parameters in the transport and authentication interfaces. 
2. Change in the call to `Sntp_SendTimeRequest` API to pass the new **blockTimeMs** parameter added to the API.  
3. Update to the clock-offfset type from `int32_t` to `int64_t` for representing information in milliseconds. To accommodate this update in the SntpSetTime_t interface, the mathematical model for representing system clock has been updated to store **slew rate** as milliseconds/second (instead of second/second). This change improves the accuracy of the WinSim demo time correction (because the milliseconds of time difference between server and client time is corrected over the entire polling interval which makes a significant difference!).  

This PR also adds demo config macros for setting the block time values passed to the `Sntp_SendTimeRequest` and `Sntp_ReceiveTimeResponse` APIs.