### PR TITLE
Remove references to coroutines in FreeRTOS+

### DIFF
--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Echo_Posix/FreeRTOSConfig.h
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Echo_Posix/FreeRTOSConfig.h
@@ -76,10 +76,6 @@ unsigned long ulGetRunTimeCounterValue( void ); /* Prototype of function that re
 void vConfigureTimerForRunTimeStats( void );	/* Prototype of function that initialises the run time counter. */
 #define configGENERATE_RUN_TIME_STATS			1
 
-/* Co-routine related configuration options. */
-#define configUSE_CO_ROUTINES 					0
-#define configMAX_CO_ROUTINE_PRIORITIES			( 2 )
-
 /* This demo can use of one or more example stats formatting functions.  These
 format the raw data provided by the uxTaskGetSystemState() function in to human
 readable ASCII form.  See the notes in the implementation of vTaskList() within

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Echo_Posix/Makefile
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Echo_Posix/Makefile
@@ -20,7 +20,6 @@ INCLUDE_DIRS += -I${FREERTOS_PLUS_DIR}/Source/FreeRTOS-Plus-TCP/source/portable/
 
 # FreeRTOS Kernel source files
 SOURCE_FILES :=
-SOURCE_FILES += ${FREERTOS_DIR}/Source/croutine.c
 SOURCE_FILES += ${FREERTOS_DIR}/Source/event_groups.c
 SOURCE_FILES += ${FREERTOS_DIR}/Source/list.c
 SOURCE_FILES += ${FREERTOS_DIR}/Source/queue.c

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Echo_Qemu_mps2/FreeRTOSConfig.h
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Echo_Qemu_mps2/FreeRTOSConfig.h
@@ -56,10 +56,7 @@ extern void vAssertCalled( void );
 #define configUSE_TRACE_FACILITY    0
 #define configUSE_16_BIT_TICKS      0
 #define configIDLE_SHOULD_YIELD     0
-#define configUSE_CO_ROUTINES       0
-
 #define configMAX_PRIORITIES            ( 10 )
-#define configMAX_CO_ROUTINE_PRIORITIES ( 2 )
 #define configTIMER_QUEUE_LENGTH          20
 #define configTIMER_TASK_PRIORITY       ( configMAX_PRIORITIES - 3 )
 #define configUSE_COUNTING_SEMAPHORES 1

--- a/FreeRTOS-Plus/Test/FreeRTOS-Cellular-Interface/Integration/Config/FreeRTOSConfig.h
+++ b/FreeRTOS-Plus/Test/FreeRTOS-Cellular-Interface/Integration/Config/FreeRTOSConfig.h
@@ -51,7 +51,6 @@
 #define configUSE_TRACE_FACILITY                   0
 #define configUSE_16_BIT_TICKS                     0
 #define configIDLE_SHOULD_YIELD                    1
-#define configUSE_CO_ROUTINES                      0
 #define configUSE_MUTEXES                          1
 #define configUSE_RECURSIVE_MUTEXES                1
 #define configQUEUE_REGISTRY_SIZE                  0
@@ -79,10 +78,6 @@
 
 /* Run time stats gathering configuration options. */
 #define configGENERATE_RUN_TIME_STATS              0
-
-/* Co-routine definitions. */
-#define configUSE_CO_ROUTINES                      0
-#define configMAX_CO_ROUTINE_PRIORITIES            ( 2 )
 
 /* Set the following definitions to 1 to include the API function, or zero
  * to exclude the API function. */

--- a/FreeRTOS-Plus/Test/FreeRTOS-Plus-TCP/Integration/Full-TCP-Networkless/Config/FreeRTOSConfig.h
+++ b/FreeRTOS-Plus/Test/FreeRTOS-Plus-TCP/Integration/Full-TCP-Networkless/Config/FreeRTOSConfig.h
@@ -1,6 +1,6 @@
 /*
  * FreeRTOS V202112.00
- * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
@@ -20,7 +20,7 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  *
  * https://www.FreeRTOS.org
- * https://aws.amazon.com/freertos
+ * https://github.com/FreeRTOS
  *
  */
 
@@ -52,7 +52,6 @@
 #define configUSE_TRACE_FACILITY				1
 #define configUSE_16_BIT_TICKS					0
 #define configIDLE_SHOULD_YIELD					1
-#define configUSE_CO_ROUTINES 					0
 #define configUSE_MUTEXES						1
 #define configUSE_RECURSIVE_MUTEXES				1
 #define configQUEUE_REGISTRY_SIZE				0
@@ -78,10 +77,6 @@
 
 /* Run time stats gathering definitions. */
 #define configGENERATE_RUN_TIME_STATS	0
