### PR TITLE
Update Fleet Provisioning Demo comments

### DIFF
--- a/FreeRTOS-Plus/Demo/AWS/Fleet_Provisioning_Windows_Simulator/Fleet_Provisioning_With_CSR_Demo/DemoTasks/FleetProvisioningDemoExample.c
+++ b/FreeRTOS-Plus/Demo/AWS/Fleet_Provisioning_Windows_Simulator/Fleet_Provisioning_With_CSR_Demo/DemoTasks/FleetProvisioningDemoExample.c
@@ -496,9 +496,8 @@ void vStartFleetProvisioningDemo()
                                mbedtls_platform_mutex_unlock );
 
     /* This example uses a single application task, which shows that how to use
-     * Device Defender library to generate and validate AWS IoT Device Defender
-     * MQTT topics, and use the coreMQTT library to communicate with the AWS
-     * IoT Device Defender service. */
+     * Fleet Provisioning library to generate and sign certificates with AWS IoT
+     * and create new IoT Things using the AWS IoT Fleet Provisioning API */
     xTaskCreate( prvFleetProvisioningTask, /* Function that implements the task. */
                  "DemoTask",               /* Text name for the task - only used for debugging. */
                  democonfigDEMO_STACKSIZE, /* Size of stack (in words, not bytes) to allocate for the task. */

--- a/FreeRTOS-Plus/Demo/AWS/Fleet_Provisioning_Windows_Simulator/Fleet_Provisioning_With_CSR_Demo/main.c
+++ b/FreeRTOS-Plus/Demo/AWS/Fleet_Provisioning_Windows_Simulator/Fleet_Provisioning_With_CSR_Demo/main.c
@@ -25,7 +25,7 @@
  */
 
 /***
- * See https://www.FreeRTOS.org/iot-device-defender for configuration and usage instructions.
+ * See https://www.FreeRTOS.org/iot-fleet-provisioning for configuration and usage instructions.
  ***/
 
 /* Standard includes. */

--- a/lexicon.txt
+++ b/lexicon.txt
@@ -51,6 +51,7 @@ appropiate
 aptime
 apu
 ar
+aren't
 args
 armv
 arp


### PR DESCRIPTION
Remove references to Device Defender which were lingering in the Fleet Provisioning Demo.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
