### PR TITLE
Fix PKCS11 demo failures

### DIFF
--- a/FreeRTOS-Plus/Demo/corePKCS11_MQTT_Mutual_Auth_Windows_Simulator/WIN32.vcxproj
+++ b/FreeRTOS-Plus/Demo/corePKCS11_MQTT_Mutual_Auth_Windows_Simulator/WIN32.vcxproj
@@ -58,7 +58,7 @@
     </Midl>
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>..\..\Source\FreeRTOS-Plus-Trace\Include;..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\include;..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\portable\BufferManagement;..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\portable\Compiler\MSVC;..\..\..\FreeRTOS-Plus\Source\Utilities\logging;..\coreMQTT_Windows_Simulator\Common;..\coreMQTT_Windows_Simulator\common\WinPCap;..\..\..\FreeRTOS\Source\include;..\..\..\FreeRTOS\Source\portable\MSVC-MingW;..\..\Source\corePKCS11\source\include;..\..\Source\corePKCS11\source\dependency\3rdparty\pkcs11;..\..\Source\Application-Protocols\coreMQTT\source\include;..\..\Source\Application-Protocols\coreMQTT\source\interface;..\..\Source\Utilities\backoff_algorithm\source\include;..\..\Source\Application-Protocols\network_transport\sockets_wrapper\freertos_plus_tcp;..\..\Source\Application-Protocols\network_transport\using_mbedtls_pkcs11;..\..\Source\Utilities\mbedtls_freertos;..\..\Source\mbedtls_utils;..\..\ThirdParty\mbedtls\include;.;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\Source\FreeRTOS-Plus-Trace\Include;..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\include;..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\portable\BufferManagement;..\..\..\FreeRTOS-Plus\Source\FreeRTOS-Plus-TCP\portable\Compiler\MSVC;..\..\..\FreeRTOS-Plus\Source\Utilities\logging;..\coreMQTT_Windows_Simulator\Common;..\coreMQTT_Windows_Simulator\common\WinPCap;..\..\..\FreeRTOS\Source\include;..\..\..\FreeRTOS\Source\portable\MSVC-MingW;..\..\Source\corePKCS11\source\include;..\..\Source\corePKCS11\source\dependency\3rdparty\pkcs11;..\..\Source\Application-Protocols\coreMQTT\source\include;..\..\Source\Application-Protocols\coreMQTT\source\interface;..\..\Source\Utilities\backoff_algorithm\source\include;..\..\Source\Application-Protocols\network_transport\sockets_wrapper\freertos_plus_tcp;..\..\Source\Application-Protocols\network_transport\using_mbedtls_pkcs11;..\..\Source\Utilities\mbedtls_freertos;..\..\Source\mbedtls_utils;..\..\ThirdParty\mbedtls\include;.;..\..\Source\corePKCS11\source\portable\os;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>MBEDTLS_CONFIG_FILE="mbedtls_config.h";WIN32;_DEBUG;_CONSOLE;_WIN32_WINNT=0x0500;WINVER=0x400;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>false</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
@@ -168,7 +168,8 @@
     <ClCompile Include="..\..\Source\corePKCS11\source\core_pkcs11.c" />
     <ClCompile Include="..\..\Source\corePKCS11\source\core_pki_utils.c" />
     <ClCompile Include="..\..\Source\corePKCS11\source\portable\mbedtls\core_pkcs11_mbedtls.c" />
-    <ClCompile Include="..\..\Source\corePKCS11\source\portable\windows\core_pkcs11_pal.c" />
+    <ClCompile Include="..\..\Source\corePKCS11\source\portable\os\core_pkcs11_pal_utils.c" />
+    <ClCompile Include="..\..\Source\corePKCS11\source\portable\os\freertos_winsim\core_pkcs11_pal.c" />
     <ClCompile Include="..\..\Source\Utilities\mbedtls_freertos\mbedtls_bio_freertos_plus_tcp.c" />
     <ClCompile Include="..\..\Source\Utilities\mbedtls_freertos\mbedtls_freertos_port.c" />
     <ClCompile Include="..\..\ThirdParty\mbedtls\library\aes.c" />
