### PR TITLE
Enable C89 flag for unit tests

### DIFF
--- a/FreeRTOS/Test/CMock/testdir.mk
+++ b/FreeRTOS/Test/CMock/testdir.mk
@@ -131,7 +131,7 @@ $(PROJ_DIR)/%.i : $(KERNEL_DIR)/%.c
 
 # compile the project objects with coverage instrumented
 $(PROJ_DIR)/%.o : $(PROJ_DIR)/%.i
-    $(CC) -c $< $(CPPFLAGS) $(CFLAGS) $(INCLUDE_DIR) $(GCC_COV_OPTS) -o $@
+    $(CC) -c $< $(CPPFLAGS) $(CFLAGS) $(INCLUDE_DIR) $(GCC_COV_OPTS) -Wall -Wextra -Werror -pedantic -std=c89 -o $@
 
 # Build mock objects
 $(SCRATCH_DIR)/mock_%.o : $(MOCKS_DIR)/mock_%.c

--- a/manifest.yml
+++ b/manifest.yml
@@ -4,7 +4,7 @@ description: "This is the standard distribution of FreeRTOS."
 
 dependencies:
   - name: "FreeRTOS-Kernel"
-    version: "78da9cb"
+    version: "e13f990"
     repository:
       type: "git"
       url: "https://github.com/FreeRTOS/FreeRTOS-Kernel.git"


### PR DESCRIPTION
Description
-----------
Enable C89 flag for unit tests. These unit tests run on every PR and this will ensure that non-C89 does not get checked-in.

Test Steps
-----------
Verified that the compilation fails without this commit - https://github.com/FreeRTOS/FreeRTOS-Kernel/commit/e13f9903850a57ed5cdf3fc330f5faf4d3096d1b


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
