### PR TITLE
fix: wrap logging buffer writes in critical section in Windows logging implementation

### DIFF
--- a/FreeRTOS-Plus/Demo/Common/Logging/windows/Logging_WinSim.c
+++ b/FreeRTOS-Plus/Demo/Common/Logging/windows/Logging_WinSim.c
@@ -403,16 +403,15 @@ void vLoggingPrintf( const char * pcFormat,
             if( xLength2 >= ( xLength + sizeof( xLength ) ) )
             {
                 /* First write in the length of the data, then write in the data
-                 * itself.  Raising the thread priority is used as a critical section
-                 * as there are potentially multiple writers.  The stream buffer is
-                 * only thread safe when there is a single writer (likewise for
-                 * reading from the buffer). */
-                xCurrentTask = GetCurrentThread();
-                iOriginalPriority = GetThreadPriority( xCurrentTask );
-                SetThreadPriority( GetCurrentThread(), THREAD_PRIORITY_TIME_CRITICAL );
+                 * itself. We are directly using taskENTER_CRITICAL() and
+                 * taskEXIT_CRITICAL() to ensure the buffer writes are inside a
+                 * critical section. */
+                taskENTER_CRITICAL();
+
                 uxStreamBufferAdd( xLogStreamBuffer, 0, ( const uint8_t * ) &( xLength ), sizeof( xLength ) );
                 uxStreamBufferAdd( xLogStreamBuffer, 0, ( const uint8_t * ) cOutputString, xLength );
-                SetThreadPriority( GetCurrentThread(), iOriginalPriority );
+                
+                taskEXIT_CRITICAL();
             }
 
             /* xDirectPrint is initialized to pdTRUE, and while it remains true the


### PR DESCRIPTION
Wrap logging buffer writes in critical section in Windows logging implementation

Description
-----------
WinSim (by virtue of Windows behavior) does not change task priority correctly/immediately. previously the logging buffer writes were protected by raising and lower task priority, which doesn't protect the buffer properly. This fix addresses that.

Test Steps
-----------
n/a

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
n/a


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
