### PR TITLE
Fix memory leak in transport_mbedtls_pkcs11.c

### DIFF
--- a/FreeRTOS-Plus/Demo/AWS/Fleet_Provisioning_Windows_Simulator/Fleet_Provisioning_With_CSR_Demo/fleet_provisioning_demo.vcxproj
+++ b/FreeRTOS-Plus/Demo/AWS/Fleet_Provisioning_Windows_Simulator/Fleet_Provisioning_With_CSR_Demo/fleet_provisioning_demo.vcxproj
@@ -164,6 +164,7 @@
     <ClCompile Include="..\..\..\..\Source\Application-Protocols\coreMQTT\source\core_mqtt_state.c" />
     <ClCompile Include="..\..\..\..\Source\Application-Protocols\network_transport\mbedtls_bio_tcp_sockets_wrapper.c" />
     <ClCompile Include="..\..\..\..\Source\Application-Protocols\network_transport\mbedtls_pk_pkcs11.c" />
+    <ClCompile Include="..\..\..\..\Source\Application-Protocols\network_transport\mbedtls_rng_pkcs11.c" />
     <ClCompile Include="..\..\..\..\Source\Application-Protocols\network_transport\tcp_sockets_wrapper\ports\freertos_plus_tcp\tcp_sockets_wrapper.c" />
     <ClCompile Include="..\..\..\..\Source\Application-Protocols\network_transport\transport_mbedtls_pkcs11.c" />
     <ClCompile Include="..\..\..\..\Source\AWS\fleet-provisioning\source\fleet_provisioning.c" />
@@ -189,7 +190,7 @@
     <ClInclude Include="..\..\..\..\Source\Application-Protocols\coreMQTT\source\include\core_mqtt_state.h" />
     <ClInclude Include="..\..\..\..\Source\Application-Protocols\coreMQTT\source\interface\transport_interface.h" />
     <ClInclude Include="..\..\..\..\Source\Application-Protocols\network_transport\mbedtls_bio_tcp_sockets_wrapper.h" />
-    <ClInclude Include="..\..\..\..\Source\Application-Protocols\network_transport\mbedtls_pk_pkcs11.h" />
+    <ClInclude Include="..\..\..\..\Source\Application-Protocols\network_transport\mbedtls_pkcs11.h" />
     <ClInclude Include="..\..\..\..\Source\Application-Protocols\network_transport\tcp_sockets_wrapper\include\tcp_sockets_wrapper.h" />
     <ClInclude Include="..\..\..\..\Source\Application-Protocols\network_transport\transport_mbedtls_pkcs11.h" />
     <ClInclude Include="..\..\..\..\Source\AWS\fleet-provisioning\source\include\fleet_provisioning.h" />

--- a/FreeRTOS-Plus/Demo/AWS/Fleet_Provisioning_Windows_Simulator/Fleet_Provisioning_With_CSR_Demo/fleet_provisioning_demo.vcxproj.filters
+++ b/FreeRTOS-Plus/Demo/AWS/Fleet_Provisioning_Windows_Simulator/Fleet_Provisioning_With_CSR_Demo/fleet_provisioning_demo.vcxproj.filters
@@ -108,6 +108,9 @@
     <ClCompile Include="..\..\..\..\Source\Application-Protocols\network_transport\mbedtls_pk_pkcs11.c">
       <Filter>Additional Network Transport Files\TCP Sockets Wrapper + PKCS11 + MbedTLS Transport</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\Application-Protocols\network_transport\mbedtls_rng_pkcs11.c">
+      <Filter>Additional Network Transport Files\TCP Sockets Wrapper + PKCS11 + MbedTLS Transport</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\..\..\Source\Application-Protocols\network_transport\transport_mbedtls_pkcs11.c">
       <Filter>Additional Network Transport Files\TCP Sockets Wrapper + PKCS11 + MbedTLS Transport</Filter>
     </ClCompile>
