### PR TITLE
Add FreeRTOS+TCP in cellular demo project for logging

### DIFF
--- a/FreeRTOS-Plus/Demo/FreeRTOS_Cellular_Interface_Windows_Simulator/MQTT_Mutual_Auth_Demo_with_BG96/mqtt_mutual_auth_demo_with_bg96.sln
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Cellular_Interface_Windows_Simulator/MQTT_Mutual_Auth_Demo_with_BG96/mqtt_mutual_auth_demo_with_bg96.sln
@@ -1,4 +1,3 @@
-
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.32929.386
@@ -11,10 +10,15 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Logging", "..\..\..\VisualS
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "MbedTLS", "..\..\..\VisualStudio_StaticProjects\MbedTLS\MbedTLS.vcxproj", "{E1016F3E-94E9-4864-9FD8-1D7C1FEFBFD7}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "FreeRTOS+TCP", "..\..\..\VisualStudio_StaticProjects\FreeRTOS+TCP\FreeRTOS+TCP.vcxproj", "{C90E6CC5-818B-4C97-8876-0986D989387C}"
+EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Statically Linked Libraries", "Statically Linked Libraries", "{68385DE7-AC0F-4213-BEEA-D07E484C093E}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug_with_Libslirp|Win32 = Debug_with_Libslirp|Win32
+		Debug_with_Libslirp|x64 = Debug_with_Libslirp|x64
+		Debug_with_Libslirp|x86 = Debug_with_Libslirp|x86
 		Debug|Win32 = Debug|Win32
 		Debug|x64 = Debug|x64
 		Debug|x86 = Debug|x86
@@ -23,6 +27,12 @@ Global
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{D5CD24A7-76BA-41EA-AFD7-86DECF58FBC1}.Debug_with_Libslirp|Win32.ActiveCfg = Debug|Win32
+		{D5CD24A7-76BA-41EA-AFD7-86DECF58FBC1}.Debug_with_Libslirp|Win32.Build.0 = Debug|Win32
+		{D5CD24A7-76BA-41EA-AFD7-86DECF58FBC1}.Debug_with_Libslirp|x64.ActiveCfg = Debug|x64
+		{D5CD24A7-76BA-41EA-AFD7-86DECF58FBC1}.Debug_with_Libslirp|x64.Build.0 = Debug|x64
+		{D5CD24A7-76BA-41EA-AFD7-86DECF58FBC1}.Debug_with_Libslirp|x86.ActiveCfg = Debug|Win32
+		{D5CD24A7-76BA-41EA-AFD7-86DECF58FBC1}.Debug_with_Libslirp|x86.Build.0 = Debug|Win32
 		{D5CD24A7-76BA-41EA-AFD7-86DECF58FBC1}.Debug|Win32.ActiveCfg = Debug|Win32
 		{D5CD24A7-76BA-41EA-AFD7-86DECF58FBC1}.Debug|Win32.Build.0 = Debug|Win32
 		{D5CD24A7-76BA-41EA-AFD7-86DECF58FBC1}.Debug|x64.ActiveCfg = Debug|x64
@@ -35,6 +45,12 @@ Global
 		{D5CD24A7-76BA-41EA-AFD7-86DECF58FBC1}.Release|x64.Build.0 = Release|x64
 		{D5CD24A7-76BA-41EA-AFD7-86DECF58FBC1}.Release|x86.ActiveCfg = Release|Win32
 		{D5CD24A7-76BA-41EA-AFD7-86DECF58FBC1}.Release|x86.Build.0 = Release|Win32
+		{72C209C4-49A4-4942-A201-44706C9D77EC}.Debug_with_Libslirp|Win32.ActiveCfg = Debug_with_Libslirp|Win32
+		{72C209C4-49A4-4942-A201-44706C9D77EC}.Debug_with_Libslirp|Win32.Build.0 = Debug_with_Libslirp|Win32
+		{72C209C4-49A4-4942-A201-44706C9D77EC}.Debug_with_Libslirp|x64.ActiveCfg = Debug_with_Libslirp|x64
+		{72C209C4-49A4-4942-A201-44706C9D77EC}.Debug_with_Libslirp|x64.Build.0 = Debug_with_Libslirp|x64
+		{72C209C4-49A4-4942-A201-44706C9D77EC}.Debug_with_Libslirp|x86.ActiveCfg = Debug_with_Libslirp|Win32
+		{72C209C4-49A4-4942-A201-44706C9D77EC}.Debug_with_Libslirp|x86.Build.0 = Debug_with_Libslirp|Win32
 		{72C209C4-49A4-4942-A201-44706C9D77EC}.Debug|Win32.ActiveCfg = Debug|Win32
 		{72C209C4-49A4-4942-A201-44706C9D77EC}.Debug|Win32.Build.0 = Debug|Win32
 		{72C209C4-49A4-4942-A201-44706C9D77EC}.Debug|x64.ActiveCfg = Debug|x64
