### PR TITLE
Update coreSNTP demo to avoid issues from open UDP socket

### DIFF
--- a/FreeRTOS-Plus/Demo/coreSNTP_Windows_Simulator/DemoTasks/SNTPClientTask.c
+++ b/FreeRTOS-Plus/Demo/coreSNTP_Windows_Simulator/DemoTasks/SNTPClientTask.c
@@ -1343,7 +1343,7 @@ static bool createUdpSocket( Socket_t * pSocket )
     else
     {
         /* Use a random UDP port for SNTP communication with server for protection against
-         *  spoofing vulnerability from "network off-path" attackers. */
+         * spoofing vulnerability from "network off-path" attackers. */
         uint16_t randomPort = ( generateRandomNumber() % UINT16_MAX );
         bindAddress.sin_port = FreeRTOS_htons( randomPort );
 

--- a/lexicon.txt
+++ b/lexicon.txt
@@ -1836,6 +1836,7 @@ psignature
 psl
 pslotlist
 psoc
+psocket
 psr
 psslcontext
 pstplatformimagestate


### PR DESCRIPTION
#### Issue
There is a possible vulnerability of Denial of Service attack by keeping the UDP socket for the SNTP client task always open in the coreSNTP demo. The Denial of Service attack can occur from receiving multiple server response (duplicated or malicious) for a single SNTP time request sent by the client, and thereby, filing the socket network buffer response packets that affect future time requests.  

#### Solution
This PR fixes this vulnerability by updating the demo to keep a UDP socket open only for the time period of waiting for server response, closing the socket on either receiving a server response or experiencing server timeout, and re-creating a UDP socket for the next polling try. This PR also adds another security functionality using a random port for UDP socket to protect against spoofing attacks from "off-network path" attackers.