### PR TITLE
Update transport interface for compatibility

### DIFF
--- a/FreeRTOS-Plus/Source/Application-Protocols/network_transport/sockets_wrapper/cellular/sockets_wrapper.h
+++ b/FreeRTOS-Plus/Source/Application-Protocols/network_transport/sockets_wrapper/cellular/sockets_wrapper.h
@@ -53,6 +53,9 @@
     #define LIBRARY_LOG_LEVEL    LOG_INFO
 #endif
 
+extern void vLoggingPrintf( const char * pcFormatString,
+                            ... );
+
 #include "logging_stack.h"
 
 /************ End of logging configuration ****************/

--- a/FreeRTOS-Plus/Source/Application-Protocols/network_transport/sockets_wrapper/freertos_plus_tcp/sockets_wrapper.h
+++ b/FreeRTOS-Plus/Source/Application-Protocols/network_transport/sockets_wrapper/freertos_plus_tcp/sockets_wrapper.h
@@ -75,6 +75,8 @@ extern void vLoggingPrintf( const char * pcFormatString,
 
 /************ End of logging configuration ****************/
 
+#define SOCKETS_INVALID_SOCKET      ( ( Socket_t ) ~0U )
+
 /**
  * @brief Establish a connection to server.
  *

--- a/FreeRTOS-Plus/Source/Application-Protocols/network_transport/using_mbedtls/using_mbedtls.c
+++ b/FreeRTOS-Plus/Source/Application-Protocols/network_transport/using_mbedtls/using_mbedtls.c
@@ -36,10 +36,6 @@
 /* FreeRTOS includes. */
 #include "FreeRTOS.h"
 
-/* FreeRTOS+TCP includes. */
-#include "FreeRTOS_IP.h"
-#include "FreeRTOS_Sockets.h"
-
 /* TLS transport header. */
 #include "using_mbedtls.h"
 
@@ -700,9 +696,9 @@ TlsTransportStatus_t TLS_FreeRTOS_Connect( NetworkContext_t * pNetworkContext,
         {
             sslContextFree( &( pTlsTransportParams->sslContext ) );
 
-            if( pTlsTransportParams->tcpSocket != FREERTOS_INVALID_SOCKET )
+            if( pTlsTransportParams->tcpSocket != SOCKETS_INVALID_SOCKET )
             {
-                ( void ) FreeRTOS_closesocket( pTlsTransportParams->tcpSocket );
+                ( void ) Sockets_Disconnect( pTlsTransportParams->tcpSocket );
             }
         }
     }

--- a/FreeRTOS-Plus/Source/Application-Protocols/network_transport/using_mbedtls_pkcs11/using_mbedtls_pkcs11.c
+++ b/FreeRTOS-Plus/Source/Application-Protocols/network_transport/using_mbedtls_pkcs11/using_mbedtls_pkcs11.c
@@ -533,11 +533,11 @@ static CK_RV readCertificateIntoContext( SSLContext_t * pSslContext,
     pcNullTerminator = memchr( pcLabelName, '\0', pkcs11configMAX_LABEL_LENGTH );
     if( NULL != pcNullTerminator )
     {
-        labelLength = pcNullTerminator - pcLabelName;
+        labelLength = ( size_t )( pcNullTerminator - pcLabelName );
     }
     else
     {
-        /* If NULL character not found set length to  pkcs11configMAX_LABEL_LENGTH */
+        /* If NULL character not found set length to pkcs11configMAX_LABEL_LENGTH. */
         labelLength = pkcs11configMAX_LABEL_LENGTH;
     }
 
@@ -660,15 +660,15 @@ static CK_RV initializeClientKeys( SSLContext_t * pxCtx,
         size_t labelLength;
         char * pcNullTerminator = NULL;
 
-        /* Check for NULL character within pkcs11configMAX_LABEL_LENGTH */
+        /* Check for NULL character within pkcs11configMAX_LABEL_LENGTH. */
         pcNullTerminator = memchr( pcLabelName, '\0', pkcs11configMAX_LABEL_LENGTH );
         if( NULL != pcNullTerminator )
         {
-            labelLength = pcNullTerminator - pcLabelName;
+            labelLength = ( size_t )( pcNullTerminator - pcLabelName );
         }
         else
         {
-            /* If NULL character not found set length to  pkcs11configMAX_LABEL_LENGTH. */
+            /* If NULL character not found set length to pkcs11configMAX_LABEL_LENGTH. */
             labelLength = pkcs11configMAX_LABEL_LENGTH;
         }
 

--- a/FreeRTOS-Plus/Source/Application-Protocols/network_transport/using_mbedtls_pkcs11/using_mbedtls_pkcs11.c
+++ b/FreeRTOS-Plus/Source/Application-Protocols/network_transport/using_mbedtls_pkcs11/using_mbedtls_pkcs11.c
@@ -39,10 +39,6 @@
 /* FreeRTOS includes. */
 #include "FreeRTOS.h"
 
-/* FreeRTOS+TCP includes. */
-#include "FreeRTOS_IP.h"
-#include "FreeRTOS_Sockets.h"
-
 /* TLS transport header. */
 #include "using_mbedtls_pkcs11.h"
 
@@ -530,12 +526,25 @@ static CK_RV readCertificateIntoContext( SSLContext_t * pSslContext,
     CK_RV xResult = CKR_OK;
     CK_ATTRIBUTE xTemplate = { 0 };
     CK_OBJECT_HANDLE xCertObj = 0;
+    size_t labelLength;
+    char * pcNullTerminator = NULL;
+
+    /* Check for NULL character within pkcs11configMAX_LABEL_LENGTH. */
+    pcNullTerminator = memchr( pcLabelName, '\0', pkcs11configMAX_LABEL_LENGTH );
+    if( NULL != pcNullTerminator )
+    {
+        labelLength = pcNullTerminator - pcLabelName;
+    }
+    else
+    {
+        /* If NULL character not found set length to  pkcs11configMAX_LABEL_LENGTH */
+        labelLength = pkcs11configMAX_LABEL_LENGTH;
+    }
 
     /* Get the handle of the certificate. */
     xResult = xFindObjectWithLabelAndClass( pSslContext->xP11Session,
                                             pcLabelName,
-                                            strnlen( pcLabelName,
-                                                     pkcs11configMAX_LABEL_LENGTH ),
+                                            labelLength,
                                             xClass,
                                             &xCertObj );
 
@@ -648,11 +657,25 @@ static CK_RV initializeClientKeys( SSLContext_t * pxCtx,
 
     if( CKR_OK == xResult )
     {
+        size_t labelLength;
+        char * pcNullTerminator = NULL;
+
+        /* Check for NULL character within pkcs11configMAX_LABEL_LENGTH */
+        pcNullTerminator = memchr( pcLabelName, '\0', pkcs11configMAX_LABEL_LENGTH );
+        if( NULL != pcNullTerminator )
+        {
+            labelLength = pcNullTerminator - pcLabelName;
+        }
+        else
+        {
+            /* If NULL character not found set length to  pkcs11configMAX_LABEL_LENGTH. */
+            labelLength = pkcs11configMAX_LABEL_LENGTH;
+        }
+
         /* Get the handle of the device private key. */
         xResult = xFindObjectWithLabelAndClass( pxCtx->xP11Session,
                                                 pcLabelName,
-                                                strnlen( pcLabelName,
-                                                         pkcs11configMAX_LABEL_LENGTH ),
+                                                labelLength,
                                                 CKO_PRIVATE_KEY,
                                                 &pxCtx->xP11PrivateKey );
     }
@@ -901,9 +924,10 @@ TlsTransportStatus_t TLS_FreeRTOS_Connect( NetworkContext_t * pNetworkContext,
     if( returnStatus != TLS_TRANSPORT_SUCCESS )
     {
         if( ( pNetworkContext != NULL ) &&
-            ( pTlsTransportParams->tcpSocket != FREERTOS_INVALID_SOCKET ) )
+            ( pTlsTransportParams != NULL ) &&
+            ( pTlsTransportParams->tcpSocket != SOCKETS_INVALID_SOCKET ) )
         {
-            ( void ) FreeRTOS_closesocket( pTlsTransportParams->tcpSocket );
+            ( void ) Sockets_Disconnect( pTlsTransportParams->tcpSocket );
         }
     }
     else

--- a/FreeRTOS-Plus/Source/Application-Protocols/network_transport/using_mbedtls_pkcs11/using_mbedtls_pkcs11.h
+++ b/FreeRTOS-Plus/Source/Application-Protocols/network_transport/using_mbedtls_pkcs11/using_mbedtls_pkcs11.h
@@ -74,7 +74,7 @@ extern void vLoggingPrintf( const char * pcFormatString,
 /************ End of logging configuration ****************/
 
 /* FreeRTOS+TCP include. */
-#include "FreeRTOS_Sockets.h"
+#include "sockets_wrapper.h"
 
 /* Transport interface include. */
 #include "transport_interface.h"

--- a/FreeRTOS-Plus/Source/Utilities/mbedtls_freertos/mbedtls_bio_freertos_cellular.c
+++ b/FreeRTOS-Plus/Source/Utilities/mbedtls_freertos/mbedtls_bio_freertos_cellular.c
@@ -31,13 +31,16 @@
 
 /* FreeRTOS includes. */
 #include "FreeRTOS.h"
-#include "FreeRTOS_Sockets.h"
 
 /* Sockets wrapper includes. */
 #include "sockets_wrapper.h"
 
 /* mbed TLS includes. */
-#include "mbedtls_config.h"
+#if !defined( MBEDTLS_CONFIG_FILE )
+    #include "config.h"
+#else
+    #include MBEDTLS_CONFIG_FILE
+#endif
 #include "threading_alt.h"
 #include "mbedtls/entropy.h"
 #include "mbedtls/ssl.h"

--- a/FreeRTOS-Plus/Source/Utilities/mbedtls_freertos/mbedtls_bio_freertos_plus_tcp.c
+++ b/FreeRTOS-Plus/Source/Utilities/mbedtls_freertos/mbedtls_bio_freertos_plus_tcp.c
@@ -34,7 +34,11 @@
 #include "FreeRTOS_Sockets.h"
 
 /* mbed TLS includes. */
-#include "mbedtls_config.h"
+#if !defined( MBEDTLS_CONFIG_FILE )
+    #include "config.h"
+#else
+    #include MBEDTLS_CONFIG_FILE
+#endif
 #include "threading_alt.h"
 #include "mbedtls/entropy.h"
 #include "mbedtls/ssl.h"


### PR DESCRIPTION
The original PR is #828. **Renesas FSP: Transport Interface Changes** contributed by renesas-adam-benson.
This PR continue the work in the original PR.

The purpose of the original PR is make transport interface and sockets wrappers compatible with Renesas FSP to support different compilers.

Description
-----------
Update transport interface for compatibility

* Update the network transport that using socket wrapper to depend on socket wrapper only.
* AT command timeout should not be changed for cellular socket buffer access mode.
* mbedTLS config include using MBEDTLS_CONFIG_FILE macro.
* Remove strnlen usage in using_mbedtls_pkcs11.

Test Steps
-----------
* Run FreeRTOS-Cellular-Interface demo with mbedtls on SARA-R4
* Run FreeRTOS-Cellular-Interface demo with mbedtls-pkcs11 on SARA-R4

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
