### PR TITLE
Upgrade kernel submodule version

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -4,7 +4,7 @@ description: "This is the standard distribution of FreeRTOS."
 
 dependencies:
   - name: "FreeRTOS-Kernel"
-    version: "349e803"
+    version: "b0a8bd8"
     repository:
       type: "git"
       url: "https://github.com/FreeRTOS/FreeRTOS-Kernel.git"


### PR DESCRIPTION
Upgrade kernel version to commit ID b0a8bd8f2

Description
-----------

Includes changes to make INCLUDE_xTaskGetCurrentTaskHandle configuration default value to 1.


Test Steps
-----------

Built successfully windows simulator demos.

Related Issue
-----------
None


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
