### PR TITLE
Show how to use picolibc in a couple of demos

### DIFF
--- a/FreeRTOS/Demo/CORTEX_M3_MPS2_QEMU_GCC/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_M3_MPS2_QEMU_GCC/FreeRTOSConfig.h
@@ -62,7 +62,7 @@ extern void vAssertCalled( const char * pcFileName,
 #endif /* __NEWLIB__ */
 
 #define configUSE_PREEMPTION                             1
-#define configUSE_TIME_SLICING                           1
+#define configUSE_TIME_SLICING                           0
 #define configUSE_PORT_OPTIMISED_TASK_SELECTION          0
 
 #define configUSE_IDLE_HOOK                              1
@@ -70,8 +70,7 @@ extern void vAssertCalled( const char * pcFileName,
 #define configUSE_DAEMON_TASK_STARTUP_HOOK               0
 #define configCPU_CLOCK_HZ                               ( ( unsigned long ) 20000000 )
 #define configTICK_RATE_HZ                               ( ( TickType_t ) 1000 )
-#define configMINIMAL_STACK_SIZE                         ( ( unsigned short ) 2000 )
-#define configTOTAL_HEAP_SIZE                            ( ( size_t ) ( 900 ) )
+#define configMINIMAL_STACK_SIZE                         ( 2048 )
 #define configMAX_TASK_NAME_LEN                          ( 10 )
 #define configUSE_TRACE_FACILITY                         1
 #define configUSE_16_BIT_TICKS                           0
@@ -83,7 +82,6 @@ extern void vAssertCalled( const char * pcFileName,
 #define configUSE_COUNTING_SEMAPHORES                    1
 #define configSUPPORT_DYNAMIC_ALLOCATION                 1
 #define configSUPPORT_STATIC_ALLOCATION                  1
-#define configNUM_TX_DESCRIPTORS                         15
 #define configSTREAM_BUFFER_TRIGGER_LEVEL_TEST_MARGIN    2
 #define configQUEUE_REGISTRY_SIZE                        20
 #define configUSE_QUEUE_SETS                             1

--- a/FreeRTOS/Demo/CORTEX_M3_MPS2_QEMU_GCC/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_M3_MPS2_QEMU_GCC/FreeRTOSConfig.h
@@ -39,13 +39,25 @@
 * See https://www.freertos.org/a00110.html
 *----------------------------------------------------------*/
 
-#define configASSERT_DEFINED                             1
-extern void vAssertCalled( void );
-#define configASSERT( x )    if( ( x ) == 0 ) vAssertCalled()
+#define configASSERT_DEFINED    1
+
+extern void vAssertCalled( const char * pcFileName,
+                           int line );
+
+#define __NAME_ARG__    ( __builtin_strrchr( __BASE_FILE__, '/' ) ? __builtin_strrchr( __BASE_FILE__, '/' ) + 1 : __BASE_FILE__ )
+
+#define configASSERT( x )                            \
+    do {                                             \
+        if( ( x ) == 0 ) {                           \
+            vAssertCalled( __NAME_ARG__, __LINE__ ); \
+        }                                            \
+    } while( 0 )
+
+
 #define configQUEUE_REGISTRY_SIZE                        20
 
 #ifdef PICOLIBC_TLS
-#define configUSE_PICOLIBC_TLS                           1
+    #define configUSE_PICOLIBC_TLS                       1
 #endif
 
 #define configUSE_PREEMPTION                             1

--- a/FreeRTOS/Demo/CORTEX_M3_MPS2_QEMU_GCC/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_M3_MPS2_QEMU_GCC/FreeRTOSConfig.h
@@ -44,6 +44,10 @@ extern void vAssertCalled( void );
 #define configASSERT( x )    if( ( x ) == 0 ) vAssertCalled()
 #define configQUEUE_REGISTRY_SIZE                        20
 
+#ifdef PICOLIBC_TLS
+#define configUSE_PICOLIBC_TLS                           1
+#endif
+
 #define configUSE_PREEMPTION                             1
 #define configUSE_TIME_SLICING                           0
 #define configUSE_PORT_OPTIMISED_TASK_SELECTION          0

--- a/FreeRTOS/Demo/CORTEX_M3_MPS2_QEMU_GCC/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_M3_MPS2_QEMU_GCC/FreeRTOSConfig.h
@@ -53,15 +53,16 @@ extern void vAssertCalled( const char * pcFileName,
         }                                            \
     } while( 0 )
 
-
-#define configQUEUE_REGISTRY_SIZE                        20
-
-#ifdef PICOLIBC_TLS
+#ifdef __PICOLIBC__
     #define configUSE_PICOLIBC_TLS                       1
-#endif
+#endif /* __PICOLIBC__ */
+
+#ifdef __NEWLIB__
+    #define configUSE_NEWLIB_REENTRANT                   1
+#endif /* __NEWLIB__ */
 
 #define configUSE_PREEMPTION                             1
-#define configUSE_TIME_SLICING                           0
+#define configUSE_TIME_SLICING                           1
 #define configUSE_PORT_OPTIMISED_TASK_SELECTION          0
 
 #define configUSE_IDLE_HOOK                              1
@@ -82,8 +83,10 @@ extern void vAssertCalled( const char * pcFileName,
 #define configUSE_COUNTING_SEMAPHORES                    1
 #define configSUPPORT_DYNAMIC_ALLOCATION                 1
 #define configSUPPORT_STATIC_ALLOCATION                  1
-#define  configNUM_TX_DESCRIPTORS                        15
+#define configNUM_TX_DESCRIPTORS                         15
 #define configSTREAM_BUFFER_TRIGGER_LEVEL_TEST_MARGIN    2
+#define configQUEUE_REGISTRY_SIZE                        20
+#define configUSE_QUEUE_SETS                             1
 
 /* Set the following definitions to 1 to include the API function, or zero
  * to exclude the API function. */

--- a/FreeRTOS/Demo/CORTEX_M3_MPS2_QEMU_GCC/Makefile
+++ b/FreeRTOS/Demo/CORTEX_M3_MPS2_QEMU_GCC/Makefile
@@ -67,26 +67,33 @@ endif
 DEFINES :=  -DQEMU_SOC_MPS2 -DHEAP3
 
 LDFLAGS = -T ./scripts/mps2_m3.ld
-ifneq ($(PICOLIBC), 1)
-LDFLAGS += -specs=nano.specs --specs=rdimon.specs -lc -lrdimon
+
+ifeq ($(PICOLIBC), 1)
+    LDFLAGS += -lc
+    CFLAGS += -specs=picolibc.specs --oslib=semihost -DPICOLIBC_INTEGER_PRINTF_SCANF -DPICOLIBC_TLS --include picolibc.h
+else
+    LDFLAGS += -lc -lrdimon
+    CFLAGS +=  -specs=nano.specs --specs=rdimon.specs --include newlib.h
 endif
+
 LDFLAGS += -Xlinker -Map=${BUILD_DIR}/output.map
 LDFLAGS += -Wl,--gc-sections
 
-CFLAGS += -nostartfiles -mthumb -mcpu=cortex-m3 -Wno-error=implicit-function-declaration
+CFLAGS += -nostartfiles
+CFLAGS += -mthumb
+CFLAGS += -mcpu=cortex-m3
+CFLAGS += -Wno-error=implicit-function-declaration
 CFLAGS += -Wno-builtin-declaration-mismatch -Werror
 CFLAGS += -Wall -Wextra
 CFLAGS += -ffunction-sections -fdata-sections
-ifeq ($(PICOLIBC), 1)
-CFLAGS += -specs=picolibc.specs -DPICOLIBC_INTEGER_PRINTF_SCANF
-endif
 
 ifeq ($(DEBUG), 1)
     CFLAGS += -ggdb3 -Og
 else
     CFLAGS += -O3
 endif
-    CFLAGS += -fstrict-aliasing -Wstrict-aliasing -Wno-error=address-of-packed-member
+
+CFLAGS += -fstrict-aliasing -Wstrict-aliasing -Wno-error=address-of-packed-member
 
 OBJ_FILES := $(SOURCE_FILES:%.c=$(BUILD_DIR)/%.o)
 
@@ -113,4 +120,3 @@ ${BUILD_DIR}/%.o : %.c Makefile
 
 clean:
 	-rm -rf build
-

--- a/FreeRTOS/Demo/CORTEX_M3_MPS2_QEMU_GCC/Makefile
+++ b/FreeRTOS/Demo/CORTEX_M3_MPS2_QEMU_GCC/Makefile
@@ -66,7 +66,10 @@ endif
 
 DEFINES :=  -DQEMU_SOC_MPS2 -DHEAP3
 
-LDFLAGS = -T ./scripts/mps2_m3.ld -specs=nano.specs --specs=rdimon.specs -lc -lrdimon
+LDFLAGS = -T ./scripts/mps2_m3.ld
+ifneq ($(PICOLIBC), 1)
+LDFLAGS += -specs=nano.specs --specs=rdimon.specs -lc -lrdimon
+endif
 LDFLAGS += -Xlinker -Map=${BUILD_DIR}/output.map
 LDFLAGS += -Wl,--gc-sections
 
@@ -74,6 +77,9 @@ CFLAGS += -nostartfiles -mthumb -mcpu=cortex-m3 -Wno-error=implicit-function-dec
 CFLAGS += -Wno-builtin-declaration-mismatch -Werror
 CFLAGS += -Wall -Wextra
 CFLAGS += -ffunction-sections -fdata-sections
+ifeq ($(PICOLIBC), 1)
+CFLAGS += -specs=picolibc.specs -DPICOLIBC_INTEGER_PRINTF_SCANF
+endif
 
 ifeq ($(DEBUG), 1)
     CFLAGS += -ggdb3 -Og

--- a/FreeRTOS/Demo/CORTEX_M3_MPS2_QEMU_GCC/Makefile
+++ b/FreeRTOS/Demo/CORTEX_M3_MPS2_QEMU_GCC/Makefile
@@ -68,10 +68,12 @@ DEFINES :=  -DQEMU_SOC_MPS2 -DHEAP3
 
 LDFLAGS = -T ./scripts/mps2_m3.ld -specs=nano.specs --specs=rdimon.specs -lc -lrdimon
 LDFLAGS += -Xlinker -Map=${BUILD_DIR}/output.map
+LDFLAGS += -Wl,--gc-sections
 
 CFLAGS += -nostartfiles -mthumb -mcpu=cortex-m3 -Wno-error=implicit-function-declaration
 CFLAGS += -Wno-builtin-declaration-mismatch -Werror
 CFLAGS += -Wall -Wextra
+CFLAGS += -ffunction-sections -fdata-sections
 
 ifeq ($(DEBUG), 1)
     CFLAGS += -ggdb3 -Og
@@ -88,7 +90,7 @@ CFLAGS += $(INCLUDE_DIRS)
 .PHONY: clean
 
 $(BUILD_DIR)/$(BIN) : $(OBJ_FILES)
-	$(CC) -ffunction-sections -fdata-sections $(CFLAGS) $(LDFLAGS) $+ -o $(@)
+	$(CC) $(CFLAGS) $(LDFLAGS) $+ -o $(@)
 
 %.d: %.c
 	@set -e; rm -f $@; \

--- a/FreeRTOS/Demo/CORTEX_M3_MPS2_QEMU_GCC/init/startup.c
+++ b/FreeRTOS/Demo/CORTEX_M3_MPS2_QEMU_GCC/init/startup.c
@@ -135,6 +135,7 @@ void Default_Handler2( void )
         " ldr r1, [r0, #24]                                         \n"
         " ldr r2, handler2_address_const                            \n"
         " bx r2                                                     \n"
+        " nop                                                       \n"
         " handler2_address_const: .word prvGetRegistersFromStack    \n"
     );
 }
@@ -167,7 +168,7 @@ void Default_Handler6( void )
     }
 }
 
