### PR TITLE
Fix header checker when copyright regex is None

### DIFF
--- a/.github/scripts/common/header_checker.py
+++ b/.github/scripts/common/header_checker.py
@@ -72,7 +72,10 @@ class HeaderChecker:
         self.padding = padding
         self.header = header
 
-        self.copyright_regex = re.compile(copyright_regex)
+        if copyright_regex:
+            self.copyright_regex = re.compile(copyright_regex)
+        else:
+            self.copyright_regex = None
 
         # Construct mutated header for assembly files
         self.asm_header = [";" + line for line in header]


### PR DESCRIPTION
Allow header_checker.py to work as it did before when no
copyright regex is defined.

Fixes regression Introduced in PR #841 .

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
