### PR TITLE
Fix data copy address error

### DIFF
--- a/FreeRTOS/Demo/AVR_ATMega323_WinAVR/serial/serial.c
+++ b/FreeRTOS/Demo/AVR_ATMega323_WinAVR/serial/serial.c
@@ -185,7 +185,7 @@ unsigned char ucByte;
 }
 /*-----------------------------------------------------------*/
 
-SIGNAL( SIG_UART_RECV )
+SIGNAL( USART_RXC_vect )
 {
 signed char cChar;
 signed portBASE_TYPE xHigherPriorityTaskWoken = pdFALSE;
@@ -204,7 +204,7 @@ signed portBASE_TYPE xHigherPriorityTaskWoken = pdFALSE;
 }
 /*-----------------------------------------------------------*/
 
-SIGNAL( SIG_UART_DATA )
+SIGNAL( USART_UDRE_vect )
 {
 signed char cChar, cTaskWoken;
 

--- a/FreeRTOS/Demo/CORTEX_M3_MPS2_QEMU_GCC/scripts/mps2_m3.ld
+++ b/FreeRTOS/Demo/CORTEX_M3_MPS2_QEMU_GCC/scripts/mps2_m3.ld
@@ -56,7 +56,6 @@ SECTIONS
         *(.rodata*)
         . = ALIGN(4);
         _etext = .;
-        _sidata = _etext;
     } > FLASH
 
 	.ARM.extab :
@@ -74,6 +73,9 @@ SECTIONS
 		__exidx_end = .;
 		. = ALIGN(4);
 	} >FLASH
+
+    /* used by the startup to initialize data */
+    _sidata = LOADADDR(.data);
 
     .interrupts_ram :
     {

--- a/FreeRTOS/Demo/CORTEX_M3_MPS2_QEMU_GCC/scripts/mps2_m3.ld
+++ b/FreeRTOS/Demo/CORTEX_M3_MPS2_QEMU_GCC/scripts/mps2_m3.ld
@@ -58,23 +58,21 @@ SECTIONS
         _etext = .;
     } > FLASH
 
-	.ARM.extab :
-	{
-		. = ALIGN(4);
-		*(.ARM.extab* .gnu.linkonce.armextab.*)
-		. = ALIGN(4);
-	} >FLASH
+    .ARM.extab :
+    {
+        . = ALIGN(4);
+        *(.ARM.extab* .gnu.linkonce.armextab.*)
+        . = ALIGN(4);
+    } >FLASH
 
-	.ARM :
-	{
-		. = ALIGN(4);
-		__exidx_start = .;
-		*(.ARM.exidx* .gnu.linkonce.armexidx.*)
-		__exidx_end = .;
-		. = ALIGN(4);
-	} >FLASH
-
-    _sidata = LOADADDR(.data);
+    .ARM :
+    {
+        . = ALIGN(4);
+        __exidx_start = .;
+        *(.ARM.exidx* .gnu.linkonce.armexidx.*)
+        __exidx_end = .;
+        . = ALIGN(4);
+    } >FLASH
 
     .interrupts_ram :
     {
@@ -84,9 +82,10 @@ SECTIONS
         . += M_VECTOR_RAM_SIZE;
         . = ALIGN(4);
         __interrupts_ram_end = .;
-
     } > RAM
-    
+
+    _sidata = LOADADDR(.data);
+
     .data : /* AT ( _sidata ) */
     {
         . = ALIGN(4);


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->
The data segment will be copied from flash to ram at startup. But the start address maybe error. In the flash data, between .text and .data, may be have .ARM data. In this case, using the end of text as the start of data will result in incorrect data content copied to ram.

............
.text
............  <=== original  copy start
.ARM
............  <==== change copy start to
.data
...........

freerots/FreeRTOS/FreeRTOS/Demo/CORTEX_M3_MPS2_QEMU_GCC/init/startup.c
`    // copy .data section from flash to RAM`
`    for (uint32_t *src = &_sidata, *dest = &_sdata; dest < &_edata;)`
`    {`
 `       *dest++ = *src++;`
`    }`

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
