### PR TITLE
Add a URL file for FreeRTOS upgrading instructions

### DIFF
--- a/Upgrading to FreeRTOS V10.3.0.url
+++ b/Upgrading to FreeRTOS V10.3.0.url
@@ -1,5 +1,0 @@
-[{000214A0-0000-0000-C000-000000000046}]
-Prop3=19,11
-[InternetShortcut]
-IDList=
-URL=https://www.freertos.org/FreeRTOS-V10.3.x.html

--- a/Upgrading-to-FreeRTOS-10.url
+++ b/Upgrading-to-FreeRTOS-10.url
@@ -1,6 +1,0 @@
-[{000214A0-0000-0000-C000-000000000046}]
-Prop3=19,2
-[InternetShortcut]
-URL=http://www.freertos.org/FreeRTOS-V10.html
-IDList=
-HotKey=0

--- a/Upgrading-to-FreeRTOS-9.url
+++ b/Upgrading-to-FreeRTOS-9.url
@@ -1,5 +1,0 @@
-[{000214A0-0000-0000-C000-000000000046}]
-Prop3=19,2
-[InternetShortcut]
-URL=http://www.freertos.org/FreeRTOS-V9.html
-IDList=

--- a/Upgrading-to-FreeRTOS-V10.4.0.url
+++ b/Upgrading-to-FreeRTOS-V10.4.0.url
@@ -1,5 +1,0 @@
-[{000214A0-0000-0000-C000-000000000046}]
-Prop3=19,11
-[InternetShortcut]
-IDList=
-URL=https://FreeRTOS.org/FreeRTOS-V10.4.x.html

--- a/Upgrading-to-FreeRTOS.url
+++ b/Upgrading-to-FreeRTOS.url
@@ -1,0 +1,5 @@
+[InternetShortcut]
+URL=https://freertos.org/a00104.html#upgrade-instructions
+IDList=
+HotKey=0
+IconIndex=0


### PR DESCRIPTION
Description
-----------
Instead of having one URL file per FreeRTOS version, we now have one URL file which points to this page - https://freertos.org/a00104.html#upgrade-instructions. This page links upgrading instructions for all FreeRTOS versions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