-const uint32_t * isr_vector[] __attribute__( ( section( ".isr_vector" ) ) ) =
+const uint32_t * isr_vector[] __attribute__( ( section( ".isr_vector" ) , used ) ) =
 {
     ( uint32_t * ) &_estack,
     ( uint32_t * ) &Reset_Handler,       /* Reset                -15 */

--- a/FreeRTOS/Demo/CORTEX_M3_MPS2_QEMU_GCC/main.c
+++ b/FreeRTOS/Demo/CORTEX_M3_MPS2_QEMU_GCC/main.c
@@ -32,6 +32,7 @@
 #include <string.h>
 #include <stdarg.h>
 #include <stdio.h>
+#include <stdlib.h>
 
 void vApplicationStackOverflowHook( TaskHandle_t pxTask,
                                     char * pcTaskName );
@@ -56,17 +57,17 @@ StackType_t uxTimerTaskStack[ configTIMER_TASK_STACK_DEPTH ];
 int main()
 {
     #if ( mainCREATE_SIMPLE_BLINKY_DEMO_ONLY == 1 )
-        {
-            main_blinky();
-        }
+    {
+        main_blinky();
+    }
     #elif ( mainCREATE_FULL_DEMO_ONLY == 1 )
-        {
-            main_full();
-        }
+    {
+        main_full();
+    }
     #else
-        {
-            #error "Invalid Selection...\nPlease Select a Demo application from the main command"
-        }
+    {
+        #error "Invalid Selection...\nPlease Select a Demo application from the main command"
+    }
     #endif /* if ( mainCREATE_SIMPLE_BLINKY_DEMO_ONLY == 1 ) */
     return 0;
 }
@@ -108,11 +109,11 @@ void vApplicationStackOverflowHook( TaskHandle_t pxTask,
 void vApplicationIdleHook( void )
 {
     #if ( mainCREATE_FULL_DEMO_ONLY == 1 )
-        {
-            /* Call the idle task processing used by the full demo.  The simple
-             * blinky demo does not use the idle task hook. */
-            vFullDemoIdleFunction();
-        }
+    {
+        /* Call the idle task processing used by the full demo.  The simple
+         * blinky demo does not use the idle task hook. */
+        vFullDemoIdleFunction();
+    }
     #endif
 }
 /*-----------------------------------------------------------*/
@@ -120,28 +121,28 @@ void vApplicationIdleHook( void )
 void vApplicationTickHook( void )
 {
     #if ( mainCREATE_FULL_DEMO_ONLY == 1 )
-        {
-            vFullDemoTickHookFunction();
-        }
+    {
+        vFullDemoTickHookFunction();
+    }
     #endif /* mainSELECTED_APPLICATION */
 }
+
 /*-----------------------------------------------------------*/
 
-void vAssertCalled( void )
+void vAssertCalled( const char * pcFileName,
+                    int line )
 {
-    volatile unsigned long looping = 0;
+    printf( "Assertion failed at %s: %d\n", pcFileName, line );
+    fflush( NULL );
 
-    taskENTER_CRITICAL();
+    while( 1 )
     {
-        /* Use the debugger to set ul to a non-zero value in order to step out
-         *      of this function to determine why it was called. */
-        while( looping == 0LU )
-        {
-            portNOP();
-        }
+        asm ( "nop" );
     }
-    taskEXIT_CRITICAL();
+
+    exit( 1 );
 }
+
 /*-----------------------------------------------------------*/
 void vLoggingPrintf( const char * pcFormat,
                      ... )

--- a/FreeRTOS/Demo/CORTEX_M3_MPS2_QEMU_GCC/scripts/mps2_m3.ld
+++ b/FreeRTOS/Demo/CORTEX_M3_MPS2_QEMU_GCC/scripts/mps2_m3.ld
@@ -74,6 +74,27 @@ SECTIONS
         . = ALIGN(4);
     } >FLASH
 
+    .tdata : {
+        *(.tdata .tdata.*)
+    } >FLASH
+
+    .tbss (NOLOAD) : {
+        *(.tbss .tbss.* .gnu.linkonce.tb.*)
+        *(.tcommon)
+        PROVIDE( __tbss_end = . );
+        PROVIDE( __tls_end = . );
+    } >FLASH
+    PROVIDE( __tdata_source = LOADADDR(.tdata) );
+    PROVIDE( __tdata_source_end = LOADADDR(.tdata) + SIZEOF(.tdata) );
+    PROVIDE( __tdata_size = SIZEOF(.tdata) );
+    PROVIDE( __tbss_offset = ADDR(.tbss) - ADDR(.tdata) );
+    PROVIDE( __tbss_start = ADDR(.tbss) );
+    PROVIDE( __tbss_size = SIZEOF(.tbss) );
+    PROVIDE( __tls_size = __tls_end - ADDR(.tdata) );
+    PROVIDE( __tls_align = MAX(ALIGNOF(.tdata), ALIGNOF(.tbss)) );
+    PROVIDE( __arm32_tls_tcb_offset = MAX(8, __tls_align) );
+    PROVIDE( __arm64_tls_tcb_offset = MAX(16, __tls_align) );
+
     .interrupts_ram :
     {
         . = ALIGN(4);

--- a/FreeRTOS/Demo/CORTEX_M3_MPS2_QEMU_GCC/scripts/mps2_m3.ld
+++ b/FreeRTOS/Demo/CORTEX_M3_MPS2_QEMU_GCC/scripts/mps2_m3.ld
@@ -144,8 +144,10 @@ SECTIONS
         PROVIDE ( end = . );
         PROVIDE ( _end = . );
         _heap_bottom = .;
+        __heap_start = .;
         . = . + _Min_Heap_Size;
         _heap_top = .;
+        __heap_end = .;
         . = . + _Min_Stack_Size;
         . = ALIGN(8);
        } >RAM

--- a/FreeRTOS/Demo/CORTEX_M3_MPS2_QEMU_GCC/syscall.c
+++ b/FreeRTOS/Demo/CORTEX_M3_MPS2_QEMU_GCC/syscall.c
@@ -50,8 +50,6 @@ extern unsigned long _heap_bottom;
 extern unsigned long _heap_top;
 extern unsigned long g_ulBase;
 
-static void * heap_end = 0;
-
 /**
  * @brief initializes the UART emulated hardware
  */
@@ -60,6 +58,34 @@ void uart_init()
     UART0_ADDR->BAUDDIV = 16;
     UART0_ADDR->CTRL = UART_CTRL_TX_EN;
 }