@@ -47,6 +63,12 @@ Global
 		{72C209C4-49A4-4942-A201-44706C9D77EC}.Release|x64.Build.0 = Release|x64
 		{72C209C4-49A4-4942-A201-44706C9D77EC}.Release|x86.ActiveCfg = Release|Win32
 		{72C209C4-49A4-4942-A201-44706C9D77EC}.Release|x86.Build.0 = Release|Win32
+		{BE362AC0-B10B-4276-B84E-6304652BA228}.Debug_with_Libslirp|Win32.ActiveCfg = Debug_with_Libslirp|Win32
+		{BE362AC0-B10B-4276-B84E-6304652BA228}.Debug_with_Libslirp|Win32.Build.0 = Debug_with_Libslirp|Win32
+		{BE362AC0-B10B-4276-B84E-6304652BA228}.Debug_with_Libslirp|x64.ActiveCfg = Debug_with_Libslirp|x64
+		{BE362AC0-B10B-4276-B84E-6304652BA228}.Debug_with_Libslirp|x64.Build.0 = Debug_with_Libslirp|x64
+		{BE362AC0-B10B-4276-B84E-6304652BA228}.Debug_with_Libslirp|x86.ActiveCfg = Debug_with_Libslirp|Win32
+		{BE362AC0-B10B-4276-B84E-6304652BA228}.Debug_with_Libslirp|x86.Build.0 = Debug_with_Libslirp|Win32
 		{BE362AC0-B10B-4276-B84E-6304652BA228}.Debug|Win32.ActiveCfg = Debug|Win32
 		{BE362AC0-B10B-4276-B84E-6304652BA228}.Debug|Win32.Build.0 = Debug|Win32
 		{BE362AC0-B10B-4276-B84E-6304652BA228}.Debug|x64.ActiveCfg = Debug|x64
@@ -59,6 +81,12 @@ Global
 		{BE362AC0-B10B-4276-B84E-6304652BA228}.Release|x64.Build.0 = Release|x64
 		{BE362AC0-B10B-4276-B84E-6304652BA228}.Release|x86.ActiveCfg = Release|Win32
 		{BE362AC0-B10B-4276-B84E-6304652BA228}.Release|x86.Build.0 = Release|Win32
+		{E1016F3E-94E9-4864-9FD8-1D7C1FEFBFD7}.Debug_with_Libslirp|Win32.ActiveCfg = Debug_with_Libslirp|Win32
+		{E1016F3E-94E9-4864-9FD8-1D7C1FEFBFD7}.Debug_with_Libslirp|Win32.Build.0 = Debug_with_Libslirp|Win32
+		{E1016F3E-94E9-4864-9FD8-1D7C1FEFBFD7}.Debug_with_Libslirp|x64.ActiveCfg = Debug_with_Libslirp|x64
+		{E1016F3E-94E9-4864-9FD8-1D7C1FEFBFD7}.Debug_with_Libslirp|x64.Build.0 = Debug_with_Libslirp|x64
+		{E1016F3E-94E9-4864-9FD8-1D7C1FEFBFD7}.Debug_with_Libslirp|x86.ActiveCfg = Debug_with_Libslirp|Win32
+		{E1016F3E-94E9-4864-9FD8-1D7C1FEFBFD7}.Debug_with_Libslirp|x86.Build.0 = Debug_with_Libslirp|Win32
 		{E1016F3E-94E9-4864-9FD8-1D7C1FEFBFD7}.Debug|Win32.ActiveCfg = Debug|Win32
 		{E1016F3E-94E9-4864-9FD8-1D7C1FEFBFD7}.Debug|Win32.Build.0 = Debug|Win32
 		{E1016F3E-94E9-4864-9FD8-1D7C1FEFBFD7}.Debug|x64.ActiveCfg = Debug|x64
@@ -71,6 +99,24 @@ Global
 		{E1016F3E-94E9-4864-9FD8-1D7C1FEFBFD7}.Release|x64.Build.0 = Release|x64
 		{E1016F3E-94E9-4864-9FD8-1D7C1FEFBFD7}.Release|x86.ActiveCfg = Release|Win32
 		{E1016F3E-94E9-4864-9FD8-1D7C1FEFBFD7}.Release|x86.Build.0 = Release|Win32
