### PR TITLE
Fix TCP echo posix demo while running with ipconfigIPv4_BACKWARD_COMPATIBLE enabled

### DIFF
--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Echo_Posix/main_networking.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Echo_Posix/main_networking.c
@@ -157,6 +157,8 @@ void main_tcp_echo_client_tasks( void )
     /* Initialise the network interface.*/
     FreeRTOS_debug_printf( ( "FreeRTOS_IPInit\r\n" ) );
 
+    memcpy( ipLOCAL_MAC_ADDRESS, ucMACAddress, sizeof( ucMACAddress ) );
+
 #if defined( ipconfigIPv4_BACKWARD_COMPATIBLE ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE == 0 )
     /* Initialise the interface descriptor for WinPCap. */
     pxFillInterfaceDescriptor( 0, &( xInterfaces[ 0 ] ) );
@@ -170,7 +172,6 @@ void main_tcp_echo_client_tasks( void )
     }
     #endif /* ( ipconfigUSE_DHCP != 0 ) */
 
-    memcpy( ipLOCAL_MAC_ADDRESS, ucMACAddress, sizeof( ucMACAddress ) );
     FreeRTOS_IPInit_Multi();
 #else
     /* Using the old /single /IPv4 library, or using backward compatible mode of the new /multi library. */


### PR DESCRIPTION
<!--- Title -->

Description
-----------
This PR fixes the the posix demo when when built with `ipconfigIPv4_BACKWARD_COMPATIBLE` enabled.
Issue: The `ipLOCAL_MAC_ADDRESS` was not set when  `ipconfigIPv4_BACKWARD_COMPATIBLE` was enabled.

Test Steps
-----------
Tested with `ipconfigIPv4_BACKWARD_COMPATIBLE` enabled and disabled in posix demo, with an EC2 instance as echo server.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
