### PR TITLE
Update Queue Unit Tests to add uxQueueItemSize

### DIFF
--- a/FreeRTOS/Test/CMock/queue/generic/queue_create_dynamic_utest.c
+++ b/FreeRTOS/Test/CMock/queue/generic/queue_create_dynamic_utest.c
@@ -68,17 +68,17 @@ int suiteTearDown( int numFailures )
 static void test_long_queue( QueueHandle_t xQueue,
                              uint32_t maxItems )
 {
-    /* Veify that queue is empty */
+    /* Verify that queue is empty */
     TEST_ASSERT_EQUAL( 0, uxQueueMessagesWaiting( xQueue ) );
 
     queue_common_add_sequential_to_queue( xQueue, maxItems );
 
-    /* Veify that queue is full */
+    /* Verify that queue is full */
     TEST_ASSERT_EQUAL( 0, uxQueueSpacesAvailable( xQueue ) );
 
     queue_common_receive_sequential_from_queue( xQueue, maxItems, maxItems, 0 );
 
-    /* Veify that queue is empty */
+    /* Verify that queue is empty */
     TEST_ASSERT_EQUAL( 0, uxQueueMessagesWaiting( xQueue ) );
 }
 
@@ -154,7 +154,10 @@ void test_macro_xQueueCreate_oneItem_zeroLength( void )
 
     TEST_ASSERT_EQUAL( QUEUE_T_SIZE, getLastMallocSize() );
 
-    /* Veify that new queue is empty */
+    /* Verify that Queue ItemSize is zero */
+    TEST_ASSERT_EQUAL( 0, uxQueueGetQueueItemSize( xQueue ) );
+
+    /* Verify that new queue is empty */
     TEST_ASSERT_EQUAL( 0, uxQueueMessagesWaiting( xQueue ) );
 
     /* Valdiate that the queue has 1 space remaining */
@@ -177,14 +180,17 @@ void test_macro_xQueueCreate_oneItem_oneLength( void )
 
     TEST_ASSERT_EQUAL( QUEUE_T_SIZE + 1, getLastMallocSize() );
 
-    /* Veify that new queue is empty */
+    /* Verify that Queue ItemSize is one */
+    TEST_ASSERT_EQUAL( 1, uxQueueGetQueueItemSize( xQueue ) );
+
+    /* Verify that new queue is empty */
     TEST_ASSERT_EQUAL( 0, uxQueueMessagesWaiting( xQueue ) );
 
     uint8_t testval = ( uint8_t ) getNextMonotonicTestValue();
 
     TEST_ASSERT_EQUAL( pdTRUE, xQueueSend( xQueue, &testval, 0 ) );
 
-    /* Veify that queue is full */
+    /* Verify that queue is full */
     TEST_ASSERT_EQUAL( 1, uxQueueMessagesWaiting( xQueue ) );
     TEST_ASSERT_EQUAL( 0, uxQueueSpacesAvailable( xQueue ) );
 
@@ -194,7 +200,7 @@ void test_macro_xQueueCreate_oneItem_oneLength( void )
     TEST_ASSERT_EQUAL( pdTRUE, xQueueReceive( xQueue, &testVal2, 0 ) );
     TEST_ASSERT_EQUAL( testval, testVal2 );
 
-    /* Veify that queue is empty */
+    /* Verify that queue is empty */
     TEST_ASSERT_EQUAL( 0, uxQueueMessagesWaiting( xQueue ) );
     TEST_ASSERT_EQUAL( 1, uxQueueSpacesAvailable( xQueue ) );
 
@@ -222,7 +228,10 @@ void test_macro_xQueueCreate_oneItem_multiLength( void )
 
         TEST_ASSERT_EQUAL( QUEUE_T_SIZE + i, getLastMallocSize() );
 
-        /* Veify that queue is empty */
+        /* Verify that Queue ItemSize is equal to the mailbox size */
+        TEST_ASSERT_EQUAL( i, uxQueueGetQueueItemSize( xQueue ) );
+
+        /* Verify that queue is empty */
         TEST_ASSERT_EQUAL( 0, uxQueueMessagesWaiting( xQueue ) );
 
         /* Mask off the bytes we won't use */
@@ -242,7 +251,7 @@ void test_macro_xQueueCreate_oneItem_multiLength( void )
 
         TEST_ASSERT_EQUAL( pdTRUE, xQueueSend( xQueue, &testVal, 0 ) );
 
-        /* Veify that queue is also full */
+        /* Verify that queue is also full */
         TEST_ASSERT_EQUAL( 0, uxQueueSpacesAvailable( xQueue ) );
 
         uint8_t testValCheck[ MAX_MULTI_LEN ];
@@ -252,7 +261,7 @@ void test_macro_xQueueCreate_oneItem_multiLength( void )
         TEST_ASSERT_EQUAL( pdTRUE, xQueueReceive( xQueue, &testValCheck, 0 ) );
         TEST_ASSERT_EQUAL_MEMORY( testValCompare, testValCheck, MAX_MULTI_LEN );
 
-        /* Veify that queue is empty */
+        /* Verify that queue is empty */
         TEST_ASSERT_EQUAL( 0, uxQueueMessagesWaiting( xQueue ) );
 
         vQueueDelete( xQueue );