+		{C90E6CC5-818B-4C97-8876-0986D989387C}.Debug_with_Libslirp|Win32.ActiveCfg = Debug_with_Libslirp|Win32
+		{C90E6CC5-818B-4C97-8876-0986D989387C}.Debug_with_Libslirp|Win32.Build.0 = Debug_with_Libslirp|Win32
+		{C90E6CC5-818B-4C97-8876-0986D989387C}.Debug_with_Libslirp|x64.ActiveCfg = Debug_with_Libslirp|x64
+		{C90E6CC5-818B-4C97-8876-0986D989387C}.Debug_with_Libslirp|x64.Build.0 = Debug_with_Libslirp|x64
+		{C90E6CC5-818B-4C97-8876-0986D989387C}.Debug_with_Libslirp|x86.ActiveCfg = Debug_with_Libslirp|Win32
+		{C90E6CC5-818B-4C97-8876-0986D989387C}.Debug_with_Libslirp|x86.Build.0 = Debug_with_Libslirp|Win32
+		{C90E6CC5-818B-4C97-8876-0986D989387C}.Debug|Win32.ActiveCfg = Debug|Win32
+		{C90E6CC5-818B-4C97-8876-0986D989387C}.Debug|Win32.Build.0 = Debug|Win32
+		{C90E6CC5-818B-4C97-8876-0986D989387C}.Debug|x64.ActiveCfg = Debug|x64
+		{C90E6CC5-818B-4C97-8876-0986D989387C}.Debug|x64.Build.0 = Debug|x64
+		{C90E6CC5-818B-4C97-8876-0986D989387C}.Debug|x86.ActiveCfg = Debug|Win32
+		{C90E6CC5-818B-4C97-8876-0986D989387C}.Debug|x86.Build.0 = Debug|Win32
+		{C90E6CC5-818B-4C97-8876-0986D989387C}.Release|Win32.ActiveCfg = Release|Win32
+		{C90E6CC5-818B-4C97-8876-0986D989387C}.Release|Win32.Build.0 = Release|Win32
+		{C90E6CC5-818B-4C97-8876-0986D989387C}.Release|x64.ActiveCfg = Release|x64
+		{C90E6CC5-818B-4C97-8876-0986D989387C}.Release|x64.Build.0 = Release|x64
+		{C90E6CC5-818B-4C97-8876-0986D989387C}.Release|x86.ActiveCfg = Release|Win32
+		{C90E6CC5-818B-4C97-8876-0986D989387C}.Release|x86.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -79,6 +125,7 @@ Global
 		{72C209C4-49A4-4942-A201-44706C9D77EC} = {68385DE7-AC0F-4213-BEEA-D07E484C093E}
 		{BE362AC0-B10B-4276-B84E-6304652BA228} = {68385DE7-AC0F-4213-BEEA-D07E484C093E}
 		{E1016F3E-94E9-4864-9FD8-1D7C1FEFBFD7} = {68385DE7-AC0F-4213-BEEA-D07E484C093E}
+		{C90E6CC5-818B-4C97-8876-0986D989387C} = {68385DE7-AC0F-4213-BEEA-D07E484C093E}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {1D441E01-8E23-4433-9EF0-63467713C0F0}

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Cellular_Interface_Windows_Simulator/MQTT_Mutual_Auth_Demo_with_HL7802/mqtt_mutual_auth_demo_with_hl7802.sln
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Cellular_Interface_Windows_Simulator/MQTT_Mutual_Auth_Demo_with_HL7802/mqtt_mutual_auth_demo_with_hl7802.sln
@@ -1,4 +1,3 @@
-
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.32929.386
@@ -11,10 +10,15 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Logging", "..\..\..\VisualS
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "MbedTLS", "..\..\..\VisualStudio_StaticProjects\MbedTLS\MbedTLS.vcxproj", "{E1016F3E-94E9-4864-9FD8-1D7C1FEFBFD7}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "FreeRTOS+TCP", "..\..\..\VisualStudio_StaticProjects\FreeRTOS+TCP\FreeRTOS+TCP.vcxproj", "{C90E6CC5-818B-4C97-8876-0986D989387C}"
+EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Statically Linked Libraries", "Statically Linked Libraries", "{68385DE7-AC0F-4213-BEEA-D07E484C093E}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug_with_Libslirp|Win32 = Debug_with_Libslirp|Win32
+		Debug_with_Libslirp|x64 = Debug_with_Libslirp|x64
+		Debug_with_Libslirp|x86 = Debug_with_Libslirp|x86
 		Debug|Win32 = Debug|Win32
 		Debug|x64 = Debug|x64
 		Debug|x86 = Debug|x86