+
+#ifdef __PICOLIBC__
+
+#include <stdio.h>
+
+/**
+ * @brief  Write byte to the UART channel to be displayed on the command line
+ *         with qemu
+ * @param [in] c     byte to send
+ * @param [in] file  ignored
+ * @returns the character written (cast to unsigned so it is not an error value)
+ */
+
+int
+_uart_putc(char c, FILE *file)
+{
+    (void) file;
+    UART_DR( UART0_ADDR ) = c;
+    return (unsigned char) c;
+}
+
+static FILE __stdio = FDEV_SETUP_STREAM(_uart_putc, NULL, NULL, _FDEV_SETUP_WRITE);
+
+FILE *const stdout = &__stdio;
+
+#else
+
+static void * heap_end = 0;
 
 /**
  * @brief not used anywhere in the code
@@ -131,6 +157,8 @@ void * _sbrk( int incr )
 
     return prev_heap_end;
 }
+
+#endif
 
 #ifdef __cplusplus
     }

--- a/FreeRTOS/Demo/RISC-V_RV32_QEMU_VIRT_GCC/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/RISC-V_RV32_QEMU_VIRT_GCC/FreeRTOSConfig.h
@@ -54,7 +54,7 @@
 #define configMINIMAL_STACK_SIZE		( ( unsigned short ) 120 )
 #define configTOTAL_HEAP_SIZE			( ( size_t ) ( 80 * 1024 ) )
 #define configMAX_TASK_NAME_LEN			( 12 )
-#define configUSE_TRACE_FACILITY		0
+#define configUSE_TRACE_FACILITY		1
 #define configUSE_16_BIT_TICKS			0
 #define configIDLE_SHOULD_YIELD			0
 #define configUSE_MUTEXES				1

--- a/FreeRTOS/Demo/RISC-V_RV32_QEMU_VIRT_GCC/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/RISC-V_RV32_QEMU_VIRT_GCC/FreeRTOSConfig.h
@@ -121,4 +121,8 @@ machine on which the test is developed). */
 #define bktPRIMARY_PRIORITY		( configMAX_PRIORITIES - 4 )
 #define bktSECONDARY_PRIORITY	( configMAX_PRIORITIES - 5 )
 
