### PR TITLE
Fix TCP echo posix demo warnings

### DIFF
--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Echo_Posix/main.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Echo_Posix/main.c
@@ -227,7 +227,9 @@ void traceOnEnter()
 
         /* clear the buffer */
         char buffer[ 1 ];
-        read( STDIN_FILENO, &buffer, 1 );
+        size_t xReadRet;
+        xReadRet = read( STDIN_FILENO, &buffer, 1 );
+        ( void ) xReadRet;
     }
 }
 

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Echo_Posix/main_networking.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Echo_Posix/main_networking.c
@@ -161,7 +161,9 @@ void main_tcp_echo_client_tasks( void )
 
 #if defined( ipconfigIPv4_BACKWARD_COMPATIBLE ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE == 0 )
     /* Initialise the interface descriptor for WinPCap. */
-    pxFillInterfaceDescriptor( 0, &( xInterfaces[ 0 ] ) );
+    extern NetworkInterface_t * pxlinux_FillInterfaceDescriptor( BaseType_t xEMACIndex,
+                                                      NetworkInterface_t * pxInterface );
+    pxlinux_FillInterfaceDescriptor( 0, &( xInterfaces[ 0 ] ) );
 
     /* === End-point 0 === */
     FreeRTOS_FillEndPoint( &( xInterfaces[ 0 ] ), &( xEndPoints [ 0 ] ), ucIPAddress, ucNetMask, ucGatewayAddress, ucDNSServerAddress, ucMACAddress );

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Echo_Posix/main_networking.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Echo_Posix/main_networking.c
@@ -161,9 +161,9 @@ void main_tcp_echo_client_tasks( void )
 
 #if defined( ipconfigIPv4_BACKWARD_COMPATIBLE ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE == 0 )
     /* Initialise the interface descriptor for WinPCap. */
-    extern NetworkInterface_t * pxlinux_FillInterfaceDescriptor( BaseType_t xEMACIndex,
+    extern NetworkInterface_t * pxLinux_FillInterfaceDescriptor( BaseType_t xEMACIndex,
                                                       NetworkInterface_t * pxInterface );
-    pxlinux_FillInterfaceDescriptor( 0, &( xInterfaces[ 0 ] ) );
+    pxLinux_FillInterfaceDescriptor( 0, &( xInterfaces[ 0 ] ) );
 
     /* === End-point 0 === */
     FreeRTOS_FillEndPoint( &( xInterfaces[ 0 ] ), &( xEndPoints [ 0 ] ), ucIPAddress, ucNetMask, ucGatewayAddress, ucDNSServerAddress, ucMACAddress );

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Echo_Posix/main_networking.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Echo_Posix/main_networking.c
@@ -161,7 +161,7 @@ void main_tcp_echo_client_tasks( void )
 
 #if defined( ipconfigIPv4_BACKWARD_COMPATIBLE ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE == 0 )
     /* Initialise the interface descriptor for WinPCap. */
-    extern NetworkInterface_t * pxLinux_FillInterfaceDescriptor( BaseType_t xEMACIndex,
+    NetworkInterface_t * pxLinux_FillInterfaceDescriptor( BaseType_t xEMACIndex,
                                                       NetworkInterface_t * pxInterface );
     pxLinux_FillInterfaceDescriptor( 0, &( xInterfaces[ 0 ] ) );
 

--- a/manifest.yml
+++ b/manifest.yml
@@ -11,7 +11,7 @@ dependencies:
       path: "FreeRTOS/Source"
 
   - name: "FreeRTOS-Plus-TCP"
-    version: "2d3f4da"
+    version: "07e9985"
     repository:
       type: "git"
       url: "https://github.com/FreeRTOS/FreeRTOS-Plus-TCP.git"


### PR DESCRIPTION
<!--- Title -->

Description
-----------
This PR fixes the warnings generated for the TCP echo posix demo.

Test Steps
-----------
Tested with posix +TCP echo demo with `( ipconfigIPv4_BACKWARD_COMPATIBLE == 1 )` and `( ipconfigIPv4_BACKWARD_COMPATIBLE == 0 )`

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
