### PR TITLE
Use 1500 Bytes as the MTU for all demos.

### DIFF
--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Echo_Qemu_mps2/FreeRTOSIPConfig.h
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Echo_Qemu_mps2/FreeRTOSIPConfig.h
@@ -248,11 +248,10 @@ extern UBaseType_t uxRand();
 #define ipconfigUSE_TCP_WIN                            ( 1 )
 
 /* The MTU is the maximum number of bytes the payload of a network frame can
- * contain.  For normal Ethernet V2 frames the maximum MTU is 1500.  Setting a
- * lower value can save RAM, depending on the buffer management scheme used.  If
- * ipconfigCAN_FRAGMENT_OUTGOING_PACKETS is 1 then (ipconfigNETWORK_MTU - 28) must
- * be divisible by 8. */
-#define ipconfigNETWORK_MTU                            1200U
+ * contain. Setting this to a number lower than that of the network you are
+ * connecting to is likely to cause dropped packets. Do not set this parameter
+ * lower than 1500 unless you fully understand the consequences. */
+#define ipconfigNETWORK_MTU                            1500U
 
 /* Set ipconfigUSE_DNS to 1 to include a basic DNS client/resolver.  DNS is used
  * through the FreeRTOS_gethostbyname() API function. */

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_IPv6_Demo/IPv6_Multi_WinSim_demo/FreeRTOSIPConfig.h
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_IPv6_Demo/IPv6_Multi_WinSim_demo/FreeRTOSIPConfig.h
@@ -232,11 +232,10 @@ extern UBaseType_t uxRand();
 #define ipconfigUSE_TCP_WIN                            ( 1 )
 
 /* The MTU is the maximum number of bytes the payload of a network frame can
- * contain.  For normal Ethernet V2 frames the maximum MTU is 1500.  Setting a
- * lower value can save RAM, depending on the buffer management scheme used.  If
- * ipconfigCAN_FRAGMENT_OUTGOING_PACKETS is 1 then (ipconfigNETWORK_MTU - 28) must
- * be divisible by 8. */
-#define ipconfigNETWORK_MTU                            1200U
+ * contain. Setting this to a number lower than that of the network you are
+ * connecting to is likely to cause dropped packets. Do not set this parameter
+ * lower than 1500 unless you fully understand the consequences. */
+#define ipconfigNETWORK_MTU                            1500U
 
 /* Set ipconfigUSE_DNS to 1 to include a basic DNS client/resolver.  DNS is used
  * through the FreeRTOS_gethostbyname() API function. */

--- a/FreeRTOS-Plus/Test/FreeRTOS-Plus-TCP/Integration/Full-TCP-Networkless/Config/FreeRTOSIPConfig.h
+++ b/FreeRTOS-Plus/Test/FreeRTOS-Plus-TCP/Integration/Full-TCP-Networkless/Config/FreeRTOSIPConfig.h
@@ -232,11 +232,10 @@ extern void vLoggingPrintf( const char * pcFormatString,
 #define ipconfigUSE_TCP_WIN                            ( 1 )
 
 /* The MTU is the maximum number of bytes the payload of a network frame can
- * contain.  For normal Ethernet V2 frames the maximum MTU is 1500.  Setting a
- * lower value can save RAM, depending on the buffer management scheme used.  If
- * ipconfigCAN_FRAGMENT_OUTGOING_PACKETS is 1 then (ipconfigNETWORK_MTU - 28) must
- * be divisible by 8. */
-#define ipconfigNETWORK_MTU                            1200U
+ * contain. Setting this to a number lower than that of the network you are
+ * connecting to is likely to cause dropped packets. Do not set this parameter
+ * lower than 1500 unless you fully understand the consequences. */
+#define ipconfigNETWORK_MTU                            1500U
 
 /* Set ipconfigUSE_DNS to 1 to include a basic DNS client/resolver.  DNS is used
  * through the FreeRTOS_gethostbyname() API function. */

--- a/FreeRTOS-Plus/Test/FreeRTOS-Plus-TCP/Integration/Full-TCP-Suite/Config/FreeRTOSIPConfig.h
+++ b/FreeRTOS-Plus/Test/FreeRTOS-Plus-TCP/Integration/Full-TCP-Suite/Config/FreeRTOSIPConfig.h
@@ -226,11 +226,10 @@ extern uint32_t ulRand();
 #define ipconfigUSE_TCP_WIN                            ( 1 )
 
 /* The MTU is the maximum number of bytes the payload of a network frame can
- * contain.  For normal Ethernet V2 frames the maximum MTU is 1500.  Setting a
- * lower value can save RAM, depending on the buffer management scheme used.  If
- * ipconfigCAN_FRAGMENT_OUTGOING_PACKETS is 1 then (ipconfigNETWORK_MTU - 28) must
- * be divisible by 8. */
-#define ipconfigNETWORK_MTU                            1200U
+ * contain. Setting this to a number lower than that of the network you are
+ * connecting to is likely to cause dropped packets. Do not set this parameter
+ * lower than 1500 unless you fully understand the consequences. */
+#define ipconfigNETWORK_MTU                            1500U
 
 /* Set ipconfigUSE_DNS to 1 to include a basic DNS client/resolver.  DNS is used
  * through the FreeRTOS_gethostbyname() API function. */


### PR DESCRIPTION
Description
-----------
Using an MTU lower than 1500 is likely to lead to erratic behavior and lost packets. Remove all cases of non-1500 byte MTUs from FreeRTOS demos.

Test Steps
-----------
Verified change in qemu mps2 demo.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ X ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