@@ -23,6 +27,12 @@ Global
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{D5CD24A7-76BA-41EA-AFD7-86DECF58FBC1}.Debug_with_Libslirp|Win32.ActiveCfg = Debug|Win32
+		{D5CD24A7-76BA-41EA-AFD7-86DECF58FBC1}.Debug_with_Libslirp|Win32.Build.0 = Debug|Win32
+		{D5CD24A7-76BA-41EA-AFD7-86DECF58FBC1}.Debug_with_Libslirp|x64.ActiveCfg = Debug|x64
+		{D5CD24A7-76BA-41EA-AFD7-86DECF58FBC1}.Debug_with_Libslirp|x64.Build.0 = Debug|x64
+		{D5CD24A7-76BA-41EA-AFD7-86DECF58FBC1}.Debug_with_Libslirp|x86.ActiveCfg = Debug|Win32
+		{D5CD24A7-76BA-41EA-AFD7-86DECF58FBC1}.Debug_with_Libslirp|x86.Build.0 = Debug|Win32
 		{D5CD24A7-76BA-41EA-AFD7-86DECF58FBC1}.Debug|Win32.ActiveCfg = Debug|Win32
 		{D5CD24A7-76BA-41EA-AFD7-86DECF58FBC1}.Debug|Win32.Build.0 = Debug|Win32
 		{D5CD24A7-76BA-41EA-AFD7-86DECF58FBC1}.Debug|x64.ActiveCfg = Debug|x64
@@ -35,6 +45,12 @@ Global
 		{D5CD24A7-76BA-41EA-AFD7-86DECF58FBC1}.Release|x64.Build.0 = Release|x64
 		{D5CD24A7-76BA-41EA-AFD7-86DECF58FBC1}.Release|x86.ActiveCfg = Release|Win32
 		{D5CD24A7-76BA-41EA-AFD7-86DECF58FBC1}.Release|x86.Build.0 = Release|Win32
+		{72C209C4-49A4-4942-A201-44706C9D77EC}.Debug_with_Libslirp|Win32.ActiveCfg = Debug_with_Libslirp|Win32
+		{72C209C4-49A4-4942-A201-44706C9D77EC}.Debug_with_Libslirp|Win32.Build.0 = Debug_with_Libslirp|Win32
+		{72C209C4-49A4-4942-A201-44706C9D77EC}.Debug_with_Libslirp|x64.ActiveCfg = Debug_with_Libslirp|x64
+		{72C209C4-49A4-4942-A201-44706C9D77EC}.Debug_with_Libslirp|x64.Build.0 = Debug_with_Libslirp|x64
+		{72C209C4-49A4-4942-A201-44706C9D77EC}.Debug_with_Libslirp|x86.ActiveCfg = Debug_with_Libslirp|Win32
+		{72C209C4-49A4-4942-A201-44706C9D77EC}.Debug_with_Libslirp|x86.Build.0 = Debug_with_Libslirp|Win32
 		{72C209C4-49A4-4942-A201-44706C9D77EC}.Debug|Win32.ActiveCfg = Debug|Win32
 		{72C209C4-49A4-4942-A201-44706C9D77EC}.Debug|Win32.Build.0 = Debug|Win32
 		{72C209C4-49A4-4942-A201-44706C9D77EC}.Debug|x64.ActiveCfg = Debug|x64
@@ -47,6 +63,12 @@ Global
 		{72C209C4-49A4-4942-A201-44706C9D77EC}.Release|x64.Build.0 = Release|x64
 		{72C209C4-49A4-4942-A201-44706C9D77EC}.Release|x86.ActiveCfg = Release|Win32
 		{72C209C4-49A4-4942-A201-44706C9D77EC}.Release|x86.Build.0 = Release|Win32
+		{BE362AC0-B10B-4276-B84E-6304652BA228}.Debug_with_Libslirp|Win32.ActiveCfg = Debug_with_Libslirp|Win32
+		{BE362AC0-B10B-4276-B84E-6304652BA228}.Debug_with_Libslirp|Win32.Build.0 = Debug_with_Libslirp|Win32
+		{BE362AC0-B10B-4276-B84E-6304652BA228}.Debug_with_Libslirp|x64.ActiveCfg = Debug_with_Libslirp|x64
+		{BE362AC0-B10B-4276-B84E-6304652BA228}.Debug_with_Libslirp|x64.Build.0 = Debug_with_Libslirp|x64
+		{BE362AC0-B10B-4276-B84E-6304652BA228}.Debug_with_Libslirp|x86.ActiveCfg = Debug_with_Libslirp|Win32
+		{BE362AC0-B10B-4276-B84E-6304652BA228}.Debug_with_Libslirp|x86.Build.0 = Debug_with_Libslirp|Win32
 		{BE362AC0-B10B-4276-B84E-6304652BA228}.Debug|Win32.ActiveCfg = Debug|Win32
 		{BE362AC0-B10B-4276-B84E-6304652BA228}.Debug|Win32.Build.0 = Debug|Win32
 		{BE362AC0-B10B-4276-B84E-6304652BA228}.Debug|x64.ActiveCfg = Debug|x64
