### PR TITLE
Fix qemu riscv build error and miss debug info in assembly code

### DIFF
--- a/FreeRTOS/Demo/RISC-V-Qemu-virt_GCC/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/RISC-V-Qemu-virt_GCC/FreeRTOSConfig.h
@@ -102,6 +102,7 @@ to exclude the API function. */
 #define INCLUDE_eTaskGetState				1
 #define INCLUDE_xTimerPendFunctionCall		1
 #define INCLUDE_xTaskAbortDelay				1
+#define INCLUDE_xTaskGetCurrentTaskHandle	1
 #define INCLUDE_xTaskGetHandle				1
 #define INCLUDE_xSemaphoreGetMutexHolder	1
 

--- a/FreeRTOS/Demo/RISC-V-Qemu-virt_GCC/Makefile
+++ b/FreeRTOS/Demo/RISC-V-Qemu-virt_GCC/Makefile
@@ -20,8 +20,8 @@ CFLAGS  = -march=rv32ima -mabi=ilp32 -mcmodel=medany \
 	-ffunction-sections \
 	-fdata-sections \
 	-fno-builtin-printf
-ASFLAGS = -march=rv32ima -mabi=ilp32 -mcmodel=medany
 LDFLAGS = -nostartfiles -Tfake_rom.lds \
+	-march=rv32ima -mabi=ilp32 -mcmodel=medany \
 	-Xlinker --gc-sections \
 	-Xlinker --defsym=__stack_size=300
 
@@ -62,7 +62,7 @@ $(BUILD_DIR)/%.o: %.c Makefile
 
 $(BUILD_DIR)/%.o: %.S Makefile
 	@mkdir -p $(@D)
-	$(CC) $(CPPFLAGS) $(ASFLAGS) -MMD -MP -c $< -o $@
+	$(CC) $(CPPFLAGS) $(CFLAGS) -MMD -MP -c $< -o $@
 
 clean:
 	rm -rf $(BUILD_DIR)

--- a/FreeRTOS/Demo/RISC-V_RV32_QEMU_VIRT_GCC/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/RISC-V_RV32_QEMU_VIRT_GCC/FreeRTOSConfig.h
@@ -98,6 +98,7 @@ to exclude the API function. */
 #define INCLUDE_eTaskGetState					1
 #define INCLUDE_xTimerPendFunctionCall			1
 #define INCLUDE_xTaskAbortDelay					1
+#define INCLUDE_xTaskGetCurrentTaskHandle		1
 #define INCLUDE_xTaskGetHandle					1
 
 /* This demo makes use of one or more example stats formatting functions.  These


### PR DESCRIPTION
Fix qemu riscv build error and miss debug info in assembly code

<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->

1. fix build error for RISC-V-Qemu-virt_GCC and RISC-V_RV32_QEMU_VIRT_GCC
        because both of demos use stream_buffer, error log are below
```
        FreeRTOS/FreeRTOS/Source/stream_buffer.c:48:6: error: #error INCLUDE_xTaskGetCurrentTaskHandle must be set to 1 to build stream_buffer.c
           48 |     #error INCLUDE_xTaskGetCurrentTaskHandle must be set to 1 to build stream_buffer.c
              |      ^~~~~
```
2. LDFLAGS add arch and abi info for linker
        RISC-V-Qemu-virt_GCC use Crosstool-NG tool-chain and has the following configs:
        ```
        CT_EXPERIMENTAL=y
        CT_ARCH_RISCV=y
        CT_ARCH_64=y
        CT_ARCH_ARCH=rv32ima
        CT_ARCH_ABI=ilp32
        CT_MULTILIB=y
        CT_DEBUG_GDB=y
        ```
        But if use other tool-chain like sifive prebuild tool-chain, the default lib version is 64bit, and the makefile use LDFLAGS to pass arg to linker but don't contain the arch and abi info, so the linker will link to 64bit lib and has linker error below
        ```
        ABI is incompatible with that of the selected emulation:
          target emulation `elf64-littleriscv' does not match `elf32-littleriscv'
        ```

3. use CFLAGS to replace ASFLAGS when compile assembly code
        the original makefile use ASFLAGS rather than CFLAGS to pass the arg, but the DEBUG arg is added to CFLAGS if we use DEBUG build, so the objfile from assmebly code will not contain debug info and can't read debug info from gdb
      
  ```
 Breakpoint 2, 0x80001ae2 in xPortStartFirstTask ()
 (gdb) s
 Single stepping until exit from function xPortStartFirstTask,
 which has no line number information.
        
```
Test Steps
-----------
<!-- Describe the steps to reproduce. -->
1.build success
2.bulid success
3.can read debug info from gdb in assembly code section
```
xPortStartFirstTask ()
    at /home/eric/eric/FreeRTOS/FreeRTOS/Source/portable/GCC/RISC-V/portASM.S:231
231         load_x  x1, 0( sp ) /* Note for starting the scheduler the exception return address is used as the function return address. */
(gdb) s
235         load_x  x7, 4 * portWORD_SIZE( sp )     /* t2 */
(gdb) s
236         load_x  x8, 5 * portWORD_SIZE( sp )     /* s0/fp */
```
Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