@@ -176,7 +179,7 @@
     <ClInclude Include="..\..\Mqtt_Demo_Helpers\mqtt_pkcs11_demo_helpers.h">
       <Filter>Headers</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\..\Source\Application-Protocols\network_transport\mbedtls_pk_pkcs11.h">
+    <ClInclude Include="..\..\..\..\Source\Application-Protocols\network_transport\mbedtls_pkcs11.h">
       <Filter>Additional Network Transport Files\TCP Sockets Wrapper + PKCS11 + MbedTLS Transport\include</Filter>
     </ClInclude>
     <ClInclude Include="..\..\..\..\Source\Application-Protocols\network_transport\transport_mbedtls_pkcs11.h">

--- a/FreeRTOS-Plus/Demo/AWS/Fleet_Provisioning_Windows_Simulator/Fleet_Provisioning_With_CSR_Demo/pkcs11_operations.c
+++ b/FreeRTOS-Plus/Demo/AWS/Fleet_Provisioning_Windows_Simulator/Fleet_Provisioning_With_CSR_Demo/pkcs11_operations.c
@@ -263,7 +263,7 @@ bool xGenerateKeyAndCsr( CK_SESSION_HANDLE xP11Session,
 
         mbedtls_x509write_csr_free( &xReq );
 
-        lPKCS11PkMbedtlsCloseSessionAndFree( &xPrivKey );
+        mbedtls_pk_free( &xPrivKey );
     }
 
     *pxOutCsrLength = strlen( pcCsrBuffer );

--- a/FreeRTOS-Plus/Demo/AWS/Fleet_Provisioning_Windows_Simulator/Fleet_Provisioning_With_CSR_Demo/pkcs11_operations.c
+++ b/FreeRTOS-Plus/Demo/AWS/Fleet_Provisioning_Windows_Simulator/Fleet_Provisioning_With_CSR_Demo/pkcs11_operations.c
@@ -44,7 +44,7 @@
 #include "core_pkcs11_config.h"
 #include "core_pki_utils.h"
 #include "mbedtls_utils.h"
-#include "mbedtls_pk_pkcs11.h"
+#include "mbedtls_pkcs11.h"
 
 /* MbedTLS include. */
 #include "mbedtls/error.h"
@@ -257,7 +257,7 @@ bool xGenerateKeyAndCsr( CK_SESSION_HANDLE xP11Session,
             mbedtls_x509write_csr_set_key( &xReq, &xPrivKey );
 
             ulMbedtlsRet = mbedtls_x509write_csr_pem( &xReq, ( unsigned char * ) pcCsrBuffer,
-                                                      xCsrBufferLength, &lPKCS11RandomCallback,
+                                                      xCsrBufferLength, &lMbedCryptoRngCallbackPKCS11,
                                                       &xP11Session );
         }
 

--- a/FreeRTOS-Plus/Demo/corePKCS11_MQTT_Mutual_Auth_Windows_Simulator/corePKCS11_MQTT_Mutual_Auth.vcxproj
+++ b/FreeRTOS-Plus/Demo/corePKCS11_MQTT_Mutual_Auth_Windows_Simulator/corePKCS11_MQTT_Mutual_Auth.vcxproj
@@ -159,6 +159,7 @@
     <ClCompile Include="..\..\Source\Application-Protocols\coreMQTT\source\core_mqtt_state.c" />
     <ClCompile Include="..\..\Source\Application-Protocols\network_transport\mbedtls_bio_tcp_sockets_wrapper.c" />
     <ClCompile Include="..\..\Source\Application-Protocols\network_transport\mbedtls_pk_pkcs11.c" />
+    <ClCompile Include="..\..\Source\Application-Protocols\network_transport\mbedtls_rng_pkcs11.c" />
     <ClCompile Include="..\..\Source\Application-Protocols\network_transport\tcp_sockets_wrapper\ports\freertos_plus_tcp\tcp_sockets_wrapper.c" />
     <ClCompile Include="..\..\Source\Application-Protocols\network_transport\transport_mbedtls_pkcs11.c" />
     <ClCompile Include="..\..\Source\Utilities\backoff_algorithm\source\backoff_algorithm.c" />
