### PR TITLE
Cleaned up report_builder in defender_demo_json

### DIFF
--- a/FreeRTOS-Plus/Demo/AWS/Device_Defender_Windows_Simulator/Device_Defender_Demo/report_builder.c
+++ b/FreeRTOS-Plus/Demo/AWS/Device_Defender_Windows_Simulator/Device_Defender_Demo/report_builder.c
@@ -53,61 +53,61 @@
 /* Formats used to generate the JSON report. */
 #define reportbuilderJSON_PORT_OBJECT_FORMAT \
     "{"                                      \
-    "\"%s\": %u"                             \
+    "\""DEFENDER_REPORT_PORT_KEY"\": %u"     \
     "},"
 
-#define reportbuilderJSON_CONNECTION_OBJECT_FORMAT \
-    "{"                                            \
-    "\"%s\": %u,"                                  \
-    "\"%s\": \"%u.%u.%u.%u:%u\""                   \
+#define reportbuilderJSON_CONNECTION_OBJECT_FORMAT              \
+    "{"                                                         \
+    "\""DEFENDER_REPORT_LOCAL_PORT_KEY"\": %u,"                 \
+    "\""DEFENDER_REPORT_REMOTE_ADDR_KEY"\": \"%u.%u.%u.%u:%u\"" \
     "},"
 
-#define reportbuilderJSON_REPORT_FORMAT_PART1 \
-    "{"                                       \
-    "\"%s\": {"                               \
-    "\"%s\": %u,"                             \
-    "\"%s\": \"%u.%u\""                       \
-    "},"                                      \
-    "\"%s\": {"                               \
-    "\"%s\": {"                               \
-    "\"%s\": "
+#define reportbuilderJSON_REPORT_FORMAT_PART1          \
+    "{"                                                \
+    "\""DEFENDER_REPORT_HEADER_KEY"\": {"              \
+    "\""DEFENDER_REPORT_ID_KEY"\": %u,"                \
+    "\""DEFENDER_REPORT_VERSION_KEY"\": \"%u.%u\""     \
+    "},"                                               \
+    "\""DEFENDER_REPORT_METRICS_KEY"\": {"             \
+    "\""DEFENDER_REPORT_TCP_LISTENING_PORTS_KEY"\": {" \
+    "\""DEFENDER_REPORT_PORTS_KEY"\": "
 
-#define reportbuilderJSON_REPORT_FORMAT_PART2 \
-    ","                                       \
-    "\"%s\": %u"                              \
-    "},"                                      \
-    "\"%s\": {"                               \
-    "\"%s\": "
+#define reportbuilderJSON_REPORT_FORMAT_PART2          \
+    ","                                                \
+    "\""DEFENDER_REPORT_TOTAL_KEY"\": %u"              \
+    "},"                                               \
+    "\""DEFENDER_REPORT_UDP_LISTENING_PORTS_KEY"\": {" \
+    "\""DEFENDER_REPORT_PORTS_KEY"\": "
 
-#define reportbuilderJSON_REPORT_FORMAT_PART3 \
-    ","                                       \
-    "\"%s\": %u"                              \
-    "},"                                      \
-    "\"%s\": {"                               \
-    "\"%s\": %u,"                             \
-    "\"%s\": %u,"                             \
-    "\"%s\": %u,"                             \
-    "\"%s\": %u"                              \
-    "},"                                      \
-    "\"%s\": {"                               \
-    "\"%s\": {"                               \
-    "\"%s\": "
+#define reportbuilderJSON_REPORT_FORMAT_PART3              \
+    ","                                                    \
+    "\""DEFENDER_REPORT_TOTAL_KEY"\": %u"                  \
+    "},"                                                   \
+    "\""DEFENDER_REPORT_NETWORK_STATS_KEY"\": {"           \
+    "\""DEFENDER_REPORT_BYTES_IN_KEY"\": %u,"              \
+    "\""DEFENDER_REPORT_BYTES_OUT_KEY"\": %u,"             \
+    "\""DEFENDER_REPORT_PKTS_IN_KEY"\": %u,"               \
+    "\""DEFENDER_REPORT_PKTS_OUT_KEY"\": %u"               \
+    "},"                                                   \
+    "\""DEFENDER_REPORT_TCP_CONNECTIONS_KEY"\": {"         \
+    "\""DEFENDER_REPORT_ESTABLISHED_CONNECTIONS_KEY"\": {" \
+    "\""DEFENDER_REPORT_CONNECTIONS_KEY"\": "
 
