### PR TITLE
Updated configMINIMAL_STACK_SIZE for POSIX demo

### DIFF
--- a/FreeRTOS/Demo/Posix_GCC/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/Posix_GCC/FreeRTOSConfig.h
@@ -43,7 +43,7 @@
 #define configUSE_TICK_HOOK                        1
 #define configUSE_DAEMON_TASK_STARTUP_HOOK         1
 #define configTICK_RATE_HZ                         ( 1000 )                  /* In this non-real time simulated environment the tick frequency has to be at least a multiple of the Win32 tick frequency, and therefore very slow. */
-#define configMINIMAL_STACK_SIZE                   ( ( unsigned short ) 70 ) /* In this simulated case, the stack only has to hold one small structure as the real stack is part of the win32 thread. */
+#define configMINIMAL_STACK_SIZE                   ( ( unsigned short ) PTHREAD_STACK_MIN ) /* The stack size being passed is equal to the minimum stack size needed by pthread_create(). */
 #define configTOTAL_HEAP_SIZE                      ( ( size_t ) ( 65 * 1024 ) )
 #define configMAX_TASK_NAME_LEN                    ( 12 )
 #define configUSE_TRACE_FACILITY                   1


### PR DESCRIPTION
<!--- Title -->

Description
-----------
Based on this thread: https://forums.freertos.org/t/c-question-about-stacks-not-sure-if-freertos-has-a-role-to-play/15983/18
It is better to change configMINIMAL_STACK_SIZE to PTHREAD_STACK_MIN as it will avoid a lot of unnecessary confusion and will save a lot of debugging time for the developer.

Test Steps
-----------
Create a task with a stack size lesser than PTHREAD_STACK_MIN. Then create some local variables in the function of that task. Those variables will not show up on the task's stack, unless the stack size is not >= PTHREAD_STACK_MIN.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
