### PR TITLE
Make static IP address configurable (when DHCP is unavailable)

### DIFF
--- a/FreeRTOS-Plus/VisualStudio_StaticProjects/FreeRTOS+TCP/plus_tcp_hooks_winsim.c
+++ b/FreeRTOS-Plus/VisualStudio_StaticProjects/FreeRTOS+TCP/plus_tcp_hooks_winsim.c
@@ -160,29 +160,34 @@ void vApplicationIPNetworkEventHook( eIPCallbackEvent_t eNetworkEvent )
 
 void vPlatformInitIpStack( void )
 {
-    UBaseType_t uxRandomNumber;
     BaseType_t xResult;
     uint8_t ucIPAddress[ 4 ];
-    uint8_t ucNetMask[ 4 ] = { 255, 255, 0, 0 };
-    uint8_t ucNullAddress[ 4 ] = { 0, 0, 0, 0 };
+    uint8_t ucNetMask[ 4 ] = { configNET_MASK0, configNET_MASK1, configNET_MASK2, configNET_MASK3 };
     uint8_t ucMACAddress[ 6 ];
+    uint8_t ucDNSServerAddress[ 4 ];
+    uint8_t ucGatewayAddress[ 4 ];
 
-    /* Generate a random number */
-    uxRandomNumber = uxRand();
+    ucMACAddress[ 0 ] = configMAC_ADDR0;
+    ucMACAddress[ 1 ] = configMAC_ADDR1;
+    ucMACAddress[ 2 ] = configMAC_ADDR2;
+    ucMACAddress[ 3 ] = configMAC_ADDR3;
+    ucMACAddress[ 4 ] = configMAC_ADDR4;
+    ucMACAddress[ 5 ] = configMAC_ADDR5;
 
-    /* Generate a random MAC address in the reserved range */
-    ucMACAddress[ 0 ] = 0x00;
-    ucMACAddress[ 1 ] = 0x11;
-    ucMACAddress[ 2 ] = ( uxRandomNumber & 0xFF );
-    ucMACAddress[ 3 ] = ( ( uxRandomNumber >> 8 ) & 0xFF );
-    ucMACAddress[ 4 ] = ( ( uxRandomNumber >> 16 ) & 0xFF );
-    ucMACAddress[ 5 ] = ( ( uxRandomNumber >> 24 ) & 0xFF );
+    ucIPAddress[ 0 ] = configIP_ADDR0;
+    ucIPAddress[ 1 ] = configIP_ADDR1;
+    ucIPAddress[ 2 ] = configIP_ADDR2;
+    ucIPAddress[ 3 ] = configIP_ADDR3;
 
-    /* Assign a link-local address in the 169.254.0.0/16 range */
-    ucIPAddress[ 0 ] = 169U;
-    ucIPAddress[ 1 ] = 254U;
-    ucIPAddress[ 2 ] = ( ( uxRandomNumber >> 16 ) & 0xFF );
-    ucIPAddress[ 3 ] = ( ( uxRandomNumber >> 24 ) & 0xFF );
+    ucDNSServerAddress[ 0 ] = configDNS_SERVER_ADDR0;
+    ucDNSServerAddress[ 1 ] = configDNS_SERVER_ADDR1;
+    ucDNSServerAddress[ 2 ] = configDNS_SERVER_ADDR2;
+    ucDNSServerAddress[ 3 ] = configDNS_SERVER_ADDR3;
+
+    ucGatewayAddress[ 0 ] = configGATEWAY_ADDR0;
+    ucGatewayAddress[ 1 ] = configGATEWAY_ADDR1;
+    ucGatewayAddress[ 2 ] = configGATEWAY_ADDR2;
+    ucGatewayAddress[ 3 ] = configGATEWAY_ADDR3;
 
     /* Initialise the network interface.*/
     FreeRTOS_debug_printf( ( "FreeRTOS_IPInit\r\n" ) );
@@ -192,7 +197,7 @@ void vPlatformInitIpStack( void )
     pxWinPcap_FillInterfaceDescriptor( 0, &( xInterfaces[ 0 ] ) );
 
     /* === End-point 0 === */
-    FreeRTOS_FillEndPoint( &( xInterfaces[ 0 ] ), &( xEndPoints[ 0 ] ), ucIPAddress, ucNetMask, ucNullAddress, ucNullAddress, ucMACAddress );
+    FreeRTOS_FillEndPoint( &( xInterfaces[ 0 ] ), &( xEndPoints[ 0 ] ), ucIPAddress, ucNetMask, ucGatewayAddress, ucDNSServerAddress, ucMACAddress );
     #if ( ipconfigUSE_DHCP != 0 )
     {
         /* End-point 0 wants to use DHCPv4. */
@@ -203,7 +208,7 @@ void vPlatformInitIpStack( void )
     xResult = FreeRTOS_IPStart();
 #else
     /* Using the old /single /IPv4 library, or using backward compatible mode of the new /multi library. */
-    xResult = FreeRTOS_IPInit( ucIPAddress, ucNetMask, ucNullAddress, ucNullAddress, ucMACAddress );
+    xResult = FreeRTOS_IPInit( ucIPAddress, ucNetMask, ucGatewayAddress, ucDNSServerAddress, ucMACAddress );
 #endif /* if defined( FREERTOS_PLUS_TCP_VERSION ) && ( FREERTOS_PLUS_TCP_VERSION >= 10 ) */
 
     configASSERT( xResult == pdTRUE );


### PR DESCRIPTION
<!--- Title -->

Description
-----------
Make the static IP address in the FreeRTOS-Plus demos configurable in absence of a DHCP server or when the user has configured the FreeRTOS+TCP stack to use static IP address.

Currently, the demos use hard coded IP-addresses which are not affected when the user changes the `configIP_ADDR[0-3]` macros. This PR updates the demos to use the configured IP-address along with MAC, DNS and Gateway addresses.

Test Steps
-----------
- Download/clone the repository.
- Open any one of the FreeRTOS-Plus demos.
- Update the `ipconfigUSE_DHCP` macro in the FreeRTOSIPConfig.h file to `0`.
- Build and run the demo.
- The configured IP-address (in `configIP_ADDR[0-3]` macros) should be the one in use.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x ] I have tested my changes. No regression in existing tests.
- [ N/A ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
