### PR TITLE
Update submodule pointer for Kernel V10.6.0

### DIFF
--- a/FreeRTOS/Test/CBMC/proofs/Task/TaskIncrementTick/Configurations.json
+++ b/FreeRTOS/Test/CBMC/proofs/Task/TaskIncrementTick/Configurations.json
@@ -48,7 +48,7 @@
   "CBMCFLAGS":
   [
     "--unwind 1",
-    "--unwindset prvInitialiseTaskLists.0:8,vListInsert.0:2,xTaskIncrementTick.5:4"
+    "--unwindset prvInitialiseTaskLists.0:8,vListInsert.0:2,xTaskIncrementTick.6:4"
   ],
   "OBJS":
   [

--- a/FreeRTOS/Test/CBMC/proofs/Task/TaskResumeAll/Configurations.json
+++ b/FreeRTOS/Test/CBMC/proofs/Task/TaskResumeAll/Configurations.json
@@ -53,7 +53,7 @@
   "CBMCFLAGS":
   [
     "--unwind 1",
-    "--unwindset prvInitialiseTaskLists.0:8,xTaskResumeAll.4:2,vListInsert.0:5,xTaskIncrementTick.5:4"
+    "--unwindset prvInitialiseTaskLists.0:8,xTaskResumeAll.5:2,vListInsert.0:5,xTaskIncrementTick.6:4"
 
   ],
   "OBJS":

--- a/manifest.yml
+++ b/manifest.yml
@@ -4,7 +4,7 @@ description: "This is the standard distribution of FreeRTOS."
 
 dependencies:
   - name: "FreeRTOS-Kernel"
-    version: "54b135"
+    version: "54b1356"
     repository:
       type: "git"
       url: "https://github.com/FreeRTOS/FreeRTOS-Kernel.git"

--- a/manifest.yml
+++ b/manifest.yml
@@ -4,7 +4,7 @@ description: "This is the standard distribution of FreeRTOS."
 
 dependencies:
   - name: "FreeRTOS-Kernel"
-    version: "d3c289f"
+    version: "b60ab2f"
     repository:
       type: "git"
       url: "https://github.com/FreeRTOS/FreeRTOS-Kernel.git"

--- a/manifest.yml
+++ b/manifest.yml
@@ -4,7 +4,7 @@ description: "This is the standard distribution of FreeRTOS."
 
 dependencies:
   - name: "FreeRTOS-Kernel"
-    version: "54b1356"
+    version: "c3dc20f"
     repository:
       type: "git"
       url: "https://github.com/FreeRTOS/FreeRTOS-Kernel.git"

--- a/manifest.yml
+++ b/manifest.yml
@@ -4,7 +4,7 @@ description: "This is the standard distribution of FreeRTOS."
 
 dependencies:
   - name: "FreeRTOS-Kernel"
-    version: "b60ab2f"
+    version: "54b135"
     repository:
       type: "git"
       url: "https://github.com/FreeRTOS/FreeRTOS-Kernel.git"


### PR DESCRIPTION
Description
-----------
Update submodule pointer for FreeRTOS Kernel V10.6.0


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
