### PR TITLE
Fix queue/static config for upstream changes

### DIFF
--- a/FreeRTOS/Test/CMock/queue/static/FreeRTOSConfig.h
+++ b/FreeRTOS/Test/CMock/queue/static/FreeRTOSConfig.h
@@ -92,7 +92,7 @@ void vConfigureTimerForRunTimeStats( void );    /* Prototype of function that in
  * format the raw data provided by the uxTaskGetSystemState() function in to human
  * readable ASCII form.  See the notes in the implementation of vTaskList() within
  * FreeRTOS/Source/tasks.c for limitations. */
-#define configUSE_STATS_FORMATTING_FUNCTIONS      1
+#define configUSE_STATS_FORMATTING_FUNCTIONS      0
 
 /* Set the following definitions to 1 to include the API function, or zero
  * to exclude the API function.  In most cases the linker will remove unused


### PR DESCRIPTION
Fix queue/static FreeRTOSConfig.h to work with upstream changes to FreeRTOS.h

See kernel [PR #427](https://github.com/FreeRTOS/FreeRTOS-Kernel/pull/427)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
