### PR TITLE
Add variable PKCS11 label support to using_mbedtls_pkcs11

### DIFF
--- a/FreeRTOS-Plus/Demo/corePKCS11_MQTT_Mutual_Auth_Windows_Simulator/DemoTasks/MutualAuthMQTTExample.c
+++ b/FreeRTOS-Plus/Demo/corePKCS11_MQTT_Mutual_Auth_Windows_Simulator/DemoTasks/MutualAuthMQTTExample.c
@@ -49,6 +49,7 @@
 
 /* Demo Specific configs. */
 #include "demo_config.h"
+#include "core_pkcs11_config.h"
 
 /* MQTT library includes. */
 #include "core_mqtt.h"
@@ -455,7 +456,9 @@ static void prvTLSConnect( NetworkCredentials_t * pxNetworkCredentials,
 
     /* Set the credentials for establishing a TLS connection. */
     pxNetworkCredentials->pRootCa = ( const unsigned char * ) democonfigROOT_CA_PEM;
-    pxNetworkCredentials->rootCaSize = sizeof( democonfigROOT_CA_PEM );
+    pxNetworkCredentials->rootCaSize = sizeof(democonfigROOT_CA_PEM); 
+    pxNetworkCredentials->pClientCertLabel = pkcs11configLABEL_DEVICE_CERTIFICATE_FOR_TLS;
+    pxNetworkCredentials->pPrivateKeyLabel = pkcs11configLABEL_DEVICE_PRIVATE_KEY_FOR_TLS;
 
     /* Attempt to create a mutually authenticated TLS connection. */
     xNetworkStatus = TLS_FreeRTOS_Connect( pxNetworkContext,

--- a/FreeRTOS-Plus/Demo/corePKCS11_MQTT_Mutual_Auth_Windows_Simulator/DemoTasks/MutualAuthMQTTExample.c
+++ b/FreeRTOS-Plus/Demo/corePKCS11_MQTT_Mutual_Auth_Windows_Simulator/DemoTasks/MutualAuthMQTTExample.c
@@ -456,7 +456,7 @@ static void prvTLSConnect( NetworkCredentials_t * pxNetworkCredentials,
 
     /* Set the credentials for establishing a TLS connection. */
     pxNetworkCredentials->pRootCa = ( const unsigned char * ) democonfigROOT_CA_PEM;
-    pxNetworkCredentials->rootCaSize = sizeof(democonfigROOT_CA_PEM); 
+    pxNetworkCredentials->rootCaSize = sizeof( democonfigROOT_CA_PEM );
     pxNetworkCredentials->pClientCertLabel = pkcs11configLABEL_DEVICE_CERTIFICATE_FOR_TLS;
     pxNetworkCredentials->pPrivateKeyLabel = pkcs11configLABEL_DEVICE_PRIVATE_KEY_FOR_TLS;
 

--- a/FreeRTOS-Plus/Source/Application-Protocols/network_transport/using_mbedtls_pkcs11/using_mbedtls_pkcs11.c
+++ b/FreeRTOS-Plus/Source/Application-Protocols/network_transport/using_mbedtls_pkcs11/using_mbedtls_pkcs11.c
@@ -177,7 +177,7 @@ static CK_RV readCertificateIntoContext( SSLContext_t * pSslContext,
  * @return Zero on success.
  */
 static CK_RV initializeClientKeys( SSLContext_t * pxCtx,
-                                    char * pcLabelName );
+                                   char * pcLabelName );
 
 /**
  * @brief Sign a cryptographic hash with the private key.
@@ -591,7 +591,7 @@ static CK_RV readCertificateIntoContext( SSLContext_t * pSslContext,
  * @return Zero on success.
  */
 static CK_RV initializeClientKeys( SSLContext_t * pxCtx,
-                                    char * pcLabelName )
+                                   char * pcLabelName )
 {
     CK_RV xResult = CKR_OK;
     CK_SLOT_ID * pxSlotIds = NULL;

--- a/FreeRTOS-Plus/Source/Application-Protocols/network_transport/using_mbedtls_pkcs11/using_mbedtls_pkcs11.c
+++ b/FreeRTOS-Plus/Source/Application-Protocols/network_transport/using_mbedtls_pkcs11/using_mbedtls_pkcs11.c
@@ -182,6 +182,13 @@ static CK_RV initializeClientKeys( SSLContext_t * pxCtx,
                                    const char * pcLabelName );
 
 /**
+ * @brief Stub function to satisfy mbedtls checks before sign operations 
+ *
+ * @return 1.
+ */
+int canDoStub( mbedtls_pk_type_t type );
+
+/**
  * @brief Sign a cryptographic hash with the private key.
  *
  * @param[in] pvContext Crypto context.
@@ -692,6 +699,25 @@ static CK_RV initializeClientKeys( SSLContext_t * pxCtx,
     {
         memcpy( &pxCtx->privKeyInfo, mbedtls_pk_info_from_type( xKeyAlgo ), sizeof( mbedtls_pk_info_t ) );
 
+        /* Assign unimplemented function pointers to NULL */
+        pxCtx->privKeyInfo.get_bitlen = NULL;
+        pxCtx->privKeyInfo.can_do = canDoStub;
+        pxCtx->privKeyInfo.verify_func = NULL;
+#if defined(MBEDTLS_ECDSA_C) && defined(MBEDTLS_ECP_RESTARTABLE)
+        pxCtx->privKeyInfo.verify_rs_func = NULL;
+        pxCtx->privKeyInfo.sign_rs_func = NULL;
+#endif /* MBEDTLS_ECDSA_C && MBEDTLS_ECP_RESTARTABLE */
+        pxCtx->privKeyInfo.decrypt_func = NULL;
+        pxCtx->privKeyInfo.encrypt_func = NULL;
+        pxCtx->privKeyInfo.check_pair_func = NULL;
+        pxCtx->privKeyInfo.ctx_alloc_func = NULL;
+        pxCtx->privKeyInfo.ctx_free_func = NULL;
+#if defined(MBEDTLS_ECDSA_C) && defined(MBEDTLS_ECP_RESTARTABLE)
+        pxCtx->privKeyInfo.rs_alloc_func = NULL;
+        pxCtx->privKeyInfo.rs_free_func = NULL;
+#endif /* MBEDTLS_ECDSA_C && MBEDTLS_ECP_RESTARTABLE */
+        pxCtx->privKeyInfo.debug_func = NULL;
+
         pxCtx->privKeyInfo.sign_func = privateKeySigningCallback;
         pxCtx->privKey.pk_info = &pxCtx->privKeyInfo;
         pxCtx->privKey.pk_ctx = pxCtx;
@@ -796,6 +822,13 @@ static int32_t privateKeySigningCallback( void * pvContext,
     }
 
     return lFinalResult;
+}
+
+/*-----------------------------------------------------------*/
+
+int canDoStub( mbedtls_pk_type_t type ) 
+{
+    return 1;
 }
 
 /*-----------------------------------------------------------*/

--- a/FreeRTOS-Plus/Source/Application-Protocols/network_transport/using_mbedtls_pkcs11/using_mbedtls_pkcs11.c
+++ b/FreeRTOS-Plus/Source/Application-Protocols/network_transport/using_mbedtls_pkcs11/using_mbedtls_pkcs11.c
@@ -320,7 +320,7 @@ static TlsTransportStatus_t tlsSetup( NetworkContext_t * pNetworkContext,
     {
         /* Setup the client private key. */
         xResult = initializeClientKeys( &( pTlsTransportParams->sslContext ),
-                                        &( pNetworkCredentials->pPrivateKeyLabel ) );
+                                        pNetworkCredentials->pPrivateKeyLabel );
 
         if( xResult != CKR_OK )
         {
@@ -640,7 +640,7 @@ static CK_RV initializeClientKeys( SSLContext_t * pxCtx,
         /* Get the handle of the device private key. */
         xResult = xFindObjectWithLabelAndClass( pxCtx->xP11Session,
                                                 pcLabelName,
-                                                sizeof( pcLabelName ) - 1UL,
+                                                strlen( pcLabelName ),
                                                 CKO_PRIVATE_KEY,
                                                 &pxCtx->xP11PrivateKey );
     }

--- a/FreeRTOS-Plus/Source/Application-Protocols/network_transport/using_mbedtls_pkcs11/using_mbedtls_pkcs11.c
+++ b/FreeRTOS-Plus/Source/Application-Protocols/network_transport/using_mbedtls_pkcs11/using_mbedtls_pkcs11.c
@@ -170,9 +170,11 @@ static CK_RV readCertificateIntoContext( SSLContext_t * pSslContext,
                                          mbedtls_x509_crt * pxCertificateContext );
 
 /**
- * @brief Helper for setting up potentially hardware-based cryptographic context.
+ * @brief Helper for setting up potentially hardware-based cryptographic context
+ * for the client TLS certificate and private key.
  *
- * @param Caller context.
+ * @param[in] Caller context.
+ * @param[in] PKCS11 label which contains the desired private key.
  *
  * @return Zero on success.
  */
@@ -586,7 +588,8 @@ static CK_RV readCertificateIntoContext( SSLContext_t * pSslContext,
  * @brief Helper for setting up potentially hardware-based cryptographic context
  * for the client TLS certificate and private key.
  *
- * @param Caller context.
+ * @param[in] Caller context.
+ * @param[in] PKCS11 label which contains the desired private key.
  *
  * @return Zero on success.
  */

--- a/FreeRTOS-Plus/Source/Application-Protocols/network_transport/using_mbedtls_pkcs11/using_mbedtls_pkcs11.c
+++ b/FreeRTOS-Plus/Source/Application-Protocols/network_transport/using_mbedtls_pkcs11/using_mbedtls_pkcs11.c
@@ -57,8 +57,8 @@
 
 /*-----------------------------------------------------------*/
 
-/** 
- * @brief Each compilation unit that consumes the NetworkContext must define it. 
+/**
+ * @brief Each compilation unit that consumes the NetworkContext must define it.
  * It should contain a single pointer as seen below whenever the header file
  * of this transport implementation is included to your project.
  *
@@ -182,7 +182,7 @@ static CK_RV initializeClientKeys( SSLContext_t * pxCtx,
                                    const char * pcLabelName );
 
 /**
- * @brief Stub function to satisfy mbedtls checks before sign operations 
+ * @brief Stub function to satisfy mbedtls checks before sign operations
  *
  * @return 1.
  */
@@ -826,7 +826,7 @@ static int32_t privateKeySigningCallback( void * pvContext,
 
 /*-----------------------------------------------------------*/
 
-int canDoStub( mbedtls_pk_type_t type ) 
+int canDoStub( mbedtls_pk_type_t type )
 {
     return 1;
 }

--- a/FreeRTOS-Plus/Source/Application-Protocols/network_transport/using_mbedtls_pkcs11/using_mbedtls_pkcs11.c
+++ b/FreeRTOS-Plus/Source/Application-Protocols/network_transport/using_mbedtls_pkcs11/using_mbedtls_pkcs11.c
@@ -527,7 +527,8 @@ static CK_RV readCertificateIntoContext( SSLContext_t * pSslContext,
     /* Get the handle of the certificate. */
     xResult = xFindObjectWithLabelAndClass( pSslContext->xP11Session,
                                             pcLabelName,
-                                            strlen( pcLabelName ),
+                                            strnlen( pcLabelName,
+                                                     pkcs11configMAX_LABEL_LENGTH ),
                                             xClass,
                                             &xCertObj );
 
@@ -643,7 +644,8 @@ static CK_RV initializeClientKeys( SSLContext_t * pxCtx,
         /* Get the handle of the device private key. */
         xResult = xFindObjectWithLabelAndClass( pxCtx->xP11Session,
                                                 pcLabelName,
-                                                strlen( pcLabelName ),
+                                                strnlen( pcLabelName,
+                                                         pkcs11configMAX_LABEL_LENGTH ),
                                                 CKO_PRIVATE_KEY,
                                                 &pxCtx->xP11PrivateKey );
     }

--- a/FreeRTOS-Plus/Source/Application-Protocols/network_transport/using_mbedtls_pkcs11/using_mbedtls_pkcs11.c
+++ b/FreeRTOS-Plus/Source/Application-Protocols/network_transport/using_mbedtls_pkcs11/using_mbedtls_pkcs11.c
@@ -165,7 +165,7 @@ static int32_t generateRandomBytes( void * pvCtx,
  * @return Zero on success.
  */
 static CK_RV readCertificateIntoContext( SSLContext_t * pSslContext,
-                                         char * pcLabelName,
+                                         const char * pcLabelName,
                                          CK_OBJECT_CLASS xClass,
                                          mbedtls_x509_crt * pxCertificateContext );
 
@@ -179,7 +179,7 @@ static CK_RV readCertificateIntoContext( SSLContext_t * pSslContext,
  * @return Zero on success.
  */
 static CK_RV initializeClientKeys( SSLContext_t * pxCtx,
-                                   char * pcLabelName );
+                                   const char * pcLabelName );
 
 /**
  * @brief Sign a cryptographic hash with the private key.
@@ -516,7 +516,7 @@ static int32_t generateRandomBytes( void * pvCtx,
 /*-----------------------------------------------------------*/
 
 static CK_RV readCertificateIntoContext( SSLContext_t * pSslContext,
-                                         char * pcLabelName,
+                                         const char * pcLabelName,
                                          CK_OBJECT_CLASS xClass,
                                          mbedtls_x509_crt * pxCertificateContext )
 {
@@ -595,7 +595,7 @@ static CK_RV readCertificateIntoContext( SSLContext_t * pSslContext,
  * @return Zero on success.
  */
 static CK_RV initializeClientKeys( SSLContext_t * pxCtx,
-                                   char * pcLabelName )
+                                   const char * pcLabelName )
 {
     CK_RV xResult = CKR_OK;
     CK_SLOT_ID * pxSlotIds = NULL;

--- a/FreeRTOS-Plus/Source/Application-Protocols/network_transport/using_mbedtls_pkcs11/using_mbedtls_pkcs11.h
+++ b/FreeRTOS-Plus/Source/Application-Protocols/network_transport/using_mbedtls_pkcs11/using_mbedtls_pkcs11.h
@@ -148,6 +148,8 @@ typedef struct NetworkCredentials
     size_t userNameSize;             /**< @brief Size associated with #NetworkCredentials.pUserName. */
     const unsigned char * pPassword; /**< @brief String representing the password for MQTT. */
     size_t passwordSize;             /**< @brief Size associated with #NetworkCredentials.pPassword. */
+    char * pClientCertLabel;         /**< @brief String representing the PKCS #11 label for the client certificate. */
+    char * pPrivateKeyLabel;         /**< @brief String representing the PKCS #11 label for the private key. */
 } NetworkCredentials_t;
 
 /**

--- a/FreeRTOS-Plus/Source/Application-Protocols/network_transport/using_mbedtls_pkcs11/using_mbedtls_pkcs11.h
+++ b/FreeRTOS-Plus/Source/Application-Protocols/network_transport/using_mbedtls_pkcs11/using_mbedtls_pkcs11.h
@@ -148,8 +148,8 @@ typedef struct NetworkCredentials
     size_t userNameSize;             /**< @brief Size associated with #NetworkCredentials.pUserName. */
     const unsigned char * pPassword; /**< @brief String representing the password for MQTT. */
     size_t passwordSize;             /**< @brief Size associated with #NetworkCredentials.pPassword. */
-    const char * pClientCertLabel;         /**< @brief String representing the PKCS #11 label for the client certificate. */
-    const char * pPrivateKeyLabel;         /**< @brief String representing the PKCS #11 label for the private key. */
+    const char * pClientCertLabel;   /**< @brief String representing the PKCS #11 label for the client certificate. */
+    const char * pPrivateKeyLabel;   /**< @brief String representing the PKCS #11 label for the private key. */
 } NetworkCredentials_t;
 
 /**

--- a/FreeRTOS-Plus/Source/Application-Protocols/network_transport/using_mbedtls_pkcs11/using_mbedtls_pkcs11.h
+++ b/FreeRTOS-Plus/Source/Application-Protocols/network_transport/using_mbedtls_pkcs11/using_mbedtls_pkcs11.h
@@ -148,8 +148,8 @@ typedef struct NetworkCredentials
     size_t userNameSize;             /**< @brief Size associated with #NetworkCredentials.pUserName. */
     const unsigned char * pPassword; /**< @brief String representing the password for MQTT. */
     size_t passwordSize;             /**< @brief Size associated with #NetworkCredentials.pPassword. */
-    char * pClientCertLabel;         /**< @brief String representing the PKCS #11 label for the client certificate. */
-    char * pPrivateKeyLabel;         /**< @brief String representing the PKCS #11 label for the private key. */
+    const char * pClientCertLabel;         /**< @brief String representing the PKCS #11 label for the client certificate. */
+    const char * pPrivateKeyLabel;         /**< @brief String representing the PKCS #11 label for the private key. */
 } NetworkCredentials_t;
 
 /**

--- a/lexicon.txt
+++ b/lexicon.txt
@@ -1524,6 +1524,7 @@ pcks
 pcl
 pclabelname
 pclientcert
+pclientcertlabel
 pclk
 pclkb
 pclwipappsblockinggettxbuffer
@@ -1693,6 +1694,7 @@ ppcmessagetodisplay
 ppollperiod
 ppr
 pprivatekey
+pprivatekeylabel
 ppublishinfo
 ppvcontext
 ppxidletaskstackbuffer


### PR DESCRIPTION
The current "using_mbedtls_pkcs11.c" implementation requires using the device key and device certificate stored under the labels "pkcs11configLABEL_DEVICE_PRIVATE_KEY_FOR_TLS" and "pkcs11configLABEL_DEVICE_CERTIFICATE_FOR_TLS".

This PR updates the NetworkCredentials to include fields for pClientCertLabel and pPrivateKeyLabel, so other labels can be used with PKCS11. This matches the [behavior seen in the CSDK](https://github.com/aws/aws-iot-device-sdk-embedded-C/blob/main/platform/posix/transport/include/mbedtls_pkcs11_posix.h#L151-L152).

This PR also updates the "pkcs11_mqtt_mutual_auth_demo" to set the newly-added NetworkCredentials fields.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
