### PR TITLE
Set configMAX_SYSCALL_INTERRUPT_PRIORITY to 4 for QEMU demo

### DIFF
--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Echo_Qemu_mps2/FreeRTOSConfig.h
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Echo_Qemu_mps2/FreeRTOSConfig.h
@@ -81,7 +81,7 @@ to exclude the API function. */
 #define configKERNEL_INTERRUPT_PRIORITY         255
 /* !!!! configMAX_SYSCALL_INTERRUPT_PRIORITY must not be set to zero !!!!
 See http://www.FreeRTOS.org/RTOS-Cortex-M3-M4.html. */
-#define configMAX_SYSCALL_INTERRUPT_PRIORITY    5 /* equivalent to 0xa0, or priority 5. */
+#define configMAX_SYSCALL_INTERRUPT_PRIORITY    4
 #define configMAC_INTERRUPT_PRIORITY            5
 
 


### PR DESCRIPTION
Set configMAX_SYSCALL_INTERRUPT_PRIORITY to 4 for QEMU demo

Description
-----------
Set configMAX_SYSCALL_INTERRUPT_PRIORITY to 4 instead of 5 to avoid hitting the assert
(configASSERT( ( configMAX_SYSCALL_INTERRUPT_PRIORITY & 0x1U ) == 0U ); )
This is in relation to the https://github.com/FreeRTOS/FreeRTOS/pull/986

Test Steps
-----------
Run the Demo on QEMU and the assert is hit, with configMAX_SYSCALL_INTERRUPT_PRIORITY as 5.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