@@ -59,6 +81,12 @@ Global
 		{BE362AC0-B10B-4276-B84E-6304652BA228}.Release|x64.Build.0 = Release|x64
 		{BE362AC0-B10B-4276-B84E-6304652BA228}.Release|x86.ActiveCfg = Release|Win32
 		{BE362AC0-B10B-4276-B84E-6304652BA228}.Release|x86.Build.0 = Release|Win32
+		{E1016F3E-94E9-4864-9FD8-1D7C1FEFBFD7}.Debug_with_Libslirp|Win32.ActiveCfg = Debug_with_Libslirp|Win32
+		{E1016F3E-94E9-4864-9FD8-1D7C1FEFBFD7}.Debug_with_Libslirp|Win32.Build.0 = Debug_with_Libslirp|Win32
+		{E1016F3E-94E9-4864-9FD8-1D7C1FEFBFD7}.Debug_with_Libslirp|x64.ActiveCfg = Debug_with_Libslirp|x64
+		{E1016F3E-94E9-4864-9FD8-1D7C1FEFBFD7}.Debug_with_Libslirp|x64.Build.0 = Debug_with_Libslirp|x64
+		{E1016F3E-94E9-4864-9FD8-1D7C1FEFBFD7}.Debug_with_Libslirp|x86.ActiveCfg = Debug_with_Libslirp|Win32
+		{E1016F3E-94E9-4864-9FD8-1D7C1FEFBFD7}.Debug_with_Libslirp|x86.Build.0 = Debug_with_Libslirp|Win32
 		{E1016F3E-94E9-4864-9FD8-1D7C1FEFBFD7}.Debug|Win32.ActiveCfg = Debug|Win32
 		{E1016F3E-94E9-4864-9FD8-1D7C1FEFBFD7}.Debug|Win32.Build.0 = Debug|Win32
 		{E1016F3E-94E9-4864-9FD8-1D7C1FEFBFD7}.Debug|x64.ActiveCfg = Debug|x64
@@ -71,6 +99,24 @@ Global
 		{E1016F3E-94E9-4864-9FD8-1D7C1FEFBFD7}.Release|x64.Build.0 = Release|x64
 		{E1016F3E-94E9-4864-9FD8-1D7C1FEFBFD7}.Release|x86.ActiveCfg = Release|Win32
 		{E1016F3E-94E9-4864-9FD8-1D7C1FEFBFD7}.Release|x86.Build.0 = Release|Win32
+		{C90E6CC5-818B-4C97-8876-0986D989387C}.Debug_with_Libslirp|Win32.ActiveCfg = Debug_with_Libslirp|Win32
+		{C90E6CC5-818B-4C97-8876-0986D989387C}.Debug_with_Libslirp|Win32.Build.0 = Debug_with_Libslirp|Win32
+		{C90E6CC5-818B-4C97-8876-0986D989387C}.Debug_with_Libslirp|x64.ActiveCfg = Debug_with_Libslirp|x64
+		{C90E6CC5-818B-4C97-8876-0986D989387C}.Debug_with_Libslirp|x64.Build.0 = Debug_with_Libslirp|x64
+		{C90E6CC5-818B-4C97-8876-0986D989387C}.Debug_with_Libslirp|x86.ActiveCfg = Debug_with_Libslirp|Win32
+		{C90E6CC5-818B-4C97-8876-0986D989387C}.Debug_with_Libslirp|x86.Build.0 = Debug_with_Libslirp|Win32
+		{C90E6CC5-818B-4C97-8876-0986D989387C}.Debug|Win32.ActiveCfg = Debug|Win32
+		{C90E6CC5-818B-4C97-8876-0986D989387C}.Debug|Win32.Build.0 = Debug|Win32
+		{C90E6CC5-818B-4C97-8876-0986D989387C}.Debug|x64.ActiveCfg = Debug|x64
+		{C90E6CC5-818B-4C97-8876-0986D989387C}.Debug|x64.Build.0 = Debug|x64
+		{C90E6CC5-818B-4C97-8876-0986D989387C}.Debug|x86.ActiveCfg = Debug|Win32
+		{C90E6CC5-818B-4C97-8876-0986D989387C}.Debug|x86.Build.0 = Debug|Win32
+		{C90E6CC5-818B-4C97-8876-0986D989387C}.Release|Win32.ActiveCfg = Release|Win32
+		{C90E6CC5-818B-4C97-8876-0986D989387C}.Release|Win32.Build.0 = Release|Win32
+		{C90E6CC5-818B-4C97-8876-0986D989387C}.Release|x64.ActiveCfg = Release|x64
+		{C90E6CC5-818B-4C97-8876-0986D989387C}.Release|x64.Build.0 = Release|x64
+		{C90E6CC5-818B-4C97-8876-0986D989387C}.Release|x86.ActiveCfg = Release|Win32
+		{C90E6CC5-818B-4C97-8876-0986D989387C}.Release|x86.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -79,6 +125,7 @@ Global
 		{72C209C4-49A4-4942-A201-44706C9D77EC} = {68385DE7-AC0F-4213-BEEA-D07E484C093E}
 		{BE362AC0-B10B-4276-B84E-6304652BA228} = {68385DE7-AC0F-4213-BEEA-D07E484C093E}
 		{E1016F3E-94E9-4864-9FD8-1D7C1FEFBFD7} = {68385DE7-AC0F-4213-BEEA-D07E484C093E}
