### PR TITLE
Fix: qemu mps2 demo bug

### DIFF
--- a/FreeRTOS/Demo/CORTEX_M3_MPS2_QEMU_GCC/main_full.c
+++ b/FreeRTOS/Demo/CORTEX_M3_MPS2_QEMU_GCC/main_full.c
@@ -186,7 +186,7 @@ static void prvReloadModeTestTimerCallback( TimerHandle_t xTimer );
 /* The variable into which error messages are latched. */
 static char * pcStatusMessage = "OK: No errors";
 
-static int xErrorCount = 1;
+static int xErrorCount = 0;
 
 
 /* This semaphore is created purely to test using the vSemaphoreDelete() and


### PR DESCRIPTION
Description
-----------
The variable `xErrorCount`, which counts the number of times an error is detected, should start with 0. It was incorrectly initialized to 1. This PR fixes it.

Test Steps
-----------
qemu mps2 full demo runs normally without any failure.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
