### PR TITLE
Update Readme for the FreeRTOS_PLUS_TCP_ECHO_QEMU_msp2

### DIFF
--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Echo_Qemu_mps2/Readme.md
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Echo_Qemu_mps2/Readme.md
@@ -1,197 +1,355 @@
-# Emulating MPS2 Cortex M3 AN385 on QEMU
+# TCP Echo Client Demo for MPS2 Cortex-M3 AN385 emulated using QEMU
+This FreeRTOS+TCP example demonstrates a TCP Echo Client which sends
+echo requests to an Echo Server and then receives the echo reply. The
+Echo Client runs on the MPS2 Cortex-M3 AN385 platform emulated using QEMU.
 
 ## Requirements
-1. GNU Arm Embedded Toolchain download [here](https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm/downloads)
-3. qemu-arm-system download [here](https://www.qemu.org/download)
-2. Make (tested on version 3.82)
-4. Linux OS (tested on Ubuntu 18.04)
+1. GNU Arm Embedded Toolchain download [here](https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm/downloads).
+3. `qemu-arm-system` download [here](https://www.qemu.org/download).
+2. Make.
+4. Linux OS (tested on Ubuntu 18.04).
 
 ## How to download
-Navigate to a parent directory of your choice and run the following command
-```
+Navigate to a directory of your choice and run the following command -
+```shell
 $ git clone https://github.com/FreeRTOS/FreeRTOS.git --recurse-submodules --depth 1
 ```
-The previous command should create a directory named **FreeRTOS**
+The previous command creates a directory named **FreeRTOS**.
 
-## Networking Echo client Demo
-To make networking support possible a few steps needs to be done on the machine
-lets assume the following interfaces using ubuntu 18.04  or Fedora 30
-(the interface names on your machine could be different)
-```
-l0:         loopback in terface
-enp0s3:     ethernet interface
-virbr0:     virtual bridge         (to be created)
-virbr0-nic: veth virtual interface (to be created)
-```
-## Setting up the QEMU Demo
+## Setup
+The demo requires 2 components -
+1. Echo Client - The demo in this repository.
+1. Echo Server - An external echo server.
 
-To setup the system for running the QEMU demo, please check these steps.
+There are two options to run these components-
+1. Echo Client and Echo Server run on 2 different machines.
 ```
-1. Setting up the client-server system
-    a. Option-1 : The demo can be run on 2 different systems, one with the client running FreeRTOS system in qemu 
-        and another running the echo server.
-    b. Option-2 : The demo could also be run on 1 system, with the QEMU client running on Ubuntu Virtual Machine (VM) and the 
-        host OS (Windows/MAC/Linux) running the server.
-
-2. Setting up MAC and IP Address
-    a. Local FreeRTOS MAC address( configMAC_ADDR0~3 ) : Set a unique MAC address for the QEMU client 
-    b. Local Host IP address : IP of the system running the Qemu client
-    c. The Local FreeRTOS IP address( configIP_ADDR0~3 ) should be an unused local IP on the QEMU network.
-    d. The subnet mask( configNET_MASK0~3 ), Gateway( configGATEWAY_ADDR0~3 ) and DNS address( configDNS_SERVER_ADDR0~3 ) 
-        should match that of the QEMU client network.
-    e. Echo server address( configECHO_SERVER_ADDR0~3 ) : IP of the system running the echo server .
-```
-A block diagram to show the QEMU demo setup process :
-
-```
-        Linux Host(remote system/VM on server)
- ┌───────────────────────────────────────────────┐
- │      Host IP (eth0/ensp03)                    ├──────┐
- │                                               │      │
- │                                               │      │
- │  ┌────────────────────────────┬──────────────┬┤      │
- │  │Virtual Bridge Setup : vibr0│              ││      │
- │  │FreeRTOS IPaddress          │   QEMU system││      │
- │  ├───────┬───────────────┬────┘              ││      │
- │  │       ├───────────────┤                   ││      │
- │  │       │NIC : vibr0-nic│                   ││      │
- │  ├───────┼───────────────┼───────────────────┼│      │
- └──┴──────────────┼──▲──────────────────────────┘    ┌─┴───────┐
-                   │  │                               │same     │
-Echo Server Port   │  │                               │physical │
-                   │  │                               │network  │
-           ┌───────▼──┴──────┐                        └─┬───────┘
-           │ Echo server IP  │                          │
-           └─────────────────┴──────────────────────────┘
-
-    Windows/MAC/Linux Server
-```
-### A few assumptions (your numbers could vary)
-```
-Local Host IP address:          192.168.1.81
-Local FreeRTOS IP address:      192.168.1.80
-Local FreeRTOS Subnet mask:     255.255.255.0
-Default Gateway IP address:     192.168.1.254
-Default DNS IP address:         192.168.1.254
-Echo Server IP address:         192.168.1.204
-Echo Server Port:               7
-Local FreeRTOS Mac address:     52:54:00:12:34:AD
++-----------------+       +------------------+
+|                 |       |                  |
+|   Echo Client   |<----->|    Echo Server   |
+|                 |       |                  |
++-----------------+       +------------------+
+    Machine 1                  Machine 2
 ```
 
-### Building and Running
+1. Utilize Virtual Machine (VM) to run Echo Client and Echo Server on the same
+physical machine. Echo Client runs in a Virtual Machine (VM) and Echo Server
+runs on the host machine.
+```
++--------------------------------------------------------+
+|  Host                                                  |
+|                                                        |
+|                          +--------------------------+  |
+|                          | Virtual Machine (VM)     |  |
+|                          |                          |  |
+|  +----------------+      |    +----------------+    |  |
+|  |                |      |    |                |    |  |
+|  |                |      |    |                |    |  |
+|  |  Echo Server   | <-------> |   Echo Client  |    |  |
+|  |                |      |    |                |    |  |
+|  |                |      |    |                |    |  |
+|  |                |      |    |                |    |  |
+|  +----------------+      |    +----------------+    |  |
+|                          |                          |  |
+|                          +--------------------------+  |
++--------------------------------------------------------+
 
-1. Fill the defines values in FreeRTOSConfig.h with what is equivalent to the
-   above values on your system
+                     Machine
+```
+
+The remaining document assumes option 1.
+
+## Launch Echo Server
+Launch Echo Server on a machine. If you are using a Linux machine, you can
+use the following command to start an Echo Server on port 7:
+```shell
+sudo nc -l 7
+```
+
+## Enable Networking in QEMU
+The Echo Client in this demo runs in QEMU. We need to enable networking in
+QEMU to enable Echo Client to be able to reach to the Echo Server.
+```
++---------------------------------------------------+
+|  Host                                             |
+|                                                   |
+|                                                   |
+|             +--------------------------------+    |
+|             |  QEMU                          |    |
+|             |                                |    |
+|             |                                |    |
+|             |                                |    |
+|             |                                |    |
+|             |                                |    |
+|             +--------------------------------+    |
+|                                                   |
++---------------------------------------------------+
+```
+
+1. Run the `ifconfig` command to find the host's network interface details:
+```
+enp0s3: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 9001
+          inet 192.168.1.81  netmask 255.255.255.0  broadcast 192.168.15.255
+          inet6 fe80::89c:55ff:fe3d:18ad  prefixlen 64  scopeid 0x20<link>
+          ether 0a:9c:55:3d:18:ad  txqueuelen 1000  (Ethernet)
+          RX packets 15001255  bytes 11443805826 (11.4 GB)
+          RX errors 0  dropped 0  overruns 0  frame 0
+          TX packets 9248218  bytes 2080385000 (2.0 GB)
+          TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
+
+```
+
+2. Define a shell variable `HOST_NETWORK_INTERFACE` and set its value to the
+name of the network interface of the host machine. For example, in the above
+output of the `ifconfig` command, name of the the network interface `enp0s3`:
+```shell
+export HOST_NETWORK_INTERFACE=enp0s3
+```
+
+3. Define a shell variable `HOST_IP_ADDRESS` and set its value to the IP address
+of the host machine. For example, in the above output of the `ifconfig` command,
+IP address of the host machine is `192.168.1.81`:
+```shell
+export HOST_IP_ADDRESS=192.168.1.81
+```
+
+4. Define a shell variable `HOST_NETMASK` and set its value to the netmask of
+the host machine. For example, in the above output of the `ifconfig` command,
+netmask of the host machine is `255.255.255.0`:
+```shell
+export HOST_NETMASK=255.255.255.0
+```
+
+5. Calculate the CIDR of the host from the netmask. If you have `ipcalc`
+installed, you can use the following command to find CIDR:
+```shell
+$ ipcalc -b 1.1.1.1 $HOST_NETMASK | grep Netmask
+Netmask:   255.255.255.0 = 24
+```
+CIDR is `24` in the above output.
+
+6. Define a shell variable `HOST_CIDR` and set its value to the CIDR of
+the host machine found in the above step.
+```shell
+export HOST_CIDR=24
+```
+
+7. Find the Default Gateway for the host machine:
+```shell
+$ ip route show
+default via 192.168.1.254 dev enp0s3 proto dhcp src 192.168.1.81 metric 100
+```
+Default Gateway is `192.168.1.254` in the above output.
+
+8. Define a shell variable `HOST_DEFAULT_GATEWAY` and set its value to the
+Default Gateway of the host machine found in the above step.
+```shell
+export HOST_DEFAULT_GATEWAY=192.168.1.254
+```
+
+9. Find the DNS Server of the host machine:
+```shell
+$ grep "nameserver" /etc/resolv.conf
+nameserver 192.168.1.254
+```
+
+10. Define a shell variable `HOST_DNS_SERVER` and set its value to the
+DNS Server of the host machine found in the above step.
+```shell
+export HOST_DNS_SERVER=192.168.1.254
+```
+
+11. Pick an IP address for the QEMU which is in the same network as the host
+machine. This IP address must not be in-use by any other machine on the same
+network. Define a shell variable `QEMU_IP_ADDRESS` and set its value to the
+picked IP Address. For example, run the following command if you picked
+`192.168.1.80`:
+```shell
+export QEMU_IP_ADDRESS=192.168.1.80
+```
+
+12. Pick a MAC address for the QEMU. Define a shell variable `QEMU_MAC_ADDRESS`
+and set its value to the picked MAC Address. For example, run the following
+command if you picked `52:54:00:12:34:AD`:
+```shell
+export QEMU_MAC_ADDRESS=52:54:00:12:34:AD
+```
+
+13. Define a shell variable `ECHO_SERVER_IP_ADDRESS` and set its value to the
+IP address of the Echo Server. For example, run the following command if the
+IP address of the Echo Server is `192.168.1.204`:
+```shell
+export ECHO_SERVER_IP_ADDRESS=192.168.1.204
+```
+
+14. Turn off firewall on the host machine.
+On Ubuntu run:
+```shell
+sudo ufw disable
+sudo ufw status
+```
+On RedHat/Fedora system run:
+```shell
+sudo systemctl status firewalld
+sudo systemctl stop firewalld
+```
+
+15. Create virtual bridge (virbr0) and virtual NIC (virbr0-nic) to enable
+networking in QEMU.
+```shell
+sudo ip link add virbr0 type bridge
+sudo ip tuntap add dev virbr0-nic mode tap
+
+sudo ip addr add $HOST_IP_ADDRESS/$HOST_CIDR dev virbr0
+
+sudo brctl addif virbr0 $HOST_NETWORK_INTERFACE
+sudo brctl addif virbr0 virbr0-nic
+
+sudo ip link set virbr0 up
+sudo ip link set virbr0-nic up
+
+sudo ip route add default via $HOST_DEFAULT_GATEWAY dev virbr0
+```
+
+The following diagram shows the setup:
+```
++-------------------------------------------------------------------------+
+|   Host                                                                  |
+|                                                                         |
+|     +-------------------------+                                         | Host NIC (enp0s3)
+|     |                         | Virtual NIC (virbr0-nic)                +--+
+|     |  QEMU                   +--+                                      |  |
+|     |                         |  |          +--------------+            |  |
+|     |                         |  +--------->|    virbr0    | ---------->|  +--------> Internet
+|     |                         |  |          +--------------+            |  |
+|     |                         +--+           Virtual Bridge             |  |
+|     |                         |                                         +--+
+|     +-------------------------+                                         |
+|                                                                         |
+|                                                                         |
++-------------------------------------------------------------------------+
+```
+
+## Build and Run
+
+1. Set `configIP_ADDR0`-`configIP_ADDR3` in `FreeRTOSIPConfig.h` to the value
+of `QEMU_IP_ADDRESS`:
+```shell
+echo $QEMU_IP_ADDRESS
+```
 ```c
 #define configIP_ADDR0          192
 #define configIP_ADDR1          168
 #define configIP_ADDR2          1
 #define configIP_ADDR3          80
+```
 
+2. Set `configNET_MASK0`-`configNET_MASK3` in `FreeRTOSIPConfig.h` to the value
+of `HOST_NETMASK`:
+```shell
+echo $HOST_NETMASK
+```
+```c
 #define configNET_MASK0         255
 #define configNET_MASK1         255
 #define configNET_MASK2         255
 #define configNET_MASK3         0
+```
 
+3. Set `configGATEWAY_ADDR0`-`configGATEWAY_ADDR3` in `FreeRTOSIPConfig.h` to
+the value of `HOST_DEFAULT_GATEWAY`:
+```shell
+echo $HOST_DEFAULT_GATEWAY
+```
+```c
 #define configGATEWAY_ADDR0     192
 #define configGATEWAY_ADDR1     168
 #define configGATEWAY_ADDR2     1
 #define configGATEWAY_ADDR3     254
+```
 
+4. Set `configDNS_SERVER_ADDR0`-`configDNS_SERVER_ADDR3` in `FreeRTOSIPConfig.h`
+to the value of `HOST_DNS_SERVER`:
+```shell
+echo $HOST_DNS_SERVER
+```
+```c
 #define configDNS_SERVER_ADDR0  192
 #define configDNS_SERVER_ADDR1  168
 #define configDNS_SERVER_ADDR2  1
 #define configDNS_SERVER_ADDR3  254
+```
 
+5. Set `configMAC_ADDR0`-`configMAC_ADDR5` in `FreeRTOSIPConfig.h` to the value
+of `QEMU_MAC_ADDRESS`:
+```shell
+echo $QEMU_MAC_ADDRESS
+```
+```c
 #define configMAC_ADDR0         0x52
 #define configMAC_ADDR1         0x54
 #define configMAC_ADDR2         0x00
 #define configMAC_ADDR3         0x12
 #define configMAC_ADDR4         0x34
 #define configMAC_ADDR5         0xAD
+```
 
+6. Set `configECHO_SERVER_ADDR0`-`configECHO_SERVER_ADDR3` in `FreeRTOSIPConfig.h`
+to the value of `ECHO_SERVER_IP_ADDRESS`:
+```shell
+echo $ECHO_SERVER_IP_ADDRESS
+```
+```c
 #define configECHO_SERVER_ADDR0 192
 #define configECHO_SERVER_ADDR1 168
 #define configECHO_SERVER_ADDR2 1
 #define configECHO_SERVER_ADDR3 204
 ```
 
-2.  Build your software
-```
-$ make
-```
-options: DEBUG=1 to build with **-O0** and debugging symbols
-
-3. On the remote machine  (ip 192.168.1.204)
-```
-$ sudo nc -l 7
-```
-4. Turn off the firewall if running
-On RedHat/Fedora system (tested Fedora 30) run:
-```
-sudo systemctl status firewalld
-sudo systemctl stop firewalld
-```
-On Ubuntu run:
-```
-$ sudo ufw disable
-$ sudo ufw status
-```
-5. Setup the local machine
-Run the following commands replacing the values and interface names
-that conform to your system
-```
-sudo ip link add virbr0 type bridge
-sudo ip tuntap add dev virbr0-nic mode tap
-
-sudo ip addr add 192.168.1.81/24 dev virbr0
-
-sudo brctl addif virbr0 enp0s3
-sudo brctl addif virbr0 virbr0-nic
-
-sudo ip link set virbr0 up
-sudo ip link set virbr0-nic up
-
-sudo ip route add default via 192.168.1.254 dev virbr0
+7. Build:
+```shell
+make
 ```
 
-6. Run the demo
-```
-$ sudo qemu-system-arm -machine mps2-an385 -cpu cortex-m3 
+7. Run:
+```shell
+sudo qemu-system-arm -machine mps2-an385 -cpu cortex-m3
           -kernel ./build/RTOSDemo.axf \
           -netdev tap,id=mynet0,ifname=virbr0-nic,script=no \
           -net nic,macaddr=52:54:00:12:34:AD,model=lan9118,netdev=mynet0 \
           -object filter-dump,id=tap_dump,netdev=mynet0,file=/tmp/qemu_tap_dump\
           -display gtk -m 16M  -nographic -serial stdio \
-          -monitor null -semihosting -semihosting-config enable=on,target=native 
-```
-Replace the value of macaddr=52:54:00:12:34:AD with your own value from
-```
-configMAC_ADDR0 through  configMAC_ADDR5
+          -monitor null -semihosting -semihosting-config enable=on,target=native
 ```
 
-7. Expectations
-On the remote machine you should expect to see something similar to the
-following:
+8. You should see that following output on the terminal of the Echo Server (which
+is running `sudo nc -l 7`):
 ```
-$ sudo nc -l 7
-Password:
-TxRx message number
 0FGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~0123456789:;<=> ?
 @ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~0123456789:;<=>?
 @ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~0123456789:;<=>?
 @ABCDEFGHIJKLM
 ```
 
-## How to start debugging
-1. gdb
-<P>
-Append the -s and -S switches to the previous command (qemu-system-arm)<br>
--s: allow gdb to be attached to the process remotely at port 1234 <br>
--S: start the program in the paused state <br>
-
-run: (make sure you build the debug version)
+## Debug
+1. Build with debugging symbols:
 ```
+make DEBUG=1
+```
+
+2. Start QEMU in the paused state waiting for GDB connection:
+```shell
+sudo qemu-system-arm -machine mps2-an385 -cpu cortex-m3 -s -S
+          -kernel ./build/RTOSDemo.axf \
+          -netdev tap,id=mynet0,ifname=virbr0-nic,script=no \
+          -net nic,macaddr=52:54:00:12:34:AD,model=lan9118,netdev=mynet0 \
+          -object filter-dump,id=tap_dump,netdev=mynet0,file=/tmp/qemu_tap_dump\
+          -display gtk -m 16M  -nographic -serial stdio \
+          -monitor null -semihosting -semihosting-config enable=on,target=native
+```
+
+3. Run GDB:
+```shell
 $ arm-none-eabi-gdb -q ./build/RTOSDemo.axf
 
 (gdb) target remote :1234
@@ -199,11 +357,8 @@ $ arm-none-eabi-gdb -q ./build/RTOSDemo.axf
 (gdb) c
 ```
 
-2. tcpdump
-To monitor packets received to qemu running the qemu command (qemu-system-arm)
-    shown above will create a network packet dump that you could inspect with
-
+4. The above QEMU command creates a network packet dump in the file
+`/tmp/qemu_tap_dump` which you can examine using `tcpdump` or WireShark:
+```shell
+sudo tcpdump -r /tmp/qemu_tap_dump  | less
 ```
-$ sudo tcpdump -r /tmp/qemu_tap_dump  | less
-```
-

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Echo_Qemu_mps2/Readme.md
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Echo_Qemu_mps2/Readme.md
@@ -313,8 +313,8 @@ make
 
 7. Run:
 ```shell
-sudo qemu-system-arm -machine mps2-an385 -cpu cortex-m3
-          -kernel ./build/RTOSDemo.axf \
+sudo qemu-system-arm -machine mps2-an385 -cpu cortex-m3 \
+          -kernel ./build/freertos_tcp_mps2_demo.axf \
           -netdev tap,id=mynet0,ifname=virbr0-nic,script=no \
           -net nic,macaddr=52:54:00:12:34:AD,model=lan9118,netdev=mynet0 \
           -object filter-dump,id=tap_dump,netdev=mynet0,file=/tmp/qemu_tap_dump\
@@ -339,8 +339,8 @@ make DEBUG=1
 
 2. Start QEMU in the paused state waiting for GDB connection:
 ```shell
-sudo qemu-system-arm -machine mps2-an385 -cpu cortex-m3 -s -S
-          -kernel ./build/RTOSDemo.axf \
+sudo qemu-system-arm -machine mps2-an385 -cpu cortex-m3 -s -S \
+          -kernel ./build/freertos_tcp_mps2_demo.axf \
           -netdev tap,id=mynet0,ifname=virbr0-nic,script=no \
           -net nic,macaddr=52:54:00:12:34:AD,model=lan9118,netdev=mynet0 \
           -object filter-dump,id=tap_dump,netdev=mynet0,file=/tmp/qemu_tap_dump\
@@ -350,7 +350,7 @@ sudo qemu-system-arm -machine mps2-an385 -cpu cortex-m3 -s -S
 
 3. Run GDB:
 ```shell
-$ arm-none-eabi-gdb -q ./build/RTOSDemo.axf
+$ arm-none-eabi-gdb -q ./build/freertos_tcp_mps2_demo.axf
 
 (gdb) target remote :1234
 (gdb) break main

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Echo_Qemu_mps2/Readme.md
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Echo_Qemu_mps2/Readme.md
@@ -60,21 +60,30 @@ runs in the Virtual Machine (VM) and Echo Server runs on the host machine.
 
 ## Launch Echo Server
 Launch Echo Server on the host machine.
-If you are using a Linux machine, you can use the following command to start an Echo Server on port 7:
-```shell
-sudo nc -l 7
-```
+### Host OS is Linux
+* Install `netcat`:
+   ```
+   sudo apt install netcat
+   ```
+* Start an Echo Server on port 7:
+   ```shell
+   sudo nc -l 7
+   ```
 
-If you are using a Windows machine, you can install [Npcap/Nmap](https://nmap.org/download.html#windows) and use the following command to start
-an Echo Server on port 7:
+### Host OS is Windows
+* Install [Npcap/Nmap](https://nmap.org/download.html#windows).
+* Start an Echo Server on port 7:
 ```shell
 ncat -l 7
 ```
 
-If you are using a MAC machine, you can use the following command to start
-an Echo Server on port 7:
+### Host OS is Mac
+* Install `netcat`:
+   ```shell
+   brew install netcat
+   ```
+* Start an Echo Server on port 7:
 ```shell
-brew install netcat
 nc -l -p 7
 ```
 

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Echo_Qemu_mps2/Readme.md
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Echo_Qemu_mps2/Readme.md
@@ -3,44 +3,22 @@ This FreeRTOS+TCP example demonstrates a TCP Echo Client which sends
 echo requests to an Echo Server and then receives the echo reply. The
 Echo Client runs on the MPS2 Cortex-M3 AN385 platform emulated using QEMU.
 
-## Requirements
-1. GNU Arm Embedded Toolchain download [here](https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm/downloads).
-3. `qemu-arm-system` download [here](https://www.qemu.org/download).
-2. Make (Version 4.3)
-4. Linux OS (tested on Ubuntu 22.04).
-
-## How to download
-Navigate to a directory of your choice and run the following command -
-```shell
-$ git clone https://github.com/FreeRTOS/FreeRTOS.git --recurse-submodules --depth 1
-```
-The previous command creates a directory named **FreeRTOS**.
-
-## Setup
+## Setup Description
 The demo requires 2 components -
 1. Echo Client - The demo in this repository.
 1. Echo Server - An external echo server.
 
-There are two options to run these components-
-1. Echo Client and Echo Server run on 2 different machines.
-```
-+-----------------+       +------------------+
-|                 |       |                  |
-|   Echo Client   |<----->|    Echo Server   |
-|                 |       |                  |
-+-----------------+       +------------------+
-    Machine 1                  Machine 2
-```
-
-2. Utilize Virtual Machine (VM) to run Echo Client and Echo Server on the same
-physical machine. Echo Client runs in a Virtual Machine (VM) and Echo Server
-runs on the host machine.
+We need a Virtual Machine (VM) running Linux OS to run this demo. Echo Client
+runs in the Virtual Machine (VM) and Echo Server runs on the host machine.
 ```
 +--------------------------------------------------------+
-|  Host                                                  |
-|                                                        |
+|  Host Machine                                          |
+|  OS - Any                                              |
+|  Runs - Echo Server                                    |
 |                          +--------------------------+  |
 |                          | Virtual Machine (VM)     |  |
+|                          | OS - Linux               |  |
+|                          | Runs - Echo Client       |  |
 |                          |                          |  |
 |  +----------------+      |    +----------------+    |  |
 |  |                |      |    |                |    |  |
@@ -53,40 +31,49 @@ runs on the host machine.
 |                          |                          |  |
 |                          +--------------------------+  |
 +--------------------------------------------------------+
-
-                     Machine
 ```
 
-The remaining document assumes option 2.
+## Setting up VM
+1. Install a Virtual Machine software on your machine. On Windows you can use
+[Oracle VirtualBox](https://www.virtualbox.org/) and on Mac you can use
+[Parallels](https://www.parallels.com/products/desktop/).
+2. Launch a Linux VM. We tested using Ubuntu 22.04.
+3. Install the following tools in the VM:
+   * [GNU Arm Embedded Toolchain](https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm/downloads).
+   * [qemu-arm-system](https://www.qemu.org/download).
+   * Make (Version 4.3):
+     ```
+     sudo apt install make
+     ```
+   * ipcalc:
+     ```
+     sudo apt install ipcalc
+     ```
+4. Clone the source code in the VM:
+    ```shell
+    git clone https://github.com/FreeRTOS/FreeRTOS.git --recurse-submodules --depth 1
+    ```
 
 ## Launch Echo Server
-Launch Echo Server on a machine. If you are using a Linux machine, you can
-use the following command to start an Echo Server on port 7:
+Launch Echo Server on the host machine. If you are using a Linux machine, you
+can use the following command to start an Echo Server on port 7:
 ```shell
 sudo nc -l 7
 ```
 
-## Enable Networking in QEMU
-The Echo Client in this demo runs in QEMU. We need to enable networking in
-QEMU to enable Echo Client to be able to reach to the Echo Server.
-```
-+---------------------------------------------------+
-|  Host                                             |
-|                                                   |
-|                                                   |
-|             +--------------------------------+    |
-|             |  QEMU                          |    |
-|             |                                |    |
-|             |                                |    |
-|             |                                |    |
-|             |                                |    |
-|             |                                |    |
-|             +--------------------------------+    |
-|                                                   |
-+---------------------------------------------------+
+If you are using a Windows machine, you can use the following command to start
+an Echo Server on port 7:
+```shell
+netcat -l 7
 ```
 
-1. Run the `ifconfig` command to find the host's network interface details:
+## Enable Networking in QEMU
+The Echo Client in this demo runs in QEMU inside the VM. We need to enable
+networking in QEMU to enable the Echo Client to be able to reach the Echo
+Server. Do the following steps in the VM:
+
+
+1. Run the `ifconfig` command to find the VM's network interface details:
 ```
 enp0s3: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 9001
           inet 192.168.1.81  netmask 255.255.255.0  broadcast 192.168.15.255
@@ -99,69 +86,68 @@ enp0s3: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 9001
 
 ```
 
-2. Define a shell variable `HOST_NETWORK_INTERFACE` and set its value to the
-name of the network interface of the host machine. For example, in the above
-output of the `ifconfig` command, name of the the network interface `enp0s3`:
+2. Define a shell variable `VM_NETWORK_INTERFACE` and set its value to the
+name of the network interface of the VM. For example, in the above output
+of the `ifconfig` command, name of the the network interface is `enp0s3`:
 ```shell
-export HOST_NETWORK_INTERFACE=enp0s3
+export VM_NETWORK_INTERFACE=enp0s3
 ```
 
-3. Define a shell variable `HOST_IP_ADDRESS` and set its value to the IP address
-of the host machine. For example, in the above output of the `ifconfig` command,
-IP address of the host machine is `192.168.1.81`:
+3. Define a shell variable `VM_IP_ADDRESS` and set its value to the IP address
+of the VM. For example, in the above output of the `ifconfig` command, IP
+address of the VM is `192.168.1.81`:
 ```shell
-export HOST_IP_ADDRESS=192.168.1.81
+export VM_IP_ADDRESS=192.168.1.81
 ```
 
-4. Define a shell variable `HOST_NETMASK` and set its value to the netmask of
-the host machine. For example, in the above output of the `ifconfig` command,
-netmask of the host machine is `255.255.255.0`:
+4. Define a shell variable `VM_NETMASK` and set its value to the netmask of
+the VM. For example, in the above output of the `ifconfig` command, netmask
+of the VM is `255.255.255.0`:
 ```shell
-export HOST_NETMASK=255.255.255.0
+export VM_NETMASK=255.255.255.0
 ```
 
-5. Calculate the CIDR of the host from the netmask. If you have `ipcalc`
-installed, you can use the following command to find CIDR:
+5. Calculate the CIDR of the VM from the netmask:
 ```shell
-$ ipcalc -b 1.1.1.1 $HOST_NETMASK | grep Netmask
+$ ipcalc -b 1.1.1.1 $VM_NETMASK | grep Netmask
 Netmask:   255.255.255.0 = 24
 ```
 CIDR is `24` in the above output.
 
-6. Define a shell variable `HOST_CIDR` and set its value to the CIDR of
-the host machine found in the above step.
+6. Define a shell variable `VM_CIDR` and set its value to the CIDR of the VM
+found in the above step.
 ```shell
-export HOST_CIDR=24
+export VM_CIDR=24
 ```
 
-7. Find the Default Gateway for the host machine:
+7. Find the Default Gateway for the VM:
 ```shell
 $ ip route show
 default via 192.168.1.254 dev enp0s3 proto dhcp src 192.168.1.81 metric 100
 ```
 Default Gateway is `192.168.1.254` in the above output.
 
-8. Define a shell variable `HOST_DEFAULT_GATEWAY` and set its value to the
-Default Gateway of the host machine found in the above step.
+8. Define a shell variable `VM_DEFAULT_GATEWAY` and set its value to the
+Default Gateway of the VM found in the above step.
 ```shell
-export HOST_DEFAULT_GATEWAY=192.168.1.254
+export VM_DEFAULT_GATEWAY=192.168.1.254
 ```
 
-9. Find the DNS Server of the host machine:
+9. Find the DNS Server of the VM:
 ```shell
 $ grep "nameserver" /etc/resolv.conf
 nameserver 192.168.1.254
 ```
 
-10. Define a shell variable `HOST_DNS_SERVER` and set its value to the
+10. Define a shell variable `VM_DNS_SERVER` and set its value to the
 DNS Server of the host machine found in the above step.
 ```shell
-export HOST_DNS_SERVER=192.168.1.254
+export VM_DNS_SERVER=192.168.1.254
 ```
 
-11. Pick an IP address for the QEMU which is in the same network as the host
-machine. This IP address must not be in-use by any other machine on the same
-network. Define a shell variable `QEMU_IP_ADDRESS` and set its value to the
+11. Pick an IP address for the QEMU which is in the same network as the VM.
+This IP address must not be in-use by any other machine on the same network.
+Define a shell variable `QEMU_IP_ADDRESS` and set its value to the
 picked IP Address. For example, run the following command if you picked
 `192.168.1.80`:
 ```shell
@@ -176,13 +162,14 @@ export QEMU_MAC_ADDRESS=52:54:00:12:34:AD
 ```
 
 13. Define a shell variable `ECHO_SERVER_IP_ADDRESS` and set its value to the
-IP address of the Echo Server. For example, run the following command if the
-IP address of the Echo Server is `192.168.1.204`:
+IP address of the Echo Server which is running on the host. For example,
+run the following command if the IP address of the Echo Server is
+`192.168.1.204`:
 ```shell
 export ECHO_SERVER_IP_ADDRESS=192.168.1.204
 ```
 
-14. Turn off firewall on the host machine.
+14. Turn off firewall on the VM.
 On Ubuntu run:
 ```shell
 sudo ufw disable
@@ -200,23 +187,23 @@ networking in QEMU.
 sudo ip link add virbr0 type bridge
 sudo ip tuntap add dev virbr0-nic mode tap
 
-sudo ip addr add $HOST_IP_ADDRESS/$HOST_CIDR dev virbr0
+sudo ip addr add $VM_IP_ADDRESS/$VM_CIDR dev virbr0
 
-sudo brctl addif virbr0 $HOST_NETWORK_INTERFACE
+sudo brctl addif virbr0 $VM_NETWORK_INTERFACE
 sudo brctl addif virbr0 virbr0-nic
 
 sudo ip link set virbr0 up
 sudo ip link set virbr0-nic up
 
-sudo ip route add default via $HOST_DEFAULT_GATEWAY dev virbr0
+sudo ip route add default via $VM_DEFAULT_GATEWAY dev virbr0
 ```
 
 The following diagram shows the setup:
 ```
 +-------------------------------------------------------------------------+
-|   Host                                                                  |
+|   Virtual Machine (VM)                                                  |
 |                                                                         |
-|     +-------------------------+                                         | Host NIC (enp0s3)
+|     +-------------------------+                                         | VM NIC (enp0s3)
 |     |                         | Virtual NIC (virbr0-nic)                +--+
 |     |  QEMU                   +--+                                      |  |
 |     |                         |  |          +--------------+            |  |
@@ -231,6 +218,7 @@ The following diagram shows the setup:
 ```
 
 ## Build and Run
+Do the following steps in the VM where you cloned the code:
 
 1. Set `configIP_ADDR0`-`configIP_ADDR3` in `FreeRTOSIPConfig.h` to the value
 of `QEMU_IP_ADDRESS`:
@@ -245,9 +233,9 @@ echo $QEMU_IP_ADDRESS
 ```
 
 2. Set `configNET_MASK0`-`configNET_MASK3` in `FreeRTOSIPConfig.h` to the value
-of `HOST_NETMASK`:
+of `VM_NETMASK`:
 ```shell
-echo $HOST_NETMASK
+echo $VM_NETMASK
 ```
 ```c
 #define configNET_MASK0         255
@@ -257,9 +245,9 @@ echo $HOST_NETMASK
 ```
 
 3. Set `configGATEWAY_ADDR0`-`configGATEWAY_ADDR3` in `FreeRTOSIPConfig.h` to
-the value of `HOST_DEFAULT_GATEWAY`:
+the value of `VM_DEFAULT_GATEWAY`:
 ```shell
-echo $HOST_DEFAULT_GATEWAY
+echo $VM_DEFAULT_GATEWAY
 ```
 ```c
 #define configGATEWAY_ADDR0     192
@@ -269,9 +257,9 @@ echo $HOST_DEFAULT_GATEWAY
 ```
 
 4. Set `configDNS_SERVER_ADDR0`-`configDNS_SERVER_ADDR3` in `FreeRTOSIPConfig.h`
-to the value of `HOST_DNS_SERVER`:
+to the value of `VM_DNS_SERVER`:
 ```shell
-echo $HOST_DNS_SERVER
+echo $VM_DNS_SERVER
 ```
 ```c
 #define configDNS_SERVER_ADDR0  192
@@ -323,7 +311,7 @@ sudo qemu-system-arm -machine mps2-an385 -cpu cortex-m3 \
 ```
 
 8. You should see that following output on the terminal of the Echo Server (which
-is running `sudo nc -l 7`):
+is running `sudo nc -l 7` or `netcat -l 7` depending on your OS):
 ```
 0FGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~0123456789:;<=> ?
 @ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~0123456789:;<=>?

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Echo_Qemu_mps2/Readme.md
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Echo_Qemu_mps2/Readme.md
@@ -73,9 +73,9 @@ Launch Echo Server on the host machine.
 ### Host OS is Windows
 * Install [Npcap/Nmap](https://nmap.org/download.html#windows).
 * Start an Echo Server on port 7:
-```shell
-ncat -l 7
-```
+    ```shell
+    ncat -l 7
+    ```
 
 ### Host OS is Mac
 * Install `netcat`:
@@ -83,9 +83,9 @@ ncat -l 7
    brew install netcat
    ```
 * Start an Echo Server on port 7:
-```shell
-nc -l -p 7
-```
+    ```shell
+    nc -l -p 7
+    ```
 
 ## Enable Networking in QEMU
 The Echo Client in this demo runs in QEMU inside the VM. We need to enable

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Echo_Qemu_mps2/Readme.md
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Echo_Qemu_mps2/Readme.md
@@ -28,15 +28,18 @@ virbr0-nic: veth virtual interface (to be created)
 To setup the system for running the QEMU demo, please check these steps.
 ```
 1. Setting up the client-server system
-    a. Option-1 : The demo can be run on 2 different systems, one with the client running FreeRTOS system in qemu and another running the echo server.
-    b. Option-2 : The demo could also be run on 1 system, with the QEMU client running on Ubuntu Virtual Machine (VM) and the host OS (Windows/MAC/Linux) running the server.
+    a. Option-1 : The demo can be run on 2 different systems, one with the client running FreeRTOS system in qemu 
+        and another running the echo server.
+    b. Option-2 : The demo could also be run on 1 system, with the QEMU client running on Ubuntu Virtual Machine (VM) and the 
+        host OS (Windows/MAC/Linux) running the server.
 
 2. Setting up MAC and IP Address
-    a. Local FreeRTOS MAC address : Set a unique MAC address for the QEMU client
+    a. Local FreeRTOS MAC address( configMAC_ADDR0~3 ) : Set a unique MAC address for the QEMU client 
     b. Local Host IP address : IP of the system running the Qemu client
-    c. The Local FreeRTOS IP address should be an unused local IP on the QEMU network.
-    d. The subnet mask, Gateway and DNS address should match that of the QEMU client network.
-    e. Echo server address : IP of the system running the echo server .
+    c. The Local FreeRTOS IP address( configIP_ADDR0~3 ) should be an unused local IP on the QEMU network.
+    d. The subnet mask( configNET_MASK0~3 ), Gateway( configGATEWAY_ADDR0~3 ) and DNS address( configDNS_SERVER_ADDR0~3 ) 
+        should match that of the QEMU client network.
+    e. Echo server address( configECHO_SERVER_ADDR0~3 ) : IP of the system running the echo server .
 ```
 A block diagram to show the QEMU demo setup process :
 

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Echo_Qemu_mps2/Readme.md
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Echo_Qemu_mps2/Readme.md
@@ -240,7 +240,7 @@ The following diagram shows the setup:
 ## Build and Run
 Do the following steps in the VM where you cloned the code:
 
-1. Set `configIP_ADDR0`-`configIP_ADDR3` in `FreeRTOSIPConfig.h` to the value
+1. Set `configIP_ADDR0`-`configIP_ADDR3` in `FreeRTOSConfig.h` to the value
 of `QEMU_IP_ADDRESS`:
 ```shell
 echo $QEMU_IP_ADDRESS
@@ -252,7 +252,7 @@ echo $QEMU_IP_ADDRESS
 #define configIP_ADDR3          80
 ```
 
-2. Set `configNET_MASK0`-`configNET_MASK3` in `FreeRTOSIPConfig.h` to the value
+2. Set `configNET_MASK0`-`configNET_MASK3` in `FreeRTOSConfig.h` to the value
 of `VM_NETMASK`:
 ```shell
 echo $VM_NETMASK
@@ -264,7 +264,7 @@ echo $VM_NETMASK
 #define configNET_MASK3         0
 ```
 
-3. Set `configGATEWAY_ADDR0`-`configGATEWAY_ADDR3` in `FreeRTOSIPConfig.h` to
+3. Set `configGATEWAY_ADDR0`-`configGATEWAY_ADDR3` in `FreeRTOSConfig.h` to
 the value of `VM_DEFAULT_GATEWAY`:
 ```shell
 echo $VM_DEFAULT_GATEWAY
@@ -276,7 +276,7 @@ echo $VM_DEFAULT_GATEWAY
 #define configGATEWAY_ADDR3     254
 ```
 
-4. Set `configDNS_SERVER_ADDR0`-`configDNS_SERVER_ADDR3` in `FreeRTOSIPConfig.h`
+4. Set `configDNS_SERVER_ADDR0`-`configDNS_SERVER_ADDR3` in `FreeRTOSConfig.h`
 to the value of `VM_DNS_SERVER`:
 ```shell
 echo $VM_DNS_SERVER
@@ -288,7 +288,7 @@ echo $VM_DNS_SERVER
 #define configDNS_SERVER_ADDR3  254
 ```
 
-5. Set `configMAC_ADDR0`-`configMAC_ADDR5` in `FreeRTOSIPConfig.h` to the value
+5. Set `configMAC_ADDR0`-`configMAC_ADDR5` in `FreeRTOSConfig.h` to the value
 of `QEMU_MAC_ADDRESS`:
 ```shell
 echo $QEMU_MAC_ADDRESS
@@ -302,7 +302,7 @@ echo $QEMU_MAC_ADDRESS
 #define configMAC_ADDR5         0xAD
 ```
 
-6. Set `configECHO_SERVER_ADDR0`-`configECHO_SERVER_ADDR3` in `FreeRTOSIPConfig.h`
+6. Set `configECHO_SERVER_ADDR0`-`configECHO_SERVER_ADDR3` in `FreeRTOSConfig.h`
 to the value of `ECHO_SERVER_IP_ADDRESS`:
 ```shell
 echo $ECHO_SERVER_IP_ADDRESS

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Echo_Qemu_mps2/Readme.md
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Echo_Qemu_mps2/Readme.md
@@ -6,8 +6,8 @@ Echo Client runs on the MPS2 Cortex-M3 AN385 platform emulated using QEMU.
 ## Requirements
 1. GNU Arm Embedded Toolchain download [here](https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm/downloads).
 3. `qemu-arm-system` download [here](https://www.qemu.org/download).
-2. Make.
-4. Linux OS (tested on Ubuntu 18.04).
+2. Make (Version 4.3)
+4. Linux OS (tested on Ubuntu 22.04).
 
 ## How to download
 Navigate to a directory of your choice and run the following command -
@@ -32,7 +32,7 @@ There are two options to run these components-
     Machine 1                  Machine 2
 ```
 
-1. Utilize Virtual Machine (VM) to run Echo Client and Echo Server on the same
+2. Utilize Virtual Machine (VM) to run Echo Client and Echo Server on the same
 physical machine. Echo Client runs in a Virtual Machine (VM) and Echo Server
 runs on the host machine.
 ```
@@ -57,7 +57,7 @@ runs on the host machine.
                      Machine
 ```
 
-The remaining document assumes option 1.
+The remaining document assumes option 2.
 
 ## Launch Echo Server
 Launch Echo Server on a machine. If you are using a Linux machine, you can
@@ -316,7 +316,7 @@ make
 sudo qemu-system-arm -machine mps2-an385 -cpu cortex-m3 \
           -kernel ./build/freertos_tcp_mps2_demo.axf \
           -netdev tap,id=mynet0,ifname=virbr0-nic,script=no \
-          -net nic,macaddr=52:54:00:12:34:AD,model=lan9118,netdev=mynet0 \
+          -net nic,macaddr=$QEMU_MAC_ADDRESS,model=lan9118,netdev=mynet0 \
           -object filter-dump,id=tap_dump,netdev=mynet0,file=/tmp/qemu_tap_dump\
           -display gtk -m 16M  -nographic -serial stdio \
           -monitor null -semihosting -semihosting-config enable=on,target=native
@@ -342,7 +342,7 @@ make DEBUG=1
 sudo qemu-system-arm -machine mps2-an385 -cpu cortex-m3 -s -S \
           -kernel ./build/freertos_tcp_mps2_demo.axf \
           -netdev tap,id=mynet0,ifname=virbr0-nic,script=no \
-          -net nic,macaddr=52:54:00:12:34:AD,model=lan9118,netdev=mynet0 \
+          -net nic,macaddr=$QEMU_MAC_ADDRESS,model=lan9118,netdev=mynet0 \
           -object filter-dump,id=tap_dump,netdev=mynet0,file=/tmp/qemu_tap_dump\
           -display gtk -m 16M  -nographic -serial stdio \
           -monitor null -semihosting -semihosting-config enable=on,target=native

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Echo_Qemu_mps2/Readme.md
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Echo_Qemu_mps2/Readme.md
@@ -49,22 +49,33 @@ runs in the Virtual Machine (VM) and Echo Server runs on the host machine.
      ```
      sudo apt install ipcalc
      ```
+   * brctl:
+     ```
+     sudo apt install bridge-utils
+     ```
 4. Clone the source code in the VM:
     ```shell
     git clone https://github.com/FreeRTOS/FreeRTOS.git --recurse-submodules --depth 1
     ```
 
 ## Launch Echo Server
-Launch Echo Server on the host machine. If you are using a Linux machine, you
-can use the following command to start an Echo Server on port 7:
+Launch Echo Server on the host machine.
+If you are using a Linux machine, you can use the following command to start an Echo Server on port 7:
 ```shell
 sudo nc -l 7
 ```
 
-If you are using a Windows machine, you can use the following command to start
+If you are using a Windows machine, you can install [Npcap/Nmap](https://nmap.org/download.html#windows) and use the following command to start
 an Echo Server on port 7:
 ```shell
-netcat -l 7
+ncat -l 7
+```
+
+If you are using a MAC machine, you can use the following command to start
+an Echo Server on port 7:
+```shell
+brew install netcat
+nc -l -p 7
 ```
 
 ## Enable Networking in QEMU

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Echo_Qemu_mps2/Readme.md
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Echo_Qemu_mps2/Readme.md
@@ -23,6 +23,46 @@ enp0s3:     ethernet interface
 virbr0:     virtual bridge         (to be created)
 virbr0-nic: veth virtual interface (to be created)
 ```
+## Setting up the QEMU Demo
+
+To setup the system for running the QEMU demo, please check these steps.
+```
+1. Setting up the client-server system
+    a. Option-1 : The demo can be run on 2 different systems, one with the client running FreeRTOS system in qemu and another running the echo server.
+    b. Option-2 : The demo could also be run on 1 system, with the QEMU client running on Ubuntu Virtual Machine (VM) and the host OS (Windows/MAC/Linux) running the server.
+
+2. Setting up MAC and IP Address
+    a. Local FreeRTOS MAC address : Set a unique MAC address for the QEMU client
+    b. Local Host IP address : IP of the system running the Qemu client
+    c. The Local FreeRTOS IP address should be an unused local IP on the QEMU network.
+    d. The subnet mask, Gateway and DNS address should match that of the QEMU client network.
+    e. Echo server address : IP of the system running the echo server .
+```
+A block diagram to show the QEMU demo setup process :
+
+```
+        Linux Host(remote system/VM on server)
+ ┌───────────────────────────────────────────────┐
+ │      Host IP (eth0/ensp03)                    ├──────┐
+ │                                               │      │
+ │                                               │      │
+ │  ┌────────────────────────────┬──────────────┬┤      │
+ │  │Virtual Bridge Setup : vibr0│              ││      │
+ │  │FreeRTOS IPaddress          │   QEMU system││      │
+ │  ├───────┬───────────────┬────┘              ││      │
+ │  │       ├───────────────┤                   ││      │
+ │  │       │NIC : vibr0-nic│                   ││      │
+ │  ├───────┼───────────────┼───────────────────┼│      │
+ └──┴──────────────┼──▲──────────────────────────┘    ┌─┴───────┐
+                   │  │                               │same     │
+Echo Server Port   │  │                               │physical │
+                   │  │                               │network  │
+           ┌───────▼──┴──────┐                        └─┬───────┘
+           │ Echo server IP  │                          │
+           └─────────────────┴──────────────────────────┘
+
+    Windows/MAC/Linux Server
+```
 ### A few assumptions (your numbers could vary)
 ```
 Local Host IP address:          192.168.1.81

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Echo_Qemu_mps2/Readme.md
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Echo_Qemu_mps2/Readme.md
@@ -299,7 +299,7 @@ echo $ECHO_SERVER_IP_ADDRESS
 make
 ```
 
-7. Run:
+8. Run:
 ```shell
 sudo qemu-system-arm -machine mps2-an385 -cpu cortex-m3 \
           -kernel ./build/freertos_tcp_mps2_demo.axf \
@@ -310,7 +310,7 @@ sudo qemu-system-arm -machine mps2-an385 -cpu cortex-m3 \
           -monitor null -semihosting -semihosting-config enable=on,target=native
 ```
 
-8. You should see that following output on the terminal of the Echo Server (which
+9. You should see that following output on the terminal of the Echo Server (which
 is running `sudo nc -l 7` or `netcat -l 7` depending on your OS):
 ```
 0FGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~0123456789:;<=> ?


### PR DESCRIPTION
Update the documentation for Readme of the FreeRTOS_PLUS_TCP_ECHO_QEMU_msp2

Description
-----------
The documentation for the ReadMe for the QEMU demo is updated , with focus on giving a clear understanding to the user of :

1. The various address need to be set as part of configuration
2. The systems needed to run the Demo on (https://forums.freertos.org/t/example-freertos-tcp-echo-qemu-is-not-providing-the-desirable-result/)
3. A pictorial representation on how the QEMU setup functions after the Virtual Bridge is setup.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