--- a/FreeRTOS/Test/CMock/queue/generic/queue_create_static_utest.c
+++ b/FreeRTOS/Test/CMock/queue/generic/queue_create_static_utest.c
@@ -69,17 +69,17 @@ int suiteTearDown( int numFailures )
 static void test_long_queue( QueueHandle_t xQueue,
                              uint32_t maxItems )
 {
-    /* Veify that queue is empty */
+    /* Verify that queue is empty */
     TEST_ASSERT_EQUAL( 0, uxQueueMessagesWaiting( xQueue ) );
 
     queue_common_add_sequential_to_queue( xQueue, maxItems );
 
-    /* Veify that queue is full */
+    /* Verify that queue is full */
     TEST_ASSERT_EQUAL( 0, uxQueueSpacesAvailable( xQueue ) );
 
     queue_common_receive_sequential_from_queue( xQueue, maxItems, maxItems, 0 );
 
-    /* Veify that queue is empty */
+    /* Verify that queue is empty */
     TEST_ASSERT_EQUAL( 0, uxQueueMessagesWaiting( xQueue ) );
 }
 
@@ -138,7 +138,10 @@ void test_macro_xQueueCreateStatic_nullQueueStorage_oneItem_zeroLength( void )
     /* validate returned queue handle */
     TEST_ASSERT_NOT_EQUAL( NULL, xQueue );
 
-    /* Veify that new queue is empty */
+    /* Verify that Queue ItemSize is zero */
+    TEST_ASSERT_EQUAL( 0, uxQueueGetQueueItemSize( xQueue ) );
+
+    /* Verify that new queue is empty */
     TEST_ASSERT_EQUAL( 0, uxQueueMessagesWaiting( xQueue ) );
 
     /* Valdiate that the queue has 1 space remaining */
@@ -184,7 +187,7 @@ void test_macro_xQueueCreateStatic_validQueueStorage_oneItem_zeroLength( void )
     uint32_t queueData;
 
     /* Expect that xQueueCreateStatic will assert because data storage is
-     *   prohibited for a zero itemLength queue */
+     * prohibited for a zero itemLength queue */
     fakeAssertExpectFail();
     QueueHandle_t xQueue = xQueueCreateStatic( 1, 0, ( void * ) &queueData, &queueBuffer );
 
@@ -204,6 +207,9 @@ void test_macro_xQueueCreateStatic_large( void )
     uint32_t queueStorage[ MAX_QUEUE_ITEMS ];
     StaticQueue_t queueBuffer;
     QueueHandle_t xQueue = xQueueCreateStatic( MAX_QUEUE_ITEMS, sizeof( uint32_t ), ( void * ) queueStorage, &queueBuffer );
+
+    /* Verify that Queue ItemSize is 4 */
+    TEST_ASSERT_EQUAL( 4, uxQueueGetQueueItemSize( xQueue ) );
 
     test_long_queue( xQueue, MAX_QUEUE_ITEMS );
     vQueueDelete( xQueue );

--- a/FreeRTOS/Test/CMock/queue/generic/queue_receive_nonblocking_utest.c
+++ b/FreeRTOS/Test/CMock/queue/generic/queue_receive_nonblocking_utest.c
@@ -294,7 +294,7 @@ void test_xQueuePeek_noop_waiting_higher_priority( void )
 
     TEST_ASSERT_EQUAL( 1, uxQueueMessagesWaiting( xQueue ) );
 
-    /* Veify that the task Yielded */
+    /* Verify that the task Yielded */
     TEST_ASSERT_EQUAL( 1, td_task_getYieldCount() );
 
     /* Check that vTaskMissedYield was called */
@@ -338,7 +338,7 @@ void test_xQueuePeek_xQueuePeek_waiting_higher_priority( void )
 
     TEST_ASSERT_EQUAL( 1, uxQueueMessagesWaiting( xQueue ) );
 
-    /* Veify that the task Yielded */
+    /* Verify that the task Yielded */
     TEST_ASSERT_EQUAL( 1, td_task_getYieldCount() );
 
     /* Check that vTaskMissedYield was called */
@@ -382,7 +382,7 @@ void test_xQueuePeek_xQueueReceive_waiting_higher_priority( void )
 
     TEST_ASSERT_EQUAL( 0, uxQueueMessagesWaiting( xQueue ) );
 
-    /* Veify that the task Yielded */
+    /* Verify that the task Yielded */
     TEST_ASSERT_EQUAL( 1, td_task_getYieldCount() );
 
     /* Check that vTaskMissedYield was called */

--- a/FreeRTOS/Test/CMock/queue/sets/queue_set_utest.c
+++ b/FreeRTOS/Test/CMock/queue/sets/queue_set_utest.c
@@ -115,10 +115,10 @@ void test_xQueueCreateSet_oneLength( void )
 
     TEST_ASSERT_EQUAL( QUEUE_T_SIZE + sizeof( void * ), getLastMallocSize() );
 
-    /* Veify that QueueSet is not full */
+    /* Verify that QueueSet is not full */
     TEST_ASSERT_EQUAL( 1, uxQueueSpacesAvailable( xQueueSet ) );
 
-    /* Veify that QueueSet is empty */
+    /* Verify that QueueSet is empty */
     TEST_ASSERT_EQUAL( 0, uxQueueMessagesWaiting( xQueueSet ) );
 
     vQueueDelete( xQueueSet );

--- a/manifest.yml
+++ b/manifest.yml
@@ -4,7 +4,7 @@ description: "This is the standard distribution of FreeRTOS."
 
 dependencies:
   - name: "FreeRTOS-Kernel"
-    version: "d3c289f"
+    version: "c3dc20f"
     repository:
       type: "git"
       url: "https://github.com/FreeRTOS/FreeRTOS-Kernel.git"


### PR DESCRIPTION
Description
-----------
This PR updates unit Tests in FreeRTOS Kernel , to add coverage for the API uxQueueItemSize().

Test Steps
-----------
```
make <Test/CMock/queue>
make coverage
```

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
