### PR TITLE
Fix some problems

### DIFF
--- a/FreeRTOS/Demo/RISC-V-Qemu-virt_GCC/Makefile
+++ b/FreeRTOS/Demo/RISC-V-Qemu-virt_GCC/Makefile
@@ -24,7 +24,7 @@ LDFLAGS = -nostartfiles -Tfake_rom.lds \
 	-march=rv32imac -mabi=ilp32 -mcmodel=medany \
 	-Xlinker --gc-sections \
 	-Xlinker --defsym=__stack_size=300 \
-	-Xlinker -Map=RTOSDemo.map
+	-Xlinker -Map=$(BUILD_DIR)/RTOSDemo.map
 
 ifeq ($(DEBUG), 1)
     CFLAGS += -Og -ggdb3

--- a/FreeRTOS/Demo/RISC-V-Qemu-virt_GCC/fake_rom.lds
+++ b/FreeRTOS/Demo/RISC-V-Qemu-virt_GCC/fake_rom.lds
@@ -30,9 +30,8 @@ SECTIONS
 		_etext = .;
 	} >rom AT>rom
 
-	.rodata.align :
+	.rodata.align ALIGN(4):
 	{
-		. = ALIGN(4);
 		_rodata = .;
 	} >rom AT>rom
 

--- a/FreeRTOS/Demo/RISC-V-spike-htif_GCC/Makefile
+++ b/FreeRTOS/Demo/RISC-V-spike-htif_GCC/Makefile
@@ -34,8 +34,8 @@ CFLAGS  = -march=$(MARCH) -mabi=$(MABI) -mcmodel=medany \
 	-ffunction-sections \
 	-fdata-sections \
 	-fno-builtin-printf
-ASFLAGS = -march=$(MARCH) -mabi=$(MABI) -mcmodel=medany
 LDFLAGS = -nostartfiles \
+	-march=$(MARCH) -mabi=$(MABI) -mcmodel=medany \
 	-Xlinker --gc-sections \
 	-Xlinker --defsym=__stack_size=$(STACK_SIZE)
 
@@ -76,7 +76,7 @@ $(BUILD_DIR)/%$(XLEN).o: %.c Makefile
 
 $(BUILD_DIR)/%$(XLEN).o: %.S Makefile
 	@mkdir -p $(@D)
-	$(CC) $(CPPFLAGS) $(ASFLAGS) -MMD -MP -c $< -o $@
+	$(CC) $(CPPFLAGS) $(CFLAGS) -MMD -MP -c $< -o $@
 
 # Run lds through the C preprocessor, to replace BASE_ADDRESS with the actual
 # value. It might be simpler to use sed instead.

--- a/FreeRTOS/Demo/RISC-V-spike-htif_GCC/fake_rom.lds
+++ b/FreeRTOS/Demo/RISC-V-spike-htif_GCC/fake_rom.lds
@@ -31,9 +31,8 @@ SECTIONS
 		_etext = .;
 	} >rom AT>rom
 
-	.rodata.align :
+	.rodata.align ALIGN(4):
 	{
-		. = ALIGN(4);
 		_rodata = .;
 	} >rom AT>rom
 

--- a/FreeRTOS/Demo/RISC-V_RV32_QEMU_VIRT_GCC/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/RISC-V_RV32_QEMU_VIRT_GCC/FreeRTOSConfig.h
@@ -103,7 +103,7 @@ to exclude the API function. */
 format the raw data provided by the uxTaskGetSystemState() function in to human
 readable ASCII form.  See the notes in the implementation of vTaskList() within
 FreeRTOS/Source/tasks.c for limitations. */
-#define configUSE_STATS_FORMATTING_FUNCTIONS	1
+#define configUSE_STATS_FORMATTING_FUNCTIONS	0
 
 /* The QEMU target is capable of running all the tests tasks at the same
  * time. */

--- a/FreeRTOS/Demo/RISC-V_RV32_QEMU_VIRT_GCC/build/gcc/fake_rom.ld
+++ b/FreeRTOS/Demo/RISC-V_RV32_QEMU_VIRT_GCC/build/gcc/fake_rom.ld
@@ -30,9 +30,8 @@ SECTIONS
 		_etext = .;
 	} >rom AT>rom
 
-	.rodata.align :
+	.rodata.align ALIGN(4):
 	{
-		. = ALIGN(4);
 		_rodata = .;
 	} >rom AT>rom
 


### PR DESCRIPTION
1. miss debug info in assembly code 
RISC-V-spike-htif_GCC
        LDFLAGS add arch and abi info for linker
            for riscv64-unknown-elf multilib, if there is no arch and abi
            info, will link to default lib and have below error
            target emulation `elf32-littleriscv' does not match `elf64-littleriscv'
        use CFLAGS to replace ASFLAGS when compile assembly code
            because DEBUG flag is added in CFLAGS, if we use ASFLAGS to compile
            assembly code, there is no debug info in assembly code objfile

3. binutils 2.39 ld warn 'has a LOAD segment with RWX permissions' 
RISC-V-Qemu-virt_GCC
RISC-V-spike-htif_GCC
RISC-V_RV32_QEMU_VIRT_GCC

5. fix build fail 
RISC-V_RV32_QEMU_VIRT_GCC

Signed-off-by: Eric Chan <e14002270@gmail.com>

<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