+#ifdef PICOLIBC_TLS
+#define configUSE_PICOLIBC_TLS                  1
+#endif
+
 #endif /* FREERTOS_CONFIG_H */

--- a/FreeRTOS/Demo/RISC-V_RV32_QEMU_VIRT_GCC/build/gcc/Makefile
+++ b/FreeRTOS/Demo/RISC-V_RV32_QEMU_VIRT_GCC/build/gcc/Makefile
@@ -10,7 +10,7 @@ SIZE = riscv64-unknown-elf-size
 MAKE = make
 
 CFLAGS += $(INCLUDE_DIRS) -DportasmHANDLE_INTERRUPT=handle_trap -fmessage-length=0 \
-          -march=rv32imac -mabi=ilp32 -mcmodel=medlow -ffunction-sections -fdata-sections \
+          -march=rv32imac_zicsr -mabi=ilp32 -mcmodel=medlow -ffunction-sections -fdata-sections \
           --specs=nano.specs -fno-builtin-printf  -Wno-unused-parameter -nostartfiles -g3 -Os
           
 LDFLAGS += -nostartfiles -Xlinker --gc-sections -Wl,-Map,$(OUTPUT_DIR)/RTOSDemo.map \

--- a/FreeRTOS/Demo/RISC-V_RV32_QEMU_VIRT_GCC/build/gcc/Makefile
+++ b/FreeRTOS/Demo/RISC-V_RV32_QEMU_VIRT_GCC/build/gcc/Makefile
@@ -11,11 +11,22 @@ MAKE = make
 
 CFLAGS += $(INCLUDE_DIRS) -DportasmHANDLE_INTERRUPT=handle_trap -fmessage-length=0 \
           -march=rv32imac_zicsr -mabi=ilp32 -mcmodel=medlow -ffunction-sections -fdata-sections \