-#define reportbuilderJSON_REPORT_FORMAT_PART4 \
-    ","                                       \
-    "\"%s\": %u"                              \
-    "}"                                       \
-    "}"                                       \
-    "},"                                      \
-    "\"%s\": {"                               \
-    "\"stack_high_water_mark\": ["            \
-    "{"                                       \
-    "\"%s\": %u"                              \
-    "}"                                       \
-    "],"                                      \
-    "\"task_numbers\": ["                     \
-    "{"                                       \
-    "\"%s\": "
+#define reportbuilderJSON_REPORT_FORMAT_PART4     \
+    ","                                           \
+    "\""DEFENDER_REPORT_TOTAL_KEY"\": %u"         \
+    "}"                                           \
+    "}"                                           \
+    "},"                                          \
+    "\""DEFENDER_REPORT_CUSTOM_METRICS_KEY"\": {" \
+    "\"stack_high_water_mark\": ["                \
+    "{"                                           \
+    "\""DEFENDER_REPORT_NUMBER_KEY"\": %u"        \
+    "}"                                           \
+    "],"                                          \
+    "\"task_numbers\": ["                         \
+    "{"                                           \
+    "\""DEFENDER_REPORT_NUMBER_LIST_KEY"\": "
 
 #define reportbuilderJSON_REPORT_FORMAT_PART5 \
     "}"                                       \
