### PR TITLE
Enable TRACE_FACILTY to fix IAR MPS2 build

### DIFF
--- a/FreeRTOS/Demo/CORTEX_MPS2_QEMU_IAR_GCC/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_MPS2_QEMU_IAR_GCC/FreeRTOSConfig.h
@@ -48,7 +48,7 @@
 #define configMINIMAL_STACK_SIZE		( ( unsigned short ) 80 )
 #define configTOTAL_HEAP_SIZE			( ( size_t ) ( 60 * 1024 ) )
 #define configMAX_TASK_NAME_LEN			( 12 )
-#define configUSE_TRACE_FACILITY		0
+#define configUSE_TRACE_FACILITY		1
 #define configUSE_16_BIT_TICKS			0
 #define configIDLE_SHOULD_YIELD			0
 #define configUSE_MUTEXES				1


### PR DESCRIPTION
Description
-----------
Enable TRACE_FACILITY macro to fix IAR MPS2 build. Without this change the demo will not build out of the box.

Test Steps
-----------
1. Cloned FreeRTOS
2. Opened IAR MPS2 Qemu demo in IAR EW for ARM
3. Clean & Build
4. Open up `.out` file with Qemu
5. Download & Debug on IAR
6. Wait for PASS statement from full demo

Demo output:
```
PASS : 5062 (1)
PASS : 10045 (1)
PASS : 15061 (6)
PASS : 20045 (11)
PASS : 25046 (16)
PASS : 30045 (23)
...  
```

Related Issue
-----------
N/A


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
