### PR TITLE
Fix clock drift issue in SNTP demo

### DIFF
--- a/FreeRTOS-Plus/Demo/coreSNTP_Windows_Simulator/DemoTasks/SNTPClientTask.c
+++ b/FreeRTOS-Plus/Demo/coreSNTP_Windows_Simulator/DemoTasks/SNTPClientTask.c
@@ -439,7 +439,7 @@ static void sntpClient_GetTime( SntpTimestamp_t * pCurrentTime );
  * 2. "Slew" correction approach is used for compensating system clock drift
  *    during the poll interval period between time synchronization attempts with
  *    time server(s) when latest time server is not known. The "slew rate" is
- *    calculated ONLY once on the occassion of the second successful time
+ *    calculated ONLY once on the occasion of the second successful time
  *    synchronization with a time server. This is because the demo initializes
  *    system time with (the first second of) the democonfigSYSTEM_START_YEAR
  *    configuration, and thus, the the actual system clock drift over a period
@@ -453,7 +453,7 @@ static void sntpClient_GetTime( SntpTimestamp_t * pCurrentTime );
  * application can use ONLY the "step" correction methodology for simplicity of system clock
  * time calculation logic if the application is not sensitive to abrupt time changes
  * (that occur at the instances of periodic time synchronization attempts). In such a case,
- * the Sntp_CalculatePollInterval() API of coreSNTP library can be used to calculate 
+ * the Sntp_CalculatePollInterval() API of coreSNTP library can be used to calculate
  * the optimum time polling period for your application based on the factors of your
  * system's clock drift rate and the maximum clock drift tolerable by your application.
  *
@@ -1514,7 +1514,7 @@ void sntpTask( void * pParameters )
         SntpStatus_t status;
         bool backoffModeFlag = false;
 
-        /* Set the polling interval for periodic time sychronization attempts by the SNTP client. */
+        /* Set the polling interval for periodic time synchronization attempts by the SNTP client. */
         systemClock.pollPeriod = democonfigSNTP_CLIENT_POLLING_INTERVAL_SECONDS;
 
         LogDebug( ( "Minimum SNTP client polling interval calculated as %lus", systemClock.pollPeriod ) );

--- a/FreeRTOS-Plus/Demo/coreSNTP_Windows_Simulator/DemoTasks/SNTPClientTask.c
+++ b/FreeRTOS-Plus/Demo/coreSNTP_Windows_Simulator/DemoTasks/SNTPClientTask.c
@@ -443,7 +443,7 @@ static void sntpClient_GetTime( SntpTimestamp_t * pCurrentTime );
  *    synchronization with a time server. This is because the demo initializes
  *    system time with (the first second of) the democonfigSYSTEM_START_YEAR
  *    configuration, and thus, the the actual system clock drift over a period
- *    of time ca be calculated only AFTER the demo system time has been synchronized
+ *    of time can be calculated only AFTER the demo system time has been synchronized
  *    with server time once. Thus, after the first time period of poll interval has
  *    transpired, the system clock drift is calculated correctly on the subsequent
  *    successful time synchronization with a time server.

--- a/FreeRTOS-Plus/Demo/coreSNTP_Windows_Simulator/WIN32.vcxproj
+++ b/FreeRTOS-Plus/Demo/coreSNTP_Windows_Simulator/WIN32.vcxproj
@@ -58,7 +58,7 @@
     </Midl>
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>..\..\Source\Utilities\mbedtls_freertos;..\..\..\Source\FreeRTOS-Plus-Trace\Include;..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\include;..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\portable\BufferManagement;..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\portable\Compiler\MSVC;..\..\..\FreeRTOS-Plus\Source\Utilities\logging;..\Common\WinPCap;..\..\..\FreeRTOS\Source\include;..\..\..\FreeRTOS-Plus\Source\corePKCS11\source\include;..\..\..\FreeRTOS-Plus\Source\corePKCS11\source\dependency\3rdparty\pkcs11;..\..\ThirdParty\mbedtls\include;..\..\..\FreeRTOS-Plus\Source\corePKCS11\source\dependency\3rdparty\mbedtls_utils;..\..\..\FreeRTOS\Source\portable\MSVC-MingW;..\..\Source\Application-Protocols\coreSNTP\source\include;.;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\Source\Utilities\mbedtls_freertos;..\..\..\Source\FreeRTOS-Plus-Trace\Include;..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\include;..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\portable\BufferManagement;..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\portable\Compiler\MSVC;..\..\..\FreeRTOS-Plus\Source\Utilities\logging;..\Common\WinPCap;..\..\..\FreeRTOS\Source\include;..\..\..\FreeRTOS-Plus\Source\corePKCS11\source\include;..\..\..\FreeRTOS-Plus\Source\corePKCS11\source\dependency\3rdparty\pkcs11;..\..\ThirdParty\mbedtls\include;..\..\..\FreeRTOS-Plus\Source\corePKCS11\source\dependency\3rdparty\mbedtls_utils;..\..\..\FreeRTOS\Source\portable\MSVC-MingW;..\..\Source\Application-Protocols\coreSNTP\source\include;..\..\Source\Utilities\backoff_algorithm\source\include;.;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;_WIN32_WINNT=0x0500;WINVER=0x400;_CRT_SECURE_NO_WARNINGS;MBEDTLS_CONFIG_FILE="mbedtls_config.h";CONFIG_MEDTLS_USE_AFR_MEMORY;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>false</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
@@ -248,6 +248,7 @@
     <ClCompile Include="..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\FreeRTOS_UDP_IP.c" />
     <ClCompile Include="..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\portable\BufferManagement\BufferAllocation_2.c" />
     <ClCompile Include="..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\portable\NetworkInterface\WinPCap\NetworkInterface.c" />
