### PR TITLE
Update Client Task Stack size for FreeRTOS_Plus_TCP_Echo_Posix Demo

### DIFF
--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Echo_Posix/TCPEchoClient_SingleTasks.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Echo_Posix/TCPEchoClient_SingleTasks.c
@@ -102,7 +102,7 @@
                 cRxBuffers[ echoNUM_ECHO_CLIENTS ][ echoBUFFER_SIZES ];
 
     static StaticTask_t echoServerTaskBuffer;
-    static StackType_t echoServerTaskStack[ PTHREAD_STACK_MIN ];
+    static StackType_t echoServerTaskStack[ PTHREAD_STACK_MIN * 2 ];
 
 /*-----------------------------------------------------------*/
 


### PR DESCRIPTION
Update Client Task Stack size for FreeRTOS_Plus_TCP_Echo_Posix Demo

Description
-----------
In **static creation** of the Echo Client Tasks, the **stack depth** is defined as (PTHREAD_STACK_MIN*2) in main.c
but the **Stack Buffer** size is defined as PTHREAD_STACK_MIN. This results in segmentation fault.
Bug Fix [https://github.com/FreeRTOS/FreeRTOS/issues/967](url)

Initial result
![2](https://user-images.githubusercontent.com/118818625/225750849-644c6b97-52af-4136-b38e-e009ef15388b.PNG)
Result after PR changes
![1](https://user-images.githubusercontent.com/118818625/225750934-7ad5162e-ff9d-47a3-93f8-5124f0c98f53.PNG)


Test Steps
-----------
Run ./build/posix_tcp_demo

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
