### PR TITLE
RISC-V-Qemu-virt: Add assert macros in FreeRTOSConfig

### DIFF
--- a/FreeRTOS/Demo/RISC-V-Qemu-virt_GCC/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/RISC-V-Qemu-virt_GCC/FreeRTOSConfig.h
@@ -67,6 +67,11 @@
 #define configGENERATE_RUN_TIME_STATS	0
 #define configUSE_PORT_OPTIMISED_TASK_SELECTION 1
 
+/* Assert definitions. */
+void vAssertCalled( void );
+#define configASSERT_DEFINED                   1
+#define configASSERT( x )                      do { if ( !(x) ) vAssertCalled(); } while(0)
+
 /* Co-routine definitions. */
 #define configUSE_CO_ROUTINES 			0
 #define configMAX_CO_ROUTINE_PRIORITIES ( 2 )

--- a/FreeRTOS/Demo/RISC-V-Qemu-virt_GCC/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/RISC-V-Qemu-virt_GCC/FreeRTOSConfig.h
@@ -20,7 +20,7 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  *
  * https://www.FreeRTOS.org
- * https://www.github.com/FreeRTOS
+ * https://github.com/FreeRTOS
  *
  */
 


### PR DESCRIPTION


<!--- Title -->

Description
-----------

`vAssertCalled()` is already defined in `main.c`. We need to set the related macros in `FreeRTOSConfig.h` as well, or the boundary checking through assert could not be executed.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Follow the steps mentioned in `Readme.md`:

```shell
$ make
$ qemu-system-riscv32 -nographic -machine virt -net none \
  -chardev stdio,id=con,mux=on -serial chardev:con \
  -mon chardev=con,mode=readline -bios none \
  -smp 4 -kernel ./build/RTOSDemo.axf
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