@@ -172,7 +173,7 @@
     <ClInclude Include="..\..\Source\Application-Protocols\coreMQTT\source\include\core_mqtt_state.h" />
     <ClInclude Include="..\..\Source\Application-Protocols\coreMQTT\source\interface\transport_interface.h" />
     <ClInclude Include="..\..\Source\Application-Protocols\network_transport\mbedtls_bio_tcp_sockets_wrapper.h" />
-    <ClInclude Include="..\..\Source\Application-Protocols\network_transport\mbedtls_pk_pkcs11.h" />
+    <ClInclude Include="..\..\Source\Application-Protocols\network_transport\mbedtls_pkcs11.h" />
     <ClInclude Include="..\..\Source\Application-Protocols\network_transport\tcp_sockets_wrapper\include\tcp_sockets_wrapper.h" />
     <ClInclude Include="..\..\Source\Application-Protocols\network_transport\transport_mbedtls_pkcs11.h" />
     <ClInclude Include="..\..\Source\Utilities\backoff_algorithm\source\include\backoff_algorithm.h" />

--- a/FreeRTOS-Plus/Demo/corePKCS11_MQTT_Mutual_Auth_Windows_Simulator/corePKCS11_MQTT_Mutual_Auth.vcxproj.filters
+++ b/FreeRTOS-Plus/Demo/corePKCS11_MQTT_Mutual_Auth_Windows_Simulator/corePKCS11_MQTT_Mutual_Auth.vcxproj.filters
@@ -98,7 +98,7 @@
     <ClInclude Include="..\..\Source\Application-Protocols\network_transport\mbedtls_bio_tcp_sockets_wrapper.h">
       <Filter>Additional Network Transport Files\TCP Sockets Wrapper + MbedTLS Transport\include</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\Source\Application-Protocols\network_transport\mbedtls_pk_pkcs11.h">
+    <ClInclude Include="..\..\Source\Application-Protocols\network_transport\mbedtls_pkcs11.h">
       <Filter>Additional Network Transport Files\TCP Sockets Wrapper + MbedTLS Transport\include</Filter>
     </ClInclude>
     <ClInclude Include="..\..\Source\Application-Protocols\network_transport\transport_mbedtls_pkcs11.h">

