### PR TITLE
Fix the implementation of gmtime_r in IPv6 demo

### DIFF
--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_IPv6_Demo/IPv6_Multi_WinSim_demo/main.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_IPv6_Demo/IPv6_Multi_WinSim_demo/main.c
@@ -869,16 +869,12 @@ static void prvServerWorkTask( void * pvArgument )
     struct tm * gmtime_r( const time_t * pxTime,
                           struct tm * tmStruct )
     {
-        struct tm tm;
-
-        memcpy( &( tm ), gmtime( pxTime ), sizeof( tm ) );
-
         if( tmStruct != NULL )
         {
-            memcpy( tmStruct, &( tm ), sizeof tm );
+            memcpy( tmStruct, gmtime( pxTime ), sizeof( struct tm ) );
         }
 
-        return &( tm );
+        return tmStruct;
     }
 /*-----------------------------------------------------------*/
 


### PR DESCRIPTION
<!--- Title -->

Description
-----------
Update the implementation of `gmtime_r` in IPv6 demo to return correct pointer.

[gmtime_r](https://linux.die.net/man/3/gmtime_r)


Test Steps
-----------
Ran the IPv6 winsim demo

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- NA ~[ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.~

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
