### PR TITLE
Update the size of privileged data section

### DIFF
--- a/FreeRTOS/Demo/CORTEX_MPU_M3_NUCLEO_L152RE_GCC/Projects/GCC/STM32L152RETX_FLASH.ld
+++ b/FreeRTOS/Demo/CORTEX_MPU_M3_NUCLEO_L152RE_GCC/Projects/GCC/STM32L152RETX_FLASH.ld
@@ -72,7 +72,7 @@ MEMORY
 /* Initial 32K Flash is used to store kernel functions and
  * initial 512 bytes of RAM is used to store kernel data. */
 __privileged_functions_region_size__  = 32K;
-__privileged_data_region_size__       = 512;
+__privileged_data_region_size__       = 32K;
 
 __FLASH_segment_start__               = ORIGIN( FLASH );
 __FLASH_segment_end__                 = __FLASH_segment_start__ + LENGTH( FLASH );


### PR DESCRIPTION
Description
-----------
This is needed because FreeRTOS heap is now placed in the privileged data section.

Related Issue
-----------
https://forums.freertos.org/t/compilation-of-freertos-mpu-demo-throws-error/13000


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
