### PR TITLE
Add mechanism for generating memory statistics report

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,8 +155,8 @@ jobs:
           path: tools
       - name: Run script to generate JSON memory statistics
         run: tools/memory_statistics/memory_statistics.py --json_report --config tools/memory_statistics/paths.json --output freertos_lts_memory_estimates.json
-      - name: Upload memory statistics as artifact
-        if: success() && ( github.ref == 'refs/heads/main' || github.ref == 'refs/heads/ci/add-memory-estimates' )
+      - name: Upload memory size report as artifact (for main and release-candidate ONLY)
+        if: success() && ( github.ref == 'refs/heads/main' || github.ref == 'refs/heads/release-candidate' )
         uses: actions/upload-artifact@v2
         with:
           name: freertos-memory-estimates

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,3 +136,34 @@ jobs:
         run: python3 -m pip install -r .github/scripts/verify_manifest_requirements.txt
       - name: Run script to verify manifest.yml
         run: python3 .github/scripts/verify_manifest.py
+
+  memory-statistics:
+    runs-on: ubuntu-latest
+    env:
+      ARM_GCC_DOWNLOAD_URL: "https://developer.arm.com/-/media/Files/downloads/gnu-rm/9-2020q2/gcc-arm-none-eabi-9-2020-q2-update-x86_64-linux.tar.bz2?revision=05382cca-1721-44e1-ae19-1e7c3dc96118&la=en&hash=D7C9D18FCA2DD9F894FD9F3C3DC9228498FA281A"
+    steps:
+      - name: Install ARM GCC
+        run: wget -qO- "${{ env.ARM_GCC_DOWNLOAD_URL }}" | sudo tar --strip-components=1 -xj -C /usr/local
+      - name: Clone FreeRTOS Repository with submodules
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - name: Clone CI-CD-Github-Actions repository
+        uses: actions/checkout@v2
+        with:
+          repository: FreeRTOS/CI-CD-Github-Actions
+          path: tools
+      - name: Run script to generate JSON memory statistics
+        run: tools/memory_statistics/memory_statistics.py --json_report --config tools/memory_statistics/paths.json --output freertos_lts_memory_estimates.json
+      - name: Upload memory statistics as artifact
+        if: success() && ( github.ref == 'refs/heads/main' || github.ref == 'refs/heads/ci/add-memory-estimates' )
+        uses: actions/upload-artifact@v2
+        with:
+          name: freertos-memory-estimates
+          path: ./freertos_lts_memory_estimates.json
+          retention-days: 2
+
+
+
+
+


### PR DESCRIPTION
To validate that the [FreeRTOS/CI-CD-Github-Actions/memory_statistics/paths.json](https://github.com/FreeRTOS/CI-CD-Github-Actions/blob/main/memory_statistics/paths.json) configuration is correct, this PR adds a CI check mechanism to generate the memory statistics report in JSON format. Additionally, the CI check also uploads the report as an artifact  (for `main` and `release-candidate` branches ONLY) for user  accessibility of the generated report.