### PR TITLE
Remove commented signing cert constant

### DIFF
--- a/FreeRTOS-Plus/Demo/AWS/Ota_Windows_Simulator/Common/Ota_PAL/Win32/ota_pal.h
+++ b/FreeRTOS-Plus/Demo/AWS/Ota_Windows_Simulator/Common/Ota_PAL/Win32/ota_pal.h
@@ -34,8 +34,6 @@
 
 #include "ota.h"
 
-//static const char signingcredentialSIGNING_CERTIFICATE_PEM[] = "Paste code signing certificate here.";
-
 /**
  * @brief Abort an OTA transfer.
  *


### PR DESCRIPTION
Description
-----------
Removes the commented signing cert constant
variable from the PAL header file. The
correct location for this constant is the
aws_ota_codesigner_certificate.h file.

Test Steps
-----------
Not tested - fairly confident this isn't going to break anything

Related Issue
-----------
Internal ticket P77100545


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