@@ -293,6 +294,7 @@
     <ClInclude Include="..\..\Source\Application-Protocols\network_transport\sockets_wrapper\freertos_plus_tcp\sockets_wrapper.h" />
     <ClInclude Include="..\..\Source\Application-Protocols\network_transport\using_mbedtls_pkcs11\using_mbedtls_pkcs11.h" />
     <ClInclude Include="..\..\Source\corePKCS11\source\include\core_pkcs11.h" />
+    <ClInclude Include="..\..\Source\corePKCS11\source\portable\os\core_pkcs11_pal_utils.h" />
     <ClInclude Include="..\..\Source\corePKCS11\source\include\core_pkcs11_pal.h" />
     <ClInclude Include="..\..\Source\corePKCS11\source\include\core_pki_utils.h" />
     <ClInclude Include="..\..\Source\FreeRTOS-Plus-TCP\include\FreeRTOS_errno_TCP.h" />

--- a/FreeRTOS-Plus/Demo/corePKCS11_MQTT_Mutual_Auth_Windows_Simulator/WIN32.vcxproj.filters
+++ b/FreeRTOS-Plus/Demo/corePKCS11_MQTT_Mutual_Auth_Windows_Simulator/WIN32.vcxproj.filters
@@ -152,9 +152,6 @@
     <ClCompile Include="..\..\Source\corePKCS11\source\portable\mbedtls\core_pkcs11_mbedtls.c">
       <Filter>FreeRTOS+\FreeRTOS IoT Libraries\standard\corePKCS11</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\Source\corePKCS11\source\portable\windows\core_pkcs11_pal.c">
-      <Filter>FreeRTOS+\FreeRTOS IoT Libraries\standard\corePKCS11</Filter>
-    </ClCompile>
     <ClCompile Include="..\..\ThirdParty\mbedtls\library\aes.c">
       <Filter>FreeRTOS+\mbedtls</Filter>
     </ClCompile>
@@ -432,6 +429,10 @@
     </ClCompile>
     <ClCompile Include="..\..\Source\Application-Protocols\network_transport\using_mbedtls_pkcs11\using_mbedtls_pkcs11.c">
       <Filter>FreeRTOS+\FreeRTOS IoT Libraries\platform\transport</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Source\corePKCS11\source\portable\os\freertos_winsim\core_pkcs11_pal.c" />
+    <ClCompile Include="..\..\Source\corePKCS11\source\portable\os\core_pkcs11_pal_utils.c">
+      <Filter>FreeRTOS+\FreeRTOS IoT Libraries\standard\corePKCS11</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -839,6 +840,11 @@
     <ClInclude Include="..\..\ThirdParty\mbedtls\include\mbedtls\error.h" />
     <ClInclude Include="..\..\Source\Application-Protocols\network_transport\using_mbedtls_pkcs11\using_mbedtls_pkcs11.h">
       <Filter>FreeRTOS+\FreeRTOS IoT Libraries\platform\transport\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ThirdParty\mbedtls\include\mbedtls\error.h" />
+    <ClInclude Include="..\..\ThirdParty\mbedtls\include\mbedtls\error.h" />
+    <ClInclude Include="..\..\Source\corePKCS11\source\portable\os\core_pkcs11_pal_utils.h">
+      <Filter>FreeRTOS+\FreeRTOS IoT Libraries\standard\corePKCS11\include</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/FreeRTOS-Plus/Demo/corePKCS11_MQTT_Mutual_Auth_Windows_Simulator/pkcs11_demo_setup.py
+++ b/FreeRTOS-Plus/Demo/corePKCS11_MQTT_Mutual_Auth_Windows_Simulator/pkcs11_demo_setup.py
@@ -5,8 +5,8 @@ from cryptography import x509
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
 
