### PR TITLE
Fix memset in USBDDriver_Initialize

### DIFF
--- a/FreeRTOS/Demo/CORTEX_A5_SAMA5D3x_Xplained_IAR/AtmelFiles/usb/device/core/USBDDriver.c
+++ b/FreeRTOS/Demo/CORTEX_A5_SAMA5D3x_Xplained_IAR/AtmelFiles/usb/device/core/USBDDriver.c
@@ -456,7 +456,7 @@ static void USBDDriver_Test(const USBDDriver *pDriver, uint8_t test)
             /*patterns, jitter, and any other dynamic waveform specifications. */
             /*The test packet is made up by concatenating the following strings. */
             /*(Note: For J/K NRZI data, and for NRZ data, the bit on the left is the first one */
-            /*transmitted. “S?indicates that a bit stuff occurs, which inserts an “extra?NRZI data bit. */
+            /*transmitted. Â“S?indicates that a bit stuff occurs, which inserts an Â“extra?NRZI data bit. */
             /*? N?is used to indicate N occurrences of a string of bits or symbols.) */
             /*A port in Test_Packet mode must send this packet repetitively. The inter-packet timing */
             /*must be no less than the minimum allowable inter-packet gap as defined in Section 7.1.18 and */
@@ -472,7 +472,7 @@ static void USBDDriver_Test(const USBDDriver *pDriver, uint8_t test)
 
         case USBFeatureRequest_TESTJ:
             /*Test mode Test_J: */
-            /*Upon command, a port’s transceiver must enter the high-speed J state and remain in that */
+            /*Upon command, a portÂ’s transceiver must enter the high-speed J state and remain in that */
             /*state until the exit action is taken. This enables the testing of the high output drive */
             /*level on the D+ line. */
 
@@ -486,7 +486,7 @@ static void USBDDriver_Test(const USBDDriver *pDriver, uint8_t test)
 
         case USBFeatureRequest_TESTK:
             /*Test mode Test_K: */
-            /*Upon command, a port’s transceiver must enter the high-speed K state and remain in */
+            /*Upon command, a portÂ’s transceiver must enter the high-speed K state and remain in */
             /*that state until the exit action is taken. This enables the testing of the high output drive */
             /*level on the D- line. */
 
@@ -499,7 +499,7 @@ static void USBDDriver_Test(const USBDDriver *pDriver, uint8_t test)
 
         case USBFeatureRequest_TESTSE0NAK:
             /*Test mode Test_SE0_NAK: */
-            /*Upon command, a port’s transceiver must enter the high-speed receive mode */
+            /*Upon command, a portÂ’s transceiver must enter the high-speed receive mode */
             /*and remain in that mode until the exit action is taken. This enables the testing */
             /*of output impedance, low level output voltage, and loading characteristics. */
             /*In addition, while in this mode, upstream facing ports (and only upstream facing ports) */
@@ -562,7 +562,7 @@ void USBDDriver_Initialize(
 
     if (pInterfaces != 0) {
 
-        memset(pInterfaces, sizeof(pInterfaces), 0);
+        memset(pInterfaces, 0, sizeof(uint8_t));
     }
 }
 

--- a/FreeRTOS/Demo/CORTEX_A5_SAMA5D4x_EK_IAR/AtmelFiles/usb/device/core/USBDDriver.c
+++ b/FreeRTOS/Demo/CORTEX_A5_SAMA5D4x_EK_IAR/AtmelFiles/usb/device/core/USBDDriver.c
@@ -456,7 +456,7 @@ static void USBDDriver_Test(const USBDDriver *pDriver, uint8_t test)
             /*patterns, jitter, and any other dynamic waveform specifications. */
             /*The test packet is made up by concatenating the following strings. */
             /*(Note: For J/K NRZI data, and for NRZ data, the bit on the left is the first one */
-            /*transmitted. “S?indicates that a bit stuff occurs, which inserts an “extra?NRZI data bit. */
+            /*transmitted. Â“S?indicates that a bit stuff occurs, which inserts an Â“extra?NRZI data bit. */
             /*? N?is used to indicate N occurrences of a string of bits or symbols.) */
             /*A port in Test_Packet mode must send this packet repetitively. The inter-packet timing */
             /*must be no less than the minimum allowable inter-packet gap as defined in Section 7.1.18 and */
@@ -472,7 +472,7 @@ static void USBDDriver_Test(const USBDDriver *pDriver, uint8_t test)
 
         case USBFeatureRequest_TESTJ:
             /*Test mode Test_J: */
-            /*Upon command, a port’s transceiver must enter the high-speed J state and remain in that */
+            /*Upon command, a portÂ’s transceiver must enter the high-speed J state and remain in that */
             /*state until the exit action is taken. This enables the testing of the high output drive */
             /*level on the D+ line. */
 
@@ -486,7 +486,7 @@ static void USBDDriver_Test(const USBDDriver *pDriver, uint8_t test)
 
         case USBFeatureRequest_TESTK:
             /*Test mode Test_K: */
-            /*Upon command, a port’s transceiver must enter the high-speed K state and remain in */
+            /*Upon command, a portÂ’s transceiver must enter the high-speed K state and remain in */
             /*that state until the exit action is taken. This enables the testing of the high output drive */
             /*level on the D- line. */
 
@@ -499,7 +499,7 @@ static void USBDDriver_Test(const USBDDriver *pDriver, uint8_t test)
 
         case USBFeatureRequest_TESTSE0NAK:
             /*Test mode Test_SE0_NAK: */
-            /*Upon command, a port’s transceiver must enter the high-speed receive mode */
+            /*Upon command, a portÂ’s transceiver must enter the high-speed receive mode */
             /*and remain in that mode until the exit action is taken. This enables the testing */
             /*of output impedance, low level output voltage, and loading characteristics. */
             /*In addition, while in this mode, upstream facing ports (and only upstream facing ports) */
@@ -562,7 +562,7 @@ void USBDDriver_Initialize(
 
     if (pInterfaces != 0) {
 
-        memset(pInterfaces, sizeof(pInterfaces), 0);
+        memset(pInterfaces, 0, sizeof(uint8_t));
     }
 }
 


### PR DESCRIPTION
<!--- Title -->
Fix memset in USBDDriver_Initialize

Description
-----------
<!--- Describe your changes in detail. -->
As #1103 described, the memset usage is incorrect.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
