### PR TITLE
Update release script to upload source code zip

### DIFF
--- a/.github/scripts/packager.py
+++ b/.github/scripts/packager.py
@@ -154,6 +154,26 @@ def prune_result_tree(path_root, exclude_files=[], dry_run=False):
 
     return files_removed
 
+def prune_result_tree_v2(tree_root, exclude_files=[], dry_run=False):
+    '''
+    Remove all files in 'exclude_files' from file tree.
+    '''
+    files_removed = []
+    for root, dirs, files in os.walk(tree_root):
+        for dir in dirs:
+            if dir in exclude_files:
+                path_full = os.path.join(root, dir)
+                if not dry_run:
+                    shutil.rmtree(path_full)
+                files_removed.append(path_full)
+        for file in files:
+            if file in exclude_files:
+                path_full = os.path.join(root, file)
+                if not dry_run:
+                    os.remove(path_full)
+                files_removed.append(path_full)
+    return files_removed
+
 def zip_result_tree(path_tree, path_outzip):
     '''
     Zip file tree rooted at 'path_root', using same compression as 7z at max compression,


### PR DESCRIPTION
Description
-----------
FreeRTOS-Kernel now contains submodules for partner-supported and community supported FreeRTOS ports. This change updates the release script to upload the complete source code (i.e. cloned with `--recurse-submodules`) with the release. 

Test Steps
-----------
Sample Run - https://github.com/aggarg/FreeRTOS-Kernel/runs/3305551555?check_suite_focus=true
Result - https://github.com/aggarg/FreeRTOS-Kernel/releases/tag/V10.4.5

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