-KEY_OUT_NAME = "FreeRTOS_P11_Key.dat"
-CERT_OUT_NAME = "FreeRTOS_P11_Certificate.dat"
+KEY_OUT_NAME = "corePKCS11_Key.dat"
+CERT_OUT_NAME = "corePKCS11_Certificate.dat"
 
 
 def convert_pem_to_der(cert_file, key_file):

--- a/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/WIN32.vcxproj
+++ b/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/WIN32.vcxproj
@@ -58,7 +58,7 @@
     </Midl>
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>..\..\..\FreeRTOS-Plus\Source\Utilities\logging;..\..\..\FreeRTOS-Plus\Source\corePKCS11\source\include;..\..\..\FreeRTOS-Plus\Source\corePKCS11\source\dependency\3rdparty\pkcs11;..\..\ThirdParty\mbedtls\include;..\..\..\FreeRTOS-Plus\Source\corePKCS11\source\dependency\3rdparty\mbedtls_utils;..\..\..\FreeRTOS\Source\include;..\..\..\FreeRTOS\Source\portable\MSVC-MingW;examples;.;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\..\FreeRTOS-Plus\Source\Utilities\logging;..\..\..\FreeRTOS-Plus\Source\corePKCS11\source\include;..\..\..\FreeRTOS-Plus\Source\corePKCS11\source\dependency\3rdparty\pkcs11;..\..\ThirdParty\mbedtls\include;..\..\..\FreeRTOS-Plus\Source\corePKCS11\source\dependency\3rdparty\mbedtls_utils;..\..\..\FreeRTOS\Source\include;..\..\..\FreeRTOS\Source\portable\MSVC-MingW;examples;.;..\..\Source\corePKCS11\source\portable\os;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;_WIN32_WINNT=0x0500;WINVER=0x400;_CRT_SECURE_NO_WARNINGS;MBEDTLS_CONFIG_FILE="aws_mbedtls_config.h";CONFIG_MEDTLS_USE_AFR_MEMORY;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>false</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
@@ -241,7 +241,8 @@
     <ClCompile Include="..\..\Source\corePKCS11\source\core_pkcs11.c" />
     <ClCompile Include="..\..\Source\corePKCS11\source\core_pki_utils.c" />
     <ClCompile Include="..\..\Source\corePKCS11\source\portable\mbedtls\core_pkcs11_mbedtls.c" />
-    <ClCompile Include="..\..\Source\corePKCS11\source\portable\windows\core_pkcs11_pal.c" />
+    <ClCompile Include="..\..\Source\corePKCS11\source\portable\os\core_pkcs11_pal_utils.c" />
+    <ClCompile Include="..\..\Source\corePKCS11\source\portable\os\freertos_winsim\core_pkcs11_pal.c" />
     <ClCompile Include="examples\demo_helpers.c" />
     <ClCompile Include="examples\management_and_rng.c" />
     <ClCompile Include="examples\objects.c" />
@@ -352,6 +353,7 @@
     <ClInclude Include="..\..\Source\corePKCS11\source\dependency\3rdparty\pkcs11\pkcs11f.h" />
     <ClInclude Include="..\..\Source\corePKCS11\source\dependency\3rdparty\pkcs11\pkcs11t.h" />
     <ClInclude Include="..\..\Source\corePKCS11\source\include\core_pkcs11.h" />
+    <ClInclude Include="..\..\Source\corePKCS11\source\portable\os\core_pkcs11_pal_utils.h" />
     <ClInclude Include="..\..\Source\corePKCS11\source\include\core_pkcs11_pal.h" />
     <ClInclude Include="..\..\Source\corePKCS11\source\include\core_pki_utils.h" />
     <ClInclude Include="core_pkcs11_config.h" />

--- a/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/WIN32.vcxproj.filters
+++ b/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/WIN32.vcxproj.filters
@@ -359,14 +359,18 @@
     <ClCompile Include="..\..\Source\corePKCS11\source\portable\mbedtls\core_pkcs11_mbedtls.c">
       <Filter>FreeRTOS+\FreeRTOS IoT Libraries\standard\corePKCS11</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\Source\corePKCS11\source\portable\windows\core_pkcs11_pal.c">
