### PR TITLE
Make changes required for MPU enhancements

### DIFF
--- a/FreeRTOS/Demo/CORTEX_MPU_M3_MPS2_QEMU_GCC/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_MPU_M3_MPS2_QEMU_GCC/FreeRTOSConfig.h
@@ -112,6 +112,7 @@ unsigned long ulGetRunTimeCounterValue( void ); /* Prototype of function that re
 #define configMAC_INTERRUPT_PRIORITY                   5
 
 #define configENFORCE_SYSTEM_CALLS_FROM_KERNEL_ONLY    ( 1 )
+#define configUSE_MPU_WRAPPERS_V1                       1
 
 /* Prototype for the function used to print out.  In this case it prints to the
  |     10 console before the network is connected then a UDP port after the network has

--- a/FreeRTOS/Test/CMock/config/portmacro.h
+++ b/FreeRTOS/Test/CMock/config/portmacro.h
@@ -164,6 +164,15 @@ typedef unsigned long    UBaseType_t;
     volatile int fool_static2 = 0;                   \
     void vFunction( void * ( pvParameters ) )
 
+/* We need to define it here because CMock does not recognize the
+ * #if ( portUSING_MPU_WRAPPERS == 1 ) guard around xTaskGetMPUSettings
+ * and then complains about the missing xMPU_SETTINGS type in the
+ * generated mocks. */
+typedef struct MPU_SETTINGS
+{
+    uint32_t ulDummy;
+} xMPU_SETTINGS;
+
 /*-----------------------------------------------------------*/
 
 /* *INDENT-OFF* */


### PR DESCRIPTION

Description
-----------
1. Add macro configUSE_MPU_WRAPPERS_V1 to allow Demo compatibility with the old mpu wrapper .

2. Add Dummy xMPU_SETTINGS in portmacro.h file for Unit Tests .


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
