### PR TITLE
Some changes for upcoming release

### DIFF
--- a/FreeRTOS-Plus/Demo/coreSNTP_Windows_Simulator/demo_config.h
+++ b/FreeRTOS-Plus/Demo/coreSNTP_Windows_Simulator/demo_config.h
@@ -116,7 +116,7 @@ extern void vLoggingPrintf( const char * pcFormatString,
  * @note Use of the AES-128-CMAC based authentication scheme in the demo requires that the symmetric key
  * is shared safely between the time server and the client device.
  *
- * #define democonfigAES_CMAC_AUTHENTICATION_SYMMETRIC_KEY  "<hexstring-key-1>", "<hexstring-key-2>", NULL
+ * #define democonfigLIST_OF_AUTHENTICATION_SYMMETRIC_KEYS  "<hexstring-key-1>", "<hexstring-key-2>", NULL
  */
 
 /**
@@ -127,8 +127,8 @@ extern void vLoggingPrintf( const char * pcFormatString,
  * The ID for a key usually represents the ID used to reference the symmetric key in the NTP/SNTP server system.
  *
  * @note This Key IDs should be configured as a comma-separated list of integer Key IDs that match the order of
- * keys in democonfigdemoconfigLIST_OF_AUTHENTICATION_SYMMETRIC_KEYS. If there is a NULL (or no key) in the list
- * of keys, then -1 can be used as the corresponding key ID.
+ * keys in democonfigLIST_OF_AUTHENTICATION_SYMMETRIC_KEYS. If there is a NULL (or no key) in the list of keys,
+ * then -1 can be used as the corresponding key ID.
  *
  * #define democonfigLIST_OF_AUTHENTICATION_KEY_IDS    <key-ID-1>, <key-ID-2>, -1
  */

--- a/History.txt
+++ b/History.txt
@@ -1,5 +1,13 @@
 Documentation and download available at https://www.FreeRTOS.org/
 
+Changes between FreeRTOS 202104.00 and FreeRTOS 202107.00 released July 2021
+
+	+ Release coreSNTP v1.0.0, a client library for SNTP communication.
+	+ Add demo showcasing use of coreSNTP library to setup SNTP client for
+	  synchronizing demo system time with time servers.
+	+ Demo Updates
+		- Update Device Shadow demo to use Named Shadow feature.
+
 Changes between FreeRTOS 202012.00 and FreeRTOS 202104.00 released April 2021
 
 	+ Released LTS versions of AWS IoT Device Defender, AWS IoT Jobs and

--- a/manifest.yml
+++ b/manifest.yml
@@ -81,7 +81,7 @@ dependencies:
       path: "FreeRTOS-Plus/ThirdParty/wolfSSL"
 
   - name: "mbedtls"
-    version: "v2.25.0"
+    version: "v2.26.0"
     repository:
       type: "git"
       url:  "https://github.com/ARMmbed/mbedtls"


### PR DESCRIPTION
This PR makes the following update for the upcoming release: 
* Update **mbedTLS** submodule tag to **[v2.26.0](https://github.com/ARMmbed/mbedtls/tree/v2.26.0)** 
* Update **History.txt**
* Fix incorrect demo config in comment documentation of `demo_config.h` of coreSNTP demo