### PR TITLE
Update the submodule pointer of FreeRTOS-Cellular-Interface

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -130,7 +130,7 @@ dependencies:
       path: "FreeRTOS/Demo/ThirdParty/Partner-Supported-Demos"
 
   - name: "FreeRTOS-Cellular-Interface"
-    version: "v1.1.0"
+    version: "v1.2.0"
     repository:
       type: "git"
       url: "https://github.com/FreeRTOS/FreeRTOS-Cellular-Interface.git"


### PR DESCRIPTION
* Update FreeRTOS-Cellular-Interface submodule pointer to latest release tag
* Update manifest.yml FreeRTOS-Cellular-Interface entry to v1.2.0