### PR TITLE
Fix build issue in FreeRTOS+TCP QEMU demo when DHCP enabled

### DIFF
--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Echo_Posix/TCPEchoClient_SingleTasks.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Echo_Posix/TCPEchoClient_SingleTasks.c
@@ -399,22 +399,22 @@
         return xReturn;
     }
 
+    #if ( ipconfigUSE_DHCP_HOOK != 0 )
+
+        #if ( ipconfigIPv4_BACKWARD_COMPATIBLE == 1 )
+            eDHCPCallbackAnswer_t xApplicationDHCPHook( eDHCPCallbackPhase_t eDHCPPhase,
+                                                        uint32_t ulIPAddress )
+        #else /* ( ipconfigIPv4_BACKWARD_COMPATIBLE == 1 ) */
+            eDHCPCallbackAnswer_t xApplicationDHCPHook_Multi( eDHCPCallbackPhase_t eDHCPPhase,
+                                                              struct xNetworkEndPoint * pxEndPoint,
+                                                              IP_Address_t * pxIPAddress )
+        #endif /* ( ipconfigIPv4_BACKWARD_COMPATIBLE == 1 ) */
+        {
+            /* Provide a stub for this function. */
+            return eDHCPContinue;
+        }
+
+    #endif /* if ( ipconfigUSE_DHCP_HOOK != 0 ) */
+
 #endif /* ipconfigUSE_TCP */
-
-#if ( ( ipconfigUSE_TCP == 1 ) && ( ipconfigUSE_DHCP_HOOK != 0 ) )
-
-    #if ( ipconfigIPv4_BACKWARD_COMPATIBLE == 1 )
-        eDHCPCallbackAnswer_t xApplicationDHCPHook( eDHCPCallbackPhase_t eDHCPPhase,
-                                                    uint32_t ulIPAddress )
-    #else /* ( ipconfigIPv4_BACKWARD_COMPATIBLE == 1 ) */
-        eDHCPCallbackAnswer_t xApplicationDHCPHook_Multi( eDHCPCallbackPhase_t eDHCPPhase,
-                                                          struct xNetworkEndPoint * pxEndPoint,
-                                                          IP_Address_t * pxIPAddress )
-    #endif /* ( ipconfigIPv4_BACKWARD_COMPATIBLE == 1 ) */
-    {
-        /* Provide a stub for this function. */
-        return eDHCPContinue;
-    }
-
-#endif /* if ( ( ipconfigUSE_TCP == 1 ) && ( ipconfigUSE_DHCP_HOOK != 0 ) ) */
 /*-----------------------------------------------------------*/

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Echo_Qemu_mps2/TCPEchoClient_SingleTasks.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Echo_Qemu_mps2/TCPEchoClient_SingleTasks.c
@@ -394,7 +394,8 @@
 
         return xReturn;
     }
-    
+
+
     #if ( ipconfigUSE_DHCP_HOOK != 0 )
 
         #if ( ipconfigIPv4_BACKWARD_COMPATIBLE == 1 )

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Echo_Qemu_mps2/TCPEchoClient_SingleTasks.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Echo_Qemu_mps2/TCPEchoClient_SingleTasks.c
@@ -394,5 +394,22 @@
 
         return xReturn;
     }
+    
+    #if ( ipconfigUSE_DHCP_HOOK != 0 )
+
+        #if ( ipconfigIPv4_BACKWARD_COMPATIBLE == 1 )
+            eDHCPCallbackAnswer_t xApplicationDHCPHook( eDHCPCallbackPhase_t eDHCPPhase,
+                                                        uint32_t ulIPAddress )
+        #else /* ( ipconfigIPv4_BACKWARD_COMPATIBLE == 1 ) */
+            eDHCPCallbackAnswer_t xApplicationDHCPHook_Multi( eDHCPCallbackPhase_t eDHCPPhase,
+                                                              struct xNetworkEndPoint * pxEndPoint,
+                                                              IP_Address_t * pxIPAddress )
+        #endif /* ( ipconfigIPv4_BACKWARD_COMPATIBLE == 1 ) */
+        {
+            /* Provide a stub for this function. */
+            return eDHCPContinue;
+        }
+
+    #endif /* if ( ipconfigUSE_DHCP_HOOK != 0 )*/
 
 #endif /* ipconfigUSE_TCP */

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Echo_Qemu_mps2/main_networking.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Echo_Qemu_mps2/main_networking.c
@@ -164,6 +164,8 @@ void main_tcp_echo_client_tasks( void )
 
     #if defined( ipconfigIPv4_BACKWARD_COMPATIBLE ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE == 0 )
         /* Initialise the interface descriptor for WinPCap. */
+        extern NetworkInterface_t * pxMPS2_FillInterfaceDescriptor( BaseType_t xEMACIndex,
+                                                                    NetworkInterface_t * pxInterface );
         pxMPS2_FillInterfaceDescriptor( 0, &( xInterfaces[ 0 ] ) );
 
         /* === End-point 0 === */


### PR DESCRIPTION
Description
-----------
This PR fixes the build issue in FreeRTOS+TCP Qemu Demo , when DHCP is enabled.

Test Steps
-----------
Build the demo with ```ipconfigUSE_DHCP = 1```
Before applying the patch
![image](https://github.com/FreeRTOS/FreeRTOS/assets/118818625/c0124d0f-c02d-48ed-bccf-56cdfce362e2)
The demo builds successfully after the patch is applied.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
