### PR TITLE
Update FreeRTOSconfig.h for M2351

### DIFF
--- a/FreeRTOS/Demo/CORTEX_MPU_M23_Nuvoton_NuMaker_PFM_M2351_IAR_GCC/Projects/IAR/Config/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_MPU_M23_Nuvoton_NuMaker_PFM_M2351_IAR_GCC/Projects/IAR/Config/FreeRTOSConfig.h
@@ -134,26 +134,16 @@
 #ifdef __NVIC_PRIO_BITS
 	#define configPRIO_BITS								__NVIC_PRIO_BITS
 #else
-	#define configPRIO_BITS								3	 /* 8 priority levels. */
+	#define configPRIO_BITS								2	 /* 4 priority levels. */
 #endif
 
 /* The lowest interrupt priority that can be used in a call to a "set priority"
  * function. */
-#define configLIBRARY_LOWEST_INTERRUPT_PRIORITY			0x07
-
-/* The highest interrupt priority that can be used by any interrupt service
- * routine that makes calls to interrupt safe FreeRTOS API functions.  DO NOT
- * CALL INTERRUPT SAFE FREERTOS API FUNCTIONS FROM ANY INTERRUPT THAT HAS A
- * HIGHER PRIORITY THAN THIS! (higher priorities are lower numeric values). */
-#define configLIBRARY_MAX_SYSCALL_INTERRUPT_PRIORITY	5
+#define configLIBRARY_LOWEST_INTERRUPT_PRIORITY			0x03
 
 /* Interrupt priorities used by the kernel port layer itself.  These are generic
  * to all Cortex-M ports, and do not rely on any particular library functions. */
 #define configKERNEL_INTERRUPT_PRIORITY					( configLIBRARY_LOWEST_INTERRUPT_PRIORITY << ( 8 - configPRIO_BITS ) )
-
-/* !!!! configMAX_SYSCALL_INTERRUPT_PRIORITY must not be set to zero !!!!
- * See http://www.FreeRTOS.org/RTOS-Cortex-M3-M4.html. */
-#define configMAX_SYSCALL_INTERRUPT_PRIORITY			( configLIBRARY_MAX_SYSCALL_INTERRUPT_PRIORITY << ( 8 - configPRIO_BITS ) )
 
 /* The #ifdef guards against the file being included from IAR assembly files. */
 #ifndef __IASMARM__

--- a/FreeRTOS/Demo/CORTEX_MPU_M23_Nuvoton_NuMaker_PFM_M2351_IAR_GCC/Projects/Keil/Config/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_MPU_M23_Nuvoton_NuMaker_PFM_M2351_IAR_GCC/Projects/Keil/Config/FreeRTOSConfig.h
@@ -129,26 +129,16 @@ extern uint32_t SystemCoreClock;
 #ifdef __NVIC_PRIO_BITS
 	#define configPRIO_BITS								__NVIC_PRIO_BITS
 #else
-	#define configPRIO_BITS								3	 /* 8 priority levels. */
+	#define configPRIO_BITS								2	 /* 4 priority levels. */
 #endif
 
 /* The lowest interrupt priority that can be used in a call to a "set priority"
  * function. */
-#define configLIBRARY_LOWEST_INTERRUPT_PRIORITY			0x07
-
-/* The highest interrupt priority that can be used by any interrupt service
- * routine that makes calls to interrupt safe FreeRTOS API functions.  DO NOT
- * CALL INTERRUPT SAFE FREERTOS API FUNCTIONS FROM ANY INTERRUPT THAT HAS A
- * HIGHER PRIORITY THAN THIS! (higher priorities are lower numeric values). */
-#define configLIBRARY_MAX_SYSCALL_INTERRUPT_PRIORITY	5
+#define configLIBRARY_LOWEST_INTERRUPT_PRIORITY			0x03
 
 /* Interrupt priorities used by the kernel port layer itself.  These are generic
  * to all Cortex-M ports, and do not rely on any particular library functions. */
 #define configKERNEL_INTERRUPT_PRIORITY					( configLIBRARY_LOWEST_INTERRUPT_PRIORITY << ( 8 - configPRIO_BITS ) )
-
-/* !!!! configMAX_SYSCALL_INTERRUPT_PRIORITY must not be set to zero !!!!
- * See http://www.FreeRTOS.org/RTOS-Cortex-M3-M4.html. */
-#define configMAX_SYSCALL_INTERRUPT_PRIORITY			( configLIBRARY_MAX_SYSCALL_INTERRUPT_PRIORITY << ( 8 - configPRIO_BITS ) )
 
 /* The #ifdef guards against the file being included from IAR assembly files. */
 #ifndef __IASMARM__