--- a/FreeRTOS-Plus/Source/Application-Protocols/network_transport/mbedtls_pk_pkcs11.c
+++ b/FreeRTOS-Plus/Source/Application-Protocols/network_transport/mbedtls_pk_pkcs11.c
@@ -387,56 +387,6 @@ CK_RV xPKCS11_initMbedtlsPkContext( mbedtls_pk_context * pxMbedtlsPkCtx,
 
 /*-----------------------------------------------------------*/
 
-int lPKCS11PkMbedtlsCloseSessionAndFree( mbedtls_pk_context * pxMbedtlsPkCtx )
-{
-    CK_RV xResult = CKR_OK;
-    P11PkCtx_t * pxP11Ctx = NULL;
-    CK_FUNCTION_LIST_PTR pxFunctionList = NULL;
-
-    configASSERT( pxMbedtlsPkCtx );
-
-    if( pxMbedtlsPkCtx )
-    {
-        if( pxMbedtlsPkCtx->pk_info->type == MBEDTLS_PK_ECKEY )
-        {
-            pxP11Ctx = &( ( ( P11EcDsaCtx_t * ) ( pxMbedtlsPkCtx->pk_ctx ) )->xP11PkCtx );
-        }
-        else if( pxMbedtlsPkCtx->pk_info->type == MBEDTLS_PK_RSA )
-        {
-            pxP11Ctx = &( ( ( P11RsaCtx_t * ) ( pxMbedtlsPkCtx->pk_ctx ) )->xP11PkCtx );
-        }
-        else
-        {
-            pxP11Ctx = NULL;
-            xResult = CKR_FUNCTION_FAILED;
-        }
-    }
-    else
-    {
-        xResult = CKR_FUNCTION_FAILED;
-    }
-
-    if( xResult == CKR_OK )
-    {
-        xResult = C_GetFunctionList( &pxFunctionList );
-    }
-
-    if( xResult == CKR_OK )
-    {
-        configASSERT( pxFunctionList );
-        xResult = pxFunctionList->C_CloseSession( pxP11Ctx->xSessionHandle );
-    }
-
-    if( xResult == CKR_OK )
-    {
-        pxP11Ctx->xSessionHandle = CK_INVALID_HANDLE;
-    }
-
-    return( xResult == CKR_OK ? 0 : -1 );
-}
-
-/*-----------------------------------------------------------*/
-
 int lPKCS11RandomCallback( void * pvCtx,
                            unsigned char * pucOutput,
                            size_t uxLen )

--- a/FreeRTOS-Plus/Source/Application-Protocols/network_transport/mbedtls_pk_pkcs11.c
+++ b/FreeRTOS-Plus/Source/Application-Protocols/network_transport/mbedtls_pk_pkcs11.c
@@ -387,44 +387,6 @@ CK_RV xPKCS11_initMbedtlsPkContext( mbedtls_pk_context * pxMbedtlsPkCtx,
 
 /*-----------------------------------------------------------*/
 
-int lPKCS11RandomCallback( void * pvCtx,
-                           unsigned char * pucOutput,
-                           size_t uxLen )
-{
-    int lRslt;
-    CK_FUNCTION_LIST_PTR pxFunctionList = NULL;
-    CK_SESSION_HANDLE * pxSessionHandle = ( CK_SESSION_HANDLE * ) pvCtx;
-
-    if( pucOutput == NULL )
-    {
-        lRslt = -1;
-    }
-    else if( pvCtx == NULL )
-    {
-        lRslt = -1;
-        LogError( ( "pvCtx must not be NULL." ) );
-    }
-    else
-    {
-        lRslt = ( int ) C_GetFunctionList( &pxFunctionList );
-    }
-
-    if( ( lRslt != CKR_OK ) ||
-        ( pxFunctionList == NULL ) ||
-        ( pxFunctionList->C_GenerateRandom == NULL ) )
-    {
-        lRslt = -1;
-    }
-    else
-    {
-        lRslt = ( int ) pxFunctionList->C_GenerateRandom( *pxSessionHandle, pucOutput, uxLen );
-    }
-
-    return lRslt;
-}
-
-/*-----------------------------------------------------------*/
-
 static void * p11_ecdsa_ctx_alloc( void )
 {
     void * pvCtx = NULL;

--- a/FreeRTOS-Plus/Source/Application-Protocols/network_transport/mbedtls_pk_pkcs11.h
+++ b/FreeRTOS-Plus/Source/Application-Protocols/network_transport/mbedtls_pk_pkcs11.h
@@ -47,15 +47,6 @@ CK_RV xPKCS11_initMbedtlsPkContext( mbedtls_pk_context * pxMbedtlsPkCtx,
                                     CK_OBJECT_HANDLE xPkHandle );
 
 /**
- * @brief Close the PKCS11 session and free the relevant pk context.
- *
- * @param pxMbedtlsPkCtx Pointer to the mbedtls_pk_context to free
- * @return 0 on success
- * @return A negative number on failure
- */
-int lPKCS11PkMbedtlsCloseSessionAndFree( mbedtls_pk_context * pxMbedtlsPkCtx );
-
-/**
  * @brief Callback to generate random data with the PKCS11 module.
  *
  * @param[in] pvCtx void pointer to the
@@ -67,7 +58,5 @@ int lPKCS11PkMbedtlsCloseSessionAndFree( mbedtls_pk_context * pxMbedtlsPkCtx );
 int lPKCS11RandomCallback( void * pvCtx,
                            unsigned char * pucOutput,
                            size_t uxLen );
-
-
 
 #endif /* MBEDTLS_PK_PKCS11_H */

--- a/FreeRTOS-Plus/Source/Application-Protocols/network_transport/mbedtls_pkcs11.h
+++ b/FreeRTOS-Plus/Source/Application-Protocols/network_transport/mbedtls_pkcs11.h
@@ -1,0 +1,62 @@
+/*
+ * FreeRTOS V202211.00
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * https://www.FreeRTOS.org
+ * https://github.com/FreeRTOS
+ *
+ */
+
+#ifndef MBEDTLS_PKCS11_H
+#define MBEDTLS_PKCS11_H
+
+#include <string.h>
+#include "mbedtls/pk.h"
+#include "core_pkcs11_config.h"
+#include "core_pkcs11.h"
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Initialize an mbedtls_pk_context for the given PKCS11 object handle.
+ *
+ * @param pxMbedtlsPkCtx Pointer to an MbedTLS PK context to initialize.
+ * @param xSessionHandle Handle of an initialize PKCS#11 session.
+ * @param xPkHandle Handle of a PKCS11 Private Key object.
+ * @return CK_RV CKR_OK on success.
+ */
+CK_RV xPKCS11_initMbedtlsPkContext( mbedtls_pk_context * pxMbedtlsPkCtx,
+                                    CK_SESSION_HANDLE xSessionHandle,
+                                    CK_OBJECT_HANDLE xPkHandle );
+
+/**
+ * @brief Callback to generate random data with the PKCS11 API.
+ *
+ * @param[in] pvCtx void pointer to a PKCS11 Session handle.
+ * @param[in] pucRandom Byte array to fill with random data.
+ * @param[in] xRandomLength Length of byte array.
+ *
+ * @return 0 on success.
+ */
+int lMbedCryptoRngCallbackPKCS11( void * pvCtx,
+                                  unsigned char * pucOutput,
+                                  size_t uxLen );
+
+#endif /* MBEDTLS_PKCS11_H */

--- a/FreeRTOS-Plus/Source/Application-Protocols/network_transport/transport_mbedtls_pkcs11.c
+++ b/FreeRTOS-Plus/Source/Application-Protocols/network_transport/transport_mbedtls_pkcs11.c
@@ -180,13 +180,6 @@ static CK_RV initializeClientKeys( SSLContext_t * pxCtx,
                                    const char * pcLabelName );
 
 /**
- * @brief Stub function to satisfy mbedtls checks before sign operations
- *
- * @return 1.
- */
-int canDoStub( mbedtls_pk_type_t type );
-
-/**
  * @brief Sign a cryptographic hash with the private key.
  *
  * @param[in] pvContext Crypto context.
@@ -237,8 +230,7 @@ static void sslContextFree( SSLContext_t * pSslContext )
     mbedtls_x509_crt_free( &( pSslContext->clientCert ) );
     mbedtls_ssl_config_free( &( pSslContext->config ) );
 
-
-    ( void ) lPKCS11PkMbedtlsCloseSessionAndFree( &( pSslContext->privKey ) );
+    mbedtls_pk_free( &( pSslContext->privKey ) );
 
     pSslContext->pxP11FunctionList->C_CloseSession( pSslContext->xP11Session );
 }

--- a/FreeRTOS-Plus/Source/Application-Protocols/network_transport/transport_mbedtls_pkcs11.c
+++ b/FreeRTOS-Plus/Source/Application-Protocols/network_transport/transport_mbedtls_pkcs11.c
@@ -52,7 +52,7 @@
 
 /* TLS transport header. */
 #include "transport_mbedtls_pkcs11.h"
-#include "mbedtls_pk_pkcs11.h"
+#include "mbedtls_pkcs11.h"
 
 /* PKCS #11 includes. */
 #include "core_pkcs11_config.h"


### PR DESCRIPTION
Description
-----------
Fix a memory leak in transport_mbedtls_pkcs11.c where the mbedtls_pk_context was not properly freed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
