### PR TITLE
Exclude stats functions from IAR assembly

### DIFF
--- a/FreeRTOS/Demo/CORTEX_MPS2_QEMU_IAR_GCC/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_MPS2_QEMU_IAR_GCC/FreeRTOSConfig.h
@@ -42,8 +42,10 @@
 #define configUSE_TRACE_FACILITY 1
 #define configGENERATE_RUN_TIME_STATS 1
 
-void vConfigureTimerForRunTimeStats( void );
-unsigned long ulGetRunTimeCounterValue( void );
+#ifndef __IASMARM__ /* Prevent C code being included in IAR asm files. */
+    void vConfigureTimerForRunTimeStats( void );
+    unsigned long ulGetRunTimeCounterValue( void );
+#endif
 
 #define portCONFIGURE_TIMER_FOR_RUN_TIME_STATS() vConfigureTimerForRunTimeStats( )
 #define portGET_RUN_TIME_COUNTER_VALUE()         ulGetRunTimeCounterValue()


### PR DESCRIPTION
Description
-----------
Wrap stats functions with IAR Assembly exclusion macro to avoid 'bad instruction' build failure.

Before build would fail due to new function prototypes with a 'bad instruction' error message. With this change the build is successful.

Test Steps
-----------
* Pull down code
* Build with IAR
* Run output file with QEMU
* Debug through IAR Embedded Workbench


Full demo output:
```
PASS : 5042 (0)
PASS : 10042 (1)
PASS :  15042 (4)
PASS : 20042 (10)
...
```


Related Issue
-----------
https://github.com/FreeRTOS/FreeRTOS/pull/890


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
