### PR TITLE
Test cases where message length does not fit in configMESSAGE_BUFFER_LENGTH_TYPE

### DIFF
--- a/FreeRTOS/Test/CMock/config/FreeRTOSConfig.h
+++ b/FreeRTOS/Test/CMock/config/FreeRTOSConfig.h
@@ -66,6 +66,7 @@
 #define configTASK_NOTIFICATION_ARRAY_ENTRIES            5
 #define configSUPPORT_STATIC_ALLOCATION                  1
 #define configINITIAL_TICK_COUNT                         ( ( TickType_t ) 0 ) /* For test. */
+#define configMESSAGE_BUFFER_LENGTH_TYPE                 uint16_t
 #define configSTREAM_BUFFER_TRIGGER_LEVEL_TEST_MARGIN    1                    /* As there are a lot of tasks running. */
 
 /* Software timer related configuration options. */


### PR DESCRIPTION
The default value of configMESSAGE_BUFFER_LENGTH_TYPE is size_t; this prevents testing cases where the type is smaller than size_t and a value that is too large is passed. This reduces the size of the type and tests that the value too large case asserts.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
