### PR TITLE
Set configMAX_SYSCALL_INTERRUPT_PRIORITY to 4

### DIFF
--- a/FreeRTOS/Demo/CORTEX_MPS2_QEMU_IAR_GCC/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_MPS2_QEMU_IAR_GCC/FreeRTOSConfig.h
@@ -102,7 +102,7 @@ FreeRTOS/Source/tasks.c for limitations. */
 #define configKERNEL_INTERRUPT_PRIORITY 		( 255 )	/* All eight bits as QEMU doesn't model the priority bits. */
 /* !!!! configMAX_SYSCALL_INTERRUPT_PRIORITY must not be set to zero !!!!
 See http://www.FreeRTOS.org/RTOS-Cortex-M3-M4.html. */
-#define configMAX_SYSCALL_INTERRUPT_PRIORITY 	( 5 )
+#define configMAX_SYSCALL_INTERRUPT_PRIORITY 	( 4 )
 
 /* Use the Cortex-M3 optimised task selection rather than the generic C code
 version. */


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->
Set configMAX_SYSCALL_INTERRUPT_PRIORITY to 4 instead of 5 to avoid hitting the assert in `Source/portable/GCC/ARM_CM3/port.c` (`configASSERT( ( configMAX_SYSCALL_INTERRUPT_PRIORITY & 0x1U ) == 0U ); `)

Test Steps
-----------
<!-- Describe the steps to reproduce. -->
Run the Demo `CORTEX_MPS2_QEMU_IAR_GCC` on QEMU and the assert is hit.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
