### PR TITLE
Fix CBMC proof failures

### DIFF
--- a/FreeRTOS/Test/CBMC/patches/0005-Remove-volatile-qualifier-from-tasks-variables.patch
+++ b/FreeRTOS/Test/CBMC/patches/0005-Remove-volatile-qualifier-from-tasks-variables.patch
@@ -41,21 +41,21 @@ Here, `uxPendedTicks` could return any value, making it impossible to unwind
 as a regular variable so that the loop can be unwound.
 
 diff --git a/FreeRTOS/Source/tasks.c b/FreeRTOS/Source/tasks.c
-index c7be57cb2..9f76465d5 100644
+index 0e7a56c60..b29c19ea5 100644
 --- a/FreeRTOS/Source/tasks.c
 +++ b/FreeRTOS/Source/tasks.c
-@@ -343,8 +343,8 @@ PRIVILEGED_DATA TCB_t * volatile pxCurrentTCB = NULL;
- PRIVILEGED_DATA static List_t pxReadyTasksLists[ configMAX_PRIORITIES ]; /*< Prioritised ready tasks. */
- PRIVILEGED_DATA static List_t xDelayedTaskList1;                         /*< Delayed tasks. */
- PRIVILEGED_DATA static List_t xDelayedTaskList2;                         /*< Delayed tasks (two lists are used - one for delays that have overflowed the current tick count. */
--PRIVILEGED_DATA static List_t * volatile pxDelayedTaskList;              /*< Points to the delayed task list currently being used. */
--PRIVILEGED_DATA static List_t * volatile pxOverflowDelayedTaskList;      /*< Points to the delayed task list currently being used to hold tasks that have overflowed the current tick count. */
-+PRIVILEGED_DATA static List_t * pxDelayedTaskList;              /*< Points to the delayed task list currently being used. */
-+PRIVILEGED_DATA static List_t * pxOverflowDelayedTaskList;      /*< Points to the delayed task list currently being used to hold tasks that have overflowed the current tick count. */
- PRIVILEGED_DATA static List_t xPendingReadyList;                         /*< Tasks that have been readied while the scheduler was suspended.  They will be moved to the ready list when the scheduler is resumed. */
- 
+@@ -339,8 +339,8 @@ portDONT_DISCARD PRIVILEGED_DATA TCB_t * volatile pxCurrentTCB = NULL;
+ PRIVILEGED_DATA static List_t pxReadyTasksLists[ configMAX_PRIORITIES ]; /**< Prioritised ready tasks. */
+ PRIVILEGED_DATA static List_t xDelayedTaskList1;                         /**< Delayed tasks. */
+ PRIVILEGED_DATA static List_t xDelayedTaskList2;                         /**< Delayed tasks (two lists are used - one for delays that have overflowed the current tick count. */
+-PRIVILEGED_DATA static List_t * volatile pxDelayedTaskList;              /**< Points to the delayed task list currently being used. */
+-PRIVILEGED_DATA static List_t * volatile pxOverflowDelayedTaskList;      /**< Points to the delayed task list currently being used to hold tasks that have overflowed the current tick count. */
++PRIVILEGED_DATA static List_t * pxDelayedTaskList;              /**< Points to the delayed task list currently being used. */
++PRIVILEGED_DATA static List_t * pxOverflowDelayedTaskList;      /**< Points to the delayed task list currently being used to hold tasks that have overflowed the current tick count. */
+ PRIVILEGED_DATA static List_t xPendingReadyList;                         /**< Tasks that have been readied while the scheduler was suspended.  They will be moved to the ready list when the scheduler is resumed. */
+
  #if ( INCLUDE_vTaskDelete == 1 )
-@@ -371,7 +371,7 @@ PRIVILEGED_DATA static volatile UBaseType_t uxCurrentNumberOfTasks = ( UBaseType
+@@ -367,7 +367,7 @@ PRIVILEGED_DATA static volatile UBaseType_t uxCurrentNumberOfTasks = ( UBaseType
  PRIVILEGED_DATA static volatile TickType_t xTickCount = ( TickType_t ) configINITIAL_TICK_COUNT;
  PRIVILEGED_DATA static volatile UBaseType_t uxTopReadyPriority = tskIDLE_PRIORITY;
  PRIVILEGED_DATA static volatile BaseType_t xSchedulerRunning = pdFALSE;

--- a/FreeRTOS/Test/CBMC/proofs/Task/TaskIncrementTick/Configurations.json
+++ b/FreeRTOS/Test/CBMC/proofs/Task/TaskIncrementTick/Configurations.json
@@ -48,7 +48,7 @@
   "CBMCFLAGS":
   [
     "--unwind 1",
-    "--unwindset prvInitialiseTaskLists.0:8,vListInsert.0:2,xTaskIncrementTick.0:4"
+    "--unwindset prvInitialiseTaskLists.0:8,vListInsert.0:2,xTaskIncrementTick.5:4"
   ],
   "OBJS":
   [

--- a/FreeRTOS/Test/CBMC/proofs/Task/TaskResumeAll/Configurations.json
+++ b/FreeRTOS/Test/CBMC/proofs/Task/TaskResumeAll/Configurations.json
@@ -53,7 +53,7 @@
   "CBMCFLAGS":
   [
     "--unwind 1",
-    "--unwindset prvInitialiseTaskLists.0:8,xTaskResumeAll.0:2,vListInsert.0:5,xTaskIncrementTick.0:4"
+    "--unwindset prvInitialiseTaskLists.0:8,xTaskResumeAll.4:2,vListInsert.0:5,xTaskIncrementTick.5:4"
 
   ],
   "OBJS":

--- a/manifest.yml
+++ b/manifest.yml
@@ -4,7 +4,7 @@ description: "This is the standard distribution of FreeRTOS."
 
 dependencies:
   - name: "FreeRTOS-Kernel"
-    version: "bb6071e1d"
+    version: "ddd50d9a8"
     repository:
       type: "git"
       url: "https://github.com/FreeRTOS/FreeRTOS-Kernel.git"


### PR DESCRIPTION
Description
-----------
These were introduced in PR #620. The following are the 2 issues addressed - 
1. A patch for CBMC failed to apply because of changes in doxygen comment. This PR re-creates the patch from the latest code.
2.  Introduction of `do...while( 0 )` caused the CBMC loop identifiers to change, causing the unwinding to fail. This PR updates the loop identifiers.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
