### PR TITLE
Fix test failure in FreeRTOS-Kernel PR #568

### DIFF
--- a/FreeRTOS/Test/CMock/tasks/tasks_1_utest.c
+++ b/FreeRTOS/Test/CMock/tasks/tasks_1_utest.c
@@ -2659,7 +2659,9 @@ void test_xTaskIncrementTick_success_unblock_tasks( void )
     TaskHandle_t task_handle2;
 
     /* setup */
+    create_task_priority = 4;
     task_handle = create_task();
+    create_task_priority = 4;
     task_handle2 = create_task();
     ptcb = task_handle;
     xPendedTicks = 3;
@@ -2680,7 +2682,7 @@ void test_xTaskIncrementTick_success_unblock_tasks( void )
     listLIST_IS_EMPTY_ExpectAndReturn( pxDelayedTaskList, pdTRUE );
     /* back */
     listCURRENT_LIST_LENGTH_ExpectAndReturn( &pxReadyTasksLists[ ptcb->uxPriority ],
-                                             1 );
+                                             2 );
 
     /* API Call */
     ret_task_incrementtick = xTaskIncrementTick();


### PR DESCRIPTION
Description
-----------
The test simulates the scenario when a task with priority equal to the currently executing task is unblocked as a result of the xTaskIncrementTick call.

Test Steps
-----------
```
  make -C FreeRTOS/Test/CMock clean
  make -C FreeRTOS/Test/CMock lcovhtml
```

Related Issue
-----------
https://github.com/FreeRTOS/FreeRTOS-Kernel/pull/568

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