+		{C90E6CC5-818B-4C97-8876-0986D989387C} = {68385DE7-AC0F-4213-BEEA-D07E484C093E}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {1D441E01-8E23-4433-9EF0-63467713C0F0}

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Cellular_Interface_Windows_Simulator/MQTT_Mutual_Auth_Demo_with_SARA_R4/mqtt_mutual_auth_demo_with_sara_r4.sln
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Cellular_Interface_Windows_Simulator/MQTT_Mutual_Auth_Demo_with_SARA_R4/mqtt_mutual_auth_demo_with_sara_r4.sln
@@ -1,4 +1,3 @@
-
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.32929.386
@@ -11,10 +10,15 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Logging", "..\..\..\VisualS
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "MbedTLS", "..\..\..\VisualStudio_StaticProjects\MbedTLS\MbedTLS.vcxproj", "{E1016F3E-94E9-4864-9FD8-1D7C1FEFBFD7}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "FreeRTOS+TCP", "..\..\..\VisualStudio_StaticProjects\FreeRTOS+TCP\FreeRTOS+TCP.vcxproj", "{C90E6CC5-818B-4C97-8876-0986D989387C}"
+EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Statically Linked Libraries", "Statically Linked Libraries", "{68385DE7-AC0F-4213-BEEA-D07E484C093E}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug_with_Libslirp|Win32 = Debug_with_Libslirp|Win32
+		Debug_with_Libslirp|x64 = Debug_with_Libslirp|x64
+		Debug_with_Libslirp|x86 = Debug_with_Libslirp|x86
 		Debug|Win32 = Debug|Win32
 		Debug|x64 = Debug|x64
 		Debug|x86 = Debug|x86
@@ -23,6 +27,12 @@ Global
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{D5CD24A7-76BA-41EA-AFD7-86DECF58FBC1}.Debug_with_Libslirp|Win32.ActiveCfg = Debug|Win32
+		{D5CD24A7-76BA-41EA-AFD7-86DECF58FBC1}.Debug_with_Libslirp|Win32.Build.0 = Debug|Win32
+		{D5CD24A7-76BA-41EA-AFD7-86DECF58FBC1}.Debug_with_Libslirp|x64.ActiveCfg = Debug|x64
+		{D5CD24A7-76BA-41EA-AFD7-86DECF58FBC1}.Debug_with_Libslirp|x64.Build.0 = Debug|x64
+		{D5CD24A7-76BA-41EA-AFD7-86DECF58FBC1}.Debug_with_Libslirp|x86.ActiveCfg = Debug|Win32
+		{D5CD24A7-76BA-41EA-AFD7-86DECF58FBC1}.Debug_with_Libslirp|x86.Build.0 = Debug|Win32
 		{D5CD24A7-76BA-41EA-AFD7-86DECF58FBC1}.Debug|Win32.ActiveCfg = Debug|Win32
 		{D5CD24A7-76BA-41EA-AFD7-86DECF58FBC1}.Debug|Win32.Build.0 = Debug|Win32
 		{D5CD24A7-76BA-41EA-AFD7-86DECF58FBC1}.Debug|x64.ActiveCfg = Debug|x64
@@ -35,6 +45,12 @@ Global
 		{D5CD24A7-76BA-41EA-AFD7-86DECF58FBC1}.Release|x64.Build.0 = Release|x64
 		{D5CD24A7-76BA-41EA-AFD7-86DECF58FBC1}.Release|x86.ActiveCfg = Release|Win32
 		{D5CD24A7-76BA-41EA-AFD7-86DECF58FBC1}.Release|x86.Build.0 = Release|Win32
