### PR TITLE
Switch Uncrustify, Kernel unit tests to Ubuntu 20.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
           git-secrets --scan
 
   formatting:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - name: Install Uncrustify

--- a/.github/workflows/core-checks.yml
+++ b/.github/workflows/core-checks.yml
@@ -5,7 +5,7 @@ on: [pull_request]
 jobs:
   core-checker:
     name: FreeRTOS Core Checks
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       # Install python 3
       - name: Tool Setup

--- a/.github/workflows/kernel-unit-tests.yml
+++ b/.github/workflows/kernel-unit-tests.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 jobs:
   run-submodule:
     name: FreeRTOS/Source Submodule Revision
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - name: Checkout Repository
       uses: actions/checkout@v2
@@ -39,7 +39,7 @@ jobs:
         path: FreeRTOS/Test/CMock/build/coverage
   run-upstream:
     name: FreeRTOS-Kernel Main Branch
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - name: Checkout Repository
       uses: actions/checkout@v2


### PR DESCRIPTION
Description
-----------
The version of uncrustify we are running is only available on Ubuntu 20.04 (see [package](https://packages.ubuntu.com/focal/uncrustify)).

Kernel unit tests are also switched, which is inspired by [this change](https://github.com/FreeRTOS/FreeRTOS-Kernel/commit/5f7ca3a55fa9ccd6137c9c557ecba629c0b96e2a) in the kernel repo.

Test Steps
-----------
Pushed commit, successfully ran CI.

Related Issue
-----------
None


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
