### PR TITLE
FIx AVR_Dx Atmel Demo

### DIFF
--- a/FreeRTOS/Demo/AVR_Dx_Atmel_Studio/RTOSDemo/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/AVR_Dx_Atmel_Studio/RTOSDemo/FreeRTOSConfig.h
@@ -109,7 +109,7 @@ For other frequency values, update clock_config.h with your own settings */
 #define INCLUDE_vTaskDelayUntil 1
 #define INCLUDE_vTaskDelay 1
 #define INCLUDE_xTaskGetSchedulerState 0
-#define INCLUDE_xTaskGetCurrentTaskHandle 0
+#define INCLUDE_xTaskGetCurrentTaskHandle 1
 #define INCLUDE_uxTaskGetStackHighWaterMark 0
 #define INCLUDE_xTaskGetIdleTaskHandle 0
 #define INCLUDE_eTaskGetState 0

--- a/FreeRTOS/Demo/AVR_Dx_Atmel_Studio/RTOSDemo/RTOSDemo.cproj
+++ b/FreeRTOS/Demo/AVR_Dx_Atmel_Studio/RTOSDemo/RTOSDemo.cproj
@@ -115,7 +115,7 @@
     <ListValues>
       <Value>../../../../Source</Value>
       <Value>../../../../Source/portable/MemMang</Value>
-      <Value>../../../../Source/portable/GCC/AVR_AVRDx</Value>
+      <Value>../../../../Source/portable/ThirdParty/Partner-Supported-Ports/GCC/AVR_AVRDx</Value>
       <Value>../../../../Source/include</Value>
       <Value>../../../Common/include</Value>
       <Value>../../../Common/Minimal</Value>
@@ -180,17 +180,17 @@
       <SubType>compile</SubType>
       <Link>freeRTOS\portable\MemMang\heap_1.c</Link>
     </Compile>
-    <Compile Include="..\..\..\Source\portable\GCC\AVR_AVRDx\port.c">
+    <Compile Include="..\..\..\Source\portable\ThirdParty\Partner-Supported-Ports\GCC\AVR_AVRDx\port.c">
       <SubType>compile</SubType>
-      <Link>freeRTOS\portable\GCC\AVR_AVRDx\port.c</Link>
+      <Link>freeRTOS\portable\ThirdParty\Partner-Supported-Ports\GCC\AVR_AVRDx\port.c</Link>
     </Compile>
-    <Compile Include="..\..\..\Source\portable\GCC\AVR_AVRDx\portmacro.h">
+    <Compile Include="..\..\..\Source\portable\ThirdParty\Partner-Supported-Ports\GCC\AVR_AVRDx\portmacro.h">
       <SubType>compile</SubType>
-      <Link>freeRTOS\portable\GCC\AVR_AVRDx\portmacro.h</Link>
+      <Link>freeRTOS\portable\ThirdParty\Partner-Supported-Ports\GCC\AVR_AVRDx\portmacro.h</Link>
     </Compile>
-    <Compile Include="..\..\..\Source\portable\GCC\AVR_AVRDx\porthardware.h">
+    <Compile Include="..\..\..\Source\portable\ThirdParty\Partner-Supported-Ports\GCC\AVR_AVRDx\porthardware.h">
       <SubType>compile</SubType>
-      <Link>freeRTOS\portable\GCC\AVR_AVRDx\porthardware.h</Link>
+      <Link>freeRTOS\portable\ThirdParty\Partner-Supported-Ports\GCC\AVR_AVRDx\porthardware.h</Link>
     </Compile>
     <Compile Include="..\..\..\Source\include\atomic.h">
       <SubType>compile</SubType>
@@ -354,7 +354,7 @@
     <Folder Include="freeRTOS\include" />
     <Folder Include="freeRTOS\portable" />
     <Folder Include="freeRTOS\portable\GCC" />
-    <Folder Include="freeRTOS\portable\GCC\AVR_AVRDx" />
+    <Folder Include="freeRTOS\portable\ThirdParty\Partner-Supported-Ports\GCC\AVR_AVRDx" />
     <Folder Include="freeRTOS\portable\MemMang" />
     <Folder Include="serial" />
     <Folder Include="ParTest" />


### PR DESCRIPTION
Description
-----------
Updates the demo .cproj file to account for new
paths since 3P restructure. Also enables the xTaskGetCurrentTaskHandle include which is needed for building.

[Related page](https://www.freertos.org/microchip-avr-dx-demo.html), Section "Building with Atmel Studio 7 and AVR-GCC"

Test Steps
-----------
1. Installed Microchip Studio
2. Opened project solution
3. Ran build

Before: Demo wouldn't build
After: Demo builds

Related Issue
-----------
[<!-- If any, please provide issue ID. -->](https://forums.freertos.org/t/avr-gcc-warning-extra-tokens-at-end-of-undef-in-porthardware-h/16365/3)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
