### PR TITLE
fix minor spelling issue by removing contraction

### DIFF
--- a/FreeRTOS/Demo/CORTEX_A9_Zynq_ZC702_Vitis_QEMU/RTOSDemo/src/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_A9_Zynq_ZC702_Vitis_QEMU/RTOSDemo/src/FreeRTOSConfig.h
@@ -67,7 +67,7 @@
  */
 
 /* Setting configUSING_QEMU results in console output when an LED toggles as
-LEDs aren't visible in QEMU. */
+LEDs are not visible in QEMU. */
 #define configUSING_QEMU						1
 
 #define configMAX_API_CALL_INTERRUPT_PRIORITY	18


### PR DESCRIPTION

Description
-----------
comment used the contraction "aren't" which failed the CI spell check.  I removed the contraction to make the english
more clear and this also fixed the spell check.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
