### PR TITLE
Cellular transport return socket closed when remote disconnected

### DIFF
--- a/FreeRTOS-Plus/Source/Application-Protocols/network_transport/tcp_sockets_wrapper/ports/cellular/tcp_sockets_wrapper.c
+++ b/FreeRTOS-Plus/Source/Application-Protocols/network_transport/tcp_sockets_wrapper/ports/cellular/tcp_sockets_wrapper.c
@@ -349,6 +349,10 @@ static BaseType_t prvNetworkRecvCellular( const cellularSocketWrapper_t * pCellu
     {
         retRecvLength = ( BaseType_t ) recvLength;
     }
+    else if( socketStatus == CELLULAR_SOCKET_CLOSED )
+    {
+        retRecvLength = TCP_SOCKETS_ERRNO_ECLOSED;
+    }
     else
     {
         LogError( ( "prvNetworkRecv failed %d", socketStatus ) );


### PR DESCRIPTION
This PR fix the problem mentioned in #913 to return TCP_SOCKETS_ERRNO_ECLOSED when socket is closed by remote server.

Description
-----------
Cellular tcp socket wrapper returns TCP_SOCKETS_ERRNO_ECLOSED instead of TCP_SOCKETS_ERRNO_ERROR when socket is closed by remote server.

Test Steps
-----------
Open socket with TCP_Sockets_Connect() and do blocking read with TCP_Sockets_Recv(), close the remote connection.
Check the return value of TCP_Sockets_Recv().
* Before this PR : TCP_SOCKETS_ERRNO_ERROR will be returned
* After this PR : TCP_SOCKETS_ERRNO_ECLOSED  will be returned

Related Issue
-----------
#913


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