-
-/* Co-routine definitions. */
-#define configUSE_CO_ROUTINES 			0
-#define configMAX_CO_ROUTINE_PRIORITIES ( 2 )
 
 /* Set the following definitions to 1 to include the API function, or zero
 to exclude the API function. */

--- a/FreeRTOS-Plus/Test/FreeRTOS-Plus-TCP/Integration/Full-TCP-Suite/Config/FreeRTOSConfig.h
+++ b/FreeRTOS-Plus/Test/FreeRTOS-Plus-TCP/Integration/Full-TCP-Suite/Config/FreeRTOSConfig.h
@@ -53,7 +53,6 @@
 #define configUSE_TRACE_FACILITY                   1
 #define configUSE_16_BIT_TICKS                     0
 #define configIDLE_SHOULD_YIELD                    1
-#define configUSE_CO_ROUTINES                      0
 #define configUSE_MUTEXES                          1
 #define configUSE_RECURSIVE_MUTEXES                1
 #define configQUEUE_REGISTRY_SIZE                  0
@@ -84,10 +83,6 @@ void vConfigureTimerForRunTimeStats(void);
 #define configGENERATE_RUN_TIME_STATS    1
 #define portCONFIGURE_TIMER_FOR_RUN_TIME_STATS()    vConfigureTimerForRunTimeStats()
 #define portGET_RUN_TIME_COUNTER_VALUE()            ulGetRunTimeCounterValue()
-
-/* Co-routine definitions. */
-#define configUSE_CO_ROUTINES                   0
-#define configMAX_CO_ROUTINE_PRIORITIES         ( 2 )
 
 /* Currently the TCP/IP stack is using dynamic allocation, and the MQTT task is
  * using static allocation. */

--- a/FreeRTOS-Plus/VisualStudio_StaticProjects/FreeRTOS-Kernel/FreeRTOS-Kernel.vcxproj
+++ b/FreeRTOS-Plus/VisualStudio_StaticProjects/FreeRTOS-Kernel/FreeRTOS-Kernel.vcxproj
@@ -136,7 +136,6 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClInclude Include="..\..\..\FreeRTOS\Source\include\atomic.h" />
-    <ClInclude Include="..\..\..\FreeRTOS\Source\include\croutine.h" />
     <ClInclude Include="..\..\..\FreeRTOS\Source\include\deprecated_definitions.h" />
     <ClInclude Include="..\..\..\FreeRTOS\Source\include\event_groups.h" />
     <ClInclude Include="..\..\..\FreeRTOS\Source\include\FreeRTOS.h" />
@@ -157,7 +156,6 @@
     <ClInclude Include="FreeRTOSConfig.h" />
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="..\..\..\FreeRTOS\Source\croutine.c" />
     <ClCompile Include="..\..\..\FreeRTOS\Source\event_groups.c" />
     <ClCompile Include="..\..\..\FreeRTOS\Source\list.c" />
     <ClCompile Include="..\..\..\FreeRTOS\Source\portable\MemMang\heap_4.c" />

--- a/FreeRTOS-Plus/VisualStudio_StaticProjects/FreeRTOS-Kernel/FreeRTOS-Kernel.vcxproj.filters
+++ b/FreeRTOS-Plus/VisualStudio_StaticProjects/FreeRTOS-Kernel/FreeRTOS-Kernel.vcxproj.filters
@@ -51,9 +51,6 @@
     <ClInclude Include="..\..\..\FreeRTOS\Source\include\atomic.h">
       <Filter>include</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\FreeRTOS\Source\include\croutine.h">
-      <Filter>include</Filter>
-    </ClInclude>
     <ClInclude Include="..\..\..\FreeRTOS\Source\include\deprecated_definitions.h">
       <Filter>include</Filter>
     </ClInclude>
@@ -83,9 +80,6 @@
       <Filter>Kernel</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\FreeRTOS\Source\event_groups.c">
-      <Filter>Kernel</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\FreeRTOS\Source\croutine.c">
       <Filter>Kernel</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\FreeRTOS\Source\portable\MemMang\heap_4.c" />

--- a/FreeRTOS-Plus/VisualStudio_StaticProjects/FreeRTOS-Kernel/FreeRTOSConfig.h
+++ b/FreeRTOS-Plus/VisualStudio_StaticProjects/FreeRTOS-Kernel/FreeRTOSConfig.h
@@ -78,9 +78,6 @@
 /* Event group related definitions. */
 #define configUSE_EVENT_GROUPS                     1
 
-/* Co-routine definitions. */
-#define configUSE_CO_ROUTINES                      0
-
 /* Set the following definitions to 1 to include the API function, or zero
  * to exclude the API function. */
 #define INCLUDE_vTaskPrioritySet                   1


### PR DESCRIPTION
Remove references to coroutines in FreeRTOS-Plus

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