+		{72C209C4-49A4-4942-A201-44706C9D77EC}.Debug_with_Libslirp|Win32.ActiveCfg = Debug_with_Libslirp|Win32
+		{72C209C4-49A4-4942-A201-44706C9D77EC}.Debug_with_Libslirp|Win32.Build.0 = Debug_with_Libslirp|Win32
+		{72C209C4-49A4-4942-A201-44706C9D77EC}.Debug_with_Libslirp|x64.ActiveCfg = Debug_with_Libslirp|x64
+		{72C209C4-49A4-4942-A201-44706C9D77EC}.Debug_with_Libslirp|x64.Build.0 = Debug_with_Libslirp|x64
+		{72C209C4-49A4-4942-A201-44706C9D77EC}.Debug_with_Libslirp|x86.ActiveCfg = Debug_with_Libslirp|Win32
+		{72C209C4-49A4-4942-A201-44706C9D77EC}.Debug_with_Libslirp|x86.Build.0 = Debug_with_Libslirp|Win32
 		{72C209C4-49A4-4942-A201-44706C9D77EC}.Debug|Win32.ActiveCfg = Debug|Win32
 		{72C209C4-49A4-4942-A201-44706C9D77EC}.Debug|Win32.Build.0 = Debug|Win32
 		{72C209C4-49A4-4942-A201-44706C9D77EC}.Debug|x64.ActiveCfg = Debug|x64
@@ -47,6 +63,12 @@ Global
 		{72C209C4-49A4-4942-A201-44706C9D77EC}.Release|x64.Build.0 = Release|x64
 		{72C209C4-49A4-4942-A201-44706C9D77EC}.Release|x86.ActiveCfg = Release|Win32
 		{72C209C4-49A4-4942-A201-44706C9D77EC}.Release|x86.Build.0 = Release|Win32
+		{BE362AC0-B10B-4276-B84E-6304652BA228}.Debug_with_Libslirp|Win32.ActiveCfg = Debug_with_Libslirp|Win32
+		{BE362AC0-B10B-4276-B84E-6304652BA228}.Debug_with_Libslirp|Win32.Build.0 = Debug_with_Libslirp|Win32
+		{BE362AC0-B10B-4276-B84E-6304652BA228}.Debug_with_Libslirp|x64.ActiveCfg = Debug_with_Libslirp|x64
+		{BE362AC0-B10B-4276-B84E-6304652BA228}.Debug_with_Libslirp|x64.Build.0 = Debug_with_Libslirp|x64
+		{BE362AC0-B10B-4276-B84E-6304652BA228}.Debug_with_Libslirp|x86.ActiveCfg = Debug_with_Libslirp|Win32
+		{BE362AC0-B10B-4276-B84E-6304652BA228}.Debug_with_Libslirp|x86.Build.0 = Debug_with_Libslirp|Win32
 		{BE362AC0-B10B-4276-B84E-6304652BA228}.Debug|Win32.ActiveCfg = Debug|Win32
 		{BE362AC0-B10B-4276-B84E-6304652BA228}.Debug|Win32.Build.0 = Debug|Win32
 		{BE362AC0-B10B-4276-B84E-6304652BA228}.Debug|x64.ActiveCfg = Debug|x64
@@ -59,6 +81,12 @@ Global
 		{BE362AC0-B10B-4276-B84E-6304652BA228}.Release|x64.Build.0 = Release|x64
 		{BE362AC0-B10B-4276-B84E-6304652BA228}.Release|x86.ActiveCfg = Release|Win32
 		{BE362AC0-B10B-4276-B84E-6304652BA228}.Release|x86.Build.0 = Release|Win32
+		{E1016F3E-94E9-4864-9FD8-1D7C1FEFBFD7}.Debug_with_Libslirp|Win32.ActiveCfg = Debug_with_Libslirp|Win32
+		{E1016F3E-94E9-4864-9FD8-1D7C1FEFBFD7}.Debug_with_Libslirp|Win32.Build.0 = Debug_with_Libslirp|Win32
+		{E1016F3E-94E9-4864-9FD8-1D7C1FEFBFD7}.Debug_with_Libslirp|x64.ActiveCfg = Debug_with_Libslirp|x64
+		{E1016F3E-94E9-4864-9FD8-1D7C1FEFBFD7}.Debug_with_Libslirp|x64.Build.0 = Debug_with_Libslirp|x64
+		{E1016F3E-94E9-4864-9FD8-1D7C1FEFBFD7}.Debug_with_Libslirp|x86.ActiveCfg = Debug_with_Libslirp|Win32
+		{E1016F3E-94E9-4864-9FD8-1D7C1FEFBFD7}.Debug_with_Libslirp|x86.Build.0 = Debug_with_Libslirp|Win32
 		{E1016F3E-94E9-4864-9FD8-1D7C1FEFBFD7}.Debug|Win32.ActiveCfg = Debug|Win32
 		{E1016F3E-94E9-4864-9FD8-1D7C1FEFBFD7}.Debug|Win32.Build.0 = Debug|Win32
 		{E1016F3E-94E9-4864-9FD8-1D7C1FEFBFD7}.Debug|x64.ActiveCfg = Debug|x64
