### PR TITLE
Update GitPython package version to avoid "Blind local file inclusion"

### DIFF
--- a/.github/scripts/common/requirements.txt
+++ b/.github/scripts/common/requirements.txt
@@ -1,5 +1,5 @@
 Deprecated
-GitPython
+GitPython==3.1.37
 PyGithub
 PyJWT
 PyYAML


### PR DESCRIPTION
<!--- Title -->
Update GitPython package version to avoid "Blind local file inclusion"

Description
-----------
<!--- Describe your changes in detail. -->
[Blind local file inclusion](https://github.com/gitpython-developers/GitPython/security/advisories/GHSA-cwvm-v4w8-q58c) is fixed after version 3.1.37. Specify the version to avoid using the vulnerable version.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
