### PR TITLE
Update Backward Compatibility Flag

### DIFF
--- a/FreeRTOS-Plus/Demo/Common/FreeRTOS_Plus_CLI_Demos/UDP-Related-CLI-commands.c
+++ b/FreeRTOS-Plus/Demo/Common/FreeRTOS_Plus_CLI_Demos/UDP-Related-CLI-commands.c
@@ -266,7 +266,7 @@ uint32_t ulAddress;
 	switch( xIndex )
 	{
 		case 0 :
-		#if defined( FREERTOS_PLUS_TCP_VERSION ) && ( FREERTOS_PLUS_TCP_VERSION >= 10 )
+		#if defined( ipconfigIPv4_BACKWARD_COMPATIBLE ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE == 0 )
 			FreeRTOS_GetEndPointConfiguration( &ulAddress, NULL, NULL, NULL, pxNetworkEndPoints );
 		#else
 			FreeRTOS_GetAddressConfiguration( &ulAddress, NULL, NULL, NULL );
@@ -277,7 +277,7 @@ uint32_t ulAddress;
 			break;
 
 		case 1 :
-		#if defined( FREERTOS_PLUS_TCP_VERSION ) && ( FREERTOS_PLUS_TCP_VERSION >= 10 )
+		#if defined( ipconfigIPv4_BACKWARD_COMPATIBLE ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE == 0 )
 			FreeRTOS_GetEndPointConfiguration( NULL, &ulAddress,  NULL, NULL, pxNetworkEndPoints );
 		#else
 			FreeRTOS_GetAddressConfiguration( NULL, &ulAddress, NULL, NULL );
@@ -288,7 +288,7 @@ uint32_t ulAddress;
 			break;
 
 		case 2 :
-		#if defined( FREERTOS_PLUS_TCP_VERSION ) && ( FREERTOS_PLUS_TCP_VERSION >= 10 )
+		#if defined( ipconfigIPv4_BACKWARD_COMPATIBLE ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE == 0 )
 			FreeRTOS_GetEndPointConfiguration( NULL, NULL, &ulAddress, NULL, pxNetworkEndPoints );
 		#else
 			FreeRTOS_GetAddressConfiguration( NULL, NULL, &ulAddress, NULL );
@@ -299,7 +299,7 @@ uint32_t ulAddress;
 			break;
 
 		case 3 :
-		#if defined( FREERTOS_PLUS_TCP_VERSION ) && ( FREERTOS_PLUS_TCP_VERSION >= 10 )
+		#if defined( ipconfigIPv4_BACKWARD_COMPATIBLE ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE == 0 )
 			FreeRTOS_GetEndPointConfiguration( NULL, NULL, NULL, &ulAddress, pxNetworkEndPoints );
 		#else
 			FreeRTOS_GetAddressConfiguration( NULL, NULL, NULL, &ulAddress );

--- a/FreeRTOS-Plus/Demo/Common/FreeRTOS_Plus_UDP_Demos/CLICommands/CLI-commands.c
+++ b/FreeRTOS-Plus/Demo/Common/FreeRTOS_Plus_UDP_Demos/CLICommands/CLI-commands.c
@@ -565,7 +565,7 @@ uint32_t ulAddress;
 	switch( xIndex )
 	{
 		case 0 :
-		#if defined( FREERTOS_PLUS_TCP_VERSION ) && ( FREERTOS_PLUS_TCP_VERSION >= 10 )
+		#if defined( ipconfigIPv4_BACKWARD_COMPATIBLE ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE == 0 )
 			FreeRTOS_GetEndPointConfiguration( &ulAddress, NULL, NULL, NULL, pxNetworkEndPoints );
 		#else
 			FreeRTOS_GetAddressConfiguration( &ulAddress, NULL, NULL, NULL );
@@ -576,7 +576,7 @@ uint32_t ulAddress;
 			break;
 
 		case 1 :
-		#if defined( FREERTOS_PLUS_TCP_VERSION ) && ( FREERTOS_PLUS_TCP_VERSION >= 10 )
+		#if defined( ipconfigIPv4_BACKWARD_COMPATIBLE ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE == 0 )
 			FreeRTOS_GetEndPointConfiguration( NULL, &ulAddress, NULL, NULL, pxNetworkEndPoints );
 		#else
 			FreeRTOS_GetAddressConfiguration( NULL, &ulAddress, NULL, NULL );
@@ -587,7 +587,7 @@ uint32_t ulAddress;
 			break;
 
 		case 2 :
-		#if defined( FREERTOS_PLUS_TCP_VERSION ) && ( FREERTOS_PLUS_TCP_VERSION >= 10 )
+		#if defined( ipconfigIPv4_BACKWARD_COMPATIBLE ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE == 0 )
 			FreeRTOS_GetEndPointConfiguration( NULL, NULL, &ulAddress, NULL, pxNetworkEndPoints );
 		#else
 			FreeRTOS_GetAddressConfiguration( NULL, NULL, &ulAddress, NULL );
@@ -598,7 +598,7 @@ uint32_t ulAddress;
 			break;
 
 		case 3 :
-		#if defined( FREERTOS_PLUS_TCP_VERSION ) && ( FREERTOS_PLUS_TCP_VERSION >= 10 )
+		#if defined( ipconfigIPv4_BACKWARD_COMPATIBLE ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE == 0 )
 			FreeRTOS_GetEndPointConfiguration( NULL, NULL, NULL, &ulAddress, pxNetworkEndPoints );
 		#else
 			FreeRTOS_GetAddressConfiguration( NULL, NULL, NULL, &ulAddress );

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Echo_Posix/main_networking.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Echo_Posix/main_networking.c
@@ -118,7 +118,7 @@ const uint8_t ucMACAddress[ 6 ] = { configMAC_ADDR0, configMAC_ADDR1, configMAC_
 /* Use by the pseudo random number generator. */
 static UBaseType_t ulNextRand;
 
-#if defined( FREERTOS_PLUS_TCP_VERSION ) && ( FREERTOS_PLUS_TCP_VERSION >= 10 )
+#if defined( ipconfigIPv4_BACKWARD_COMPATIBLE ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE == 0 )
 
     /* In case multiple interfaces are used, define them statically. */
 
@@ -128,7 +128,7 @@ static UBaseType_t ulNextRand;
     /* It will have several end-points. */
     static NetworkEndPoint_t xEndPoints[ 4 ];
 
-#endif /* if defined( FREERTOS_PLUS_TCP_VERSION ) && ( FREERTOS_PLUS_TCP_VERSION >= 10 ) */
+#endif /* if defined( ipconfigIPv4_BACKWARD_COMPATIBLE ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE == 0 ) */
 
 
 /*-----------------------------------------------------------*/
@@ -157,7 +157,7 @@ void main_tcp_echo_client_tasks( void )
     /* Initialise the network interface.*/
     FreeRTOS_debug_printf( ( "FreeRTOS_IPInit\r\n" ) );
 
-#if defined( FREERTOS_PLUS_TCP_VERSION ) && ( FREERTOS_PLUS_TCP_VERSION >= 10 )
+#if defined( ipconfigIPv4_BACKWARD_COMPATIBLE ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE == 0 )
     /* Initialise the interface descriptor for WinPCap. */
     pxFillInterfaceDescriptor( 0, &( xInterfaces[ 0 ] ) );
 
@@ -175,7 +175,7 @@ void main_tcp_echo_client_tasks( void )
 #else
     /* Using the old /single /IPv4 library, or using backward compatible mode of the new /multi library. */
     FreeRTOS_IPInit( ucIPAddress, ucNetMask, ucGatewayAddress, ucDNSServerAddress, ucMACAddress );
-#endif /* if defined( FREERTOS_PLUS_TCP_VERSION ) && ( FREERTOS_PLUS_TCP_VERSION >= 10 ) */
+#endif /* if defined( ipconfigIPv4_BACKWARD_COMPATIBLE ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE == 0 ) */
 
     /* Start the RTOS scheduler. */
     FreeRTOS_debug_printf( ( "vTaskStartScheduler\n" ) );
@@ -225,7 +225,7 @@ void vApplicationIPNetworkEventHook( eIPCallbackEvent_t eNetworkEvent )
 
         /* Print out the network configuration, which may have come from a DHCP
          * server. */
-        #if defined( FREERTOS_PLUS_TCP_VERSION ) && ( FREERTOS_PLUS_TCP_VERSION >= 10 )
+        #if defined( ipconfigIPv4_BACKWARD_COMPATIBLE ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE == 0 )
             FreeRTOS_GetEndPointConfiguration( &ulIPAddress, &ulNetMask, &ulGatewayAddress, &ulDNSServerAddress, pxNetworkEndPoints );
         #else
             FreeRTOS_GetAddressConfiguration( &ulIPAddress, &ulNetMask, &ulGatewayAddress, &ulDNSServerAddress );

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Echo_Posix/main_networking.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Echo_Posix/main_networking.c
@@ -171,7 +171,7 @@ void main_tcp_echo_client_tasks( void )
     #endif /* ( ipconfigUSE_DHCP != 0 ) */
 
     memcpy( ipLOCAL_MAC_ADDRESS, ucMACAddress, sizeof( ucMACAddress ) );
-    FreeRTOS_IPStart();
+    FreeRTOS_IPInit_Multi();
 #else
     /* Using the old /single /IPv4 library, or using backward compatible mode of the new /multi library. */
     FreeRTOS_IPInit( ucIPAddress, ucNetMask, ucGatewayAddress, ucDNSServerAddress, ucMACAddress );

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Echo_Qemu_mps2/main_networking.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Echo_Qemu_mps2/main_networking.c
@@ -124,7 +124,7 @@ const uint8_t ucMACAddress[ 6 ] =
 /* Use by the pseudo random number generator. */
 static UBaseType_t ulNextRand;
 
-#if defined( FREERTOS_PLUS_TCP_VERSION ) && ( FREERTOS_PLUS_TCP_VERSION >= 10 )
+#if defined( ipconfigIPv4_BACKWARD_COMPATIBLE ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE == 0 )
 
     /* In case multiple interfaces are used, define them statically. */
 
@@ -134,7 +134,7 @@ static UBaseType_t ulNextRand;
     /* It will have several end-points. */
     static NetworkEndPoint_t xEndPoints[ 4 ];
 
-#endif /* if defined( FREERTOS_PLUS_TCP_VERSION ) && ( FREERTOS_PLUS_TCP_VERSION >= 10 ) */
+#endif /* if defined( ipconfigIPv4_BACKWARD_COMPATIBLE ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE == 0 ) */
 
 /*-----------------------------------------------------------*/
 
@@ -162,7 +162,7 @@ void main_tcp_echo_client_tasks( void )
     /* Initialise the network interface.*/
     FreeRTOS_debug_printf( ( "FreeRTOS_IPInit\r\n" ) );
 
-#if defined( FREERTOS_PLUS_TCP_VERSION ) && ( FREERTOS_PLUS_TCP_VERSION >= 10 )
+#if defined( ipconfigIPv4_BACKWARD_COMPATIBLE ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE == 0 )
     /* Initialise the interface descriptor for WinPCap. */
     pxMPS2_FillInterfaceDescriptor( 0, &( xInterfaces[ 0 ] ) );
 
@@ -181,7 +181,7 @@ void main_tcp_echo_client_tasks( void )
 #else
     /* Using the old /single /IPv4 library, or using backward compatible mode of the new /multi library. */
     FreeRTOS_IPInit( ucIPAddress, ucNetMask, ucGatewayAddress, ucDNSServerAddress, ucMACAddress );
-#endif /* if defined( FREERTOS_PLUS_TCP_VERSION ) && ( FREERTOS_PLUS_TCP_VERSION >= 10 ) */
+#endif /* if defined( ipconfigIPv4_BACKWARD_COMPATIBLE ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE == 0 ) */
 
 
     /* Start the RTOS scheduler. */
@@ -237,7 +237,7 @@ void vApplicationIPNetworkEventHook( eIPCallbackEvent_t eNetworkEvent )
 
         /* Print out the network configuration, which may have come from a DHCP
          * server. */
-        #if defined( FREERTOS_PLUS_TCP_VERSION ) && ( FREERTOS_PLUS_TCP_VERSION >= 10 )
+        #if defined( ipconfigIPv4_BACKWARD_COMPATIBLE ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE == 0 )
             FreeRTOS_GetEndPointConfiguration( &ulIPAddress, &ulNetMask, &ulGatewayAddress, &ulDNSServerAddress, pxNetworkEndPoints );
         #else
             FreeRTOS_GetAddressConfiguration( &ulIPAddress, &ulNetMask, &ulGatewayAddress, &ulDNSServerAddress );

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Echo_Qemu_mps2/main_networking.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Echo_Qemu_mps2/main_networking.c
@@ -177,7 +177,7 @@ void main_tcp_echo_client_tasks( void )
 
     memcpy( ipLOCAL_MAC_ADDRESS, ucMACAddress, sizeof( ucMACAddress ) );
 
-    FreeRTOS_IPStart();
+    FreeRTOS_IPInit_Multi();
 #else
     /* Using the old /single /IPv4 library, or using backward compatible mode of the new /multi library. */
     FreeRTOS_IPInit( ucIPAddress, ucNetMask, ucGatewayAddress, ucDNSServerAddress, ucMACAddress );

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_IPv6_Demo/IPv6_Multi_WinSim_demo/FreeRTOSIPConfig.h
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_IPv6_Demo/IPv6_Multi_WinSim_demo/FreeRTOSIPConfig.h
@@ -310,7 +310,6 @@ extern UBaseType_t uxRand();
 #define portINLINE                          __inline
 
 #define ipconfigMULTI_INTERFACE             1
-#define ipconfigCOMPATIBLE_WITH_SINGLE      0
 #define ipconfigUSE_NTP_DEMO                1
 #define ipconfigDNS_USE_CALLBACKS           1
 #define ipconfigSUPPORT_SIGNALS             1

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_IPv6_Demo/IPv6_Multi_WinSim_demo/UDPEchoClient_SingleTasks.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_IPv6_Demo/IPv6_Multi_WinSim_demo/UDPEchoClient_SingleTasks.c
@@ -178,7 +178,7 @@ static void prvUDPEchoClientTask(void* pvParameters)
             /*
             * First obtain a buffer of adequate length from the TCP/IP stack into which
             * the string will be written. */
-            uint8_t* pucBuffer = FreeRTOS_GetUDPPayloadBuffer_ByIPType(TX_RX_STR_SIZE, portMAX_DELAY, ucIPType);
+            uint8_t* pucBuffer = FreeRTOS_GetUDPPayloadBuffer_Multi(TX_RX_STR_SIZE, portMAX_DELAY, ucIPType);
             configASSERT(pucBuffer != NULL);
             memcpy(pucBuffer, &cTxString, strlen((const char*)cTxString) + 1);
 

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_IPv6_Demo/IPv6_Multi_WinSim_demo/main.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_IPv6_Demo/IPv6_Multi_WinSim_demo/main.c
@@ -396,9 +396,9 @@ void vAssertCalled( const char * pcFile,
 /* Called by FreeRTOS+TCP when the network connects or disconnects.  Disconnect
  * events are only received if implemented in the MAC driver. */
 /* *INDENT-OFF* */
-#if defined( ipconfigIPv4_BACKWARD_COMPATIBLE ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE == 1 )
+#if defined( ipconfigIPv4_BACKWARD_COMPATIBLE ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE == 0 )
     /* The multi version: each end-point comes up individually. */
-    void vApplicationIPNetworkEventHook( eIPCallbackEvent_t eNetworkEvent,
+    void vApplicationIPNetworkEventHook_Multi( eIPCallbackEvent_t eNetworkEvent,
                                          NetworkEndPoint_t * pxEndPoint )
 #else
     /* The single version, the interface comes up as a whole. */
@@ -614,7 +614,7 @@ static void prvMiscInitialisation( void )
 /*-----------------------------------------------------------*/
 
     #if ( ipconfigMULTI_INTERFACE != 0 )
-        BaseType_t xApplicationDNSQueryHook( NetworkEndPoint_t * pxEndPoint,
+        BaseType_t xApplicationDNSQueryHook_Multi( NetworkEndPoint_t * pxEndPoint,
                                              const char * pcName )
     #else
         BaseType_t xApplicationDNSQueryHook( const char * pcName )

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_IPv6_Demo/IPv6_Multi_WinSim_demo/main.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_IPv6_Demo/IPv6_Multi_WinSim_demo/main.c
@@ -63,6 +63,10 @@
     #define ARRAY_SIZE( x )    ( int ) ( sizeof( x ) / sizeof( x )[ 0 ] )
 #endif
 
+#ifdef ipconfigCOMPATIBLE_WITH_SINGLE
+    #undef ipconfigCOMPATIBLE_WITH_SINGLE
+#endif
+
 /* Simple UDP client and server task parameters. */
 #define mainSIMPLE_UDP_CLIENT_SERVER_TASK_PRIORITY    ( tskIDLE_PRIORITY )
 #define mainSIMPLE_UDP_CLIENT_SERVER_PORT             ( 5005UL )
@@ -186,7 +190,7 @@ BaseType_t xHandleTestingCommand( char * pcCommand,
 void xHandleTesting( void );
 void showEndPoint( NetworkEndPoint_t * pxEndPoint );
 
-#if defined( ipconfigIPv4_BACKWARD_COMPATIBLE ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE == 0 )
+#if ( ipconfigMULTI_INTERFACE == 1 ) && ( ipconfigCOMPATIBLE_WITH_SINGLE == 0 )
     /* In case multiple interfaces are used, define them statically. */
 
 /* With WinPCap there is only 1 physical interface. */
@@ -199,7 +203,7 @@ void showEndPoint( NetworkEndPoint_t * pxEndPoint );
  * of type 'NetworkInterface_t'. */
     NetworkInterface_t * pxWinPcap_FillInterfaceDescriptor( BaseType_t xEMACIndex,
                                                             NetworkInterface_t * pxInterface );
-#endif
+#endif /* ipconfigMULTI_INTERFACE */
 
 int main( void )
 {
@@ -226,7 +230,7 @@ int main( void )
      * are used if ipconfigUSE_DHCP is set to 0, or if ipconfigUSE_DHCP is set to 1
      * but a DHCP server cannot be	contacted. */
 
-    #if defined( ipconfigIPv4_BACKWARD_COMPATIBLE ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE == 1 )
+    #if ( ipconfigMULTI_INTERFACE == 0 ) || ( ipconfigCOMPATIBLE_WITH_SINGLE == 1 )
         /* Using the old /single /IPv4 library, or using backward compatible mode of the new /multi library. */
         FreeRTOS_debug_printf( ( "FreeRTOS_IPInit\r\n" ) );
         FreeRTOS_IPInit( ucIPAddress, ucNetMask, ucGatewayAddress, ucDNSServerAddress, ucMACAddress );
@@ -335,7 +339,7 @@ int main( void )
         #endif /* ( mainNETWORK_UP_COUNT >= 3U ) */
 
         FreeRTOS_IPInit_Multi();
-    #endif
+    #endif /* if ( ipconfigMULTI_INTERFACE == 0 ) || ( ipconfigCOMPATIBLE_WITH_SINGLE == 1 ) */
     xTaskCreate( prvServerWorkTask, "SvrWork", mainTCP_SERVER_STACK_SIZE, NULL, mainTCP_SERVER_TASK_PRIORITY, NULL );
 
     /* Start the RTOS scheduler. */
@@ -396,7 +400,7 @@ void vAssertCalled( const char * pcFile,
 /* Called by FreeRTOS+TCP when the network connects or disconnects.  Disconnect
  * events are only received if implemented in the MAC driver. */
 /* *INDENT-OFF* */
-#if defined( ipconfigIPv4_BACKWARD_COMPATIBLE ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE == 0 )
+#if ( ipconfigMULTI_INTERFACE != 0 ) || ( ipconfigCOMPATIBLE_WITH_SINGLE != 0 )
     /* The multi version: each end-point comes up individually. */
     void vApplicationIPNetworkEventHook_Multi( eIPCallbackEvent_t eNetworkEvent,
                                          NetworkEndPoint_t * pxEndPoint )

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_IPv6_Demo/IPv6_Multi_WinSim_demo/main.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_IPv6_Demo/IPv6_Multi_WinSim_demo/main.c
@@ -338,7 +338,7 @@ int main( void )
             }
         #endif /* ( mainNETWORK_UP_COUNT >= 3U ) */
 
-        FreeRTOS_IPStart();
+        FreeRTOS_IPInit_Multi();
     #endif /* if ( ipconfigMULTI_INTERFACE == 0 ) || ( ipconfigCOMPATIBLE_WITH_SINGLE == 1 ) */
     xTaskCreate( prvServerWorkTask, "SvrWork", mainTCP_SERVER_STACK_SIZE, NULL, mainTCP_SERVER_TASK_PRIORITY, NULL );
 

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_IPv6_Demo/IPv6_Multi_WinSim_demo/main.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_IPv6_Demo/IPv6_Multi_WinSim_demo/main.c
@@ -63,10 +63,6 @@
     #define ARRAY_SIZE( x )    ( int ) ( sizeof( x ) / sizeof( x )[ 0 ] )
 #endif
 
-#ifdef ipconfigCOMPATIBLE_WITH_SINGLE
-    #undef ipconfigCOMPATIBLE_WITH_SINGLE
-#endif
-
 /* Simple UDP client and server task parameters. */
 #define mainSIMPLE_UDP_CLIENT_SERVER_TASK_PRIORITY    ( tskIDLE_PRIORITY )
 #define mainSIMPLE_UDP_CLIENT_SERVER_PORT             ( 5005UL )
@@ -190,7 +186,7 @@ BaseType_t xHandleTestingCommand( char * pcCommand,
 void xHandleTesting( void );
 void showEndPoint( NetworkEndPoint_t * pxEndPoint );
 
-#if ( ipconfigMULTI_INTERFACE == 1 ) && ( ipconfigCOMPATIBLE_WITH_SINGLE == 0 )
+#if defined( ipconfigIPv4_BACKWARD_COMPATIBLE ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE == 0 )
     /* In case multiple interfaces are used, define them statically. */
 
 /* With WinPCap there is only 1 physical interface. */
@@ -203,7 +199,7 @@ void showEndPoint( NetworkEndPoint_t * pxEndPoint );
  * of type 'NetworkInterface_t'. */
     NetworkInterface_t * pxWinPcap_FillInterfaceDescriptor( BaseType_t xEMACIndex,
                                                             NetworkInterface_t * pxInterface );
-#endif /* ipconfigMULTI_INTERFACE */
+#endif
 
 int main( void )
 {
@@ -230,7 +226,7 @@ int main( void )
      * are used if ipconfigUSE_DHCP is set to 0, or if ipconfigUSE_DHCP is set to 1
      * but a DHCP server cannot be	contacted. */
 
-    #if ( ipconfigMULTI_INTERFACE == 0 ) || ( ipconfigCOMPATIBLE_WITH_SINGLE == 1 )
+    #if defined( ipconfigIPv4_BACKWARD_COMPATIBLE ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE == 1 )
         /* Using the old /single /IPv4 library, or using backward compatible mode of the new /multi library. */
         FreeRTOS_debug_printf( ( "FreeRTOS_IPInit\r\n" ) );
         FreeRTOS_IPInit( ucIPAddress, ucNetMask, ucGatewayAddress, ucDNSServerAddress, ucMACAddress );
@@ -339,7 +335,7 @@ int main( void )
         #endif /* ( mainNETWORK_UP_COUNT >= 3U ) */
 
         FreeRTOS_IPInit_Multi();
-    #endif /* if ( ipconfigMULTI_INTERFACE == 0 ) || ( ipconfigCOMPATIBLE_WITH_SINGLE == 1 ) */
+    #endif
     xTaskCreate( prvServerWorkTask, "SvrWork", mainTCP_SERVER_STACK_SIZE, NULL, mainTCP_SERVER_TASK_PRIORITY, NULL );
 
     /* Start the RTOS scheduler. */
@@ -400,7 +396,7 @@ void vAssertCalled( const char * pcFile,
 /* Called by FreeRTOS+TCP when the network connects or disconnects.  Disconnect
  * events are only received if implemented in the MAC driver. */
 /* *INDENT-OFF* */
-#if ( ipconfigMULTI_INTERFACE != 0 ) || ( ipconfigCOMPATIBLE_WITH_SINGLE != 0 )
+#if defined( ipconfigIPv4_BACKWARD_COMPATIBLE ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE == 1 )
     /* The multi version: each end-point comes up individually. */
     void vApplicationIPNetworkEventHook( eIPCallbackEvent_t eNetworkEvent,
                                          NetworkEndPoint_t * pxEndPoint )

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_IPv6_Demo/IPv6_Multi_WinSim_demo/main.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_IPv6_Demo/IPv6_Multi_WinSim_demo/main.c
@@ -49,9 +49,7 @@
     #include "NTPDemo.h"
 #endif
 
-#if ( ipconfigMULTI_INTERFACE == 1 )
-    #include "FreeRTOS_ND.h"
-#endif
+#include "FreeRTOS_ND.h"
 
 #include "logging.h"
 
@@ -61,10 +59,6 @@
 
 #ifndef ARRAY_SIZE
     #define ARRAY_SIZE( x )    ( int ) ( sizeof( x ) / sizeof( x )[ 0 ] )
-#endif
-
-#ifdef ipconfigCOMPATIBLE_WITH_SINGLE
-    #undef ipconfigCOMPATIBLE_WITH_SINGLE
 #endif
 
 /* Simple UDP client and server task parameters. */
@@ -105,11 +99,11 @@
  * mainCREATE_TCP_ECHO_SERVER_TASK:  When set to 1 a task is created that accepts
  * connections on the standard echo port (port 7), then echos back any data
  * received on that connection.
- * 
+ *
  * mainCREATE_UDP_ECHO_SERVER_TASK:  When set to 1 a task is created that sends data
- * to the address configECHO_SERVER_ADDR_STRING (IPv4/Ipv6) where it is 
+ * to the address configECHO_SERVER_ADDR_STRING (IPv4/Ipv6) where it is
  * expected to echo back the data, which, the created tasks receives.
- * 
+ *
  */
 #define mainCREATE_SIMPLE_UDP_CLIENT_SERVER_TASKS     0
 #define mainCREATE_TCP_ECHO_TASKS_SINGLE              1 /* 1 */
@@ -190,20 +184,17 @@ BaseType_t xHandleTestingCommand( char * pcCommand,
 void xHandleTesting( void );
 void showEndPoint( NetworkEndPoint_t * pxEndPoint );
 
-#if ( ipconfigMULTI_INTERFACE == 1 ) && ( ipconfigCOMPATIBLE_WITH_SINGLE == 0 )
-    /* In case multiple interfaces are used, define them statically. */
 
 /* With WinPCap there is only 1 physical interface. */
-    static NetworkInterface_t xInterfaces[ 1 ];
+static NetworkInterface_t xInterfaces[ 1 ];
 
 /* It will have several end-points. */
-    static NetworkEndPoint_t xEndPoints[ 4 ];
+static NetworkEndPoint_t xEndPoints[ 4 ];
 
 /* A function from NetInterface.c to initialise the interface descriptor
  * of type 'NetworkInterface_t'. */
-    NetworkInterface_t * pxWinPcap_FillInterfaceDescriptor( BaseType_t xEMACIndex,
-                                                            NetworkInterface_t * pxInterface );
-#endif /* ipconfigMULTI_INTERFACE */
+NetworkInterface_t * pxWinPcap_FillInterfaceDescriptor( BaseType_t xEMACIndex,
+                                                        NetworkInterface_t * pxInterface );
 
 int main( void )
 {
@@ -230,116 +221,111 @@ int main( void )
      * are used if ipconfigUSE_DHCP is set to 0, or if ipconfigUSE_DHCP is set to 1
      * but a DHCP server cannot be	contacted. */
 
-    #if ( ipconfigMULTI_INTERFACE == 0 ) || ( ipconfigCOMPATIBLE_WITH_SINGLE == 1 )
-        /* Using the old /single /IPv4 library, or using backward compatible mode of the new /multi library. */
-        FreeRTOS_debug_printf( ( "FreeRTOS_IPInit\r\n" ) );
-        FreeRTOS_IPInit( ucIPAddress, ucNetMask, ucGatewayAddress, ucDNSServerAddress, ucMACAddress );
-    #else
-        /* Initialise the interface descriptor for WinPCap. */
-        pxWinPcap_FillInterfaceDescriptor( 0, &( xInterfaces[ 0 ] ) );
+    /* Initialise the interface descriptor for WinPCap. */
+    pxWinPcap_FillInterfaceDescriptor( 0, &( xInterfaces[ 0 ] ) );
 
-        /* === End-point 0 === */
-        FreeRTOS_FillEndPoint( &( xInterfaces[ 0 ] ), &( xEndPoints[ 0 ] ), ucIPAddress, ucNetMask, ucGatewayAddress, ucDNSServerAddress, ucMACAddress );
-        #if ( ipconfigUSE_DHCP != 0 )
-            {
-                /* End-point 0 wants to use DHCPv4. */
-                xEndPoints[ 0 ].bits.bWantDHCP = pdTRUE;
-            }
-        #endif /* ( ipconfigUSE_DHCP != 0 ) */
+    /* === End-point 0 === */
+    FreeRTOS_FillEndPoint( &( xInterfaces[ 0 ] ), &( xEndPoints[ 0 ] ), ucIPAddress, ucNetMask, ucGatewayAddress, ucDNSServerAddress, ucMACAddress );
+    #if ( ipconfigUSE_DHCP != 0 )
+        {
+            /* End-point 0 wants to use DHCPv4. */
+            xEndPoints[ 0 ].bits.bWantDHCP = pdTRUE;
+        }
+    #endif /* ( ipconfigUSE_DHCP != 0 ) */
 
-        /*
-         *     End-point-1 : public
-         *     Network: 2001:470:ed44::/64
-         *     IPv6   : 2001:470:ed44::4514:89d5:4589:8b79/128
-         *     Gateway: fe80::ba27:ebff:fe5a:d751  // obtained from Router Advertisement
-         */
-        #if ( ipconfigUSE_IPv6 != 0 && USES_IPV6_ENDPOINT != 0 )
+    /*
+     *     End-point-1 : public
+     *     Network: 2001:470:ed44::/64
+     *     IPv6   : 2001:470:ed44::4514:89d5:4589:8b79/128
+     *     Gateway: fe80::ba27:ebff:fe5a:d751  // obtained from Router Advertisement
+     */
+    #if ( ipconfigUSE_IPv6 != 0 && USES_IPV6_ENDPOINT != 0 )
+        {
+            IPv6_Address_t xIPAddress;
+            IPv6_Address_t xPrefix;
+            IPv6_Address_t xGateWay;
+            IPv6_Address_t xDNSServer1, xDNSServer2;
+
+            FreeRTOS_inet_pton6( "2001:470:ed44::", xPrefix.ucBytes );
+
+            FreeRTOS_CreateIPv6Address( &xIPAddress, &xPrefix, 64, pdTRUE );
+            FreeRTOS_inet_pton6( "fe80::ba27:ebff:fe5a:d751", xGateWay.ucBytes );
+
+            FreeRTOS_FillEndPoint_IPv6( &( xInterfaces[ 0 ] ),
+                                        &( xEndPoints[ 1 ] ),
+                                        &( xIPAddress ),
+                                        &( xPrefix ),
+                                        64uL, /* Prefix length. */
+                                        &( xGateWay ),
+                                        NULL, /* pxDNSServerAddress: Not used yet. */
+                                        ucMACAddress );
+            FreeRTOS_inet_pton6( "2001:4860:4860::8888", xEndPoints[ 1 ].ipv6_settings.xDNSServerAddresses[ 0 ].ucBytes );
+            FreeRTOS_inet_pton6( "fe80::1", xEndPoints[ 1 ].ipv6_settings.xDNSServerAddresses[ 1 ].ucBytes );
+            FreeRTOS_inet_pton6( "2001:4860:4860::8888", xEndPoints[ 1 ].ipv6_defaults.xDNSServerAddresses[ 0 ].ucBytes );
+            FreeRTOS_inet_pton6( "fe80::1", xEndPoints[ 1 ].ipv6_defaults.xDNSServerAddresses[ 1 ].ucBytes );
+
+            #if ( ipconfigUSE_RA != 0 )
+                {
+                    /* End-point 1 wants to use Router Advertisement */
+                    xEndPoints[ 1 ].bits.bWantRA = pdTRUE;
+                }
+            #endif /* #if( ipconfigUSE_RA != 0 ) */
+            #if ( ipconfigUSE_DHCPv6 != 0 )
+                {
+                    /* End-point 1 wants to use DHCPv6. */
+                    xEndPoints[ 1 ].bits.bWantDHCP = pdTRUE;
+                }
+            #endif /* ( ipconfigUSE_DHCPv6 != 0 ) */
+        }
+    #endif /* ( ipconfigUSE_IPv6 != 0 ) */
+    #if ( ipconfigUSE_IPv6 != 0 && USES_IPV6_ENDPOINT != 0 )
+        {
+            /*
+             *     End-point-3 : private
+             *     Network: fe80::/10 (link-local)
+             *     IPv6   : fe80::d80e:95cc:3154:b76a/128
+             *     Gateway: -
+             */
             {
                 IPv6_Address_t xIPAddress;
                 IPv6_Address_t xPrefix;
-                IPv6_Address_t xGateWay;
-                IPv6_Address_t xDNSServer1, xDNSServer2;
 
-                FreeRTOS_inet_pton6( "2001:470:ed44::", xPrefix.ucBytes );
+                FreeRTOS_inet_pton6( "fe80::", xPrefix.ucBytes );
+                FreeRTOS_inet_pton6( "fe80::7009", xIPAddress.ucBytes );
 
-                FreeRTOS_CreateIPv6Address( &xIPAddress, &xPrefix, 64, pdTRUE );
-                FreeRTOS_inet_pton6( "fe80::ba27:ebff:fe5a:d751", xGateWay.ucBytes );
-
-                FreeRTOS_FillEndPoint_IPv6( &( xInterfaces[ 0 ] ),
-                                            &( xEndPoints[ 1 ] ),
-                                            &( xIPAddress ),
-                                            &( xPrefix ),
-                                            64uL, /* Prefix length. */
-                                            &( xGateWay ),
-                                            NULL, /* pxDNSServerAddress: Not used yet. */
-                                            ucMACAddress );
-                FreeRTOS_inet_pton6( "2001:4860:4860::8888", xEndPoints[ 1 ].ipv6_settings.xDNSServerAddresses[ 0 ].ucBytes );
-                FreeRTOS_inet_pton6( "fe80::1", xEndPoints[ 1 ].ipv6_settings.xDNSServerAddresses[ 1 ].ucBytes );
-                FreeRTOS_inet_pton6( "2001:4860:4860::8888", xEndPoints[ 1 ].ipv6_defaults.xDNSServerAddresses[ 0 ].ucBytes );
-                FreeRTOS_inet_pton6( "fe80::1", xEndPoints[ 1 ].ipv6_defaults.xDNSServerAddresses[ 1 ].ucBytes );
-
-                #if ( ipconfigUSE_RA != 0 )
-                    {
-                        /* End-point 1 wants to use Router Advertisement */
-                        xEndPoints[ 1 ].bits.bWantRA = pdTRUE;
-                    }
-                #endif /* #if( ipconfigUSE_RA != 0 ) */
-                #if ( ipconfigUSE_DHCPv6 != 0 )
-                    {
-                        /* End-point 1 wants to use DHCPv6. */
-                        xEndPoints[ 1 ].bits.bWantDHCP = pdTRUE;
-                    }
-                #endif /* ( ipconfigUSE_DHCPv6 != 0 ) */
+                FreeRTOS_FillEndPoint_IPv6(
+                    &( xInterfaces[ 0 ] ),
+                    &( xEndPoints[ 2 ] ),
+                    &( xIPAddress ),
+                    &( xPrefix ),
+                    10U,  /* Prefix length. */
+                    NULL, /* No gateway */
+                    NULL, /* pxDNSServerAddress: Not used yet. */
+                    ucMACAddress );
             }
-        #endif /* ( ipconfigUSE_IPv6 != 0 ) */
-        #if ( ipconfigUSE_IPv6 != 0 && USES_IPV6_ENDPOINT != 0 )
-            {
-                /*
-                 *     End-point-3 : private
-                 *     Network: fe80::/10 (link-local)
-                 *     IPv6   : fe80::d80e:95cc:3154:b76a/128
-                 *     Gateway: -
-                 */
+        }
+    #endif /* if ( ipconfigUSE_IPv6 != 0 ) */
+    /* === End-point 0 === */
+    #if ( ( mainNETWORK_UP_COUNT >= 4U ) || ( USES_IPV6_ENDPOINT == 0 && mainNETWORK_UP_COUNT >= 2U ) )
+        {
+            /*172.25.201.204 */
+            /*netmask 255.255.240.0 */
+            const uint8_t ucMACAddress2[ 6 ] = { 0x00, 0x22, 0x22, 0x22, 0x22, 82 };
+            const uint8_t ucIPAddress2[ 4 ] = { 192, 168, 2, 210 };
+            const uint8_t ucNetMask2[ 4 ] = { 255, 255, 255, 0 };
+            const uint8_t ucGatewayAddress2[ 4 ] = { 0, 0, 0, 0 };
+            FreeRTOS_FillEndPoint( &( xInterfaces[ 0 ] ), &( xEndPoints[ 3 ] ), ucIPAddress2, ucNetMask2, ucGatewayAddress2, ucDNSServerAddress, ucMACAddress2 );
+            #if ( ipconfigUSE_DHCP != 0 )
                 {
-                    IPv6_Address_t xIPAddress;
-                    IPv6_Address_t xPrefix;
-
-                    FreeRTOS_inet_pton6( "fe80::", xPrefix.ucBytes );
-                    FreeRTOS_inet_pton6( "fe80::7009", xIPAddress.ucBytes );
-
-                    FreeRTOS_FillEndPoint_IPv6(
-                        &( xInterfaces[ 0 ] ),
-                        &( xEndPoints[ 2 ] ),
-                        &( xIPAddress ),
-                        &( xPrefix ),
-                        10U,  /* Prefix length. */
-                        NULL, /* No gateway */
-                        NULL, /* pxDNSServerAddress: Not used yet. */
-                        ucMACAddress );
+                    /* End-point 0 wants to use DHCPv4. */
+                    xEndPoints[ 3 ].bits.bWantDHCP = pdTRUE;
                 }
-            }
-        #endif /* if ( ipconfigUSE_IPv6 != 0 ) */
-        /* === End-point 0 === */
-        #if ( ( mainNETWORK_UP_COUNT >= 4U ) || ( USES_IPV6_ENDPOINT == 0 && mainNETWORK_UP_COUNT >= 2U ) )
-            {
-                /*172.25.201.204 */
-                /*netmask 255.255.240.0 */
-                const uint8_t ucMACAddress2[ 6 ] = { 0x00, 0x22, 0x22, 0x22, 0x22, 82 };
-                const uint8_t ucIPAddress2[ 4 ] = { 192, 168, 2, 210 };
-                const uint8_t ucNetMask2[ 4 ] = { 255, 255, 255, 0 };
-                const uint8_t ucGatewayAddress2[ 4 ] = { 0, 0, 0, 0 };
-                FreeRTOS_FillEndPoint( &( xInterfaces[ 0 ] ), &( xEndPoints[ 3 ] ), ucIPAddress2, ucNetMask2, ucGatewayAddress2, ucDNSServerAddress, ucMACAddress2 );
-                #if ( ipconfigUSE_DHCP != 0 )
-                    {
-                        /* End-point 0 wants to use DHCPv4. */
-                        xEndPoints[ 3 ].bits.bWantDHCP = pdTRUE;
-                    }
-                #endif /* ( ipconfigUSE_DHCP != 0 ) */
-            }
-        #endif /* ( mainNETWORK_UP_COUNT >= 3U ) */
+            #endif /* ( ipconfigUSE_DHCP != 0 ) */
+        }
+    #endif /* ( mainNETWORK_UP_COUNT >= 3U ) */
 
-        FreeRTOS_IPInit_Multi();
-    #endif /* if ( ipconfigMULTI_INTERFACE == 0 ) || ( ipconfigCOMPATIBLE_WITH_SINGLE == 1 ) */
+    FreeRTOS_IPInit_Multi();
+
     xTaskCreate( prvServerWorkTask, "SvrWork", mainTCP_SERVER_STACK_SIZE, NULL, mainTCP_SERVER_TASK_PRIORITY, NULL );
 
     /* Start the RTOS scheduler. */
@@ -400,14 +386,9 @@ void vAssertCalled( const char * pcFile,
 /* Called by FreeRTOS+TCP when the network connects or disconnects.  Disconnect
  * events are only received if implemented in the MAC driver. */
 /* *INDENT-OFF* */
-#if ( ipconfigMULTI_INTERFACE != 0 ) || ( ipconfigCOMPATIBLE_WITH_SINGLE != 0 )
-    /* The multi version: each end-point comes up individually. */
-    void vApplicationIPNetworkEventHook_Multi( eIPCallbackEvent_t eNetworkEvent,
+
+void vApplicationIPNetworkEventHook_Multi( eIPCallbackEvent_t eNetworkEvent,
                                          NetworkEndPoint_t * pxEndPoint )
-#else
-    /* The single version, the interface comes up as a whole. */
-    void vApplicationIPNetworkEventHook( eIPCallbackEvent_t eNetworkEvent )
-#endif
 /* *INDENT-ON* */
 {
     static BaseType_t xTasksAlreadyCreated = pdFALSE;
@@ -448,7 +429,7 @@ void vAssertCalled( const char * pcFile,
 
             #if ( mainCREATE_UDP_ECHO_SERVER_TASK == 1 )
                 {
-                    vStartUDPEchoClientTasks_SingleTasks(mainECHO_SERVER_TASK_STACK_SIZE, mainECHO_SERVER_TASK_PRIORITY);
+                    vStartUDPEchoClientTasks_SingleTasks( mainECHO_SERVER_TASK_STACK_SIZE, mainECHO_SERVER_TASK_PRIORITY );
                 }
             #endif
 
@@ -463,32 +444,9 @@ void vAssertCalled( const char * pcFile,
             FreeRTOS_printf( ( "IPv4 address = %xip\n", FreeRTOS_ntohl( pxEndPoint->ipv4_settings.ulIPAddress ) ) );
         }
 
-        #if ( ipconfigMULTI_INTERFACE == 0 )
-            {
-                uint32_t ulIPAddress, ulNetMask, ulGatewayAddress, ulDNSServerAddress;
-
-                /* Print out the network configuration, which may have come from a DHCP
-                 * server. */
-                FreeRTOS_GetAddressConfiguration( &ulIPAddress, &ulNetMask, &ulGatewayAddress, &ulDNSServerAddress );
-                FreeRTOS_inet_ntoa( ulIPAddress, cBuffer );
-                FreeRTOS_printf( ( "\r\n\r\nIP Address: %s\r\n", cBuffer ) );
-
-                FreeRTOS_inet_ntoa( ulNetMask, cBuffer );
-                FreeRTOS_printf( ( "Subnet Mask: %s\r\n", cBuffer ) );
-
-                FreeRTOS_inet_ntoa( ulGatewayAddress, cBuffer );
-                FreeRTOS_printf( ( "Gateway Address: %s\r\n", cBuffer ) );
-
-                FreeRTOS_inet_ntoa( ulDNSServerAddress, cBuffer );
-                FreeRTOS_printf( ( "DNS Server Address: %s\r\n\r\n\r\n", cBuffer ) );
-            }
-        #else /* if ( ipconfigMULTI_INTERFACE == 0 ) */
-            {
-                /* Print out the network configuration, which may have come from a DHCP
-                 * server. */
-                showEndPoint( pxEndPoint );
-            }
-        #endif /* ipconfigMULTI_INTERFACE */
+        /* Print out the network configuration, which may have come from a DHCP
+         * server. */
+        showEndPoint( pxEndPoint );
     }
 }
 /*-----------------------------------------------------------*/
@@ -562,7 +520,7 @@ static void prvMiscInitialisation( void )
 
 #if ( ipconfigUSE_MDNS != 0 ) || ( ipconfigUSE_LLMNR != 0 ) || ( ipconfigUSE_NBNS != 0 )
 
-    #if ( ipconfigMULTI_INTERFACE != 0 ) && ( ipconfigUSE_IPv6 != 0 ) && ( TESTING_PATCH == 0 )
+    #if ( ipconfigUSE_IPv6 != 0 ) && ( TESTING_PATCH == 0 )
         static BaseType_t setEndPoint( NetworkEndPoint_t * pxEndPoint )
         {
             NetworkEndPoint_t * px;
@@ -613,16 +571,12 @@ static void prvMiscInitialisation( void )
 
             return xDone;
         }
-    #endif /* ( ipconfigMULTI_INTERFACE != 0 ) */
+    #endif /* if ( ipconfigUSE_IPv6 != 0 ) && ( TESTING_PATCH == 0 ) */
 
 /*-----------------------------------------------------------*/
 
-    #if ( ipconfigMULTI_INTERFACE != 0 )
-        BaseType_t xApplicationDNSQueryHook_Multi( NetworkEndPoint_t * pxEndPoint,
-                                             const char * pcName )
-    #else
-        BaseType_t xApplicationDNSQueryHook( const char * pcName )
-    #endif
+    BaseType_t xApplicationDNSQueryHook_Multi( NetworkEndPoint_t * pxEndPoint,
+                                               const char * pcName )
     {
         BaseType_t xReturn;
 
@@ -657,14 +611,14 @@ static void prvMiscInitialisation( void )
             xReturn = pdFAIL;
         }
 
-        #if ( ipconfigMULTI_INTERFACE != 0 ) && ( ipconfigUSE_IPv6 != 0 ) && ( TESTING_PATCH == 0 )
+        #if ( ipconfigUSE_IPv6 != 0 ) && ( TESTING_PATCH == 0 )
             if( xReturn == pdTRUE )
             {
                 xReturn = setEndPoint( pxEndPoint );
             }
         #endif
         {
-            #if ( ipconfigMULTI_INTERFACE != 0 ) && ( ipconfigUSE_IPv6 != 0 )
+            #if ( ipconfigUSE_IPv6 != 0 )
                 FreeRTOS_printf( ( "%s query '%s' = %d IPv%c\n", serviceName, pcName, ( int ) xReturn, pxEndPoint->bits.bIPv6 ? '6' : '4' ) );
             #else
                 FreeRTOS_printf( ( "%s query '%s' = %d IPv4 only\n", serviceName, pcName, ( int ) xReturn ) );

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Minimal_Windows_Simulator/DemoTasks/SimpleUDPClientAndServer.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Minimal_Windows_Simulator/DemoTasks/SimpleUDPClientAndServer.c
@@ -254,7 +254,7 @@ const size_t xStringLength = strlen( pcStringToSend ) + 15;
 			do
 			{
 			#if defined( ipconfigIPv4_BACKWARD_COMPATIBLE ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE == 0 )
-			} while( ( pucUDPPayloadBuffer = ( uint8_t * ) FreeRTOS_GetUDPPayloadBuffer_ByIPType( xStringLength, portMAX_DELAY, ipTYPE_IPv4 ) ) == NULL );
+			} while( ( pucUDPPayloadBuffer = ( uint8_t * ) FreeRTOS_GetUDPPayloadBuffer_Multi( xStringLength, portMAX_DELAY, ipTYPE_IPv4 ) ) == NULL );
 			#else
 			} while( ( pucUDPPayloadBuffer = ( uint8_t * ) FreeRTOS_GetUDPPayloadBuffer( xStringLength, portMAX_DELAY ) ) == NULL );
 			#endif

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Minimal_Windows_Simulator/DemoTasks/SimpleUDPClientAndServer.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Minimal_Windows_Simulator/DemoTasks/SimpleUDPClientAndServer.c
@@ -104,7 +104,7 @@ const TickType_t x150ms = 150UL / portTICK_PERIOD_MS;
 	so the IP address can be obtained immediately.  store the IP address being
 	used in ulIPAddress.  This is done so the socket can send to a different
 	port on the same IP address. */
-#if defined( FREERTOS_PLUS_TCP_VERSION ) && ( FREERTOS_PLUS_TCP_VERSION >= 10 )
+#if defined( ipconfigIPv4_BACKWARD_COMPATIBLE ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE == 0 )
 	FreeRTOS_GetEndPointConfiguration( &ulIPAddress, NULL, NULL, NULL, pxNetworkEndPoints );
 #else
 	FreeRTOS_GetAddressConfiguration( &ulIPAddress, NULL, NULL, NULL );
@@ -217,7 +217,7 @@ const size_t xStringLength = strlen( pcStringToSend ) + 15;
 	so the IP address can be obtained immediately.  store the IP address being
 	used in ulIPAddress.  This is done so the socket can send to a different
 	port on the same IP address. */
-#if defined( FREERTOS_PLUS_TCP_VERSION ) && ( FREERTOS_PLUS_TCP_VERSION >= 10 )
+#if defined( ipconfigIPv4_BACKWARD_COMPATIBLE ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE == 0 )
 	FreeRTOS_GetEndPointConfiguration( &ulIPAddress, NULL, NULL, NULL, pxNetworkEndPoints );
 #else
 	FreeRTOS_GetAddressConfiguration( &ulIPAddress, NULL, NULL, NULL );
@@ -253,7 +253,7 @@ const size_t xStringLength = strlen( pcStringToSend ) + 15;
 			the do while loop is used to ensure a buffer is obtained. */
 			do
 			{
-			#if defined( FREERTOS_PLUS_TCP_VERSION ) && ( FREERTOS_PLUS_TCP_VERSION >= 10 )
+			#if defined( ipconfigIPv4_BACKWARD_COMPATIBLE ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE == 0 )
 			} while( ( pucUDPPayloadBuffer = ( uint8_t * ) FreeRTOS_GetUDPPayloadBuffer_ByIPType( xStringLength, portMAX_DELAY, ipTYPE_IPv4 ) ) == NULL );
 			#else
 			} while( ( pucUDPPayloadBuffer = ( uint8_t * ) FreeRTOS_GetUDPPayloadBuffer( xStringLength, portMAX_DELAY ) ) == NULL );
@@ -327,7 +327,7 @@ Socket_t xListeningSocket;
 	the address being bound to.  The strange casting is to try and remove
 	compiler warnings on 32 bit machines.  Note that this task is only created
 	after the network is up, so the IP address is valid here. */
-#if defined( FREERTOS_PLUS_TCP_VERSION ) && ( FREERTOS_PLUS_TCP_VERSION >= 10 )
+#if defined( ipconfigIPv4_BACKWARD_COMPATIBLE ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE == 0 )
 	FreeRTOS_GetEndPointConfiguration( &ulIPAddress, NULL, NULL, NULL, pxNetworkEndPoints );
 #else
 	FreeRTOS_GetAddressConfiguration( &ulIPAddress, NULL, NULL, NULL );

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Minimal_Windows_Simulator/main.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Minimal_Windows_Simulator/main.c
@@ -130,7 +130,7 @@ const uint8_t ucMACAddress[ 6 ] = { configMAC_ADDR0, configMAC_ADDR1, configMAC_
 static UBaseType_t ulNextRand;
 /*-----------------------------------------------------------*/
 
-#if defined( FREERTOS_PLUS_TCP_VERSION ) && ( FREERTOS_PLUS_TCP_VERSION >= 10 )
+#if defined( ipconfigIPv4_BACKWARD_COMPATIBLE ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE == 0 )
     /* In case multiple interfaces are used, define them statically. */
 
     /* With WinPCap there is only 1 physical interface. */
@@ -139,7 +139,7 @@ static UBaseType_t ulNextRand;
     /* It will have several end-points. */
     static NetworkEndPoint_t xEndPoints[ 4 ];
 
-#endif /* if defined( FREERTOS_PLUS_TCP_VERSION ) && ( FREERTOS_PLUS_TCP_VERSION >= 10 ) */
+#endif /* if defined( ipconfigIPv4_BACKWARD_COMPATIBLE ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE == 0 ) */
 
 /*-----------------------------------------------------------*/
 
@@ -167,7 +167,7 @@ int main( void )
     /* Initialise the network interface.*/
     FreeRTOS_debug_printf( ( "FreeRTOS_IPInit\r\n" ) );
 
-#if defined( FREERTOS_PLUS_TCP_VERSION ) && ( FREERTOS_PLUS_TCP_VERSION >= 10 )
+#if defined( ipconfigIPv4_BACKWARD_COMPATIBLE ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE == 0 )
     /* Initialise the interface descriptor for WinPCap. */
     pxWinPcap_FillInterfaceDescriptor( 0, &( xInterfaces[ 0 ] ) );
 
@@ -186,7 +186,7 @@ int main( void )
 #else
     /* Using the old /single /IPv4 library, or using backward compatible mode of the new /multi library. */
     FreeRTOS_IPInit( ucIPAddress, ucNetMask, ucGatewayAddress, ucDNSServerAddress, ucMACAddress );
-#endif /* if defined( FREERTOS_PLUS_TCP_VERSION ) && ( FREERTOS_PLUS_TCP_VERSION >= 10 ) */
+#endif /* if defined( ipconfigIPv4_BACKWARD_COMPATIBLE ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE == 0 ) */
 
     /* Start the RTOS scheduler. */
     FreeRTOS_debug_printf( ( "vTaskStartScheduler\r\n" ) );
@@ -260,10 +260,10 @@ void vApplicationIPNetworkEventHook( eIPCallbackEvent_t eNetworkEvent )
         /* Print out the network configuration, which may have come from a DHCP
          * server. */
 
-        /* Using FREERTOS_PLUS_TCP_VERSION as the substitute of the
+        /* Using ipconfigIPv4_BACKWARD_COMPATIBLE as the substitute of the
          * downward compatibility*/
 
-    #if defined( FREERTOS_PLUS_TCP_VERSION ) && ( FREERTOS_PLUS_TCP_VERSION >= 10 )
+    #if defined( ipconfigIPv4_BACKWARD_COMPATIBLE ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE == 0 )
         FreeRTOS_GetEndPointConfiguration( &ulIPAddress, &ulNetMask, &ulGatewayAddress, &ulDNSServerAddress, pxNetworkEndPoints );
     #else
         FreeRTOS_GetAddressConfiguration( &ulIPAddress, &ulNetMask, &ulGatewayAddress, &ulDNSServerAddress );

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Minimal_Windows_Simulator/main.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Minimal_Windows_Simulator/main.c
@@ -182,7 +182,7 @@ int main( void )
 
     memcpy( ipLOCAL_MAC_ADDRESS, ucMACAddress, sizeof( ucMACAddress ) );
 
-    FreeRTOS_IPStart();
+    FreeRTOS_IPInit_Multi();
 #else
     /* Using the old /single /IPv4 library, or using backward compatible mode of the new /multi library. */
     FreeRTOS_IPInit( ucIPAddress, ucNetMask, ucGatewayAddress, ucDNSServerAddress, ucMACAddress );

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_UDP_Mode_CLI_Windows_Simulator/DemoTasks/CLI-commands.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_UDP_Mode_CLI_Windows_Simulator/DemoTasks/CLI-commands.c
@@ -532,7 +532,7 @@ uint32_t ulAddress;
 	switch( xIndex )
 	{
 		case 0 :
-		#if defined( FREERTOS_PLUS_TCP_VERSION ) && ( FREERTOS_PLUS_TCP_VERSION >= 10 )
+		#if defined( ipconfigIPv4_BACKWARD_COMPATIBLE ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE == 0 )
 			FreeRTOS_GetEndPointConfiguration( &ulAddress, NULL, NULL, NULL, pxNetworkEndPoints );
 		#else
 			FreeRTOS_GetAddressConfiguration( &ulAddress, NULL, NULL, NULL );
@@ -543,7 +543,7 @@ uint32_t ulAddress;
 			break;
 
 		case 1 :
-		#if defined( FREERTOS_PLUS_TCP_VERSION ) && ( FREERTOS_PLUS_TCP_VERSION >= 10 )
+		#if defined( ipconfigIPv4_BACKWARD_COMPATIBLE ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE == 0 )
 			FreeRTOS_GetEndPointConfiguration( NULL, &ulAddress, NULL, NULL, pxNetworkEndPoints );
 		#else
 			FreeRTOS_GetAddressConfiguration( NULL, &ulAddress, NULL, NULL );
@@ -554,7 +554,7 @@ uint32_t ulAddress;
 			break;
 
 		case 2 :
-		#if defined( FREERTOS_PLUS_TCP_VERSION ) && ( FREERTOS_PLUS_TCP_VERSION >= 10 )
+		#if defined( ipconfigIPv4_BACKWARD_COMPATIBLE ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE == 0 )
 			FreeRTOS_GetEndPointConfiguration( NULL, NULL, &ulAddress, NULL, pxNetworkEndPoints );
 		#else
 			FreeRTOS_GetAddressConfiguration( NULL, NULL, &ulAddress, NULL );
@@ -565,7 +565,7 @@ uint32_t ulAddress;
 			break;
 
 		case 3 :
-		#if defined( FREERTOS_PLUS_TCP_VERSION ) && ( FREERTOS_PLUS_TCP_VERSION >= 10 )
+		#if defined( ipconfigIPv4_BACKWARD_COMPATIBLE ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE == 0 )
 			FreeRTOS_GetEndPointConfiguration( NULL, NULL, NULL, &ulAddress, pxNetworkEndPoints );
 		#else
 			FreeRTOS_GetAddressConfiguration( NULL, NULL, NULL, &ulAddress );

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_UDP_Mode_CLI_Windows_Simulator/DemoTasks/SimpleClientAndServer.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_UDP_Mode_CLI_Windows_Simulator/DemoTasks/SimpleClientAndServer.c
@@ -94,7 +94,7 @@ const portTickType x150ms = 150UL / portTICK_RATE_MS;
 	so the IP address can be obtained immediately.  store the IP address being
 	used in ulIPAddress.  This is done so the socket can send to a different
 	port on the same IP address. */
-#if defined( FREERTOS_PLUS_TCP_VERSION ) && ( FREERTOS_PLUS_TCP_VERSION >= 10 )
+#if defined( ipconfigIPv4_BACKWARD_COMPATIBLE ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE == 0 )
 	FreeRTOS_GetEndPointConfiguration( &ulIPAddress, NULL, NULL, NULL, pxNetworkEndPoints );
 #else
 	FreeRTOS_GetAddressConfiguration( &ulIPAddress, NULL, NULL, NULL );
@@ -214,7 +214,7 @@ const size_t xStringLength = strlen( ( char * ) pucStringToSend ) + 15;
 	so the IP address can be obtained immediately.  store the IP address being
 	used in ulIPAddress.  This is done so the socket can send to a different
 	port on the same IP address. */
-#if defined( FREERTOS_PLUS_TCP_VERSION ) && ( FREERTOS_PLUS_TCP_VERSION >= 10 )
+#if defined( ipconfigIPv4_BACKWARD_COMPATIBLE ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE == 0 )
 	FreeRTOS_GetEndPointConfiguration( &ulIPAddress, NULL, NULL, NULL, pxNetworkEndPoints );
 #else
 	FreeRTOS_GetAddressConfiguration( &ulIPAddress, NULL, NULL, NULL );
@@ -250,7 +250,7 @@ const size_t xStringLength = strlen( ( char * ) pucStringToSend ) + 15;
 			the do while loop is used to ensure a buffer is obtained. */
 			do
 			{
-			#if defined( FREERTOS_PLUS_TCP_VERSION ) && ( FREERTOS_PLUS_TCP_VERSION >= 10 )
+			#if defined( ipconfigIPv4_BACKWARD_COMPATIBLE ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE == 0 )
 			} while( ( pucUDPPayloadBuffer = ( uint8_t * ) FreeRTOS_GetUDPPayloadBuffer_ByIPType( xStringLength, portMAX_DELAY, ipTYPE_IPv4 ) ) == NULL );
 			#else
 			} while( ( pucUDPPayloadBuffer = ( uint8_t * ) FreeRTOS_GetUDPPayloadBuffer( xStringLength, portMAX_DELAY ) ) == NULL );
@@ -324,7 +324,7 @@ Socket_t xListeningSocket;
 	the address being bound to.  The strange casting is to try and remove
 	compiler warnings on 32 bit machines.  Note that this task is only created
 	after the network is up, so the IP address is valid here. */
-#if defined( FREERTOS_PLUS_TCP_VERSION ) && ( FREERTOS_PLUS_TCP_VERSION >= 10 )
+#if defined( ipconfigIPv4_BACKWARD_COMPATIBLE ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE == 0 )
 	FreeRTOS_GetEndPointConfiguration( &ulIPAddress, NULL, NULL, NULL, pxNetworkEndPoints );
 #else
 	FreeRTOS_GetAddressConfiguration( &ulIPAddress, NULL, NULL, NULL );

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_UDP_Mode_CLI_Windows_Simulator/DemoTasks/SimpleClientAndServer.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_UDP_Mode_CLI_Windows_Simulator/DemoTasks/SimpleClientAndServer.c
@@ -251,7 +251,7 @@ const size_t xStringLength = strlen( ( char * ) pucStringToSend ) + 15;
 			do
 			{
 			#if defined( ipconfigIPv4_BACKWARD_COMPATIBLE ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE == 0 )
-			} while( ( pucUDPPayloadBuffer = ( uint8_t * ) FreeRTOS_GetUDPPayloadBuffer_ByIPType( xStringLength, portMAX_DELAY, ipTYPE_IPv4 ) ) == NULL );
+			} while( ( pucUDPPayloadBuffer = ( uint8_t * ) FreeRTOS_GetUDPPayloadBuffer_Multi( xStringLength, portMAX_DELAY, ipTYPE_IPv4 ) ) == NULL );
 			#else
 			} while( ( pucUDPPayloadBuffer = ( uint8_t * ) FreeRTOS_GetUDPPayloadBuffer( xStringLength, portMAX_DELAY ) ) == NULL );
 			#endif

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_UDP_Mode_CLI_Windows_Simulator/DemoTasks/TwoEchoClients.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_UDP_Mode_CLI_Windows_Simulator/DemoTasks/TwoEchoClients.c
@@ -296,7 +296,7 @@ const size_t xBufferLength = strlen( ( char * ) pucStringToSend ) + 15;
 			ipconfigMAX_SEND_BLOCK_TIME_TICKS, hence the test to ensure a buffer
 			was actually obtained. */
 
-		#if defined( FREERTOS_PLUS_TCP_VERSION ) && ( FREERTOS_PLUS_TCP_VERSION >= 10 )
+		#if defined( ipconfigIPv4_BACKWARD_COMPATIBLE ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE == 0 )
 			pucUDPPayloadBuffer = ( uint8_t * ) FreeRTOS_GetUDPPayloadBuffer_ByIPType( xBufferLength, portMAX_DELAY, ipTYPE_IPv4 );
 		#else
 			pucUDPPayloadBuffer = ( uint8_t * ) FreeRTOS_GetUDPPayloadBuffer( xBufferLength, portMAX_DELAY );

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_UDP_Mode_CLI_Windows_Simulator/DemoTasks/TwoEchoClients.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_UDP_Mode_CLI_Windows_Simulator/DemoTasks/TwoEchoClients.c
@@ -297,7 +297,7 @@ const size_t xBufferLength = strlen( ( char * ) pucStringToSend ) + 15;
 			was actually obtained. */
 
 		#if defined( ipconfigIPv4_BACKWARD_COMPATIBLE ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE == 0 )
-			pucUDPPayloadBuffer = ( uint8_t * ) FreeRTOS_GetUDPPayloadBuffer_ByIPType( xBufferLength, portMAX_DELAY, ipTYPE_IPv4 );
+			pucUDPPayloadBuffer = ( uint8_t * ) FreeRTOS_GetUDPPayloadBuffer_Multi( xBufferLength, portMAX_DELAY, ipTYPE_IPv4 );
 		#else
 			pucUDPPayloadBuffer = ( uint8_t * ) FreeRTOS_GetUDPPayloadBuffer( xBufferLength, portMAX_DELAY );
 		#endif

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_UDP_Mode_CLI_Windows_Simulator/main.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_UDP_Mode_CLI_Windows_Simulator/main.c
@@ -108,7 +108,7 @@ const BaseType_t xLogToStdout = pdTRUE, xLogToFile = pdFALSE, xLogToUDP = pdFALS
 /* Used by the pseudo random number generator. */
 static UBaseType_t ulNextRand;
 
-#if defined( FREERTOS_PLUS_TCP_VERSION ) && ( FREERTOS_PLUS_TCP_VERSION >= 10 )
+#if defined( ipconfigIPv4_BACKWARD_COMPATIBLE ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE == 0 )
 
     /* In case multiple interfaces are used, define them statically. */
 
@@ -118,7 +118,7 @@ static UBaseType_t ulNextRand;
     /* It will have several end-points. */
     static NetworkEndPoint_t xEndPoints[ 4 ];
 
-#endif /* if defined( FREERTOS_PLUS_TCP_VERSION ) && ( FREERTOS_PLUS_TCP_VERSION >= 10 ) */
+#endif /* if defined( ipconfigIPv4_BACKWARD_COMPATIBLE ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE == 0 ) */
 
 /******************************************************************************
  *
@@ -145,7 +145,7 @@ const uint32_t ulLongTime_ms = 250UL;
     /* Initialise the network interface.*/
     FreeRTOS_debug_printf( ( "FreeRTOS_IPInit\r\n" ) );
 
-#if defined( FREERTOS_PLUS_TCP_VERSION ) && ( FREERTOS_PLUS_TCP_VERSION >= 10 )
+#if defined( ipconfigIPv4_BACKWARD_COMPATIBLE ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE == 0 )
     /* Initialise the interface descriptor for WinPCap. */
     pxWinPcap_FillInterfaceDescriptor( 0, &( xInterfaces[ 0 ] ) );
 
@@ -162,7 +162,7 @@ const uint32_t ulLongTime_ms = 250UL;
 #else
     /* Using the old /single /IPv4 library, or using backward compatible mode of the new /multi library. */
     FreeRTOS_IPInit( ucIPAddress, ucNetMask, ucGatewayAddress, ucDNSServerAddress, ucMACAddress );
-#endif /* if defined( FREERTOS_PLUS_TCP_VERSION ) && ( FREERTOS_PLUS_TCP_VERSION >= 10 ) */
+#endif /* if defined( ipconfigIPv4_BACKWARD_COMPATIBLE ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE == 0 ) */
 
     /* Initialise the logging. */
     uint32_t ulLoggingIPAddress;

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_UDP_Mode_CLI_Windows_Simulator/main.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_UDP_Mode_CLI_Windows_Simulator/main.c
@@ -158,7 +158,7 @@ const uint32_t ulLongTime_ms = 250UL;
     }
     #endif /* ( ipconfigUSE_DHCP != 0 ) */
     memcpy( ipLOCAL_MAC_ADDRESS, ucMACAddress, sizeof( ucMACAddress ) );
-    FreeRTOS_IPStart();
+    FreeRTOS_IPInit_Multi();
 #else
     /* Using the old /single /IPv4 library, or using backward compatible mode of the new /multi library. */
     FreeRTOS_IPInit( ucIPAddress, ucNetMask, ucGatewayAddress, ucDNSServerAddress, ucMACAddress );

--- a/FreeRTOS-Plus/VisualStudio_StaticProjects/FreeRTOS+TCP/NetworkInterface_WinPCap.c
+++ b/FreeRTOS-Plus/VisualStudio_StaticProjects/FreeRTOS+TCP/NetworkInterface_WinPCap.c
@@ -39,7 +39,7 @@
 #include "FreeRTOS_IP.h"
 #include "FreeRTOS_IP_Private.h"
 #include "NetworkBufferManagement.h"
-#if defined( FREERTOS_PLUS_TCP_VERSION ) && ( FREERTOS_PLUS_TCP_VERSION >= 10 )
+#if defined( ipconfigIPv4_BACKWARD_COMPATIBLE ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE == 0 )
     #include "FreeRTOS_Routing.h"
 #endif
 
@@ -153,7 +153,7 @@ static StreamBuffer_t * xRecvBuffer = NULL;
 /* Logs the number of WinPCAP send failures, for viewing in the debugger only. */
 static volatile uint32_t ulWinPCAPSendFailures = 0;
 
-#if defined( FREERTOS_PLUS_TCP_VERSION ) && ( FREERTOS_PLUS_TCP_VERSION >= 10 )
+#if defined( ipconfigIPv4_BACKWARD_COMPATIBLE ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE == 0 )
 /*
  * A pointer to the network interface is needed later when receiving packets.
  */
@@ -173,7 +173,7 @@ static volatile uint32_t ulWinPCAPSendFailures = 0;
 
 /*-----------------------------------------------------------*/
 
-#if defined( FREERTOS_PLUS_TCP_VERSION ) && ( FREERTOS_PLUS_TCP_VERSION >= 10 )
+#if defined( ipconfigIPv4_BACKWARD_COMPATIBLE ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE == 0 )
     static BaseType_t xWinPcap_NetworkInterfaceInitialise( NetworkInterface_t * pxInterface )
 #else
     BaseType_t xNetworkInterfaceInitialise( void )
@@ -282,7 +282,7 @@ static size_t prvStreamBufferAdd( StreamBuffer_t * pxBuffer,
 
 /*-----------------------------------------------------------*/
 
-#if defined( FREERTOS_PLUS_TCP_VERSION ) && ( FREERTOS_PLUS_TCP_VERSION >= 10 )
+#if defined( ipconfigIPv4_BACKWARD_COMPATIBLE ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE == 0 )
     static BaseType_t xWinPcap_NetworkInterfaceOutput( NetworkInterface_t * pxInterface,
                                                        NetworkBufferDescriptor_t * const pxNetworkBuffer,
                                                        BaseType_t bReleaseAfterSend )
@@ -329,7 +329,7 @@ static size_t prvStreamBufferAdd( StreamBuffer_t * pxBuffer,
 }
 /*-----------------------------------------------------------*/
 
-#if defined( FREERTOS_PLUS_TCP_VERSION ) && ( FREERTOS_PLUS_TCP_VERSION >= 10 )
+#if defined( ipconfigIPv4_BACKWARD_COMPATIBLE ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE == 0 )
 
     static BaseType_t xWinPcap_GetPhyLinkStatus( NetworkInterface_t * pxInterface )
     {
@@ -668,7 +668,7 @@ DWORD WINAPI prvWinPcapSendThread( void * pvParam )
 }
 /*-----------------------------------------------------------*/
 
-#if defined  ( FREERTOS_PLUS_TCP_VERSION ) && ( FREERTOS_PLUS_TCP_VERSION >= 10 )
+#if defined  ( ipconfigIPv4_BACKWARD_COMPATIBLE ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE == 0 )
 
     static BaseType_t xPacketBouncedBack( const uint8_t * pucBuffer )
     {
@@ -803,7 +803,7 @@ static void prvInterruptSimulatorTask( void * pvParameters )
                         if( pxNetworkBuffer != NULL )
                         {
                             xRxEvent.pvData = ( void * ) pxNetworkBuffer;
-                        #if defined ( FREERTOS_PLUS_TCP_VERSION ) && ( FREERTOS_PLUS_TCP_VERSION >= 10 )
+                        #if defined ( ipconfigIPv4_BACKWARD_COMPATIBLE ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE == 0 )
                             pxNetworkBuffer->pxInterface = pxMyInterface;
                             pxNetworkBuffer->pxEndPoint = FreeRTOS_MatchingEndpoint( pxMyInterface, pxNetworkBuffer->pucEthernetBuffer );
 

--- a/FreeRTOS-Plus/VisualStudio_StaticProjects/FreeRTOS+TCP/plus_tcp_hooks_winsim.c
+++ b/FreeRTOS-Plus/VisualStudio_StaticProjects/FreeRTOS+TCP/plus_tcp_hooks_winsim.c
@@ -37,7 +37,7 @@
 
 /*-----------------------------------------------------------*/
 
-#if defined( FREERTOS_PLUS_TCP_VERSION ) && ( FREERTOS_PLUS_TCP_VERSION >= 10 )
+#if defined( ipconfigIPv4_BACKWARD_COMPATIBLE ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE == 0 )
 
     /* In case multiple interfaces are used, define them statically. */
 
@@ -47,7 +47,7 @@
     /* It will have several end-points. */
     static NetworkEndPoint_t xEndPoints[ 4 ];
 
-#endif /* if defined( FREERTOS_PLUS_TCP_VERSION ) && ( FREERTOS_PLUS_TCP_VERSION >= 10 ) */
+#endif /* if defined( ipconfigIPv4_BACKWARD_COMPATIBLE ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE == 0 ) */
 
 /*-----------------------------------------------------------*/
 
@@ -136,11 +136,11 @@ void vApplicationIPNetworkEventHook( eIPCallbackEvent_t eNetworkEvent )
     {
         /* Print out the network configuration, which may have come from a DHCP
          * server. */
-    #if defined( FREERTOS_PLUS_TCP_VERSION ) && ( FREERTOS_PLUS_TCP_VERSION >= 10 )
+    #if defined( ipconfigIPv4_BACKWARD_COMPATIBLE ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE == 10 )
         FreeRTOS_GetEndPointConfiguration( &ulIPAddress, &ulNetMask, &ulGatewayAddress, &ulDNSServerAddress, pxNetworkEndPoints );
     #else
         FreeRTOS_GetAddressConfiguration( &ulIPAddress, &ulNetMask, &ulGatewayAddress, &ulDNSServerAddress );
-    #endif /* if defined( FREERTOS_PLUS_TCP_VERSION ) && ( FREERTOS_PLUS_TCP_VERSION >= 10 ) */
+    #endif /* if defined( ipconfigIPv4_BACKWARD_COMPATIBLE ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE == 0 ) */
 
         FreeRTOS_inet_ntoa( ulIPAddress, cBuffer );
         FreeRTOS_printf( ( "\r\n\r\nIP Address: %s\r\n", cBuffer ) );
@@ -192,7 +192,7 @@ void vPlatformInitIpStack( void )
     /* Initialise the network interface.*/
     FreeRTOS_debug_printf( ( "FreeRTOS_IPInit\r\n" ) );
 
-#if defined( FREERTOS_PLUS_TCP_VERSION ) && ( FREERTOS_PLUS_TCP_VERSION >= 10 )
+#if defined( ipconfigIPv4_BACKWARD_COMPATIBLE ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE == 0 )
     /* Initialise the interface descriptor for WinPCap. */
     pxWinPcap_FillInterfaceDescriptor( 0, &( xInterfaces[ 0 ] ) );
 


### PR DESCRIPTION
<!--- Title -->

Description
-----------
Add backward compatibility with IPv4 single endpoint branch by adding following changes:

- Update the backward compatibility flag for IPv4 only build to ipconfigIPv4_BACKWARD_COMPATIBLE.
- Rename FreeRTOS_GetUDPPayloadBuffer_ByIPType to FreeRTOS_GetUDPPayloadBuffer_Multi.
- Rename FreeRTOS_IPStart to FreeRTOS_IPInit_Multi

Test Steps
-----------
Run Demos on Jenkins.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