+    <ClCompile Include="..\..\Source\Utilities\backoff_algorithm\source\backoff_algorithm.c" />
     <ClCompile Include="..\..\Source\Application-Protocols\coreSNTP\source\core_sntp_serializer.c" />
     <ClCompile Include="..\..\Source\Application-Protocols\coreSNTP\source\core_sntp_client.c" />
     <ClCompile Include="..\..\..\FreeRTOS-Plus\Demo\Common\Logging\windows\Logging_WinSim.c" />
@@ -378,6 +379,7 @@
     <ClInclude Include="..\..\Source\corePKCS11\source\include\core_pkcs11.h" />
     <ClInclude Include="..\..\Source\corePKCS11\source\include\core_pkcs11_pal.h" />
     <ClInclude Include="..\..\Source\corePKCS11\source\include\core_pki_utils.h" />
+    <ClInclude Include="..\..\Source\Utilities\backoff_algorithm\source\include\backoff_algorithm.h" />
     <ClInclude Include="..\..\Source\Application-Protocols\coreSNTP\source\include\core_sntp_config_defaults.h" />
     <ClInclude Include="..\..\Source\Application-Protocols\coreSNTP\source\include\core_sntp_serializer.h" />
     <ClInclude Include="..\..\Source\Application-Protocols\coreSNTP\source\include\core_sntp_client.h" />

--- a/FreeRTOS-Plus/Demo/coreSNTP_Windows_Simulator/demo_config.h
+++ b/FreeRTOS-Plus/Demo/coreSNTP_Windows_Simulator/demo_config.h
@@ -68,23 +68,15 @@ extern void vLoggingPrintf( const char * pcFormatString,
 /************ End of logging configuration ****************/
 
 /**
- * @brief The desired accuracy (in milliseconds) of system clock in relation with internet time.
- * In other words, this is the maximum tolerance desired for clock drift in the system.
- */
-#define democonfigDESIRED_CLOCK_ACCURACY_MS     ( 1000 )
-
-/**
- * @brief The system clock tolerance (in parts per million) that represents the rate of clock
- * drift of the system. The rate can be viewed as the system clock drift that occurs as milliseconds
- * per second.
+ * @brief The time period between consecutive time polling requests that are sent by the
+ * SNTP client in the demo application.
  *
- * @note In systems with a HW oscillator based clock, the frequency tolerance can be obtained from the
- * hardware specification of the clock oscillator.
- * @note This demo DOES NOT use a hardware clock oscillator as it runs on Windows Simulator. The configuration
- * ONLY provides the user to view the impact of the settings for "Clock Tolerance" and "Desired
- * Clock Accuracy" configurations on the calculated "SNTP polling period".
+ * @note According to the SNTPv4 specification, the polling interval MUST NOT be less
+ * than 15 seconds for responsible use of time servers by SNTP clients.
+ * 
+ * 
+ * #define democonfigSNTP_CLIENT_POLLING_INTERVAL_SECONDS                  ( 16 )
  */
-#define democonfigSYSTEM_CLOCK_TOLERANCE_PPM    ( 32000 )
 
 /**
  * @brief The set of time servers, in decreasing order of priority, for configuring the SNTP client.


### PR DESCRIPTION
### Issue
The existing **clock discipline algorithm** in the `coreSNTP` demo yields an inaccurate wall-clock time (in UTC) that is always behind the astronomical UTC time by the chosen polling interval period of the demo. The issue with the clock discipline algorithm was that it was calculating the **slew rate** to make the system clock be gradually compensated for the previous time synchronization clock drift over the period of the subsequent polling time interval. Thereby, the clock slew rate correction calculated is always lower than it should be (because it does not incorporate possible clock drift that would occur over another period of time polling interval till the next time synchronization attempt). 

### Fix
This PR fixes the clock discipline algorithm to make the demo calculate its system time that matches the astronomical UTC time.
The fix involves simplifying the clock discipline algorithm to use a combination of **step** and **slew** correction approaches where: 
1) **step** correction is applied on EVERY time successful synchronization with a time server. This immediately corrects the system time to match server time.
2) **slew** rate is calculated ONCE (on the second successful time synchronization with server) and applied henceforth, on every time polling interval period to _compensate gradually_ for the system clock drift during the period.