### PR TITLE
Set ETHERNET_IRQn priority in main_networking.c

### DIFF
--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Echo_Qemu_mps2/TCPEchoClient_SingleTasks.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Echo_Qemu_mps2/TCPEchoClient_SingleTasks.c
@@ -110,9 +110,6 @@
     {
         BaseType_t x;
 
-        /* Set Ethernet interrupt priority to configMAC_INTERRUPT_PRIORITY. */
-        NVIC_SetPriority( ETHERNET_IRQn, configMAC_INTERRUPT_PRIORITY );
-
         /* Create the echo client tasks. */
         for( x = 0; x < echoNUM_ECHO_CLIENTS; x++ )
         {

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Echo_Qemu_mps2/main_networking.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Echo_Qemu_mps2/main_networking.c
@@ -35,7 +35,6 @@
 #include <time.h>
 #include <unistd.h>
 
-
 /* FreeRTOS includes. */
 #include <FreeRTOS.h>
 #include "task.h"
@@ -44,6 +43,7 @@
 #include "FreeRTOS_IP.h"
 #include "FreeRTOS_Sockets.h"
 #include "TCPEchoClient_SingleTasks.h"
+#include "CMSIS/CMSDK_CM3.h"
 
 /* Echo client task parameters  */
 #define mainECHO_CLIENT_TASK_STACK_SIZE     ( configMINIMAL_STACK_SIZE * 2 )                /* Not used in the linux port. */
@@ -161,6 +161,9 @@ void main_tcp_echo_client_tasks( void )
 
     /* Initialise the network interface.*/
     FreeRTOS_debug_printf( ( "FreeRTOS_IPInit\r\n" ) );
+
+    /* Set Ethernet interrupt priority to configMAC_INTERRUPT_PRIORITY. */
+    NVIC_SetPriority( ETHERNET_IRQn, configMAC_INTERRUPT_PRIORITY );
 
     #if defined( ipconfigIPv4_BACKWARD_COMPATIBLE ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE == 0 )
         /* Initialise the interface descriptor for WinPCap. */


### PR DESCRIPTION
Description
-----------
This allows the qemu-mps2 demo to use DHCP which requires ethernet mac functionality prior to when vApplicationIPNetworkEventHook or vApplicationIPNetworkEventHook_Multi are called.

Test Steps
-----------
Attempting to use the mps2-an385 TCP demo fails every time with DHCP due to this bug.

To validate the fix, set ipconfigUSE_DHCP to 1 and run the mps2 demo on a network with DHCP.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
