### PR TITLE
Move FreeRTOS-Kernel submodule pointer to 10.4.6

### DIFF
--- a/FreeRTOS/Test/CMock/testdir.mk
+++ b/FreeRTOS/Test/CMock/testdir.mk
@@ -131,7 +131,7 @@ $(PROJ_DIR)/%.i : $(KERNEL_DIR)/%.c
 
 # compile the project objects with coverage instrumented
 $(PROJ_DIR)/%.o : $(PROJ_DIR)/%.i
-    $(CC) -c $< $(CPPFLAGS) $(CFLAGS) $(INCLUDE_DIR) $(GCC_COV_OPTS) -Wall -Wextra -Werror -pedantic -std=c89 -o $@
+    $(CC) -c $< $(CPPFLAGS) $(CFLAGS) $(INCLUDE_DIR) $(GCC_COV_OPTS) -o $@
 
 # Build mock objects
 $(SCRATCH_DIR)/mock_%.o : $(MOCKS_DIR)/mock_%.c

--- a/manifest.yml
+++ b/manifest.yml
@@ -4,7 +4,7 @@ description: "This is the standard distribution of FreeRTOS."
 
 dependencies:
   - name: "FreeRTOS-Kernel"
-    version: "e13f990"
+    version: "V10.4.6"
     repository:
       type: "git"
       url: "https://github.com/FreeRTOS/FreeRTOS-Kernel.git"


### PR DESCRIPTION
Description
-----------
Move FreeRTOS-Kernel submodule pointer to 10.4.6

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
