### PR TITLE
Define INCLUDE_xTaskGetCurrentTaskHandle in FreeRTOSConfig.h

### DIFF
--- a/FreeRTOS/Test/CMock/config/FreeRTOSConfig.h
+++ b/FreeRTOS/Test/CMock/config/FreeRTOSConfig.h
@@ -112,6 +112,7 @@ void vConfigureTimerForRunTimeStats( void );    /* Prototype of function that in
 #define INCLUDE_xSemaphoreGetMutexHolder          1
 #define INCLUDE_xTimerPendFunctionCall            1
 #define INCLUDE_xTaskAbortDelay                   1
+#define INCLUDE_xTaskGetCurrentTaskHandle         1
 
 /* It is a good idea to define configASSERT() while developing.  configASSERT()
  * uses the same semantics as the standard C assert() macro. */

--- a/FreeRTOS/Test/CMock/message_buffer/size_mismatch/FreeRTOSConfig.h
+++ b/FreeRTOS/Test/CMock/message_buffer/size_mismatch/FreeRTOSConfig.h
@@ -114,6 +114,7 @@ void vConfigureTimerForRunTimeStats( void );    /* Prototype of function that in
 #define INCLUDE_xSemaphoreGetMutexHolder          1
 #define INCLUDE_xTimerPendFunctionCall            1
 #define INCLUDE_xTaskAbortDelay                   1
+#define INCLUDE_xTaskGetCurrentTaskHandle         1
 
 /* It is a good idea to define configASSERT() while developing.  configASSERT()
  * uses the same semantics as the standard C assert() macro. */

--- a/FreeRTOS/Test/CMock/message_buffer/size_mismatch/FreeRTOSConfig.h
+++ b/FreeRTOS/Test/CMock/message_buffer/size_mismatch/FreeRTOSConfig.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS V202111.00
+ * FreeRTOS V202112.00
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of


### PR DESCRIPTION
Description
-----------
This is needed to fix build issues in https://github.com/FreeRTOS/FreeRTOS-Kernel/pull/507

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
