### PR TITLE
Add a unit test for tasks.c

### DIFF
--- a/FreeRTOS/Test/CMock/tasks/tasks_1_utest.c
+++ b/FreeRTOS/Test/CMock/tasks/tasks_1_utest.c
@@ -2693,6 +2693,9 @@ void test_xTaskIncrementTick_success_unblock_tasks( void )
     TEST_ASSERT_EQUAL( portMAX_DELAY, xNextTaskUnblockTime );
 }
 
+/* Tests the scenario when a task with priority equal to the
+ * currently executing task is unblocked as a result of the
+ * xTaskIncrementTick call. */
 void test_xTaskIncrementTick_success_unblock_tasks2( void )
 {
     BaseType_t ret_task_incrementtick;
@@ -2736,6 +2739,9 @@ void test_xTaskIncrementTick_success_unblock_tasks2( void )
     TEST_ASSERT_EQUAL( portMAX_DELAY, xNextTaskUnblockTime );
 }
 
+/* Tests the scenario when a task with priority higher than the
+ * currently executing task is unblocked as a result of the
+ * xTaskIncrementTick call. */
 void test_xTaskIncrementTick_success_unblock_tasks3( void )
 {
     BaseType_t ret_task_incrementtick;

--- a/FreeRTOS/Test/CMock/tasks/tasks_1_utest.c
+++ b/FreeRTOS/Test/CMock/tasks/tasks_1_utest.c
@@ -2652,6 +2652,10 @@ void test_xTaskIncrementTick_success_update_next_unblock( void )
     TEST_ASSERT_EQUAL( xTickCount + 4, xNextTaskUnblockTime );
 }
 
+/* Tests the scenario when a task with priority equal to the
+ * currently executing task is unblocked as a result of the
+ * xTaskIncrementTick call. Also, xPendedTicks is set to
+ * non-zero to ensure that tick hook is not called. */
 void test_xTaskIncrementTick_success_unblock_tasks( void )
 {
     BaseType_t ret_task_incrementtick;
@@ -2695,7 +2699,8 @@ void test_xTaskIncrementTick_success_unblock_tasks( void )
 
 /* Tests the scenario when a task with priority equal to the
  * currently executing task is unblocked as a result of the
- * xTaskIncrementTick call. */
+ * xTaskIncrementTick call. Also, xPendedTicks is set to 0 to
+ * ensure that tick hook is called. */
 void test_xTaskIncrementTick_success_unblock_tasks2( void )
 {
     BaseType_t ret_task_incrementtick;
@@ -2741,7 +2746,8 @@ void test_xTaskIncrementTick_success_unblock_tasks2( void )
 
 /* Tests the scenario when a task with priority higher than the
  * currently executing task is unblocked as a result of the
- * xTaskIncrementTick call. */
+ * xTaskIncrementTick call. Also, xPendedTicks is set to
+ * non-zero to ensure that tick hook is not called. */
 void test_xTaskIncrementTick_success_unblock_tasks3( void )
 {
     BaseType_t ret_task_incrementtick;


### PR DESCRIPTION
Description
-----------
This test simulates the scenario when a task with priority higher than the currently executing task is unblocked as a result of the xTaskIncrementTick call.

This is needed to fix the coverage drop in PR https://github.com/FreeRTOS/FreeRTOS-Kernel/pull/568.

Test Steps
-----------
```
cd FreeRTOS/Test/CMock/
make
```
Results:
```
Overall coverage rate:
  lines......: 96.4% (2288 of 2373 lines)
  functions..: 98.4% (187 of 190 functions)
  branches...: 94.1% (1189 of 1263 branches)
```
Related Issue
-----------
https://github.com/FreeRTOS/FreeRTOS-Kernel/pull/568


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
