### PR TITLE
Return error if invalid input detected in transport layer (Send/Recv)

### DIFF
--- a/FreeRTOS-Plus/Source/Application-Protocols/network_transport/using_mbedtls/using_mbedtls.c
+++ b/FreeRTOS-Plus/Source/Application-Protocols/network_transport/using_mbedtls/using_mbedtls.c
@@ -773,7 +773,21 @@ int32_t TLS_FreeRTOS_recv( NetworkContext_t * pNetworkContext,
     TlsTransportParams_t * pTlsTransportParams = NULL;
     int32_t tlsStatus = 0;
 
-    configASSERT( ( pNetworkContext != NULL ) && ( pNetworkContext->pParams != NULL ) );
+    if ((pNetworkContext == NULL) || pNetworkContext->pParams == NULL)
+    {
+        LogError(("invalid input, pNetworkContext=%p", pNetworkContext));
+        return -1;
+    }
+    else if (pBuffer == NULL)
+    {
+        LogError(("invalid input, pBuffer == NULL"));
+        return -1;
+    }
+    else if (bytesToRecv == 0)
+    {
+        LogError(("invalid input, bytesToRecv == 0"));
+        return -1;
+    }
 
     pTlsTransportParams = pNetworkContext->pParams;
     tlsStatus = ( int32_t ) mbedtls_ssl_read( &( pTlsTransportParams->sslContext.context ),
@@ -815,7 +829,21 @@ int32_t TLS_FreeRTOS_send( NetworkContext_t * pNetworkContext,
     TlsTransportParams_t * pTlsTransportParams = NULL;
     int32_t tlsStatus = 0;
 
-    configASSERT( ( pNetworkContext != NULL ) && ( pNetworkContext->pParams != NULL ) );
+    if ((pNetworkContext == NULL) || pNetworkContext->pParams == NULL)
+    {
+        LogError(("invalid input, pNetworkContext=%p", pNetworkContext));
+        return -1;
+    }
+    else if (pBuffer == NULL)
+    {
+        LogError(("invalid input, pBuffer == NULL"));
+        return -1;
+    }
+    else if (bytesToSend == 0)
+    {
+        LogError(("invalid input, bytesToSend == 0"));
+        return -1;
+    }
 
     pTlsTransportParams = pNetworkContext->pParams;
     tlsStatus = ( int32_t ) mbedtls_ssl_write( &( pTlsTransportParams->sslContext.context ),

--- a/FreeRTOS-Plus/Source/Application-Protocols/network_transport/using_mbedtls/using_mbedtls.c
+++ b/FreeRTOS-Plus/Source/Application-Protocols/network_transport/using_mbedtls/using_mbedtls.c
@@ -776,46 +776,49 @@ int32_t TLS_FreeRTOS_recv( NetworkContext_t * pNetworkContext,
     if( ( pNetworkContext == NULL ) || ( pNetworkContext->pParams == NULL ) )
     {
         LogError( ( "invalid input, pNetworkContext=%p", pNetworkContext ) );
-        return -1;
+        tlsStatus = -1;
     }
     else if( pBuffer == NULL )
     {
         LogError( ( "invalid input, pBuffer == NULL" ) );
-        return -1;
+        tlsStatus = -1;
     }
     else if( bytesToRecv == 0 )
     {
         LogError( ( "invalid input, bytesToRecv == 0" ) );
-        return -1;
-    }
-
-    pTlsTransportParams = pNetworkContext->pParams;
-    tlsStatus = ( int32_t ) mbedtls_ssl_read( &( pTlsTransportParams->sslContext.context ),
-                                              pBuffer,
-                                              bytesToRecv );
-
-    if( ( tlsStatus == MBEDTLS_ERR_SSL_TIMEOUT ) ||
-        ( tlsStatus == MBEDTLS_ERR_SSL_WANT_READ ) ||
-        ( tlsStatus == MBEDTLS_ERR_SSL_WANT_WRITE ) )
-    {
-        LogDebug( ( "Failed to read data. However, a read can be retried on this error. "
-                    "mbedTLSError= %s : %s.",
-                    mbedtlsHighLevelCodeOrDefault( tlsStatus ),
-                    mbedtlsLowLevelCodeOrDefault( tlsStatus ) ) );
-
-        /* Mark these set of errors as a timeout. The libraries may retry read
-         * on these errors. */
-        tlsStatus = 0;
-    }
-    else if( tlsStatus < 0 )
-    {
-        LogError( ( "Failed to read data: mbedTLSError= %s : %s.",
-                    mbedtlsHighLevelCodeOrDefault( tlsStatus ),
-                    mbedtlsLowLevelCodeOrDefault( tlsStatus ) ) );
+        tlsStatus = -1;
     }
     else
     {
-        /* Empty else marker. */
+        pTlsTransportParams = pNetworkContext->pParams;
+
+        tlsStatus = ( int32_t ) mbedtls_ssl_read( &( pTlsTransportParams->sslContext.context ),
+                                                  pBuffer,
+                                                  bytesToRecv );
+
+        if( ( tlsStatus == MBEDTLS_ERR_SSL_TIMEOUT ) ||
+            ( tlsStatus == MBEDTLS_ERR_SSL_WANT_READ ) ||
+            ( tlsStatus == MBEDTLS_ERR_SSL_WANT_WRITE ) )
+        {
+            LogDebug( ( "Failed to read data. However, a read can be retried on this error. "
+                        "mbedTLSError= %s : %s.",
+                        mbedtlsHighLevelCodeOrDefault( tlsStatus ),
+                        mbedtlsLowLevelCodeOrDefault( tlsStatus ) ) );
+
+            /* Mark these set of errors as a timeout. The libraries may retry read
+             * on these errors. */
+            tlsStatus = 0;
+        }
+        else if( tlsStatus < 0 )
+        {
+            LogError( ( "Failed to read data: mbedTLSError= %s : %s.",
+                        mbedtlsHighLevelCodeOrDefault( tlsStatus ),
+                        mbedtlsLowLevelCodeOrDefault( tlsStatus ) ) );
+        }
+        else
+        {
+            /* Empty else marker. */
+        }
     }
 
     return tlsStatus;
@@ -832,46 +835,49 @@ int32_t TLS_FreeRTOS_send( NetworkContext_t * pNetworkContext,
     if( ( pNetworkContext == NULL ) || ( pNetworkContext->pParams == NULL ) )
     {
         LogError( ( "invalid input, pNetworkContext=%p", pNetworkContext ) );
-        return -1;
+        tlsStatus = -1;
     }
     else if( pBuffer == NULL )
     {
         LogError( ( "invalid input, pBuffer == NULL" ) );
-        return -1;
+        tlsStatus = -1;
     }
     else if( bytesToSend == 0 )
     {
         LogError( ( "invalid input, bytesToSend == 0" ) );
-        return -1;
-    }
-
-    pTlsTransportParams = pNetworkContext->pParams;
-    tlsStatus = ( int32_t ) mbedtls_ssl_write( &( pTlsTransportParams->sslContext.context ),
-                                               pBuffer,
-                                               bytesToSend );
-
-    if( ( tlsStatus == MBEDTLS_ERR_SSL_TIMEOUT ) ||
-        ( tlsStatus == MBEDTLS_ERR_SSL_WANT_READ ) ||
-        ( tlsStatus == MBEDTLS_ERR_SSL_WANT_WRITE ) )
-    {
-        LogDebug( ( "Failed to send data. However, send can be retried on this error. "
-                    "mbedTLSError= %s : %s.",
-                    mbedtlsHighLevelCodeOrDefault( tlsStatus ),
-                    mbedtlsLowLevelCodeOrDefault( tlsStatus ) ) );
-
-        /* Mark these set of errors as a timeout. The libraries may retry send
-         * on these errors. */
-        tlsStatus = 0;
-    }
-    else if( tlsStatus < 0 )
-    {
-        LogError( ( "Failed to send data:  mbedTLSError= %s : %s.",
-                    mbedtlsHighLevelCodeOrDefault( tlsStatus ),
-                    mbedtlsLowLevelCodeOrDefault( tlsStatus ) ) );
+        tlsStatus = -1;
     }
     else
     {
-        /* Empty else marker. */
+        pTlsTransportParams = pNetworkContext->pParams;
+
+        tlsStatus = ( int32_t ) mbedtls_ssl_write( &( pTlsTransportParams->sslContext.context ),
+                                                   pBuffer,
+                                                   bytesToSend );
+
+        if( ( tlsStatus == MBEDTLS_ERR_SSL_TIMEOUT ) ||
+            ( tlsStatus == MBEDTLS_ERR_SSL_WANT_READ ) ||
+            ( tlsStatus == MBEDTLS_ERR_SSL_WANT_WRITE ) )
+        {
+            LogDebug( ( "Failed to send data. However, send can be retried on this error. "
+                        "mbedTLSError= %s : %s.",
+                        mbedtlsHighLevelCodeOrDefault( tlsStatus ),
+                        mbedtlsLowLevelCodeOrDefault( tlsStatus ) ) );
+
+            /* Mark these set of errors as a timeout. The libraries may retry send
+             * on these errors. */
+            tlsStatus = 0;
+        }
+        else if( tlsStatus < 0 )
+        {
+            LogError( ( "Failed to send data:  mbedTLSError= %s : %s.",
+                        mbedtlsHighLevelCodeOrDefault( tlsStatus ),
+                        mbedtlsLowLevelCodeOrDefault( tlsStatus ) ) );
+        }
+        else
+        {
+            /* Empty else marker. */
+        }
     }
 
     return tlsStatus;

--- a/FreeRTOS-Plus/Source/Application-Protocols/network_transport/using_mbedtls/using_mbedtls.c
+++ b/FreeRTOS-Plus/Source/Application-Protocols/network_transport/using_mbedtls/using_mbedtls.c
@@ -773,19 +773,19 @@ int32_t TLS_FreeRTOS_recv( NetworkContext_t * pNetworkContext,
     TlsTransportParams_t * pTlsTransportParams = NULL;
     int32_t tlsStatus = 0;
 
-    if ((pNetworkContext == NULL) || pNetworkContext->pParams == NULL)
+    if( ( pNetworkContext == NULL ) || ( pNetworkContext->pParams == NULL ) )
     {
-        LogError(("invalid input, pNetworkContext=%p", pNetworkContext));
+        LogError( ( "invalid input, pNetworkContext=%p", pNetworkContext ) );
         return -1;
     }
-    else if (pBuffer == NULL)
+    else if( pBuffer == NULL )
     {
-        LogError(("invalid input, pBuffer == NULL"));
+        LogError( ( "invalid input, pBuffer == NULL" ) );
         return -1;
     }
-    else if (bytesToRecv == 0)
+    else if( bytesToRecv == 0 )
     {
-        LogError(("invalid input, bytesToRecv == 0"));
+        LogError( ( "invalid input, bytesToRecv == 0" ) );
         return -1;
     }
 
@@ -829,19 +829,19 @@ int32_t TLS_FreeRTOS_send( NetworkContext_t * pNetworkContext,
     TlsTransportParams_t * pTlsTransportParams = NULL;
     int32_t tlsStatus = 0;
 
-    if ((pNetworkContext == NULL) || pNetworkContext->pParams == NULL)
+    if( ( pNetworkContext == NULL ) || ( pNetworkContext->pParams == NULL ) )
     {
-        LogError(("invalid input, pNetworkContext=%p", pNetworkContext));
+        LogError( ( "invalid input, pNetworkContext=%p", pNetworkContext ) );
         return -1;
     }
-    else if (pBuffer == NULL)
+    else if( pBuffer == NULL )
     {
-        LogError(("invalid input, pBuffer == NULL"));
+        LogError( ( "invalid input, pBuffer == NULL" ) );
         return -1;
     }
-    else if (bytesToSend == 0)
+    else if( bytesToSend == 0 )
     {
-        LogError(("invalid input, bytesToSend == 0"));
+        LogError( ( "invalid input, bytesToSend == 0" ) );
         return -1;
     }
 

--- a/FreeRTOS-Plus/Source/Application-Protocols/network_transport/using_mbedtls_pkcs11/using_mbedtls_pkcs11.c
+++ b/FreeRTOS-Plus/Source/Application-Protocols/network_transport/using_mbedtls_pkcs11/using_mbedtls_pkcs11.c
@@ -978,46 +978,49 @@ int32_t TLS_FreeRTOS_recv( NetworkContext_t * pNetworkContext,
     if( ( pNetworkContext == NULL ) || ( pNetworkContext->pParams == NULL ) )
     {
         LogError( ( "invalid input, pNetworkContext=%p", pNetworkContext ) );
-        return -1;
+        tlsStatus = -1;
     }
     else if( pBuffer == NULL )
     {
         LogError( ( "invalid input, pBuffer == NULL" ) );
-        return -1;
+        tlsStatus = -1;
     }
     else if( bytesToRecv == 0 )
     {
         LogError( ( "invalid input, bytesToRecv == 0" ) );
-        return -1;
-    }
-
-    pTlsTransportParams = pNetworkContext->pParams;
-    tlsStatus = ( int32_t ) mbedtls_ssl_read( &( pTlsTransportParams->sslContext.context ),
-                                              pBuffer,
-                                              bytesToRecv );
-
-    if( ( tlsStatus == MBEDTLS_ERR_SSL_TIMEOUT ) ||
-        ( tlsStatus == MBEDTLS_ERR_SSL_WANT_READ ) ||
-        ( tlsStatus == MBEDTLS_ERR_SSL_WANT_WRITE ) )
-    {
-        LogDebug( ( "Failed to read data. However, a read can be retried on this error. "
-                    "mbedTLSError= %s : %s.",
-                    mbedtlsHighLevelCodeOrDefault( tlsStatus ),
-                    mbedtlsLowLevelCodeOrDefault( tlsStatus ) ) );
-
-        /* Mark these set of errors as a timeout. The libraries may retry read
-         * on these errors. */
-        tlsStatus = 0;
-    }
-    else if( tlsStatus < 0 )
-    {
-        LogError( ( "Failed to read data: mbedTLSError= %s : %s.",
-                    mbedtlsHighLevelCodeOrDefault( tlsStatus ),
-                    mbedtlsLowLevelCodeOrDefault( tlsStatus ) ) );
+        tlsStatus = -1;
     }
     else
     {
-        /* Empty else marker. */
+        pTlsTransportParams = pNetworkContext->pParams;
+
+        tlsStatus = ( int32_t ) mbedtls_ssl_read( &( pTlsTransportParams->sslContext.context ),
+                                                  pBuffer,
+                                                  bytesToRecv );
+
+        if( ( tlsStatus == MBEDTLS_ERR_SSL_TIMEOUT ) ||
+            ( tlsStatus == MBEDTLS_ERR_SSL_WANT_READ ) ||
+            ( tlsStatus == MBEDTLS_ERR_SSL_WANT_WRITE ) )
+        {
+            LogDebug( ( "Failed to read data. However, a read can be retried on this error. "
+                        "mbedTLSError= %s : %s.",
+                        mbedtlsHighLevelCodeOrDefault( tlsStatus ),
+                        mbedtlsLowLevelCodeOrDefault( tlsStatus ) ) );
+
+            /* Mark these set of errors as a timeout. The libraries may retry read
+             * on these errors. */
+            tlsStatus = 0;
+        }
+        else if( tlsStatus < 0 )
+        {
+            LogError( ( "Failed to read data: mbedTLSError= %s : %s.",
+                        mbedtlsHighLevelCodeOrDefault( tlsStatus ),
+                        mbedtlsLowLevelCodeOrDefault( tlsStatus ) ) );
+        }
+        else
+        {
+            /* Empty else marker. */
+        }
     }
 
     return tlsStatus;
@@ -1035,46 +1038,48 @@ int32_t TLS_FreeRTOS_send( NetworkContext_t * pNetworkContext,
     if( ( pNetworkContext == NULL ) || ( pNetworkContext->pParams == NULL ) )
     {
         LogError( ( "invalid input, pNetworkContext=%p", pNetworkContext ) );
-        return -1;
+        tlsStatus = -1;
     }
     else if( pBuffer == NULL )
     {
         LogError( ( "invalid input, pBuffer == NULL" ) );
-        return -1;
+        tlsStatus = -1;
     }
     else if( bytesToSend == 0 )
     {
         LogError( ( "invalid input, bytesToSend == 0" ) );
-        return -1;
-    }
-
-    pTlsTransportParams = pNetworkContext->pParams;
-    tlsStatus = ( int32_t ) mbedtls_ssl_write( &( pTlsTransportParams->sslContext.context ),
-                                               pBuffer,
-                                               bytesToSend );
-
-    if( ( tlsStatus == MBEDTLS_ERR_SSL_TIMEOUT ) ||
-        ( tlsStatus == MBEDTLS_ERR_SSL_WANT_READ ) ||
-        ( tlsStatus == MBEDTLS_ERR_SSL_WANT_WRITE ) )
-    {
-        LogDebug( ( "Failed to send data. However, send can be retried on this error. "
-                    "mbedTLSError= %s : %s.",
-                    mbedtlsHighLevelCodeOrDefault( tlsStatus ),
-                    mbedtlsLowLevelCodeOrDefault( tlsStatus ) ) );
-
-        /* Mark these set of errors as a timeout. The libraries may retry send
-         * on these errors. */
-        tlsStatus = 0;
-    }
-    else if( tlsStatus < 0 )
-    {
-        LogError( ( "Failed to send data:  mbedTLSError= %s : %s.",
-                    mbedtlsHighLevelCodeOrDefault( tlsStatus ),
-                    mbedtlsLowLevelCodeOrDefault( tlsStatus ) ) );
+        tlsStatus = -1;
     }
     else
     {
-        /* Empty else marker. */
+        pTlsTransportParams = pNetworkContext->pParams;
+        tlsStatus = ( int32_t ) mbedtls_ssl_write( &( pTlsTransportParams->sslContext.context ),
+                                                   pBuffer,
+                                                   bytesToSend );
+
+        if( ( tlsStatus == MBEDTLS_ERR_SSL_TIMEOUT ) ||
+            ( tlsStatus == MBEDTLS_ERR_SSL_WANT_READ ) ||
+            ( tlsStatus == MBEDTLS_ERR_SSL_WANT_WRITE ) )
+        {
+            LogDebug( ( "Failed to send data. However, send can be retried on this error. "
+                        "mbedTLSError= %s : %s.",
+                        mbedtlsHighLevelCodeOrDefault( tlsStatus ),
+                        mbedtlsLowLevelCodeOrDefault( tlsStatus ) ) );
+
+            /* Mark these set of errors as a timeout. The libraries may retry send
+             * on these errors. */
+            tlsStatus = 0;
+        }
+        else if( tlsStatus < 0 )
+        {
+            LogError( ( "Failed to send data:  mbedTLSError= %s : %s.",
+                        mbedtlsHighLevelCodeOrDefault( tlsStatus ),
+                        mbedtlsLowLevelCodeOrDefault( tlsStatus ) ) );
+        }
+        else
+        {
+            /* Empty else marker. */
+        }
     }
 
     return tlsStatus;

--- a/FreeRTOS-Plus/Source/Application-Protocols/network_transport/using_mbedtls_pkcs11/using_mbedtls_pkcs11.c
+++ b/FreeRTOS-Plus/Source/Application-Protocols/network_transport/using_mbedtls_pkcs11/using_mbedtls_pkcs11.c
@@ -88,7 +88,7 @@ static const char * pNoLowLevelMbedTlsCodeStr = "<No-Low-Level-Code>";
  * @brief Utility for converting the high-level code in an mbedTLS error to string,
  * if the code-contains a high-level code; otherwise, using a default string.
  */
-#define mbedtlsHighLevelCodeOrDefault( mbedTlsCode )        \
+#define mbedtlsHighLevelCodeOrDefault( mbedTlsCode )       \
     ( mbedtls_high_level_strerr( mbedTlsCode ) != NULL ) ? \
     mbedtls_high_level_strerr( mbedTlsCode ) : pNoHighLevelMbedTlsCodeStr
 
@@ -96,7 +96,7 @@ static const char * pNoLowLevelMbedTlsCodeStr = "<No-Low-Level-Code>";
  * @brief Utility for converting the level-level code in an mbedTLS error to string,
  * if the code-contains a level-level code; otherwise, using a default string.
  */
-#define mbedtlsLowLevelCodeOrDefault( mbedTlsCode )        \
+#define mbedtlsLowLevelCodeOrDefault( mbedTlsCode )       \
     ( mbedtls_low_level_strerr( mbedTlsCode ) != NULL ) ? \
     mbedtls_low_level_strerr( mbedTlsCode ) : pNoLowLevelMbedTlsCodeStr
 
@@ -208,9 +208,9 @@ static int32_t privateKeySigningCallback( void * pvContext,
                                           size_t xHashLen,
                                           unsigned char * pucSig,
                                           size_t * pxSigLen,
-                                          int32_t ( * piRng )( void *,
-                                                               unsigned char *,
-                                                               size_t ),
+                                          int32_t ( *piRng )( void *,
+                                                              unsigned char *,
+                                                              size_t ),
                                           void * pvRng );
 
 
@@ -703,19 +703,19 @@ static CK_RV initializeClientKeys( SSLContext_t * pxCtx,
         pxCtx->privKeyInfo.get_bitlen = NULL;
         pxCtx->privKeyInfo.can_do = canDoStub;
         pxCtx->privKeyInfo.verify_func = NULL;
-#if defined(MBEDTLS_ECDSA_C) && defined(MBEDTLS_ECP_RESTARTABLE)
-        pxCtx->privKeyInfo.verify_rs_func = NULL;
-        pxCtx->privKeyInfo.sign_rs_func = NULL;
-#endif /* MBEDTLS_ECDSA_C && MBEDTLS_ECP_RESTARTABLE */
+        #if defined( MBEDTLS_ECDSA_C ) && defined( MBEDTLS_ECP_RESTARTABLE )
+            pxCtx->privKeyInfo.verify_rs_func = NULL;
+            pxCtx->privKeyInfo.sign_rs_func = NULL;
+        #endif /* MBEDTLS_ECDSA_C && MBEDTLS_ECP_RESTARTABLE */
         pxCtx->privKeyInfo.decrypt_func = NULL;
         pxCtx->privKeyInfo.encrypt_func = NULL;
         pxCtx->privKeyInfo.check_pair_func = NULL;
         pxCtx->privKeyInfo.ctx_alloc_func = NULL;
         pxCtx->privKeyInfo.ctx_free_func = NULL;
-#if defined(MBEDTLS_ECDSA_C) && defined(MBEDTLS_ECP_RESTARTABLE)
-        pxCtx->privKeyInfo.rs_alloc_func = NULL;
-        pxCtx->privKeyInfo.rs_free_func = NULL;
-#endif /* MBEDTLS_ECDSA_C && MBEDTLS_ECP_RESTARTABLE */
+        #if defined( MBEDTLS_ECDSA_C ) && defined( MBEDTLS_ECP_RESTARTABLE )
+            pxCtx->privKeyInfo.rs_alloc_func = NULL;
+            pxCtx->privKeyInfo.rs_free_func = NULL;
+        #endif /* MBEDTLS_ECDSA_C && MBEDTLS_ECP_RESTARTABLE */
         pxCtx->privKeyInfo.debug_func = NULL;
 
         pxCtx->privKeyInfo.sign_func = privateKeySigningCallback;
@@ -737,9 +737,9 @@ static int32_t privateKeySigningCallback( void * pvContext,
                                           size_t xHashLen,
                                           unsigned char * pucSig,
                                           size_t * pxSigLen,
-                                          int32_t ( * piRng )( void *,
-                                                               unsigned char *,
-                                                               size_t ),
+                                          int32_t ( *piRng )( void *,
+                                                              unsigned char *,
+                                                              size_t ),
                                           void * pvRng )
 {
     CK_RV xResult = CKR_OK;
@@ -923,7 +923,7 @@ void TLS_FreeRTOS_Disconnect( NetworkContext_t * pNetworkContext )
     TlsTransportParams_t * pTlsTransportParams = NULL;
     BaseType_t tlsStatus = 0;
 
-    if( pNetworkContext != NULL && pNetworkContext->pParams != NULL )
+    if( ( pNetworkContext != NULL ) && ( pNetworkContext->pParams != NULL ) )
     {
         pTlsTransportParams = pNetworkContext->pParams;
         /* Attempting to terminate TLS connection. */
@@ -975,19 +975,19 @@ int32_t TLS_FreeRTOS_recv( NetworkContext_t * pNetworkContext,
     TlsTransportParams_t * pTlsTransportParams = NULL;
     int32_t tlsStatus = 0;
 
-    if (pNetworkContext == NULL || pNetworkContext->pParams == NULL)
+    if( ( pNetworkContext == NULL ) || ( pNetworkContext->pParams == NULL ) )
     {
-        LogError(("invalid input, pNetworkContext=%p", pNetworkContext));
+        LogError( ( "invalid input, pNetworkContext=%p", pNetworkContext ) );
         return -1;
     }
-    else if (pBuffer == NULL)
+    else if( pBuffer == NULL )
     {
-        LogError(("invalid input, pBuffer == NULL"));
+        LogError( ( "invalid input, pBuffer == NULL" ) );
         return -1;
     }
-    else if (bytesToRecv == 0)
+    else if( bytesToRecv == 0 )
     {
-        LogError(("invalid input, bytesToRecv == 0"));
+        LogError( ( "invalid input, bytesToRecv == 0" ) );
         return -1;
     }
 
@@ -1032,19 +1032,19 @@ int32_t TLS_FreeRTOS_send( NetworkContext_t * pNetworkContext,
     TlsTransportParams_t * pTlsTransportParams = NULL;
     int32_t tlsStatus = 0;
 
-    if (pNetworkContext == NULL || pNetworkContext->pParams == NULL)
+    if( ( pNetworkContext == NULL ) || ( pNetworkContext->pParams == NULL ) )
     {
-        LogError(("invalid input, pNetworkContext=%p", pNetworkContext));
+        LogError( ( "invalid input, pNetworkContext=%p", pNetworkContext ) );
         return -1;
     }
-    else if (pBuffer == NULL)
+    else if( pBuffer == NULL )
     {
-        LogError(("invalid input, pBuffer == NULL"));
+        LogError( ( "invalid input, pBuffer == NULL" ) );
         return -1;
     }
-    else if (bytesToSend == 0)
+    else if( bytesToSend == 0 )
     {
-        LogError(("invalid input, bytesToSend == 0"));
+        LogError( ( "invalid input, bytesToSend == 0" ) );
         return -1;
     }
 

--- a/FreeRTOS-Plus/Source/Application-Protocols/network_transport/using_mbedtls_pkcs11/using_mbedtls_pkcs11.c
+++ b/FreeRTOS-Plus/Source/Application-Protocols/network_transport/using_mbedtls_pkcs11/using_mbedtls_pkcs11.c
@@ -975,7 +975,21 @@ int32_t TLS_FreeRTOS_recv( NetworkContext_t * pNetworkContext,
     TlsTransportParams_t * pTlsTransportParams = NULL;
     int32_t tlsStatus = 0;
 
-    configASSERT( ( pNetworkContext != NULL ) && ( pNetworkContext->pParams != NULL ) );
+    if (pNetworkContext == NULL || pNetworkContext->pParams == NULL)
+    {
+        LogError(("invalid input, pNetworkContext=%p", pNetworkContext));
+        return -1;
+    }
+    else if (pBuffer == NULL)
+    {
+        LogError(("invalid input, pBuffer == NULL"));
+        return -1;
+    }
+    else if (bytesToRecv == 0)
+    {
+        LogError(("invalid input, bytesToRecv == 0"));
+        return -1;
+    }
 
     pTlsTransportParams = pNetworkContext->pParams;
     tlsStatus = ( int32_t ) mbedtls_ssl_read( &( pTlsTransportParams->sslContext.context ),
@@ -1018,7 +1032,21 @@ int32_t TLS_FreeRTOS_send( NetworkContext_t * pNetworkContext,
     TlsTransportParams_t * pTlsTransportParams = NULL;
     int32_t tlsStatus = 0;
 
-    configASSERT( ( pNetworkContext != NULL ) && ( pNetworkContext->pParams != NULL ) );
+    if (pNetworkContext == NULL || pNetworkContext->pParams == NULL)
+    {
+        LogError(("invalid input, pNetworkContext=%p", pNetworkContext));
+        return -1;
+    }
+    else if (pBuffer == NULL)
+    {
+        LogError(("invalid input, pBuffer == NULL"));
+        return -1;
+    }
+    else if (bytesToSend == 0)
+    {
+        LogError(("invalid input, bytesToSend == 0"));
+        return -1;
+    }
 
     pTlsTransportParams = pNetworkContext->pParams;
     tlsStatus = ( int32_t ) mbedtls_ssl_write( &( pTlsTransportParams->sslContext.context ),

--- a/FreeRTOS-Plus/Source/Application-Protocols/network_transport/using_plaintext/using_plaintext.c
+++ b/FreeRTOS-Plus/Source/Application-Protocols/network_transport/using_plaintext/using_plaintext.c
@@ -133,7 +133,21 @@ int32_t Plaintext_FreeRTOS_recv( NetworkContext_t * pNetworkContext,
     PlaintextTransportParams_t * pPlaintextTransportParams = NULL;
     int32_t socketStatus = 1;
 
-    configASSERT( ( pNetworkContext != NULL ) && ( pNetworkContext->pParams != NULL ) );
+    if (pNetworkContext == NULL || pNetworkContext->pParams == NULL)
+    {
+        LogError(("invalid input, pNetworkContext=%p", pNetworkContext));
+        return -1;
+    }
+    else if (pBuffer == NULL)
+    {
+        LogError(("invalid input, pBuffer == NULL"));
+        return -1;
+    }
+    else if (bytesToRecv == 0)
+    {
+        LogError(("invalid input, bytesToRecv == 0"));
+        return -1;
+    }
 
     pPlaintextTransportParams = pNetworkContext->pParams;
 
@@ -169,7 +183,21 @@ int32_t Plaintext_FreeRTOS_send( NetworkContext_t * pNetworkContext,
     PlaintextTransportParams_t * pPlaintextTransportParams = NULL;
     int32_t socketStatus = 0;
 
-    configASSERT( ( pNetworkContext != NULL ) && ( pNetworkContext->pParams != NULL ) );
+    if (pNetworkContext == NULL || pNetworkContext->pParams == NULL)
+    {
+        LogError(("invalid input, pNetworkContext=%p", pNetworkContext));
+        return -1;
+    }
+    else if (pBuffer == NULL)
+    {
+        LogError(("invalid input, pBuffer == NULL"));
+        return -1;
+    }
+    else if (bytesToSend == 0)
+    {
+        LogError(("invalid input, bytesToSend == 0"));
+        return -1;
+    }
 
     pPlaintextTransportParams = pNetworkContext->pParams;
     socketStatus = FreeRTOS_send( pPlaintextTransportParams->tcpSocket,

--- a/FreeRTOS-Plus/Source/Application-Protocols/network_transport/using_plaintext/using_plaintext.c
+++ b/FreeRTOS-Plus/Source/Application-Protocols/network_transport/using_plaintext/using_plaintext.c
@@ -136,41 +136,43 @@ int32_t Plaintext_FreeRTOS_recv( NetworkContext_t * pNetworkContext,
     if( ( pNetworkContext == NULL ) || ( pNetworkContext->pParams == NULL ) )
     {
         LogError( ( "invalid input, pNetworkContext=%p", pNetworkContext ) );
-        return -1;
+        socketStatus = -1;
     }
     else if( pBuffer == NULL )
     {
         LogError( ( "invalid input, pBuffer == NULL" ) );
-        return -1;
+        socketStatus = -1;
     }
     else if( bytesToRecv == 0 )
     {
         LogError( ( "invalid input, bytesToRecv == 0" ) );
-        return -1;
+        socketStatus = -1;
     }
-
-    pPlaintextTransportParams = pNetworkContext->pParams;
-
-    /* The TCP socket may have a receive block time.  If bytesToRecv is greater
-     * than 1 then a frame is likely already part way through reception and
-     * blocking to wait for the desired number of bytes to be available is the
-     * most efficient thing to do.  If bytesToRecv is 1 then this may be a
-     * speculative call to read to find the start of a new frame, in which case
-     * blocking is not desirable as it could block an entire protocol agent
-     * task for the duration of the read block time and therefore negatively
-     * impact performance.  So if bytesToRecv is 1 then don't call recv unless
-     * it is known that bytes are already available. */
-    if( bytesToRecv == 1 )
+    else
     {
-        socketStatus = ( int32_t ) FreeRTOS_recvcount( pPlaintextTransportParams->tcpSocket );
-    }
+        pPlaintextTransportParams = pNetworkContext->pParams;
 
-    if( socketStatus > 0 )
-    {
-        socketStatus = FreeRTOS_recv( pPlaintextTransportParams->tcpSocket,
-                                      pBuffer,
-                                      bytesToRecv,
-                                      0 );
+        /* The TCP socket may have a receive block time.  If bytesToRecv is greater
+         * than 1 then a frame is likely already part way through reception and
+         * blocking to wait for the desired number of bytes to be available is the
+         * most efficient thing to do.  If bytesToRecv is 1 then this may be a
+         * speculative call to read to find the start of a new frame, in which case
+         * blocking is not desirable as it could block an entire protocol agent
+         * task for the duration of the read block time and therefore negatively
+         * impact performance.  So if bytesToRecv is 1 then don't call recv unless
+         * it is known that bytes are already available. */
+        if( bytesToRecv == 1 )
+        {
+            socketStatus = ( int32_t ) FreeRTOS_recvcount( pPlaintextTransportParams->tcpSocket );
+        }
+
+        if( socketStatus > 0 )
+        {
+            socketStatus = FreeRTOS_recv( pPlaintextTransportParams->tcpSocket,
+                                          pBuffer,
+                                          bytesToRecv,
+                                          0 );
+        }
     }
 
     return socketStatus;
@@ -186,42 +188,44 @@ int32_t Plaintext_FreeRTOS_send( NetworkContext_t * pNetworkContext,
     if( ( pNetworkContext == NULL ) || ( pNetworkContext->pParams == NULL ) )
     {
         LogError( ( "invalid input, pNetworkContext=%p", pNetworkContext ) );
-        return -1;
+        socketStatus = -1;
     }
     else if( pBuffer == NULL )
     {
         LogError( ( "invalid input, pBuffer == NULL" ) );
-        return -1;
+        socketStatus = -1;
     }
     else if( bytesToSend == 0 )
     {
         LogError( ( "invalid input, bytesToSend == 0" ) );
-        return -1;
+        socketStatus = -1;
     }
-
-    pPlaintextTransportParams = pNetworkContext->pParams;
-    socketStatus = FreeRTOS_send( pPlaintextTransportParams->tcpSocket,
-                                  pBuffer,
-                                  bytesToSend,
-                                  0 );
-
-    if( socketStatus == -pdFREERTOS_ERRNO_ENOSPC )
+    else
     {
-        /* The TCP buffers could not accept any more bytes so zero bytes were sent.
-         * This is not necessarily an error that should cause a disconnect
-         * unless it persists. */
-        socketStatus = 0;
-    }
+        pPlaintextTransportParams = pNetworkContext->pParams;
+        socketStatus = FreeRTOS_send( pPlaintextTransportParams->tcpSocket,
+                                      pBuffer,
+                                      bytesToSend,
+                                      0 );
 
-    #if ( configUSE_PREEMPTION == 0 )
+        if( socketStatus == -pdFREERTOS_ERRNO_ENOSPC )
         {
-            /* FreeRTOS_send adds the packet to be sent to the IP task's queue for later processing.
-             * The packet is sent later by the IP task. When FreeRTOS is used in collaborative
-             * mode (i.e. configUSE_PREEMPTION is 0), call taskYIELD to give IP task a chance to run
-             * so that the packet is actually sent before this function returns. */
-            taskYIELD();
+            /* The TCP buffers could not accept any more bytes so zero bytes were sent.
+             * This is not necessarily an error that should cause a disconnect
+             * unless it persists. */
+            socketStatus = 0;
         }
-    #endif
+
+        #if ( configUSE_PREEMPTION == 0 )
+            {
+                /* FreeRTOS_send adds the packet to be sent to the IP task's queue for later processing.
+                 * The packet is sent later by the IP task. When FreeRTOS is used in collaborative
+                 * mode (i.e. configUSE_PREEMPTION is 0), call taskYIELD to give IP task a chance to run
+                 * so that the packet is actually sent before this function returns. */
+                taskYIELD();
+            }
+        #endif
+    }
 
     return socketStatus;
 }

--- a/FreeRTOS-Plus/Source/Application-Protocols/network_transport/using_plaintext/using_plaintext.c
+++ b/FreeRTOS-Plus/Source/Application-Protocols/network_transport/using_plaintext/using_plaintext.c
@@ -133,19 +133,19 @@ int32_t Plaintext_FreeRTOS_recv( NetworkContext_t * pNetworkContext,
     PlaintextTransportParams_t * pPlaintextTransportParams = NULL;
     int32_t socketStatus = 1;
 
-    if (pNetworkContext == NULL || pNetworkContext->pParams == NULL)
+    if( ( pNetworkContext == NULL ) || ( pNetworkContext->pParams == NULL ) )
     {
-        LogError(("invalid input, pNetworkContext=%p", pNetworkContext));
+        LogError( ( "invalid input, pNetworkContext=%p", pNetworkContext ) );
         return -1;
     }
-    else if (pBuffer == NULL)
+    else if( pBuffer == NULL )
     {
-        LogError(("invalid input, pBuffer == NULL"));
+        LogError( ( "invalid input, pBuffer == NULL" ) );
         return -1;
     }
-    else if (bytesToRecv == 0)
+    else if( bytesToRecv == 0 )
     {
-        LogError(("invalid input, bytesToRecv == 0"));
+        LogError( ( "invalid input, bytesToRecv == 0" ) );
         return -1;
     }
 
@@ -183,19 +183,19 @@ int32_t Plaintext_FreeRTOS_send( NetworkContext_t * pNetworkContext,
     PlaintextTransportParams_t * pPlaintextTransportParams = NULL;
     int32_t socketStatus = 0;
 
-    if (pNetworkContext == NULL || pNetworkContext->pParams == NULL)
+    if( ( pNetworkContext == NULL ) || ( pNetworkContext->pParams == NULL ) )
     {
-        LogError(("invalid input, pNetworkContext=%p", pNetworkContext));
+        LogError( ( "invalid input, pNetworkContext=%p", pNetworkContext ) );
         return -1;
     }
-    else if (pBuffer == NULL)
+    else if( pBuffer == NULL )
     {
-        LogError(("invalid input, pBuffer == NULL"));
+        LogError( ( "invalid input, pBuffer == NULL" ) );
         return -1;
     }
-    else if (bytesToSend == 0)
+    else if( bytesToSend == 0 )
     {
-        LogError(("invalid input, bytesToSend == 0"));
+        LogError( ( "invalid input, bytesToSend == 0" ) );
         return -1;
     }
 

--- a/FreeRTOS-Plus/Source/Application-Protocols/network_transport/using_wolfSSL/using_wolfSSL.c
+++ b/FreeRTOS-Plus/Source/Application-Protocols/network_transport/using_wolfSSL/using_wolfSSL.c
@@ -482,7 +482,25 @@ int32_t TLS_FreeRTOS_recv( NetworkContext_t * pNetworkContext,
 {
     int32_t tlsStatus = 0;
     int iResult = 0;
-    WOLFSSL * pSsl = pNetworkContext->sslContext.ssl;
+    WOLFSSL * pSsl = NULL;
+
+    if( pNetworkContext == NULL || pNetworkContext->sslContext.ssl == NULL )
+    {
+        LogError(("invalid input, pNetworkContext=%p", pNetworkContext));
+        return -1;
+    }
+    else if( pBuffer == NULL )
+    {
+        LogError(("invalid input, pBuffer == NULL"));
+        return -1;
+    }
+    else if( bytesToRecv == 0 )
+    {
+        LogError(("invalid input, bytesToRecv == 0"));
+        return -1;
+    }
+
+    pSsl = pNetworkContext->sslContext.ssl;
 
     iResult = wolfSSL_read( pSsl, pBuffer, bytesToRecv );
 
@@ -512,7 +530,25 @@ int32_t TLS_FreeRTOS_send( NetworkContext_t * pNetworkContext,
 {
     int32_t tlsStatus = 0;
     int iResult = 0;
-    WOLFSSL * pSsl = pNetworkContext->sslContext.ssl;
+    WOLFSSL * pSsl = NULL;
+
+    if( pNetworkContext == NULL || pNetworkContext->sslContext.ssl == NULL )
+    {
+        LogError(("invalid input, pNetworkContext=%p", pNetworkContext));
+        return -1;
+    }
+    else if( pBuffer == NULL )
+    {
+        LogError(("invalid input, pBuffer == NULL"));
+        return -1;
+    }
+    else if( bytesToSend == 0 )
+    {
+        LogError(("invalid input, bytesToSend == 0"));
+        return -1;
+    }
+
+    pSsl = pNetworkContext->sslContext.ssl;
 
     iResult = wolfSSL_write( pSsl, pBuffer, bytesToSend );
 

--- a/FreeRTOS-Plus/Source/Application-Protocols/network_transport/using_wolfSSL/using_wolfSSL.c
+++ b/FreeRTOS-Plus/Source/Application-Protocols/network_transport/using_wolfSSL/using_wolfSSL.c
@@ -242,7 +242,7 @@ static TlsTransportStatus_t loadCredentials( NetworkContext_t * pNetCtx,
         }
 
         return returnStatus;
-    #else  /* if defined( democonfigCREDENTIALS_IN_BUFFER ) */
+    #else /* if defined( democonfigCREDENTIALS_IN_BUFFER ) */
         if( wolfSSL_CTX_load_verify_locations( pNetCtx->sslContext.ctx,
                                                ( const char * ) ( pNetCred->pRootCa ), NULL ) == SSL_SUCCESS )
         {
@@ -484,19 +484,19 @@ int32_t TLS_FreeRTOS_recv( NetworkContext_t * pNetworkContext,
     int iResult = 0;
     WOLFSSL * pSsl = NULL;
 
-    if( pNetworkContext == NULL || pNetworkContext->sslContext.ssl == NULL )
+    if( ( pNetworkContext == NULL ) || ( pNetworkContext->sslContext.ssl == NULL ) )
     {
-        LogError(("invalid input, pNetworkContext=%p", pNetworkContext));
+        LogError( ( "invalid input, pNetworkContext=%p", pNetworkContext ) );
         return -1;
     }
     else if( pBuffer == NULL )
     {
-        LogError(("invalid input, pBuffer == NULL"));
+        LogError( ( "invalid input, pBuffer == NULL" ) );
         return -1;
     }
     else if( bytesToRecv == 0 )
     {
-        LogError(("invalid input, bytesToRecv == 0"));
+        LogError( ( "invalid input, bytesToRecv == 0" ) );
         return -1;
     }
 
@@ -532,19 +532,19 @@ int32_t TLS_FreeRTOS_send( NetworkContext_t * pNetworkContext,
     int iResult = 0;
     WOLFSSL * pSsl = NULL;
 
-    if( pNetworkContext == NULL || pNetworkContext->sslContext.ssl == NULL )
+    if( ( pNetworkContext == NULL ) || ( pNetworkContext->sslContext.ssl == NULL ) )
     {
-        LogError(("invalid input, pNetworkContext=%p", pNetworkContext));
+        LogError( ( "invalid input, pNetworkContext=%p", pNetworkContext ) );
         return -1;
     }
     else if( pBuffer == NULL )
     {
-        LogError(("invalid input, pBuffer == NULL"));
+        LogError( ( "invalid input, pBuffer == NULL" ) );
         return -1;
     }
     else if( bytesToSend == 0 )
     {
-        LogError(("invalid input, bytesToSend == 0"));
+        LogError( ( "invalid input, bytesToSend == 0" ) );
         return -1;
     }
 

--- a/FreeRTOS-Plus/Source/Application-Protocols/network_transport/using_wolfSSL/using_wolfSSL.c
+++ b/FreeRTOS-Plus/Source/Application-Protocols/network_transport/using_wolfSSL/using_wolfSSL.c
@@ -487,36 +487,38 @@ int32_t TLS_FreeRTOS_recv( NetworkContext_t * pNetworkContext,
     if( ( pNetworkContext == NULL ) || ( pNetworkContext->sslContext.ssl == NULL ) )
     {
         LogError( ( "invalid input, pNetworkContext=%p", pNetworkContext ) );
-        return -1;
+        tlsStatus = -1;
     }
     else if( pBuffer == NULL )
     {
         LogError( ( "invalid input, pBuffer == NULL" ) );
-        return -1;
+        tlsStatus = -1;
     }
     else if( bytesToRecv == 0 )
     {
         LogError( ( "invalid input, bytesToRecv == 0" ) );
-        return -1;
-    }
-
-    pSsl = pNetworkContext->sslContext.ssl;
-
-    iResult = wolfSSL_read( pSsl, pBuffer, bytesToRecv );
-
-    if( iResult > 0 )
-    {
-        tlsStatus = iResult;
-    }
-    else if( wolfSSL_want_read( pSsl ) == 1 )
-    {
-        tlsStatus = 0;
+        tlsStatus = -1;
     }
     else
     {
-        tlsStatus = wolfSSL_state( pSsl );
-        LogError( ( "Error from wolfSSL_read %d : %s ",
-                    iResult, wolfSSL_ERR_reason_error_string( tlsStatus ) ) );
+        pSsl = pNetworkContext->sslContext.ssl;
+
+        iResult = wolfSSL_read( pSsl, pBuffer, bytesToRecv );
+
+        if( iResult > 0 )
+        {
+            tlsStatus = iResult;
+        }
+        else if( wolfSSL_want_read( pSsl ) == 1 )
+        {
+            tlsStatus = 0;
+        }
+        else
+        {
+            tlsStatus = wolfSSL_state( pSsl );
+            LogError( ( "Error from wolfSSL_read %d : %s ",
+                        iResult, wolfSSL_ERR_reason_error_string( tlsStatus ) ) );
+        }
     }
 
     return tlsStatus;
@@ -535,36 +537,38 @@ int32_t TLS_FreeRTOS_send( NetworkContext_t * pNetworkContext,
     if( ( pNetworkContext == NULL ) || ( pNetworkContext->sslContext.ssl == NULL ) )
     {
         LogError( ( "invalid input, pNetworkContext=%p", pNetworkContext ) );
-        return -1;
+        tlsStatus = -1;
     }
     else if( pBuffer == NULL )
     {
         LogError( ( "invalid input, pBuffer == NULL" ) );
-        return -1;
+        tlsStatus = -1;
     }
     else if( bytesToSend == 0 )
     {
         LogError( ( "invalid input, bytesToSend == 0" ) );
-        return -1;
-    }
-
-    pSsl = pNetworkContext->sslContext.ssl;
-
-    iResult = wolfSSL_write( pSsl, pBuffer, bytesToSend );
-
-    if( iResult > 0 )
-    {
-        tlsStatus = iResult;
-    }
-    else if( wolfSSL_want_write( pSsl ) == 1 )
-    {
-        tlsStatus = 0;
+        tlsStatus = -1;
     }
     else
     {
-        tlsStatus = wolfSSL_state( pSsl );
-        LogError( ( "Error from wolfSL_write %d : %s ",
-                    iResult, wolfSSL_ERR_reason_error_string( tlsStatus ) ) );
+        pSsl = pNetworkContext->sslContext.ssl;
+
+        iResult = wolfSSL_write( pSsl, pBuffer, bytesToSend );
+
+        if( iResult > 0 )
+        {
+            tlsStatus = iResult;
+        }
+        else if( wolfSSL_want_write( pSsl ) == 1 )
+        {
+            tlsStatus = 0;
+        }
+        else
+        {
+            tlsStatus = wolfSSL_state( pSsl );
+            LogError( ( "Error from wolfSL_write %d : %s ",
+                        iResult, wolfSSL_ERR_reason_error_string( tlsStatus ) ) );
+        }
     }
 
     return tlsStatus;


### PR DESCRIPTION
Return error if invalid input detected in transport layer

Description
-----------
Check the input at *FreeRTOS_send/recv function and return negative value if input is invalid.

Test Steps
-----------
1. Open Windows simulator to test different transport layers.
2. Send/Receive with valid/invalid inputs
3. Assert happened when testing invalid inputs.
using_mbedtls_pcks11: corePKCS11_MQTT_Mutual_Auth_Windows_Simulator
using_mbedtls: FreeRTOS_Cellular_Interface_Windows_Simulator
using_plaintext: coreMQTT_Windows_Simulator/MQTT_Plain_Text
using_wolfSSL: coreMQTT_Windows_Simulator/MQTT_Mutual_Auth_wolfSSL

Related Issue
-----------
Refer to [API reference](https://www.freertos.org/network-interface.html)

Openssl_Recv should return negative value when byteToRecv is 0.
Openssl_Send should return negative value when byteToSend is 0.

TransportRecv_t:

If no data is available on the network to read and no error has occurred, zero MUST be the return value. A zero return value SHOULD represent that the read operation can be retried by calling the API function. Zero MUST NOT be returned if a network disconnection has occurred.

TransportSend_t:

If no data is transmitted over the network due to a full TX buffer and no network error has occurred, this MUST return zero as the return value. A zero return value SHOULD represent that the send operation can be retried by calling the API function. Zero MUST NOT be returned if a network disconnection has occurred.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
