### PR TITLE
Add note in coreSNTP demo about Network Time Security (NTS)

### DIFF
--- a/FreeRTOS-Plus/Demo/coreSNTP_Windows_Simulator/DemoTasks/SNTPClientTask.c
+++ b/FreeRTOS-Plus/Demo/coreSNTP_Windows_Simulator/DemoTasks/SNTPClientTask.c
@@ -31,13 +31,22 @@
  *
  * This file contains the SNTP client (daemon) task as well as functionality for
  * maintaining wall-clock or UTC time in RAM. The SNTP client periodically synchronizes
- * system clock with an SNTP/NTP servers. Any other task running an application in the
+ * system clock with SNTP/NTP server(s). Any other task running an application in the
  * system can query the system time. For an example of an application task querying time
  * from the system, refer to the SampleAppTask.c file in this project.
  *
- * !!! NOTE !!!
- * This SNTP demo does not authenticate the server nor the client.
- * Hence, this demo should not be used as production ready code.
+ * This demo shows how the coreSNTP library can be used to communicate with SNTP/NTP
+ * servers in a mutually authenticated through the use of symmetric-key based AES-128-CMAC
+ * algorithm. To run this demo with an SNTP/NTP server in authenticated mode, the AES-128-CMACM
+ * symmetric key needs to be pre-shared between the client (i.e. this demo) and the server.
+ *
+ * !!!Note!!!: 
+ * Even though this demo shows the use of AES-128-CMAC, a symmetric-key cyrptographic based
+ * solution, for authenticating SNTP communication between the demo (SNTP client) and
+ * SNTP/NTP server, we instead RECOMMEND that production devices use the most secure authentication
+ * mechanism alternative available with the Network Time Security (NTS) protocol, an asymmetric-key
+ * cryptographic protocol. For more information, refer to the NTS specification here:
+ * https://datatracker.ietf.org/doc/html/rfc8915
  */
 
 /* Standard includes. */

--- a/FreeRTOS-Plus/Demo/coreSNTP_Windows_Simulator/DemoTasks/SNTPClientTask.c
+++ b/FreeRTOS-Plus/Demo/coreSNTP_Windows_Simulator/DemoTasks/SNTPClientTask.c
@@ -37,11 +37,11 @@
  *
  * This demo shows how the coreSNTP library can be used to communicate with SNTP/NTP
  * servers in a mutually authenticated through the use of symmetric-key based AES-128-CMAC
- * algorithm. To run this demo with an SNTP/NTP server in authenticated mode, the AES-128-CMACM
+ * algorithm. To run this demo with an SNTP/NTP server in authenticated mode, the AES-128-CMAC
  * symmetric key needs to be pre-shared between the client (i.e. this demo) and the server.
  *
  * !!!Note!!!:
- * Even though this demo shows the use of AES-128-CMAC, a symmetric-key cyrptographic based
+ * Even though this demo shows the use of AES-128-CMAC, a symmetric-key cryptographic based
  * solution, for authenticating SNTP communication between the demo (SNTP client) and
  * SNTP/NTP server, we instead RECOMMEND that production devices use the most secure authentication
  * mechanism alternative available with the Network Time Security (NTS) protocol, an asymmetric-key

--- a/FreeRTOS-Plus/Demo/coreSNTP_Windows_Simulator/demo_config.h
+++ b/FreeRTOS-Plus/Demo/coreSNTP_Windows_Simulator/demo_config.h
@@ -109,7 +109,7 @@ extern void vLoggingPrintf( const char * pcFormatString,
  * It is RECOMMENDED to use an authentication mechanism for protecting devices against server spoofing
  * attacks.
  *
- * @note Even though this demo shows the use of AES-128-CMAC, a symmetric-key cyrptographic based
+ * @note Even though this demo shows the use of AES-128-CMAC, a symmetric-key cryptographic based
  * solution, for authenticating SNTP communication between the demo (SNTP client) and
  * SNTP/NTP server, we instead RECOMMEND that production devices use the most secure authentication
  * mechanism alternative available with the Network Time Security (NTS) protocol, an asymmetric-key

--- a/FreeRTOS-Plus/Demo/coreSNTP_Windows_Simulator/demo_config.h
+++ b/FreeRTOS-Plus/Demo/coreSNTP_Windows_Simulator/demo_config.h
@@ -109,6 +109,13 @@ extern void vLoggingPrintf( const char * pcFormatString,
  * It is RECOMMENDED to use an authentication mechanism for protecting devices against server spoofing
  * attacks.
  *
+ * @note Even though this demo shows the use of AES-128-CMAC, a symmetric-key cyrptographic based
+ * solution, for authenticating SNTP communication between the demo (SNTP client) and
+ * SNTP/NTP server, we instead RECOMMEND that production devices use the most secure authentication
+ * mechanism alternative available with the Network Time Security (NTS) protocol, an asymmetric-key
+ * cryptographic protocol. For more information, refer to the NTS specification here:
+ * https://datatracker.ietf.org/doc/html/rfc8915
+ *
  * @note Please provide the 128-bit keys as comma separated list of hexadecimal strings in the order matching
  * the list of time servers configured in democonfigLIST_OF_TIME_SERVERS configuration. If a time server does
  * not support authentication, then NULL should be used to indicate use of no authentication mechanism for the

--- a/lexicon.txt
+++ b/lexicon.txt
@@ -705,6 +705,7 @@ filteration
 findfirst
 findobjects
 fips
+firstbackoffattempt 
 fixme
 flase
 flasg
@@ -1226,6 +1227,7 @@ mingw
 minilistitem
 minimise
 minimised
+minpollperiod 
 mips
 misc
 misra
@@ -1325,6 +1327,7 @@ nsec
 nt
 ntp
 ntpdemo
+nts
 nullptr
 num
 numaker
@@ -1611,6 +1614,7 @@ ppass
 ppassword
 ppc
 ppcmessagetodisplay
+ppollperiod 
 ppr
 pprivatekey
 ppublishinfo

--- a/lexicon.txt
+++ b/lexicon.txt
@@ -2210,6 +2210,7 @@ shadownamelength
 shadowstatus
 shasum
 shigherprioritytaskwoken
+shouldinitializecontext
 shouldn
 shtml
 sice


### PR DESCRIPTION
This PR makes the following changes in the `coreSNTP` demo: 
* To suggest the most secure way of using SNTP communication, we are **adding a documentation note** about the **Network Time Security** in the SNTP demo. 
* **Hygiene update** of using the **FreeRTOS/backoffAlgorithm** utility library for calculating time polling period interval backoff when time requests are rejected by a time server.