-      <Filter>FreeRTOS+\FreeRTOS IoT Libraries\standard\corePKCS11</Filter>
-    </ClCompile>
     <ClCompile Include="..\..\Source\corePKCS11\source\core_pki_utils.c">
       <Filter>FreeRTOS+\FreeRTOS IoT Libraries\standard\corePKCS11</Filter>
     </ClCompile>
     <ClCompile Include="..\..\Source\corePKCS11\source\dependency\3rdparty\mbedtls_utils\mbedtls_utils.c">
       <Filter>FreeRTOS+\FreeRTOS IoT Libraries\platform\mbedtls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ThirdParty\mbedtls\library\error.c" />
+    <ClCompile Include="..\..\Source\corePKCS11\source\portable\os\core_pkcs11_pal_utils.c">
+      <Filter>FreeRTOS+\FreeRTOS IoT Libraries\standard\corePKCS11</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Source\corePKCS11\source\portable\os\freertos_winsim\core_pkcs11_pal.c">
+      <Filter>FreeRTOS+\FreeRTOS IoT Libraries\standard\corePKCS11</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -711,6 +715,10 @@
     </ClInclude>
     <ClInclude Include="core_pkcs11_config.h">
       <Filter>Config</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ThirdParty\mbedtls\include\mbedtls\error.h" />
+    <ClInclude Include="..\..\Source\corePKCS11\source\portable\os\core_pkcs11_pal_utils.h">
+      <Filter>FreeRTOS+\FreeRTOS IoT Libraries\standard\corePKCS11\include</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/examples/objects.c
+++ b/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/examples/objects.c
@@ -248,7 +248,7 @@ static void prvObjectImporting( void )
      * Compare the hard coded x509, in PEM format, with the DER formatted
      * x509 certificate that is created by the Cryptoki library, with the following
      * OpenSSL command:
-     * "$ openssl x509 -in FreeRTOS_P11_Certificate.dat -inform der -text"
+     * "$ openssl x509 -in corePKCS11_Certificate.dat -inform der -text"
      *
      * See this explanation for the difference between the PEM format and the
      * DER format:
@@ -263,7 +263,7 @@ static void prvObjectImporting( void )
     configASSERT( xResult == CKR_OK );
     configASSERT( xCertHandle != CK_INVALID_HANDLE );
 
-    configPRINTF( ( "FreeRTOS_P11_Certificate.dat has been created in the Visual Studio" \
+    configPRINTF( ( "corePKCS11_Certificate.dat has been created in the Visual Studio" \
                     " Solution directory\r\n" ) );
 
     vPortFree( pucDerObject );
@@ -365,7 +365,7 @@ static void prvObjectGeneration( void )
                     pkcs11configLABEL_DEVICE_PUBLIC_KEY_FOR_TLS ) );
 
     /* This function will generate a new EC private and public key pair. You can
-     * use " $openssl ec -inform der -in FreeRTOS_P11_Key.dat -text " to see
+     * use " $openssl ec -inform der -in corePKCS11_Key.dat -text " to see
      * the structure of the keys that were generated.
      */
     xResult = pxFunctionList->C_GenerateKeyPair( hSession,
@@ -377,7 +377,7 @@ static void prvObjectGeneration( void )
                                                  &xPublicKeyHandle,
                                                  &xPrivateKeyHandle );
     configASSERT( xResult == CKR_OK );
-    configPRINTF( ( "FreeRTOS_P11_Key.dat has been created in the Visual Studio" \
+    configPRINTF( ( "corePKCS11_Key.dat has been created in the Visual Studio" \
                     " Solution directory\r\n" ) );
     configPRINTF( ( "Extracting public key bytes...\r\n" ) );
 


### PR DESCRIPTION
The PKCS11 demos were not functioning due to changes made in corePKCS11. This PR fixes the improper references and the python script used to generate the .dat files required for the following demos:

- corePKCS11_MQTT_Mutual_Auth_Windows_Simulator
- corePKCS11_Windows_Simulator

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