-          --specs=nano.specs -fno-builtin-printf  -Wno-unused-parameter -nostartfiles -g3 -Os
+          -Wno-unused-parameter -nostartfiles -g3 -Os
           
+ifeq ($(PICOLIBC),1)
+CFLAGS += --specs=picolibc.specs -DPICOLIBC_INTEGER_PRINTF_SCANF 
+else
+CFLAGS += --specs=nano.specs -fno-builtin-printf
+endif
+
 LDFLAGS += -nostartfiles -Xlinker --gc-sections -Wl,-Map,$(OUTPUT_DIR)/RTOSDemo.map \
            -T./fake_rom.ld -march=rv32imac -mabi=ilp32 -mcmodel=medlow -Xlinker \
-           --defsym=__stack_size=350 -Wl,--start-group -Wl,--end-group -Wl,--wrap=malloc \
+           --defsym=__stack_size=350 -Wl,--start-group -Wl,--end-group
+
+ifeq ($(PICOLIBC),1)
+LDFLAGS += --specs=picolibc.specs --oslib=semihost --crt0=minimal -DPICOLIBC_INTEGER_PRINTF_SCANF
+else
+LDFLAGS +=  -Wl,--wrap=malloc \
            -Wl,--wrap=free -Wl,--wrap=open -Wl,--wrap=lseek -Wl,--wrap=read -Wl,--wrap=write \
            -Wl,--wrap=fstat -Wl,--wrap=stat -Wl,--wrap=close -Wl,--wrap=link -Wl,--wrap=unlink \
            -Wl,--wrap=execve -Wl,--wrap=fork -Wl,--wrap=getpid -Wl,--wrap=kill -Wl,--wrap=wait \
