### PR TITLE
Fix doxygen 1.9.5 errors by rolling back to 1.9.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,7 @@ jobs:
           # List of directories containing libraries whose doxygen output will be generated.
           libs_parent_dir_path: FreeRTOS-Plus/Source,FreeRTOS-Plus/Source/AWS,FreeRTOS-Plus/Source/Application-Protocols,FreeRTOS-Plus/Source/Utilities
           generate_zip: true
+          doxygen_link: "https://sourceforge.net/projects/doxygen/files/rel-1.9.2/doxygen-1.9.2.linux.bin.tar.gz"
       - name: Upload doxygen artifact if main branch
         if: success() && ( github.ref == 'refs/heads/main' || github.ref == 'refs/heads/release-candidate' )
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,7 @@ jobs:
           libs_parent_dir_path: FreeRTOS-Plus/Source,FreeRTOS-Plus/Source/AWS,FreeRTOS-Plus/Source/Application-Protocols,FreeRTOS-Plus/Source/Utilities
           generate_zip: true
           doxygen_link: "https://sourceforge.net/projects/doxygen/files/rel-1.9.2/doxygen-1.9.2.linux.bin.tar.gz"
+          doxygen_dependencies: libclang-9-dev libclang-cpp9 graphviz
       - name: Upload doxygen artifact if main branch
         if: success() && ( github.ref == 'refs/heads/main' || github.ref == 'refs/heads/release-candidate' )
         env:


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->
I updated the doxygen github action in this [commit](https://github.com/FreeRTOS/CI-CD-Github-Actions/commit/f067d23d61abd629990b75ce4e195f879aa76907) to allow for a user to pass dependencies of the doxygen download being used, and with that change, I updated the workflow in this repo to use doxygen 1.9.2 with the right dependencies, fixing the doxygen warnings.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
