### PR TITLE
Remove cast from configMINIMAL_STACK_SIZE

### DIFF
--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Echo_Posix/FreeRTOSConfig.h
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Echo_Posix/FreeRTOSConfig.h
@@ -43,7 +43,7 @@
 #define configUSE_TICK_HOOK						1
 #define configUSE_DAEMON_TASK_STARTUP_HOOK		1
 #define configTICK_RATE_HZ						( 1000 ) /* In this non-real time simulated environment the tick frequency has to be at least a multiple of the Win32 tick frequency, and therefore very slow. */
-#define configMINIMAL_STACK_SIZE				( ( unsigned short ) PTHREAD_STACK_MIN ) /* In this simulated case, the stack only has to hold one small structure as the real stack is part of the win32 thread. */
+#define configMINIMAL_STACK_SIZE				( PTHREAD_STACK_MIN )
 #define configTOTAL_HEAP_SIZE					( ( size_t ) ( 84 * 1024 ) )
 #define configMAX_TASK_NAME_LEN					( 12 )
 #define configUSE_TRACE_FACILITY				1


### PR DESCRIPTION
Description
-----------
The configMINIMAL_STACK_SIZE was defined to PTHREAD_STACK_MIN with cast to unsigned short. This cast cab be too restrictive and result in truncation on some platforms. This commit removes this unnecessary cast.

Related Issue
-----------
https://github.com/FreeRTOS/FreeRTOS/issues/967

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
