### PR TITLE
Update FreeRTOS submodule to be on the latest main

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -4,7 +4,7 @@ description: "This is the standard distribution of FreeRTOS."
 
 dependencies:
   - name: "FreeRTOS-Kernel"
-    version: "fa0f5c4"
+    version: "a432a68"
     repository:
       type: "git"
       url: "https://github.com/FreeRTOS/FreeRTOS-Kernel.git"


### PR DESCRIPTION
Update FreeRTOS submodule to be on the latest main

Description
-----------
Update the FreeRTOS submodule to point to the most recent commit on the main branch of the kernel.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
