### PR TITLE
Update kernel submodule pointer for equal priority test cases

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -4,7 +4,7 @@ description: "This is the standard distribution of FreeRTOS."
 
 dependencies:
   - name: "FreeRTOS-Kernel"
-    version: "V10.5.1"
+    version: "bb6071e1d"
     repository:
       type: "git"
       url: "https://github.com/FreeRTOS/FreeRTOS-Kernel.git"


### PR DESCRIPTION
Update kernel submodule pointer for preempt equal priority task test cases in #903 

Description
-----------
<!--- Describe your changes in detail. -->

Test Steps
-----------
Before this PR, there will be the following test cases failure
tasks_1_utest.c:1211:test_xTaskResumeAll_success_2_tasks_eq_prio_running_no_yield:FAIL: Expected FALSE Was TRUE
tasks_1_utest.c:1314:test_vTaskPrioritySet_success_eq_curr_prio_curr_tcb:FAIL: Expected FALSE Was TRUE
tasks_1_utest.c:2417:test_vTaskResume_success_eq_curr_prio_not_yield:FAIL: Expected FALSE Was TRUE
tasks_1_utest.c:2591:test_xTaskResumeFromISR_success_curr_prio_eq_suspended_task:FAIL: Expected 0 Was 1

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
