### PR TITLE
Add uxQueueGetQueueLength API in queue unit tests

### DIFF
--- a/FreeRTOS/Test/CMock/queue/generic/queue_create_dynamic_utest.c
+++ b/FreeRTOS/Test/CMock/queue/generic/queue_create_dynamic_utest.c
@@ -154,6 +154,9 @@ void test_macro_xQueueCreate_oneItem_zeroLength( void )
 
     TEST_ASSERT_EQUAL( QUEUE_T_SIZE, getLastMallocSize() );
 
+    /* Verify that Queue Length is one */
+    TEST_ASSERT_EQUAL( 1, uxQueueGetQueueLength( xQueue ) );
+
     /* Verify that Queue ItemSize is zero */
     TEST_ASSERT_EQUAL( 0, uxQueueGetQueueItemSize( xQueue ) );
 
@@ -179,6 +182,9 @@ void test_macro_xQueueCreate_oneItem_oneLength( void )
     TEST_ASSERT_NOT_EQUAL( NULL, xQueue );
 
     TEST_ASSERT_EQUAL( QUEUE_T_SIZE + 1, getLastMallocSize() );
+
+    /* Verify that Queue Length is one */
+    TEST_ASSERT_EQUAL( 1, uxQueueGetQueueLength( xQueue ) );
 
     /* Verify that Queue ItemSize is one */
     TEST_ASSERT_EQUAL( 1, uxQueueGetQueueItemSize( xQueue ) );
@@ -227,6 +233,9 @@ void test_macro_xQueueCreate_oneItem_multiLength( void )
         QueueHandle_t xQueue = xQueueCreate( 1, i );
 
         TEST_ASSERT_EQUAL( QUEUE_T_SIZE + i, getLastMallocSize() );
+
+        /* Verify that Queue Length is one */
+        TEST_ASSERT_EQUAL( 1, uxQueueGetQueueLength( xQueue ) );
 
         /* Verify that Queue ItemSize is equal to the mailbox size */
         TEST_ASSERT_EQUAL( i, uxQueueGetQueueItemSize( xQueue ) );

--- a/FreeRTOS/Test/CMock/queue/generic/queue_create_static_utest.c
+++ b/FreeRTOS/Test/CMock/queue/generic/queue_create_static_utest.c
@@ -138,6 +138,9 @@ void test_macro_xQueueCreateStatic_nullQueueStorage_oneItem_zeroLength( void )
     /* validate returned queue handle */
     TEST_ASSERT_NOT_EQUAL( NULL, xQueue );
 
+    /* Verify that Queue Length is one */
+    TEST_ASSERT_EQUAL( 1, uxQueueGetQueueLength( xQueue ) );
+
     /* Verify that Queue ItemSize is zero */
     TEST_ASSERT_EQUAL( 0, uxQueueGetQueueItemSize( xQueue ) );
 
@@ -207,6 +210,9 @@ void test_macro_xQueueCreateStatic_large( void )
     uint32_t queueStorage[ MAX_QUEUE_ITEMS ];
     StaticQueue_t queueBuffer;
     QueueHandle_t xQueue = xQueueCreateStatic( MAX_QUEUE_ITEMS, sizeof( uint32_t ), ( void * ) queueStorage, &queueBuffer );
+
+    /* Verify that Queue Length is equal to the MAX_QUEUE_ITEMS */
+    TEST_ASSERT_EQUAL( MAX_QUEUE_ITEMS, uxQueueGetQueueLength( xQueue ) );
 
     /* Verify that Queue ItemSize is 4 */
     TEST_ASSERT_EQUAL( 4, uxQueueGetQueueItemSize( xQueue ) );

--- a/manifest.yml
+++ b/manifest.yml
@@ -4,7 +4,7 @@ description: "This is the standard distribution of FreeRTOS."
 
 dependencies:
   - name: "FreeRTOS-Kernel"
-    version: "ae3a498e4"
+    version: "cdd3678c2"
     repository:
       type: "git"
       url: "https://github.com/FreeRTOS/FreeRTOS-Kernel.git"


### PR DESCRIPTION
Description
-----------
This PR adds the API uxQueueGetQueueLength() in FreeRTOS/CMock/queue unit tests, for code coverage for the latest release V10.6.1

Test Steps
-----------
Ran the Queue unit tests locally, with all tests passing.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
