### PR TITLE
Update sigv4 submodule pointer to latest release tag

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -25,7 +25,7 @@ dependencies:
       path: "FreeRTOS-Plus/Source/coreJSON"
 
   - name: "sigv4"
-    version: "1945a7e"
+    version: "v1.1.0"
     repository:
       type: "git"
       url: "https://github.com/aws/SigV4-for-AWS-IoT-embedded-sdk.git"


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->
Makes sigv4 submodule ptr point to v1.1.0 release tag

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
