### PR TITLE
Use MQTTAgent_CancelAll to clear agent queue in OTA demos

### DIFF
--- a/FreeRTOS-Plus/Demo/AWS/Ota_Windows_Simulator/Ota_Over_Http_Demo/DemoTasks/OtaOverHttpDemoExample.c
+++ b/FreeRTOS-Plus/Demo/AWS/Ota_Windows_Simulator/Ota_Over_Http_Demo/DemoTasks/OtaOverHttpDemoExample.c
@@ -2132,7 +2132,7 @@ static void prvMQTTAgentTask(void* pParam)
         xMQTTStatus = MQTTAgent_CommandLoop(&xGlobalMqttAgentContext);
 
         /* Clear Agent queue so that no any pending MQTT operations are processed. */
-        xQueueReset(xCommandQueue.queue);
+        MQTTAgent_CancelAll(&xGlobalMqttAgentContext);
 
         /* Success is returned for application initiated disconnect or termination. The socket will also be disconnected by the caller. */
         if (xMQTTStatus != MQTTSuccess)

--- a/FreeRTOS-Plus/Demo/AWS/Ota_Windows_Simulator/Ota_Over_Mqtt_Demo/DemoTasks/OtaOverMqttDemoExample.c
+++ b/FreeRTOS-Plus/Demo/AWS/Ota_Windows_Simulator/Ota_Over_Mqtt_Demo/DemoTasks/OtaOverMqttDemoExample.c
@@ -1725,7 +1725,7 @@ static void prvMQTTAgentTask(void* pParam)
         xMQTTStatus = MQTTAgent_CommandLoop(&xGlobalMqttAgentContext);
 
         /* Clear Agent queue so that no any pending MQTT operations are processed. */
-        xQueueReset(xCommandQueue.queue);
+        MQTTAgent_CancelAll(&xGlobalMqttAgentContext);
 
         /* Success is returned for application initiated disconnect or termination. The socket will also be disconnected by the caller. */
         if (xMQTTStatus != MQTTSuccess)


### PR DESCRIPTION
Use MQTTAgent_CancelAll to clear agent queue

Description
-----------
MQTTAgent_CancelAll concludes all MQTTAgentCommand_t and returns command buffer to commandStructMessageCtx.

Test Steps
-----------
Run the OTA over MQTT demo and disconnect/connect the network several times during.
The error message "No command structure available." should not be observed

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
