### PR TITLE
RISC-V-Qemu-virt_GCC: correct configCPU_CLOCK_HZ define

### DIFF
--- a/FreeRTOS/Demo/RISC-V-Qemu-virt_GCC/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/RISC-V-Qemu-virt_GCC/FreeRTOSConfig.h
@@ -1,6 +1,6 @@
 /*
  * FreeRTOS V202212.00
- * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/FreeRTOS/Demo/RISC-V-Qemu-virt_GCC/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/RISC-V-Qemu-virt_GCC/FreeRTOSConfig.h
@@ -48,7 +48,7 @@
 #define configUSE_PREEMPTION			1
 #define configUSE_IDLE_HOOK				0
 #define configUSE_TICK_HOOK				1
-#define configCPU_CLOCK_HZ				( 1000000 )
+#define configCPU_CLOCK_HZ				( 10000000 )
 #define configTICK_RATE_HZ				( ( TickType_t ) 1000 )
 #define configMAX_PRIORITIES			( 7 )
 #define configMINIMAL_STACK_SIZE		( ( unsigned short ) 512 )


### PR DESCRIPTION
Fix configCPU_CLOCK_HZ define for correct freeRTOS tick

Description
-----------
Qemu simulator runs at 10MHZ, defined by RISCV_ACLINT_DEFAULT_TIMEBASE_FREQ
at https://github.com/qemu/qemu/blob/master/include/hw/intc/riscv_aclint.h.
Thus correct configCPU_CLOCK_HZ to 10MHZ for correct freeRTOS tick.

Test Steps
-----------
Build Demo 'RISC-V-Qemu-virt_GCC' and run at Qemu riscv simulator.
Observes the log print frequency not match with mainQUEUE_SEND_FREQUENCY_MS
defined in ./Demo/RISC-V-Qemu-virt_GCC/main_blinky.c, whiel then after applied
this patch and re-build, it works as excepted.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
