### PR TITLE
added configUSE_TICKLESS_IDLE to CORTEX_MPS2_QEMU_IAR_GCC demo

### DIFF
--- a/FreeRTOS/Demo/CORTEX_MPS2_QEMU_IAR_GCC/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_MPS2_QEMU_IAR_GCC/FreeRTOSConfig.h
@@ -39,6 +39,7 @@
  * See http://www.freertos.org/a00110.html
  *----------------------------------------------------------*/
 
+#define configUSE_TICKLESS_IDLE         0
 #define configUSE_PREEMPTION			1
 #define configUSE_IDLE_HOOK				0
 #define configUSE_TICK_HOOK				1


### PR DESCRIPTION
Description
-----------
Added the configUSE_TICKLESS_IDLE defaulting to disabled to the CORTEX_MPS2_QEMU_IAR_GCC demo.
This demo is often used to verify port code so adding this config simplifies testing of TICKLESS IDLE changes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
