### PR TITLE
Always prepare source tree for cbmc proofs

### DIFF
--- a/FreeRTOS/Test/CBMC/proofs/run-cbmc-proofs.py
+++ b/FreeRTOS/Test/CBMC/proofs/run-cbmc-proofs.py
@@ -276,9 +276,8 @@ def main():
     proof_root = pathlib.Path(__file__).resolve().parent
     litani = get_litani_path(proof_root)
 
+    run_cmd(["./prepare.py"], check=True, cwd=str(proof_root))
     if not args.no_standalone:
-        run_cmd(
-            ["./prepare.py"], check=True, cwd=str(proof_root))
         run_cmd(
             [str(litani), "init", "--project", args.project_name], check=True)
 


### PR DESCRIPTION
This patch ensures that the prepare script is always run before the cbmc proofs are run.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
