### PR TITLE
Update unit test for task state pending ready

### DIFF
--- a/FreeRTOS/Test/CMock/tasks/tasks_1_utest.c
+++ b/FreeRTOS/Test/CMock/tasks/tasks_1_utest.c
@@ -1741,7 +1741,7 @@ void test_eTaskGetState_success_not_current_tcb_pending_ready( void )
     /* API Call */
     ret_task_state = eTaskGetState( task_handle );
     /* Validations */
-    TEST_ASSERT_EQUAL( eReady, ret_task_state );
+    TEST_ASSERT_EQUAL( ePendingReady, ret_task_state );
 }
 
 void test_eTaskGetState_success_not_current_tcb_blocked_delayed( void )


### PR DESCRIPTION
Update eTaskGetState unit test cases for task in a pending ready list. This PR updates the unit test for the [kernel PR](https://github.com/FreeRTOS/FreeRTOS-Kernel/pull/696).

Description
-----------
* Update the expected task state from eReady to ePendingReady in test_eTaskGetState_success_not_current_tcb_pending_ready.

Test Steps
-----------
Update the Kernel submodule pointer to include PR #696.
The unit test should has no failure test case.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
