### PR TITLE
Posix demo use heap_3 in cmake

### DIFF
--- a/FreeRTOS/Demo/Posix_GCC/CMakeLists.txt
+++ b/FreeRTOS/Demo/Posix_GCC/CMakeLists.txt
@@ -46,7 +46,7 @@ target_include_directories( freertos_config
 )
 
 # Select the heap port
-set( FREERTOS_HEAP "4" CACHE STRING "" FORCE)
+set( FREERTOS_HEAP "3" CACHE STRING "" FORCE)
 
 # Select the native compile PORT
 set( FREERTOS_PORT "GCC_POSIX" CACHE STRING "" FORCE)


### PR DESCRIPTION

Description
-----------
* Use heap_3.c in Posix_GCC demo cmakefile to align with makefile.

Test Steps
-----------
* Before this PR. There will be malloc failed.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
