### PR TITLE
Use alternate mirrors for glib and libslirp dependencies

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -42,7 +42,7 @@
 	url = https://github.com/wolfSSL/wolfssl.git
 [submodule "FreeRTOS-Plus/ThirdParty/libslirp"]
 	path = FreeRTOS-Plus/ThirdParty/libslirp
-	url = https://gitlab.freedesktop.org/slirp/libslirp.git
+	url = https://gitlab.com/qemu-project/libslirp.git
 [submodule "FreeRTOS-Plus/ThirdParty/glib"]
 	path = FreeRTOS-Plus/ThirdParty/glib
 	url = https://github.com/GNOME/glib.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -45,7 +45,7 @@
 	url = https://gitlab.freedesktop.org/slirp/libslirp.git
 [submodule "FreeRTOS-Plus/ThirdParty/glib"]
 	path = FreeRTOS-Plus/ThirdParty/glib
-	url = https://gitlab.gnome.org/GNOME/glib.git
+	url = https://github.com/GNOME/glib.git
 [submodule "FreeRTOS-Plus/Source/Application-Protocols/coreMQTT-Agent"]
 	path = FreeRTOS-Plus/Source/Application-Protocols/coreMQTT-Agent
 	url = https://github.com/FreeRTOS/coreMQTT-Agent.git


### PR DESCRIPTION
Use alternate mirrors for glib and libslirp dependencies
Description
-----------
[gitlab.freedesktop.org](https://gitlab.freedesktop.org/) and [gitlab.gnome.org](https://gitlab.gnome.org/GNOME) are current not accessible. Replace these repositories with accessible mirrors until the situation gets sorted by Gnome / Freedesktop.

Test Steps
-----------
Clone the FreeRTOS/FreeRTOS repository recursively.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have tested my changes. No regression in existing tests.
- [ N/A ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
