### PR TITLE
Create CloudFormation template for Fleet Provisioning demo setup

### DIFF
--- a/FreeRTOS-Plus/Demo/AWS/Fleet_Provisioning_Windows_Simulator/Fleet_Provisioning_With_CSR_Demo/demo_cloudformation_template.json
+++ b/FreeRTOS-Plus/Demo/AWS/Fleet_Provisioning_Windows_Simulator/Fleet_Provisioning_With_CSR_Demo/demo_cloudformation_template.json
@@ -5,11 +5,12 @@
             "Description": "Enter the \"certificateId\" of the certificate created using the \"aws iot create-keys-and-certificate\" command.\nFor more information, see the documentation: https://freertos.org/iot-fleet-provisioning/demo.html"
         }
     },
+
     "Resources": {
         "FPDemoRole": {
             "Type": "AWS::IAM::Role",
             "Properties": {
-                "RoleName": "FleetProvisioningDemoRole",
+                "RoleName": "CF_FleetProvisioningDemoRole",
                 "AssumeRolePolicyDocument": {
                     "Version": "2012-10-17",
                     "Statement": [
@@ -30,7 +31,7 @@
         "FPDemoThingPolicy": {
             "Type": "AWS::IoT::Policy",
             "Properties": {
-                "PolicyName": "FleetProvisioningDemoThingPolicy",
+                "PolicyName": "CF_FleetProvisioningDemoThingPolicy",
                 "PolicyDocument": {
                     "Version": "2012-10-17",
                     "Statement": [
@@ -60,7 +61,7 @@
         "FPDemoTemplate": {
             "Type": "AWS::IoT::ProvisioningTemplate",
             "Properties": {
-                "TemplateName": "FleetProvisioningDemoTemplate",
+                "TemplateName": "CF_FleetProvisioningDemoTemplate",
                 "Enabled": "true",
                 "ProvisioningRoleArn": {
                     "Fn::Join": [
@@ -77,13 +78,13 @@
                         ]
                     ]
                 },
-                "TemplateBody": "{ \"Parameters\": { \"SerialNumber\": { \"Type\": \"String\" }, \"AWS::IoT::Certificate::Id\": { \"Type\": \"String\" } }, \"Resources\": { \"certificate\": { \"Properties\": { \"CertificateId\": { \"Ref\": \"AWS::IoT::Certificate::Id\" }, \"Status\": \"Active\" }, \"Type\": \"AWS::IoT::Certificate\" }, \"policy\": { \"Properties\": { \"PolicyName\": \"FleetProvisioningDemoThingPolicy\" }, \"Type\": \"AWS::IoT::Policy\" }, \"thing\": { \"OverrideSettings\": { \"AttributePayload\": \"MERGE\", \"ThingGroups\": \"DO_NOTHING\" }, \"Properties\": { \"AttributePayload\": {}, \"ThingGroups\": [], \"ThingName\": { \"Fn::Join\": [ \"\", [ \"fp_demo_\", { \"Ref\": \"SerialNumber\" } ] ] } }, \"Type\": \"AWS::IoT::Thing\" } }, \"DeviceConfiguration\": { \"Foo\": \"Bar\" } }"
+                "TemplateBody": "{ \"Parameters\": { \"SerialNumber\": { \"Type\": \"String\" }, \"AWS::IoT::Certificate::Id\": { \"Type\": \"String\" } }, \"Resources\": { \"certificate\": { \"Properties\": { \"CertificateId\": { \"Ref\": \"AWS::IoT::Certificate::Id\" }, \"Status\": \"Active\" }, \"Type\": \"AWS::IoT::Certificate\" }, \"policy\": { \"Properties\": { \"PolicyName\": \"CF_FleetProvisioningDemoThingPolicy\" }, \"Type\": \"AWS::IoT::Policy\" }, \"thing\": { \"OverrideSettings\": { \"AttributePayload\": \"MERGE\", \"ThingGroups\": \"DO_NOTHING\" }, \"Properties\": { \"AttributePayload\": {}, \"ThingGroups\": [], \"ThingName\": { \"Fn::Join\": [ \"\", [ \"fp_demo_\", { \"Ref\": \"SerialNumber\" } ] ] } }, \"Type\": \"AWS::IoT::Thing\" } }, \"DeviceConfiguration\": { \"Foo\": \"Bar\" } }"
             }
         },
         "FPDemoClaimPolicy": {
             "Type": "AWS::IoT::Policy",
             "Properties": {
-                "PolicyName": "FleetProvisioningDemoClaimPolicy",
+                "PolicyName": "CF_FleetProvisioningDemoClaimPolicy",
                 "PolicyDocument": {
                     "Version": "2012-10-17",
                     "Statement": [

--- a/FreeRTOS-Plus/Demo/AWS/Fleet_Provisioning_Windows_Simulator/Fleet_Provisioning_With_CSR_Demo/demo_cloudformation_template.json
+++ b/FreeRTOS-Plus/Demo/AWS/Fleet_Provisioning_Windows_Simulator/Fleet_Provisioning_With_CSR_Demo/demo_cloudformation_template.json
@@ -1,0 +1,216 @@
+{
+    "Parameters": {
+        "CertificateId": {
+            "Type": "String",
+            "Description": "Enter the \"certificateId\" of the certificate created using the \"aws iot create-keys-and-certificate\" command.\nFor more information, see the documentation: https://freertos.org/iot-fleet-provisioning/demo.html"
+        }
+    },
+    "Resources": {
+        "FPDemoRole": {
+            "Type": "AWS::IAM::Role",
+            "Properties": {
+                "RoleName": "FleetProvisioningDemoRole",
+                "AssumeRolePolicyDocument": {
+                    "Version": "2012-10-17",
+                    "Statement": [
+                        {
+                            "Action": "sts:AssumeRole",
+                            "Effect": "Allow",
+                            "Principal": {
+                                "Service": "iot.amazonaws.com"
+                            }
+                        }
+                    ]
+                },
+                "ManagedPolicyArns": [
+                    "arn:aws:iam::aws:policy/service-role/AWSIoTThingsRegistration"
+                ]
+            }
+        },
+        "FPDemoThingPolicy": {
+            "Type": "AWS::IoT::Policy",
+            "Properties": {
+                "PolicyName": "FleetProvisioningDemoThingPolicy",
+                "PolicyDocument": {
+                    "Version": "2012-10-17",
+                    "Statement": [
+                        {
+                            "Effect": "Allow",
+                            "Action": "iot:Connect",
+                            "Resource": {
+                                "Fn::Join": [
+                                    ":",
+                                    [
+                                        "arn:aws:iot",
+                                        {
+                                            "Ref": "AWS::Region"
+                                        },
+                                        {
+                                            "Ref": "AWS::AccountId"
+                                        },
+                                        "*"
+                                    ]
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        },
+        "FPDemoTemplate": {
+            "Type": "AWS::IoT::ProvisioningTemplate",
+            "Properties": {
+                "TemplateName": "FleetProvisioningDemoTemplate",
+                "Enabled": "true",
+                "ProvisioningRoleArn": {
+                    "Fn::Join": [
+                        "",
+                        [
+                            "arn:aws:iam::",
+                            {
+                                "Ref": "AWS::AccountId"
+                            },
+                            ":role/",
+                            {
+                                "Ref": "FPDemoRole"
+                            }
+                        ]
+                    ]
+                },
+                "TemplateBody": "{ \"Parameters\": { \"SerialNumber\": { \"Type\": \"String\" }, \"AWS::IoT::Certificate::Id\": { \"Type\": \"String\" } }, \"Resources\": { \"certificate\": { \"Properties\": { \"CertificateId\": { \"Ref\": \"AWS::IoT::Certificate::Id\" }, \"Status\": \"Active\" }, \"Type\": \"AWS::IoT::Certificate\" }, \"policy\": { \"Properties\": { \"PolicyName\": \"FleetProvisioningDemoThingPolicy\" }, \"Type\": \"AWS::IoT::Policy\" }, \"thing\": { \"OverrideSettings\": { \"AttributePayload\": \"MERGE\", \"ThingGroups\": \"DO_NOTHING\" }, \"Properties\": { \"AttributePayload\": {}, \"ThingGroups\": [], \"ThingName\": { \"Fn::Join\": [ \"\", [ \"fp_demo_\", { \"Ref\": \"SerialNumber\" } ] ] } }, \"Type\": \"AWS::IoT::Thing\" } }, \"DeviceConfiguration\": { \"Foo\": \"Bar\" } }"
+            }
+        },
+        "FPDemoClaimPolicy": {
+            "Type": "AWS::IoT::Policy",
+            "Properties": {
+                "PolicyName": "FleetProvisioningDemoClaimPolicy",
+                "PolicyDocument": {
+                    "Version": "2012-10-17",
+                    "Statement": [
+                        {
+                            "Effect": "Allow",
+                            "Action": [
+                                "iot:Connect"
+                            ],
+                            "Resource": "*"
+                        },
+                        {
+                            "Effect": "Allow",
+                            "Action": [
+                                "iot:Publish",
+                                "iot:Receive"
+                            ],
+                            "Resource": [
+                                {
+                                    "Fn::Join": [
+                                        "",
+                                        [
+                                            "arn:aws:iot:",
+                                            {
+                                                "Ref": "AWS::Region"
+                                            },
+                                            ":",
+                                            {
+                                                "Ref": "AWS::AccountId"
+                                            },
+                                            ":topic/$aws/certificates/create-from-csr/*"
+                                        ]
+                                    ]
+                                },
+                                {
+                                    "Fn::Join": [
+                                        "",
+                                        [
+                                            "arn:aws:iot:",
+                                            {
+                                                "Ref": "AWS::Region"
+                                            },
+                                            ":",
+                                            {
+                                                "Ref": "AWS::AccountId"
+                                            },
+                                            ":topic/$aws/provisioning-templates/",
+                                            {
+                                                "Ref": "FPDemoTemplate"
+                                            },
+                                            "/provision/*"
+                                        ]
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "Effect": "Allow",
+                            "Action": "iot:Subscribe",
+                            "Resource": [
+                                {
+                                    "Fn::Join": [
+                                        "",
+                                        [
+                                            "arn:aws:iot:",
+                                            {
+                                                "Ref": "AWS::Region"
+                                            },
+                                            ":",
+                                            {
+                                                "Ref": "AWS::AccountId"
+                                            },
+                                            ":topicfilter/$aws/certificates/create-from-csr/*"
+                                        ]
+                                    ]
+                                },
+                                {
+                                    "Fn::Join": [
+                                        "",
+                                        [
+                                            "arn:aws:iot:",
+                                            {
+                                                "Ref": "AWS::Region"
+                                            },
+                                            ":",
+                                            {
+                                                "Ref": "AWS::AccountId"
+                                            },
+                                            ":topicfilter/$aws/provisioning-templates/",
+                                            {
+                                                "Ref": "FPDemoTemplate"
+                                            },
+                                            "/provision/*"
+                                        ]
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        },
+        "FPAttachPolicy": {
+            "Type": "AWS::IoT::PolicyPrincipalAttachment",
+            "Properties": {
+                "PolicyName": {
+                    "Ref": "FPDemoClaimPolicy"
+                },
+                "Principal": {
+                    "Fn::Join": [
+                        "",
+                        [
+                            "arn:aws:iot:",
+                            {
+                                "Ref": "AWS::Region"
+                            },
+                            ":",
+                            {
+                                "Ref": "AWS::AccountId"
+                            },
+                            ":cert/",
+                            {
+                                "Ref": "CertificateId"
+                            }
+                        ]
+                    ]
+                }
+            }
+        }
+    }
+}

--- a/FreeRTOS-Plus/Demo/AWS/Fleet_Provisioning_Windows_Simulator/Fleet_Provisioning_With_CSR_Demo/demo_config.h
+++ b/FreeRTOS-Plus/Demo/AWS/Fleet_Provisioning_Windows_Simulator/Fleet_Provisioning_With_CSR_Demo/demo_config.h
@@ -145,6 +145,10 @@ extern void vLoggingPrintf( const char * pcFormatString,
  * @note The provisioning template MUST be created in AWS IoT before running the
  * demo.
  *
+ * @note If you followed the manual setup steps on https://freertos.org/iot-fleet-provisioning/demo.html,
+ * the provisioning template name is "FleetProvisioningDemoTemplate".
+ * However, if you used CloudFormation to set up the demo, the template name is "CF_FleetProvisioningDemoTemplate"
+ *
  * #define democonfigPROVISIONING_TEMPLATE_NAME    "...insert here..."
  */
 


### PR DESCRIPTION
CloudFormation allows multiple AWS resources to be created and grouped together. This PR adds a CloudFormation template which sets up all the [various AWS resources required for the Fleet Provisioning demo](https://freertos.org/iot-fleet-provisioning/demo.html#setting-up). Using the template requires the AWS CLI to be installed and configured.

To use the template, first create the keys in the same directory as the Fleet Provisioning demo:
```
aws iot create-keys-and-certificate \
 --certificate-pem-outfile "ClaimCertificate.pem" \
 --public-key-outfile "ClaimPubKey.pem" \
 --private-key-outfile "ClaimPrivateKey.pem" \
 --set-as-active
```

Then, run the following command after replacing \<certificateId> with the certificateId listed in the previous command's output:
```
aws cloudformation create-stack \
  --stack-name FPDemoStack \
  --template-body file://demo_cloudformation_template.json \
  --capabilities CAPABILITY_NAMED_IAM \
  --parameters ParameterKey=CertificateId,ParameterValue=<certificateId>
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
