### PR TITLE
Fix data copy address error

### DIFF
--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Echo_Qemu_mps2/scripts/mps2_m3.ld
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Echo_Qemu_mps2/scripts/mps2_m3.ld
@@ -56,7 +56,6 @@ SECTIONS
         *(.rodata*)
         . = ALIGN(4);
         _etext = .;
-        _sidata = _etext;
     } > FLASH
 
 	.ARM.extab :
@@ -85,7 +84,9 @@ SECTIONS
         __interrupts_ram_end = .;
 
     } > RAM
-    
+
+    _sidata = LOADADDR(.data);
+
     .data : /* AT ( _sidata ) */
     {
         . = ALIGN(4);


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->
Same issue as https://github.com/FreeRTOS/FreeRTOS/pull/632

The data segment will be copied from flash to ram at startup. But the start address maybe error. In the flash data, between .text and .data, may be have .ARM data. In this case, using the end of text as the start of data will result in incorrect data content copied to ram.

............
.text
............ <=== original copy start
.ARM
............ <==== change copy start to
.data
...........

freerots/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Echo_Qemu_mps2/init/startup.c
// copy .data section from flash to RAM
for (uint32_t *src = &_sidata, *dest = &_sdata; dest < &_edata;)
{
*dest++ = *src++;
}

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
