### PR TITLE
Added support for static memory allocation in FreeRTOS-Plus-CLI

### DIFF
--- a/FreeRTOS-Plus/Source/FreeRTOS-Plus-CLI/FreeRTOS_CLI.c
+++ b/FreeRTOS-Plus/Source/FreeRTOS-Plus-CLI/FreeRTOS_CLI.c
@@ -29,8 +29,8 @@
 #include <stdint.h>
 
 /* FreeRTOS includes. */
-#include "../../../FreeRTOS/Source/include/FreeRTOS.h"
-#include "../../../FreeRTOS/Source/include/task.h"
+#include "FreeRTOS.h"
+#include "task.h"
 
 /* Utils includes. */
 #include "FreeRTOS_CLI.h"

--- a/FreeRTOS-Plus/Source/FreeRTOS-Plus-CLI/FreeRTOS_CLI.c
+++ b/FreeRTOS-Plus/Source/FreeRTOS-Plus-CLI/FreeRTOS_CLI.c
@@ -120,10 +120,10 @@ BaseType_t xReturn = pdFAIL;
 	{
 		taskENTER_CRITICAL();
 		{
-            /* Reference the command being registered from the newly created
+			/* Reference the command being registered from the newly created
 			list item. */
 			pxNewListItem->pxCommandLineDefinition = pxCommandToRegister;
-		    
+
 			/* The new list item will get added to the end of the list, so
 			pxNext has nowhere to point. */
 			pxNewListItem->pxNext = NULL;

--- a/FreeRTOS-Plus/Source/FreeRTOS-Plus-CLI/FreeRTOS_CLI.c
+++ b/FreeRTOS-Plus/Source/FreeRTOS-Plus-CLI/FreeRTOS_CLI.c
@@ -1,6 +1,6 @@
 /*
- * FreeRTOS+CLI V1.0.4
- * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ * FreeRTOS V202212.00
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
@@ -20,7 +20,7 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  *
  * https://www.FreeRTOS.org
- * https://aws.amazon.com/freertos
+ * https://github.com/FreeRTOS
  *
  */
 
@@ -37,7 +37,7 @@
 
 /* If the application writer needs to place the buffer used by the CLI at a
 fixed address then set configAPPLICATION_PROVIDES_cOutputBuffer to 1 in
-FreeRTOSConfig.h, then declare an array with the following name and size in 
+FreeRTOSConfig.h, then declare an array with the following name and size in
 one of the application files:
 	char cOutputBuffer[ configCOMMAND_INT_MAX_OUTPUT_SIZE ];
 */
@@ -45,11 +45,15 @@ one of the application files:
 	#define configAPPLICATION_PROVIDES_cOutputBuffer 0
 #endif
 
-/* If static memory allocation is used, then pvPortMalloc may not be defined.
-Simply return NULL, as if the malloc had failed */
-#ifndef pvPortMalloc
-	#define pvPortMalloc( x ) NULL
-#endif
+/*
+ * Register the command passed in using the pxCommandToRegister parameter
+ * and using pxCliDefinitionListItemBuffer as the memory for command line
+ * list items. Registering a command adds the command to the list of
+ * commands that are handled by the command interpreter.  Once a command
+ * has been registered it can be executed from the command line.
+ */
+static void prvRegisterCommand( const CLI_Command_Definition_t * const pxCommandToRegister,
+								CLI_Definition_List_Item_t * pxCliDefinitionListItemBuffer );
 
 /*
  * The callback function that is executed when "help" is entered.  This is the
@@ -101,47 +105,47 @@ buffer needs to be placed at a fixed address (rather than by the linker). */
 
 /*-----------------------------------------------------------*/
 
-BaseType_t FreeRTOS_CLIGenericRegisterCommand( const CLI_Command_Definition_t * const pxCommandToRegister, CLI_Definition_List_Item_t * pxNewListItem )
-{
-static CLI_Definition_List_Item_t *pxLastCommandInList = &xRegisteredCommands;
-BaseType_t xReturn = pdFAIL;
+#if ( configSUPPORT_DYNAMIC_ALLOCATION == 1 )
 
-	/* Check the parameter is not NULL. */
-	configASSERT( pxCommandToRegister );
-
-    if ( pxNewListItem == NULL )
-    {
-	    /* Create a new list item that will reference the command being registered. */
-	    pxNewListItem = ( CLI_Definition_List_Item_t * ) pvPortMalloc( sizeof( CLI_Definition_List_Item_t ) );
-	    configASSERT( pxNewListItem );
-    }
-    
-	if( pxNewListItem != NULL )
+	BaseType_t FreeRTOS_CLIRegisterCommand( const CLI_Command_Definition_t * const pxCommandToRegister )
 	{
-		taskENTER_CRITICAL();
+	BaseType_t xReturn = pdFAIL;
+	CLI_Definition_List_Item_t *pxNewListItem;
+
+		/* Check the parameter is not NULL. */
+		configASSERT( pxCommandToRegister != NULL );
+
+		/* Create a new list item that will reference the command being registered. */
+		pxNewListItem = ( CLI_Definition_List_Item_t * ) pvPortMalloc( sizeof( CLI_Definition_List_Item_t ) );
+		configASSERT( pxNewListItem != NULL );
+
+		if( pxNewListItem != NULL )
 		{
-			/* Reference the command being registered from the newly created
-			list item. */
-			pxNewListItem->pxCommandLineDefinition = pxCommandToRegister;
-
-			/* The new list item will get added to the end of the list, so
-			pxNext has nowhere to point. */
-			pxNewListItem->pxNext = NULL;
-
-			/* Add the newly created list item to the end of the already existing
-			list. */
-			pxLastCommandInList->pxNext = pxNewListItem;
-
-			/* Set the end of list marker to the new list item. */
-			pxLastCommandInList = pxNewListItem;
+			prvRegisterCommand( pxCommandToRegister, pxNewListItem );
+			xReturn = pdPASS;
 		}
-		taskEXIT_CRITICAL();
 
-		xReturn = pdPASS;
+		return xReturn;
 	}
 
-	return xReturn;
-}
+#endif /* #if ( configSUPPORT_DYNAMIC_ALLOCATION == 1 ) */
+/*-----------------------------------------------------------*/
+
+#if ( configSUPPORT_STATIC_ALLOCATION == 1 )
+
+	BaseType_t FreeRTOS_CLIRegisterCommandStatic( const CLI_Command_Definition_t * const pxCommandToRegister,
+												  CLI_Definition_List_Item_t * pxCliDefinitionListItemBuffer )
+	{
+		/* Check the parameters are not NULL. */
+		configASSERT( pxCommandToRegister != NULL );
+		configASSERT( pxCliDefinitionListItemBuffer != NULL );
+
+		prvRegisterCommand( pxCommandToRegister, pxCliDefinitionListItemBuffer );
+
+		return pdPASS;
+	}
+
+#endif /* #if ( configSUPPORT_STATIC_ALLOCATION == 1 ) */
 /*-----------------------------------------------------------*/
 
 BaseType_t FreeRTOS_CLIProcessCommand( const char * const pcCommandInput, char * pcWriteBuffer, size_t xWriteBufferLen  )
@@ -281,6 +285,36 @@ const char *pcReturn = NULL;
 }
 /*-----------------------------------------------------------*/
 
+static void prvRegisterCommand( const CLI_Command_Definition_t * const pxCommandToRegister,
+								CLI_Definition_List_Item_t * pxCliDefinitionListItemBuffer )
+{
+static CLI_Definition_List_Item_t *pxLastCommandInList = &xRegisteredCommands;
+
+	/* Check the parameters are not NULL. */
+	configASSERT( pxCommandToRegister != NULL );
+	configASSERT( pxCliDefinitionListItemBuffer != NULL );
+
+	taskENTER_CRITICAL();
+	{
+		/* Reference the command being registered from the newly created
+		list item. */
+		pxCliDefinitionListItemBuffer->pxCommandLineDefinition = pxCommandToRegister;
+
+		/* The new list item will get added to the end of the list, so
+		pxNext has nowhere to point. */
+		pxCliDefinitionListItemBuffer->pxNext = NULL;
+
+		/* Add the newly created list item to the end of the already existing
+		list. */
+		pxLastCommandInList->pxNext = pxCliDefinitionListItemBuffer;
+
+		/* Set the end of list marker to the new list item. */
+		pxLastCommandInList = pxCliDefinitionListItemBuffer;
+	}
+	taskEXIT_CRITICAL();
+}
+/*-----------------------------------------------------------*/
+
 static BaseType_t prvHelpCommand( char *pcWriteBuffer, size_t xWriteBufferLen, const char *pcCommandString )
 {
 static const CLI_Definition_List_Item_t * pxCommand = NULL;
@@ -349,4 +383,4 @@ BaseType_t xLastCharacterWasSpace = pdFALSE;
 	as the first word should be the command itself. */
 	return cParameters;
 }
-
+/*-----------------------------------------------------------*/

--- a/FreeRTOS-Plus/Source/FreeRTOS-Plus-CLI/FreeRTOS_CLI.c
+++ b/FreeRTOS-Plus/Source/FreeRTOS-Plus-CLI/FreeRTOS_CLI.c
@@ -106,7 +106,7 @@ BaseType_t FreeRTOS_CLIGenericRegisterCommand( const CLI_Command_Definition_t * 
 static CLI_Definition_List_Item_t *pxLastCommandInList = &xRegisteredCommands;
 BaseType_t xReturn = pdFAIL;
 
-	/* Check the command parameter is NULL */
+	/* Check the parameter is not NULL. */
 	configASSERT( pxCommandToRegister );
 
     if ( pxNewListItem == NULL )
@@ -122,12 +122,12 @@ BaseType_t xReturn = pdFAIL;
 		{
             /* Reference the command being registered from the newly created
 			list item. */
-		    pxNewListItem->pxCommandLineDefinition = pxCommandToRegister;
+			pxNewListItem->pxCommandLineDefinition = pxCommandToRegister;
 		    
-		    /* The new list item will get added to the end of the list, so
-		    pxNext has nowhere to point. */
-		    pxNewListItem->pxNext = NULL;
-            
+			/* The new list item will get added to the end of the list, so
+			pxNext has nowhere to point. */
+			pxNewListItem->pxNext = NULL;
+
 			/* Add the newly created list item to the end of the already existing
 			list. */
 			pxLastCommandInList->pxNext = pxNewListItem;

--- a/FreeRTOS-Plus/Source/FreeRTOS-Plus-CLI/FreeRTOS_CLI.h
+++ b/FreeRTOS-Plus/Source/FreeRTOS-Plus-CLI/FreeRTOS_CLI.h
@@ -50,6 +50,14 @@ typedef struct xCOMMAND_LINE_INPUT
 	int8_t cExpectedNumberOfParameters;			/* Commands expect a fixed number of parameters, which may be zero. */
 } CLI_Command_Definition_t;
 
+/* The structure that defines a command line list entry. */
+typedef struct xCOMMAND_INPUT_LIST
+{
+	const CLI_Command_Definition_t *pxCommandLineDefinition;
+	struct xCOMMAND_INPUT_LIST *pxNext;
+} CLI_Definition_List_Item_t;
+
+
 /* For backward compatibility. */
 #define xCommandLineInput CLI_Command_Definition_t
 
@@ -59,7 +67,17 @@ typedef struct xCOMMAND_LINE_INPUT
  * handled by the command interpreter.  Once a command has been registered it
  * can be executed from the command line.
  */
-BaseType_t FreeRTOS_CLIRegisterCommand( const CLI_Command_Definition_t * const pxCommandToRegister );
+BaseType_t FreeRTOS_CLIGenericRegisterCommand( const CLI_Command_Definition_t * const pxCommandToRegister, CLI_Definition_List_Item_t * pxNewListItem );
+
+#if ( configSUPPORT_DYNAMIC_ALLOCATION == 1 )
+    #define FreeRTOS_CLIRegisterCommand( pxCommandToRegister )                  \
+        FreeRTOS_CLIGenericRegisterCommand( pxCommandToRegister, NULL )
+#endif
+
+#if ( configSUPPORT_STATIC_ALLOCATION == 1 )
+    #define FreeRTOS_CLIRegisterCommandStatic( pxCommandToRegister, pxNewListItem ) \
+        FreeRTOS_CLIGenericRegisterCommand( pxCommandToRegister, pxNewListItem )
+#endif
 
 /*
  * Runs the command interpreter for the command string "pcCommandInput".  Any

--- a/FreeRTOS-Plus/Source/FreeRTOS-Plus-CLI/FreeRTOS_CLI.h
+++ b/FreeRTOS-Plus/Source/FreeRTOS-Plus-CLI/FreeRTOS_CLI.h
@@ -1,6 +1,6 @@
 /*
- * FreeRTOS+CLI V1.0.4
- * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ * FreeRTOS V202212.00
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
@@ -20,7 +20,7 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  *
  * https://www.FreeRTOS.org
- * https://aws.amazon.com/freertos
+ * https://github.com/FreeRTOS
  *
  */
 
@@ -57,7 +57,6 @@ typedef struct xCOMMAND_INPUT_LIST
 	struct xCOMMAND_INPUT_LIST *pxNext;
 } CLI_Definition_List_Item_t;
 
-
 /* For backward compatibility. */
 #define xCommandLineInput CLI_Command_Definition_t
 
@@ -67,16 +66,17 @@ typedef struct xCOMMAND_INPUT_LIST
  * handled by the command interpreter.  Once a command has been registered it
  * can be executed from the command line.
  */
-BaseType_t FreeRTOS_CLIGenericRegisterCommand( const CLI_Command_Definition_t * const pxCommandToRegister, CLI_Definition_List_Item_t * pxNewListItem );
-
 #if ( configSUPPORT_DYNAMIC_ALLOCATION == 1 )
-    #define FreeRTOS_CLIRegisterCommand( pxCommandToRegister )                  \
-        FreeRTOS_CLIGenericRegisterCommand( pxCommandToRegister, NULL )
+	BaseType_t FreeRTOS_CLIRegisterCommand( const CLI_Command_Definition_t * const pxCommandToRegister );
 #endif
 
+/*
+ * Static version of the above function which allows the application writer
+ * to supply the memory used for a command line list entry.
+ */
 #if ( configSUPPORT_STATIC_ALLOCATION == 1 )
-    #define FreeRTOS_CLIRegisterCommandStatic( pxCommandToRegister, pxNewListItem ) \
-        FreeRTOS_CLIGenericRegisterCommand( pxCommandToRegister, pxNewListItem )
+	BaseType_t FreeRTOS_CLIRegisterCommandStatic( const CLI_Command_Definition_t * const pxCommandToRegister,
+												  CLI_Definition_List_Item_t * pxCliDefinitionListItemBuffer );
 #endif
 
 /*
@@ -119,16 +119,4 @@ const char *FreeRTOS_CLIGetParameter( const char *pcCommandString, UBaseType_t u
 /* *INDENT-ON* */
 
 #endif /* COMMAND_INTERPRETER_H */
-
-
-
-
-
-
-
-
-
-
-
-
 

--- a/lexicon.txt
+++ b/lexicon.txt
@@ -2171,6 +2171,7 @@ pxcertificatebufferlength
 pxcertificatecontext
 pxcertificateidbufferlength
 pxclass
+pxclidefinitionlistitembuffer
 pxclient
 pxcommand
 pxcommandcontext


### PR DESCRIPTION
Static memory support for FreeRTOS-Plus-CLI

Description
-----------
Originally posted in the [FreeRTOS forums](https://forums.freertos.org/t/freertos-plus-cli-static-memory-allocation/17117/), I was suggested to create a pull request on GitHub. This patch allows the usage of FreeRTOS-Plus-CLI when _pvPortMalloc_ is not defined and _configSUPPORT_STATIC_ALLOCATION_ is set to 1.

Test Steps
-----------
Create a new project without heap support and try to build FreeRTOS-Plus-CLI. The project will not build without the patch.

Checklist:
----------
- [ x ] I have tested my changes. No regression in existing tests.
- [  ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