@@ -24,6 +35,7 @@ LDFLAGS += -nostartfiles -Xlinker --gc-sections -Wl,-Map,$(OUTPUT_DIR)/RTOSDemo.
            -Wl,--wrap=_fstat -Wl,--wrap=_stat -Wl,--wrap=_close -Wl,--wrap=_link -Wl,--wrap=_unlink \
            -Wl,--wrap=_execve -Wl,--wrap=_fork -Wl,--wrap=_getpid -Wl,--wrap=_kill -Wl,--wrap=_wait \
            -Wl,--wrap=_isatty -Wl,--wrap=_times -Wl,--wrap=_sbrk -Wl,--wrap=__exit -Wl,--wrap=_puts
+endif
 
 # -Wl,--wrap=_exit
 #
@@ -92,7 +104,9 @@ SOURCE_FILES += (DEMO_PROJECT)/main_full.c
 SOURCE_FILES += (DEMO_PROJECT)/ns16550.c
 SOURCE_FILES += (DEMO_PROJECT)/riscv-virt.c
 # Lightweight print formatting to use in place of the heavier GCC equivalent.
+ifneq ($(PICOLIBC),1)
 SOURCE_FILES += ./printf-stdarg.c
+endif
 ASM_SOURCE_FILES += ./start.S
 ASM_SOURCE_FILES += ./RegTest.S
 ASM_SOURCE_FILES += ./vector.S