@@ -229,7 +229,6 @@ static eReportBuilderStatus prvWritePortsArray( char * pcBuffer,
         lCharactersWritten = snprintf( pcCurrentWritePos,
                                        ulRemainingBufferLength,
                                        reportbuilderJSON_PORT_OBJECT_FORMAT,
-                                       DEFENDER_REPORT_PORT_KEY,
                                        pusOpenPortsArray[ i ] );
 
         if( !reportbuilderSNPRINTF_SUCCESS( lCharactersWritten, ulRemainingBufferLength ) )
@@ -305,9 +304,7 @@ static eReportBuilderStatus prvWriteConnectionsArray( char * pcBuffer,
         lCharactersWritten = snprintf( pcCurrentWritePos,
                                        ulRemainingBufferLength,
                                        reportbuilderJSON_CONNECTION_OBJECT_FORMAT,
-                                       DEFENDER_REPORT_LOCAL_PORT_KEY,
                                        pxConn->usLocalPort,
-                                       DEFENDER_REPORT_REMOTE_ADDR_KEY,
                                        ( pxConn->ulRemoteIp >> 24 ) & 0xFF,
                                        ( pxConn->ulRemoteIp >> 16 ) & 0xFF,
                                        ( pxConn->ulRemoteIp >> 8 ) & 0xFF,
@@ -464,16 +461,9 @@ eReportBuilderStatus eGenerateJsonReport( char * pcBuffer,
         lCharactersWritten = snprintf( pcCurrentWritePos,
                                        ulRemainingBufferLength,
                                        reportbuilderJSON_REPORT_FORMAT_PART1,
-                                       DEFENDER_REPORT_HEADER_KEY,
-                                       DEFENDER_REPORT_ID_KEY,
                                        ulReportId,
-                                       DEFENDER_REPORT_VERSION_KEY,
                                        ulMajorReportVersion,
-                                       ulMinorReportVersion,
-                                       DEFENDER_REPORT_METRICS_KEY,
-                                       DEFENDER_REPORT_TCP_LISTENING_PORTS_KEY,
-                                       DEFENDER_REPORT_PORTS_KEY
-                                       );
+                                       ulMinorReportVersion );
 
         if( !reportbuilderSNPRINTF_SUCCESS( lCharactersWritten, ulRemainingBufferLength ) )
         {
@@ -513,11 +503,7 @@ eReportBuilderStatus eGenerateJsonReport( char * pcBuffer,
         lCharactersWritten = snprintf( pcCurrentWritePos,
                                        ulRemainingBufferLength,
                                        reportbuilderJSON_REPORT_FORMAT_PART2,
-                                       DEFENDER_REPORT_TOTAL_KEY,
-                                       pxMetrics->ulOpenTcpPortsArrayLength,
-                                       DEFENDER_REPORT_UDP_LISTENING_PORTS_KEY,
-                                       DEFENDER_REPORT_PORTS_KEY
-                                       );
+                                       pxMetrics->ulOpenTcpPortsArrayLength );
 
         if( !reportbuilderSNPRINTF_SUCCESS( lCharactersWritten, ulRemainingBufferLength ) )
         {
@@ -557,21 +543,12 @@ eReportBuilderStatus eGenerateJsonReport( char * pcBuffer,
         lCharactersWritten = snprintf( pcCurrentWritePos,
                                        ulRemainingBufferLength,
                                        reportbuilderJSON_REPORT_FORMAT_PART3,
-                                       DEFENDER_REPORT_TOTAL_KEY,
                                        pxMetrics->ulOpenUdpPortsArrayLength,
-                                       DEFENDER_REPORT_NETWORK_STATS_KEY,
-                                       DEFENDER_REPORT_BYTES_IN_KEY,
                                        pxMetrics->pxNetworkStats->ulBytesReceived,
-                                       DEFENDER_REPORT_BYTES_OUT_KEY,
                                        pxMetrics->pxNetworkStats->ulBytesSent,
-                                       DEFENDER_REPORT_PKTS_IN_KEY,
                                        pxMetrics->pxNetworkStats->ulPacketsReceived,
-                                       DEFENDER_REPORT_PKTS_OUT_KEY,
                                        pxMetrics->pxNetworkStats->ulPacketsSent,
-                                       DEFENDER_REPORT_TCP_CONNECTIONS_KEY,
-                                       DEFENDER_REPORT_ESTABLISHED_CONNECTIONS_KEY,
-                                       DEFENDER_REPORT_CONNECTIONS_KEY
-                                       );
+                                       DEFENDER_REPORT_ESTABLISHED_CONNECTIONS_KEY );
 
         if( !reportbuilderSNPRINTF_SUCCESS( lCharactersWritten, ulRemainingBufferLength ) )
         {
@@ -611,13 +588,8 @@ eReportBuilderStatus eGenerateJsonReport( char * pcBuffer,
         lCharactersWritten = snprintf( pcCurrentWritePos,
                                        ulRemainingBufferLength,
                                        reportbuilderJSON_REPORT_FORMAT_PART4,
-                                       DEFENDER_REPORT_TOTAL_KEY,
                                        pxMetrics->ulEstablishedConnectionsArrayLength,
-                                       DEFENDER_REPORT_CUSTOM_METRICS_KEY,
-                                       DEFENDER_REPORT_NUMBER_KEY,
-                                       pxMetrics->ulStackHighWaterMark,
-                                       DEFENDER_REPORT_NUMBER_LIST_KEY
-                                       );
+                                       pxMetrics->ulStackHighWaterMark );
 
         if( !reportbuilderSNPRINTF_SUCCESS( lCharactersWritten, ulRemainingBufferLength ) )
         {


### PR DESCRIPTION
<!--- Title -->

Description
-----------
With the parentheses in `DEFENDER_REPORT_SELECT_KEY` removed, json key macros from `defender.h` can now be used as strings to concatenate with other strings at build time. This PR cleans up `report_builder` in `defender_demo_json` by replacing "%s" in json formatting strings with appropriate key macros from `defender.h`.

Test Steps
-----------
This PR is tested by building defender_demo_json and running it. By default without `DEFENDER_USE_LONG_KEYS` defined, the json report is as follow:
```
{"hed": {"rid": 5658,"v": "1.0"},"met": {"tp": {"pts": [{"pt": 4456}],"t": 1},"up": {"pts": [],"t": 0},"ns": {"bi": 9635,"bo": 4085,"pi": 46,"po": 28},"tc": {"ec": {"cs": [{"lp": 4456,"rad": "54.213.72.205:8883"}],"t": 1}}},"cmet": {"stack_high_water_mark": [{"number": 57}],"task_numbers": [{"number_list": [2,5,4,1,3]}]}}
```
With `DEFENDER_USE_LONG_KEYS` defined to 1, the report is as follow:
```
{"header": {"report_id": 441,"version": "1.0"},"metrics": {"listening_tcp_ports": {"ports": [{"port": 33123}],"total": 1},"listening_udp_ports": {"ports": [],"total": 0},"network_stats": {"bytes_in": 7921,"bytes_out": 3670,"packets_in": 23,"packets_out": 25},"tcp_connections": {"established_connections": {"connections": [{"local_port": 33123,"remote_addr": "52.88.128.89:8883"}],"total": 1}}},"custom_metrics": {"stack_high_water_mark": [{"number": 57}],"task_numbers": [{"number_list": [2,5,4,1,3]}]}}
```



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