--- a/FreeRTOS/Demo/CORTEX_MPU_M23_Nuvoton_NuMaker_PFM_M2351_IAR_GCC/Projects_NTZ/IAR/Config/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_MPU_M23_Nuvoton_NuMaker_PFM_M2351_IAR_GCC/Projects_NTZ/IAR/Config/FreeRTOSConfig.h
@@ -135,26 +135,16 @@
 #ifdef __NVIC_PRIO_BITS
 	#define configPRIO_BITS								__NVIC_PRIO_BITS
 #else
-	#define configPRIO_BITS								3	 /* 8 priority levels. */
+	#define configPRIO_BITS								2	 /* 4 priority levels. */
 #endif
 
 /* The lowest interrupt priority that can be used in a call to a "set priority"
  * function. */
-#define configLIBRARY_LOWEST_INTERRUPT_PRIORITY			0x07
-
-/* The highest interrupt priority that can be used by any interrupt service
- * routine that makes calls to interrupt safe FreeRTOS API functions.  DO NOT
- * CALL INTERRUPT SAFE FREERTOS API FUNCTIONS FROM ANY INTERRUPT THAT HAS A
- * HIGHER PRIORITY THAN THIS! (higher priorities are lower numeric values). */
-#define configLIBRARY_MAX_SYSCALL_INTERRUPT_PRIORITY	5
+#define configLIBRARY_LOWEST_INTERRUPT_PRIORITY			0x03
 
 /* Interrupt priorities used by the kernel port layer itself.  These are generic
  * to all Cortex-M ports, and do not rely on any particular library functions. */
 #define configKERNEL_INTERRUPT_PRIORITY					( configLIBRARY_LOWEST_INTERRUPT_PRIORITY << ( 8 - configPRIO_BITS ) )
-
-/* !!!! configMAX_SYSCALL_INTERRUPT_PRIORITY must not be set to zero !!!!
- * See http://www.FreeRTOS.org/RTOS-Cortex-M3-M4.html. */
-#define configMAX_SYSCALL_INTERRUPT_PRIORITY			( configLIBRARY_MAX_SYSCALL_INTERRUPT_PRIORITY << ( 8 - configPRIO_BITS ) )
 
 /* The #ifdef guards against the file being included from IAR assembly files. */
 #ifndef __IASMARM__

--- a/FreeRTOS/Demo/CORTEX_MPU_M23_Nuvoton_NuMaker_PFM_M2351_IAR_GCC/Projects_NTZ/Keil/Config/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_MPU_M23_Nuvoton_NuMaker_PFM_M2351_IAR_GCC/Projects_NTZ/Keil/Config/FreeRTOSConfig.h
@@ -130,26 +130,16 @@ extern uint32_t SystemCoreClock;
 #ifdef __NVIC_PRIO_BITS
 	#define configPRIO_BITS								__NVIC_PRIO_BITS
 #else
-	#define configPRIO_BITS								3	 /* 8 priority levels. */
+	#define configPRIO_BITS								2	 /* 4 priority levels. */
 #endif
 
 /* The lowest interrupt priority that can be used in a call to a "set priority"
  * function. */
-#define configLIBRARY_LOWEST_INTERRUPT_PRIORITY			0x07
-
-/* The highest interrupt priority that can be used by any interrupt service
- * routine that makes calls to interrupt safe FreeRTOS API functions.  DO NOT
- * CALL INTERRUPT SAFE FREERTOS API FUNCTIONS FROM ANY INTERRUPT THAT HAS A
- * HIGHER PRIORITY THAN THIS! (higher priorities are lower numeric values). */
-#define configLIBRARY_MAX_SYSCALL_INTERRUPT_PRIORITY	5
+#define configLIBRARY_LOWEST_INTERRUPT_PRIORITY			0x03
 
 /* Interrupt priorities used by the kernel port layer itself.  These are generic
  * to all Cortex-M ports, and do not rely on any particular library functions. */
 #define configKERNEL_INTERRUPT_PRIORITY					( configLIBRARY_LOWEST_INTERRUPT_PRIORITY << ( 8 - configPRIO_BITS ) )
-
-/* !!!! configMAX_SYSCALL_INTERRUPT_PRIORITY must not be set to zero !!!!
- * See http://www.FreeRTOS.org/RTOS-Cortex-M3-M4.html. */
-#define configMAX_SYSCALL_INTERRUPT_PRIORITY			( configLIBRARY_MAX_SYSCALL_INTERRUPT_PRIORITY << ( 8 - configPRIO_BITS ) )
 
 /* The #ifdef guards against the file being included from IAR assembly files. */
 #ifndef __IASMARM__


### PR DESCRIPTION
<!--- Title -->
Update FreeRTOSconfig.h for M2351

Description
-----------
The number of implemented priority bits for Armv8-M baseline implementation is defined by the architecture as 2. Therefore the config option `configPRIO_BITS` is updated to 2.

In addition, in Armv8-M baseline implementation BASEPRI is RES0. Therefore, `configMAX_SYSCALL_INTERRUPT_PRIORITY` is not supported. Hence this config option is removed.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