--- a/FreeRTOS/Demo/RISC-V_RV32_QEMU_VIRT_GCC/build/gcc/fake_rom.ld
+++ b/FreeRTOS/Demo/RISC-V_RV32_QEMU_VIRT_GCC/build/gcc/fake_rom.ld
@@ -51,6 +51,25 @@ SECTIONS
 		_erodata = .;
 	} >rom AT>rom
 
+	.tdata : {
+		*(.tdata .tdata.*)
+	} >rom AT>rom
+
+	.tbss (NOLOAD) : {
+		*(.tbss .tbss.* .gnu.linkonce.tb.*)
+		*(.tcommon)
+		PROVIDE( __tbss_end = . );
+		PROVIDE( __tls_end = . );
+	} >rom AT>rom
+	PROVIDE( __tdata_source = LOADADDR(.tdata) );
+	PROVIDE( __tdata_source_end = LOADADDR(.tdata) + SIZEOF(.tdata) );
+	PROVIDE( __tdata_size = SIZEOF(.tdata) );
+	PROVIDE( __tbss_offset = ADDR(.tbss) - ADDR(.tdata) );
+	PROVIDE( __tbss_start = ADDR(.tbss) );
+	PROVIDE( __tbss_size = SIZEOF(.tbss) );
+	PROVIDE( __tls_size = __tls_end - ADDR(.tdata) );
+	PROVIDE( __tls_align = MAX(ALIGNOF(.tdata), ALIGNOF(.tbss)) );
+
 	.data.align :
 	{
 		. = ALIGN(4);


### PR DESCRIPTION
Show how to use picolibc in the CORTEX_M3_MPS2_QEMU_GCC and  RISC-V_RV32_QEMU_VIRT_GCC demos

Description
-----------
This series shows how Picolibc can be used with FreeRTOS with changes to two demonstration applications. The modifications can be broken down into discrete steps:

 1. Set `configUSE_PICOLIBC_TLS = 1` when using Picolibc with TLS enabled
 2. Add TLS support to the linker script. This has no effect when not using TLS variables
 3. Replace any POSIX apis provided to support stdio and/or malloc with code suitable for picolibc
 4. Adjust CFLAGS and LDFLAGS to pass --specs=picolibc.specs in place of any other C library-specfic flags

This series includes some unrelated changes; in  CORTEX_M3_MPS2_QEMU_GCC, it appeared to intend to elide unused code with the linker but didn't include the `--gc-sections` flag to the linker, and I had trouble building the Risc-V demo because of some feature conflicts in its configuration. I can pull those out into a separate series if desired.

Requirements
-----------
This test requires an arm toolchain with both newlib and picolibc and a risc-v toolchain with picolibc. On Debian (stable, testing or unstable) or Ubuntu (22.04 or later) systems, these can be obtained with:
```
# apt install picolibc-arm-none-eabi libnewlib-arm-none-eabi picolibc-riscv64-unknown-elf
```

Test Steps
-----------
```
$ cd Demo/CORTEX_M3_MPS2_QEMU_GCC
$ make
$ size build/RTOSDemo.axf
   text	   data	    bss	    dec	    hex	filename
   15016	    240	3187744	3203000	 30dfb8	build/RTOSDemo.axf
$ make clean; make PICOLIBC=1
$ size build/RTOSDemo.axf
   text	   data	    bss	    dec	    hex	filename
   9380	    148	3187576	3197104	 30c8b0	build/RTOSDemo.axf
$ cd ../RISC-V_RV32_QEMU_VIRT_GCC
$ make -C build/gcc PICOLIBC=1
$ size build/gcc/output/RTOSDemo.elf
   text	   data	    bss	    dec	    hex	filename
  63428	    116	  89232	 152776	  254c8	build/gcc/output/RTOSDemo.elf
```

Test Requirements
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