@@ -71,6 +99,24 @@ Global
 		{E1016F3E-94E9-4864-9FD8-1D7C1FEFBFD7}.Release|x64.Build.0 = Release|x64
 		{E1016F3E-94E9-4864-9FD8-1D7C1FEFBFD7}.Release|x86.ActiveCfg = Release|Win32
 		{E1016F3E-94E9-4864-9FD8-1D7C1FEFBFD7}.Release|x86.Build.0 = Release|Win32
+		{C90E6CC5-818B-4C97-8876-0986D989387C}.Debug_with_Libslirp|Win32.ActiveCfg = Debug_with_Libslirp|Win32
+		{C90E6CC5-818B-4C97-8876-0986D989387C}.Debug_with_Libslirp|Win32.Build.0 = Debug_with_Libslirp|Win32
+		{C90E6CC5-818B-4C97-8876-0986D989387C}.Debug_with_Libslirp|x64.ActiveCfg = Debug_with_Libslirp|x64
+		{C90E6CC5-818B-4C97-8876-0986D989387C}.Debug_with_Libslirp|x64.Build.0 = Debug_with_Libslirp|x64
+		{C90E6CC5-818B-4C97-8876-0986D989387C}.Debug_with_Libslirp|x86.ActiveCfg = Debug_with_Libslirp|Win32
+		{C90E6CC5-818B-4C97-8876-0986D989387C}.Debug_with_Libslirp|x86.Build.0 = Debug_with_Libslirp|Win32
+		{C90E6CC5-818B-4C97-8876-0986D989387C}.Debug|Win32.ActiveCfg = Debug|Win32
+		{C90E6CC5-818B-4C97-8876-0986D989387C}.Debug|Win32.Build.0 = Debug|Win32
+		{C90E6CC5-818B-4C97-8876-0986D989387C}.Debug|x64.ActiveCfg = Debug|x64
+		{C90E6CC5-818B-4C97-8876-0986D989387C}.Debug|x64.Build.0 = Debug|x64
+		{C90E6CC5-818B-4C97-8876-0986D989387C}.Debug|x86.ActiveCfg = Debug|Win32
+		{C90E6CC5-818B-4C97-8876-0986D989387C}.Debug|x86.Build.0 = Debug|Win32
+		{C90E6CC5-818B-4C97-8876-0986D989387C}.Release|Win32.ActiveCfg = Release|Win32
+		{C90E6CC5-818B-4C97-8876-0986D989387C}.Release|Win32.Build.0 = Release|Win32
+		{C90E6CC5-818B-4C97-8876-0986D989387C}.Release|x64.ActiveCfg = Release|x64
+		{C90E6CC5-818B-4C97-8876-0986D989387C}.Release|x64.Build.0 = Release|x64
+		{C90E6CC5-818B-4C97-8876-0986D989387C}.Release|x86.ActiveCfg = Release|Win32
+		{C90E6CC5-818B-4C97-8876-0986D989387C}.Release|x86.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -79,6 +125,7 @@ Global
 		{72C209C4-49A4-4942-A201-44706C9D77EC} = {68385DE7-AC0F-4213-BEEA-D07E484C093E}
 		{BE362AC0-B10B-4276-B84E-6304652BA228} = {68385DE7-AC0F-4213-BEEA-D07E484C093E}
 		{E1016F3E-94E9-4864-9FD8-1D7C1FEFBFD7} = {68385DE7-AC0F-4213-BEEA-D07E484C093E}
+		{C90E6CC5-818B-4C97-8876-0986D989387C} = {68385DE7-AC0F-4213-BEEA-D07E484C093E}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {1D441E01-8E23-4433-9EF0-63467713C0F0}


### PR DESCRIPTION
<!--- Title -->

Description
-----------
The cellular demo doesn't required the FreeRTOS+TCP. However, the logging library supports log to UDP and makes use of stream buffer in FreeRTOS+TCP. Therefore, it is required for the logging and should be included in the cellular interface demo.

Test Steps
-----------
Before this patch, there will be FreeRTOS+TCP.lib not found error mentioned in #1098 with the following steps:
* Remove the FreeRTOS+TCP build result from other project.
```
FreeRTOS/FreeRTOS-Plus/VisualStudio_StaticProjects/FreeRTOS+TCP/build/FreeRTOS+TCP/Win32/Debug/FreeRTOS+TCP.lib
```
* Building the demo with visual studio 2019 ( MSBuild.exe can't reproduce this problem )

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
#1098


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
