### PR TITLE
Set the mtvec register in the Spike demonstraction

### DIFF
--- a/FreeRTOS/Demo/RISC-V-spike-htif_GCC/main.c
+++ b/FreeRTOS/Demo/RISC-V-spike-htif_GCC/main.c
@@ -31,10 +31,17 @@
 /* Run a simple demo just prints 'Blink' */
 #define DEMO_BLINKY	1
 
+extern void freertos_risc_v_trap_handler( void );
+
 void vApplicationMallocFailedHook( void );
 void vApplicationIdleHook( void );
 void vApplicationStackOverflowHook( TaskHandle_t pxTask, char *pcTaskName );
 void vApplicationTickHook( void );
+
+/*
+ * Setup the Spike simulator to run this demo.
+ */
+static void prvSetupSpike( void );
 
 int main_blinky( void );
 
@@ -43,6 +50,7 @@ int main_blinky( void );
 int main( void )
 {
 	int ret;
+	prvSetupSpike();
 
 #if defined(DEMO_BLINKY)
 	ret = main_blinky();
@@ -51,6 +59,11 @@ int main( void )
 #endif
 
 	return ret;
+}
+/*-----------------------------------------------------------*/
+static void prvSetupSpike( void )
+{
+	__asm__ volatile( "csrw mtvec, %0" :: "r"( freertos_risc_v_trap_handler ) );
 }
 
 /*-----------------------------------------------------------*/


### PR DESCRIPTION
<!--- Title -->

Description
-----------
Set the mtvec register to freertos_risc_v_trap_handler. Otherwise, there is no context switching in this application.

Test Steps
-----------
Compile the application with `make`. I can see the string output on the Spike simulator.

Related Issue
-----------
#792 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
