### PR TITLE
Fix IAR GCC buid not to use trace

### DIFF
--- a/FreeRTOS/Demo/CORTEX_MPS2_QEMU_IAR_GCC/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_MPS2_QEMU_IAR_GCC/FreeRTOSConfig.h
@@ -39,14 +39,8 @@
  * See http://www.freertos.org/a00110.html
  *----------------------------------------------------------*/
 
-#define configUSE_TRACE_FACILITY 1
-#define configGENERATE_RUN_TIME_STATS 1
-
-void vConfigureTimerForRunTimeStats( void );
-unsigned long ulGetRunTimeCounterValue( void );
-
-#define portCONFIGURE_TIMER_FOR_RUN_TIME_STATS() vConfigureTimerForRunTimeStats( )
-#define portGET_RUN_TIME_COUNTER_VALUE()         ulGetRunTimeCounterValue()
+#define configUSE_TRACE_FACILITY 0
+#define configGENERATE_RUN_TIME_STATS 0
 
 #define configUSE_TICKLESS_IDLE         0
 #define configUSE_PREEMPTION			1
@@ -103,7 +97,7 @@ to exclude the API function. */
 format the raw data provided by the uxTaskGetSystemState() function in to human
 readable ASCII form.  See the notes in the implementation of vTaskList() within
 FreeRTOS/Source/tasks.c for limitations. */
-#define configUSE_STATS_FORMATTING_FUNCTIONS	1
+#define configUSE_STATS_FORMATTING_FUNCTIONS	0
 
 #define configKERNEL_INTERRUPT_PRIORITY 		( 255 )	/* All eight bits as QEMU doesn't model the priority bits. */
 /* !!!! configMAX_SYSCALL_INTERRUPT_PRIORITY must not be set to zero !!!!

--- a/FreeRTOS/Demo/CORTEX_MPS2_QEMU_IAR_GCC/build/gcc/output/placeholder.txt
+++ b/FreeRTOS/Demo/CORTEX_MPS2_QEMU_IAR_GCC/build/gcc/output/placeholder.txt
@@ -1,0 +1,3 @@
+File included to ensure the "output" directory is not empty, and can therefore
+be checked into Git.  This prevents the necessity to have a cross platform
+method of creating the directory from within the makefile.

--- a/FreeRTOS/Demo/CORTEX_MPS2_QEMU_IAR_GCC/build/gcc/output/placeholder.txt
+++ b/FreeRTOS/Demo/CORTEX_MPS2_QEMU_IAR_GCC/build/gcc/output/placeholder.txt
@@ -1,3 +1,0 @@
-File included to ensure the "output" directory is not empty, and can therefore
-be checked into Git.  This prevents the necessity to have a cross platform
-method of creating the directory from within the makefile.

--- a/FreeRTOS/Demo/CORTEX_MPS2_QEMU_IAR_GCC/main.c
+++ b/FreeRTOS/Demo/CORTEX_MPS2_QEMU_IAR_GCC/main.c
@@ -50,8 +50,6 @@
 #include "FreeRTOS.h"
 #include "task.h"
 
-#include "CMSDK_CM3.h"
-
 /* Standard includes. */
 #include <stdio.h>
 #include <string.h>
@@ -76,11 +74,6 @@ required UART registers. */
 #define UART0_CTRL		( * ( ( ( volatile uint32_t * )( UART0_ADDRESS + 8UL ) ) ) )
 #define UART0_BAUDDIV	( * ( ( ( volatile uint32_t * )( UART0_ADDRESS + 16UL ) ) ) )
 #define TX_BUFFER_MASK	( 1UL )
-
-#define TIMER_POSTSCALER    ( 8UL )
-
-/* Time at start of day (in ns). */
-static volatile unsigned long ulRunTimeOverflowCount = 0U;
 
 /*
  * main_blinky() is used when mainCREATE_SIMPLE_BLINKY_DEMO_ONLY is set to 1.
@@ -108,7 +101,6 @@ void main( void )
 	/* See https://www.freertos.org/freertos-on-qemu-mps2-an385-model.html for
 	instructions. */
 
-	
 	/* Hardware initialisation.  printf() output uses the UART for IO. */
 	prvUARTInit();
 
@@ -313,38 +305,5 @@ void *malloc( size_t size )
 	portDISABLE_INTERRUPTS();
 	for( ;; );
 
-}
-/*-----------------------------------------------------------*/
-
-void vConfigureTimerForRunTimeStats( void )
-{
-    /* PCLK / SystemCoreClock is 25MHz, Timer clock is always PCLK */
-
-    CMSDK_TIMER0->CTRL &= ~( CMSDK_TIMER_CTRL_EN_Msk );
-
-    CMSDK_TIMER0->RELOAD = 0xFFFFFFFF;
-
-    /* Enable overflow interrupt and start the timer */
-    CMSDK_TIMER0->CTRL |= CMSDK_TIMER_CTRL_IRQEN_Msk;
-    CMSDK_TIMER0->CTRL |= CMSDK_TIMER_CTRL_EN_Msk;
-
-}
-/*-----------------------------------------------------------*/
-
-unsigned long ulGetRunTimeCounterValue( void )
-{
-    unsigned long ulTimerValue = CMSDK_TIMER0->RELOAD - CMSDK_TIMER0->VALUE;
-
-    /*
-     * 32 bits will overflow after ~ ( 2**32 / 25000000 ) == 171 seconds,
-     * So we remove the lower 8 bits and borrow 8 bits from the overflow counter.
-     */
-
-    ulTimerValue = ( ulTimerValue >> TIMER_POSTSCALER );
-
-    /* Add remaining 8 bits from ulRunTimeOverflowCount */
-    ulTimerValue |= ( ulRunTimeOverflowCount << ( 32UL - TIMER_POSTSCALER ) );
-
-    return ulTimerValue;
 }
 


### PR DESCRIPTION
Fix IAR GCC buid not to use trace in Demo

Description
-----------
timer interrupt already in use which is causing a time conflict

Test Steps
-----------
tested with qemu




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
