### PR TITLE
Remove deprecated ipconfigRAND32

### DIFF
--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Echo_Posix/FreeRTOSIPConfig.h
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Echo_Posix/FreeRTOSIPConfig.h
@@ -74,26 +74,26 @@ extern void vLoggingPrintf( const char * pcFormatString,
 
 /* Define the byte order of the target MCU (the MCU FreeRTOS+TCP is executing
  * on). Valid options are pdFREERTOS_BIG_ENDIAN and pdFREERTOS_LITTLE_ENDIAN. */
-#define ipconfigBYTE_ORDER                         pdFREERTOS_LITTLE_ENDIAN
+#define ipconfigBYTE_ORDER                             pdFREERTOS_LITTLE_ENDIAN
 
 /* If the network card/driver includes checksum offloading (IP/TCP/UDP checksums)
  * then set ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM to 1 to prevent the software
  * stack repeating the checksum calculations. */
-#define ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM     1
+#define ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM         1
 
 /* Several API's will block until the result is known, or the action has been
  * performed, for example FreeRTOS_send() and FreeRTOS_recv(). The timeouts can be
  * set per socket, using setsockopt(). If not set, the times below will be
  * used as defaults. */
-#define ipconfigSOCK_DEFAULT_RECEIVE_BLOCK_TIME    ( 5000 )
-#define ipconfigSOCK_DEFAULT_SEND_BLOCK_TIME       ( 5000 )
+#define ipconfigSOCK_DEFAULT_RECEIVE_BLOCK_TIME        ( 5000 )
+#define ipconfigSOCK_DEFAULT_SEND_BLOCK_TIME           ( 5000 )
 
 /* Include support for LLMNR: Link-local Multicast Name Resolution
  * (non-Microsoft) */
-#define ipconfigUSE_LLMNR                          ( 1 )
+#define ipconfigUSE_LLMNR                              ( 1 )
 
 /* Include support for NBNS: NetBIOS Name Service (Microsoft) */
-#define ipconfigUSE_NBNS                           ( 1 )
+#define ipconfigUSE_NBNS                               ( 1 )
 
 /* Include support for DNS caching. For TCP, having a small DNS cache is very
  * useful. When a cache is present, ipconfigDNS_REQUEST_ATTEMPTS can be kept low
@@ -101,10 +101,10 @@ extern void vLoggingPrintf( const char * pcFormatString,
  * socket has been destroyed, the result will be stored into the cache. The next
  * call to FreeRTOS_gethostbyname() will return immediately, without even creating
  * a socket. */
-#define ipconfigUSE_DNS_CACHE                      ( 1 )
-#define ipconfigDNS_CACHE_NAME_LENGTH              ( 16 )
-#define ipconfigDNS_CACHE_ENTRIES                  ( 4 )
-#define ipconfigDNS_REQUEST_ATTEMPTS               ( 2 )
+#define ipconfigUSE_DNS_CACHE                          ( 1 )
+#define ipconfigDNS_CACHE_NAME_LENGTH                  ( 16 )
+#define ipconfigDNS_CACHE_ENTRIES                      ( 4 )
+#define ipconfigDNS_REQUEST_ATTEMPTS                   ( 2 )
 
 /* The IP stack executes it its own task (although any application task can make
  * use of its services through the published sockets API). ipconfigUDP_TASK_PRIORITY
@@ -115,14 +115,14 @@ extern void vLoggingPrintf( const char * pcFormatString,
  * FreeRTOSConfig.h, not FreeRTOSIPConfig.h. Consideration needs to be given as to
  * the priority assigned to the task executing the IP stack relative to the
  * priority assigned to tasks that use the IP stack. */
-#define ipconfigIP_TASK_PRIORITY                   ( configMAX_PRIORITIES - 2 )
+#define ipconfigIP_TASK_PRIORITY                       ( configMAX_PRIORITIES - 2 )
 
 /* The size, in words (not bytes), of the stack allocated to the FreeRTOS+TCP
  * task. This setting is less important when the FreeRTOS Win32 simulator is used
  * as the Win32 simulator only stores a fixed amount of information on the task
  * stack. FreeRTOS includes optional stack overflow detection, see:
  * http://www.freertos.org/Stacks-and-stack-overflow-checking.html */
-#define ipconfigIP_TASK_STACK_SIZE_WORDS           ( configMINIMAL_STACK_SIZE * 5 )
+#define ipconfigIP_TASK_STACK_SIZE_WORDS               ( configMINIMAL_STACK_SIZE * 5 )
 
 /* If ipconfigUSE_NETWORK_EVENT_HOOK is set to 1 then FreeRTOS+TCP will call the
  * network event hook at the appropriate times. If ipconfigUSE_NETWORK_EVENT_HOOK

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Echo_Posix/FreeRTOSIPConfig.h
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Echo_Posix/FreeRTOSIPConfig.h
@@ -124,14 +124,6 @@ extern void vLoggingPrintf( const char * pcFormatString,
  * http://www.freertos.org/Stacks-and-stack-overflow-checking.html */
 #define ipconfigIP_TASK_STACK_SIZE_WORDS           ( configMINIMAL_STACK_SIZE * 5 )
 
-/* ipconfigRAND32() is called by the IP stack to generate random numbers for
- * things such as a DHCP transaction number or initial sequence number. Random
- * number generation is performed via this macro to allow applications to use their
- * own random number generation method. For example, it might be possible to
- * generate a random number by sampling noise on an analogue input. */
-extern UBaseType_t uxRand();
-#define ipconfigRAND32()    uxRand()
-
 /* If ipconfigUSE_NETWORK_EVENT_HOOK is set to 1 then FreeRTOS+TCP will call the
  * network event hook at the appropriate times. If ipconfigUSE_NETWORK_EVENT_HOOK
  * is not set to 1 then the network event hook will never be called. See

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Echo_Posix/main_networking.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Echo_Posix/main_networking.c
@@ -288,6 +288,7 @@ static void prvMiscInitialisation( void )
     ( void ) xApplicationGetRandomNumber( &ulRandomNumbers[ 1 ] );
     ( void ) xApplicationGetRandomNumber( &ulRandomNumbers[ 2 ] );
     ( void ) xApplicationGetRandomNumber( &ulRandomNumbers[ 3 ] );
+
     FreeRTOS_debug_printf( ( "Random numbers: %08X %08X %08X %08X\n",
                              ulRandomNumbers[ 0 ],
                              ulRandomNumbers[ 1 ],

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Echo_Qemu_mps2/FreeRTOSIPConfig.h
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Echo_Qemu_mps2/FreeRTOSIPConfig.h
@@ -79,26 +79,26 @@ extern void vLoggingPrintf( const char * pcFormatString,
 
 /* Define the byte order of the target MCU (the MCU FreeRTOS+TCP is executing
  * on).  Valid options are pdFREERTOS_BIG_ENDIAN and pdFREERTOS_LITTLE_ENDIAN. */
-#define ipconfigBYTE_ORDER                         pdFREERTOS_LITTLE_ENDIAN
+#define ipconfigBYTE_ORDER                             pdFREERTOS_LITTLE_ENDIAN
 
 /* If the network card/driver includes checksum offloading (IP/TCP/UDP checksums)
  * then set ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM to 1 to prevent the software
  * stack repeating the checksum calculations. */
-#define ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM     1
+#define ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM         1
 
 /* Several API's will block until the result is known, or the action has been
  * performed, for example FreeRTOS_send() and FreeRTOS_recv().  The timeouts can be
  * set per socket, using setsockopt().  If not set, the times below will be
  * used as defaults. */
-#define ipconfigSOCK_DEFAULT_RECEIVE_BLOCK_TIME    ( 5000 )
-#define ipconfigSOCK_DEFAULT_SEND_BLOCK_TIME       ( 5000 )
+#define ipconfigSOCK_DEFAULT_RECEIVE_BLOCK_TIME        ( 5000 )
+#define ipconfigSOCK_DEFAULT_SEND_BLOCK_TIME           ( 5000 )
 
 /* Include support for LLMNR: Link-local Multicast Name Resolution
  * (non-Microsoft) */
-#define ipconfigUSE_LLMNR                          ( 1 )
+#define ipconfigUSE_LLMNR                              ( 1 )
 
 /* Include support for NBNS: NetBIOS Name Service (Microsoft) */
-#define ipconfigUSE_NBNS                           ( 1 )
+#define ipconfigUSE_NBNS                               ( 1 )
 
 /* Include support for DNS caching.  For TCP, having a small DNS cache is very
  * useful.  When a cache is present, ipconfigDNS_REQUEST_ATTEMPTS can be kept low
@@ -106,10 +106,10 @@ extern void vLoggingPrintf( const char * pcFormatString,
  * socket has been destroyed, the result will be stored into the cache.  The next
  * call to FreeRTOS_gethostbyname() will return immediately, without even creating
  * a socket. */
-#define ipconfigUSE_DNS_CACHE                      ( 1 )
-#define ipconfigDNS_CACHE_NAME_LENGTH              ( 16 )
-#define ipconfigDNS_CACHE_ENTRIES                  ( 4 )
-#define ipconfigDNS_REQUEST_ATTEMPTS               ( 2 )
+#define ipconfigUSE_DNS_CACHE                          ( 1 )
+#define ipconfigDNS_CACHE_NAME_LENGTH                  ( 16 )
+#define ipconfigDNS_CACHE_ENTRIES                      ( 4 )
+#define ipconfigDNS_REQUEST_ATTEMPTS                   ( 2 )
 
 /* The IP stack executes it its own task (although any application task can make
  * use of its services through the published sockets API). ipconfigUDP_TASK_PRIORITY
@@ -120,14 +120,14 @@ extern void vLoggingPrintf( const char * pcFormatString,
  * FreeRTOSConfig.h, not FreeRTOSIPConfig.h. Consideration needs to be given as to
  * the priority assigned to the task executing the IP stack relative to the
  * priority assigned to tasks that use the IP stack. */
-#define ipconfigIP_TASK_PRIORITY                   ( configMAX_PRIORITIES - 2 )
+#define ipconfigIP_TASK_PRIORITY                       ( configMAX_PRIORITIES - 2 )
 
 /* The size, in words (not bytes), of the stack allocated to the FreeRTOS+TCP
  * task.  This setting is less important when the FreeRTOS Win32 simulator is used
  * as the Win32 simulator only stores a fixed amount of information on the task
  * stack.  FreeRTOS includes optional stack overflow detection, see:
  * http://www.freertos.org/Stacks-and-stack-overflow-checking.html */
-#define ipconfigIP_TASK_STACK_SIZE_WORDS           ( configMINIMAL_STACK_SIZE * 5 )
+#define ipconfigIP_TASK_STACK_SIZE_WORDS               ( configMINIMAL_STACK_SIZE * 5 )
 
 /* If ipconfigUSE_NETWORK_EVENT_HOOK is set to 1 then FreeRTOS+TCP will call the
  * network event hook at the appropriate times.  If ipconfigUSE_NETWORK_EVENT_HOOK

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Echo_Qemu_mps2/FreeRTOSIPConfig.h
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Echo_Qemu_mps2/FreeRTOSIPConfig.h
@@ -129,14 +129,6 @@ extern void vLoggingPrintf( const char * pcFormatString,
  * http://www.freertos.org/Stacks-and-stack-overflow-checking.html */
 #define ipconfigIP_TASK_STACK_SIZE_WORDS           ( configMINIMAL_STACK_SIZE * 5 )
 
-/* ipconfigRAND32() is called by the IP stack to generate random numbers for
- * things such as a DHCP transaction number or initial sequence number.  Random
- * number generation is performed via this macro to allow applications to use their
- * own random number generation method.  For example, it might be possible to
- * generate a random number by sampling noise on an analogue input. */
-extern UBaseType_t uxRand();
-#define ipconfigRAND32()    uxRand()
-
 /* If ipconfigUSE_NETWORK_EVENT_HOOK is set to 1 then FreeRTOS+TCP will call the
  * network event hook at the appropriate times.  If ipconfigUSE_NETWORK_EVENT_HOOK
  * is not set to 1 then the network event hook will never be called.  See

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_IPv6_Demo/IPv6_Multi_WinSim_demo/FreeRTOSIPConfig.h
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_IPv6_Demo/IPv6_Multi_WinSim_demo/FreeRTOSIPConfig.h
@@ -60,26 +60,26 @@ extern void vLoggingPrintf( const char * pcFormatString,
 
 /* Define the byte order of the target MCU (the MCU FreeRTOS+TCP is executing
  * on).  Valid options are pdFREERTOS_BIG_ENDIAN and pdFREERTOS_LITTLE_ENDIAN. */
-#define ipconfigBYTE_ORDER                         pdFREERTOS_LITTLE_ENDIAN
+#define ipconfigBYTE_ORDER                             pdFREERTOS_LITTLE_ENDIAN
 
 /* If the network card/driver includes checksum offloading (IP/TCP/UDP checksums)
  * then set ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM to 1 to prevent the software
  * stack repeating the checksum calculations. */
-#define ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM     1
+#define ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM         1
 
 /* Several API's will block until the result is known, or the action has been
  * performed, for example FreeRTOS_send() and FreeRTOS_recv().  The timeouts can be
  * set per socket, using setsockopt().  If not set, the times below will be
  * used as defaults. */
-#define ipconfigSOCK_DEFAULT_RECEIVE_BLOCK_TIME    ( 5000 )
-#define ipconfigSOCK_DEFAULT_SEND_BLOCK_TIME       ( 5000 )
+#define ipconfigSOCK_DEFAULT_RECEIVE_BLOCK_TIME        ( 5000 )
+#define ipconfigSOCK_DEFAULT_SEND_BLOCK_TIME           ( 5000 )
 
 /* Include support for LLMNR: Link-local Multicast Name Resolution
  * (non-Microsoft) */
-#define ipconfigUSE_LLMNR                          ( 1 )
+#define ipconfigUSE_LLMNR                              ( 1 )
 
 /* Include support for NBNS: NetBIOS Name Service (Microsoft) */
-#define ipconfigUSE_NBNS                           ( 1 )
+#define ipconfigUSE_NBNS                               ( 1 )
 
 /* Include support for DNS caching.  For TCP, having a small DNS cache is very
  * useful.  When a cache is present, ipconfigDNS_REQUEST_ATTEMPTS can be kept low
@@ -87,13 +87,13 @@ extern void vLoggingPrintf( const char * pcFormatString,
  * socket has been destroyed, the result will be stored into the cache.  The next
  * call to FreeRTOS_gethostbyname() will return immediately, without even creating
  * a socket. */
-#define ipconfigUSE_DNS_CACHE                      ( 1 )
-#define ipconfigDNS_CACHE_NAME_LENGTH              ( 33 )
-#define ipconfigDNS_CACHE_ENTRIES                  ( 4 )
-#define ipconfigDNS_REQUEST_ATTEMPTS               ( 2 )
+#define ipconfigUSE_DNS_CACHE                          ( 1 )
+#define ipconfigDNS_CACHE_NAME_LENGTH                  ( 33 )
+#define ipconfigDNS_CACHE_ENTRIES                      ( 4 )
+#define ipconfigDNS_REQUEST_ATTEMPTS                   ( 2 )
 
 /* Let DNS wait for 3 seconds for an answer. */
-#define ipconfigDNS_RECEIVE_BLOCK_TIME_TICKS       pdMS_TO_TICKS( 3000U )
+#define ipconfigDNS_RECEIVE_BLOCK_TIME_TICKS           pdMS_TO_TICKS( 3000U )
 
 /* The IP stack executes it its own task (although any application task can make
  * use of its services through the published sockets API). ipconfigUDP_TASK_PRIORITY
@@ -104,14 +104,14 @@ extern void vLoggingPrintf( const char * pcFormatString,
  * FreeRTOSConfig.h, not FreeRTOSIPConfig.h. Consideration needs to be given as to
  * the priority assigned to the task executing the IP stack relative to the
  * priority assigned to tasks that use the IP stack. */
-#define ipconfigIP_TASK_PRIORITY                   ( configMAX_PRIORITIES - 2 )
+#define ipconfigIP_TASK_PRIORITY                       ( configMAX_PRIORITIES - 2 )
 
 /* The size, in words (not bytes), of the stack allocated to the FreeRTOS+TCP
  * task.  This setting is less important when the FreeRTOS Win32 simulator is used
  * as the Win32 simulator only stores a fixed amount of information on the task
  * stack.  FreeRTOS includes optional stack overflow detection, see:
  * http://www.freertos.org/Stacks-and-stack-overflow-checking.html */
-#define ipconfigIP_TASK_STACK_SIZE_WORDS           ( configMINIMAL_STACK_SIZE * 5 )
+#define ipconfigIP_TASK_STACK_SIZE_WORDS               ( configMINIMAL_STACK_SIZE * 5 )
 
 /* If ipconfigUSE_NETWORK_EVENT_HOOK is set to 1 then FreeRTOS+TCP will call the
  * network event hook at the appropriate times.  If ipconfigUSE_NETWORK_EVENT_HOOK

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_IPv6_Demo/IPv6_Multi_WinSim_demo/FreeRTOSIPConfig.h
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_IPv6_Demo/IPv6_Multi_WinSim_demo/FreeRTOSIPConfig.h
@@ -113,14 +113,6 @@ extern void vLoggingPrintf( const char * pcFormatString,
  * http://www.freertos.org/Stacks-and-stack-overflow-checking.html */
 #define ipconfigIP_TASK_STACK_SIZE_WORDS           ( configMINIMAL_STACK_SIZE * 5 )
 
-/* ipconfigRAND32() is called by the IP stack to generate random numbers for
- * things such as a DHCP transaction number or initial sequence number.  Random
- * number generation is performed via this macro to allow applications to use their
- * own random number generation method.  For example, it might be possible to
- * generate a random number by sampling noise on an analogue input. */
-extern UBaseType_t uxRand();
-#define ipconfigRAND32()    uxRand()
-
 /* If ipconfigUSE_NETWORK_EVENT_HOOK is set to 1 then FreeRTOS+TCP will call the
  * network event hook at the appropriate times.  If ipconfigUSE_NETWORK_EVENT_HOOK
  * is not set to 1 then the network event hook will never be called.  See

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_IPv6_Demo/IPv6_Multi_WinSim_demo/main.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_IPv6_Demo/IPv6_Multi_WinSim_demo/main.c
@@ -938,32 +938,38 @@ static void dns_test( const char * pcHostName )
     uint32_t ulID;
     BaseType_t rc;
 
-    ( void ) xApplicationGetRandomNumber( &ulID );
-    FreeRTOS_dnsclear();
+    if( xApplicationGetRandomNumber( &( ulID ) ) != pdFALSE )
+    {
+        FreeRTOS_dnsclear();
 
-    struct freertos_addrinfo xHints;
-    struct freertos_addrinfo * pxResult = NULL;
+        struct freertos_addrinfo xHints;
+        struct freertos_addrinfo * pxResult = NULL;
 
-    memset( &xHints, 0, sizeof xHints );
-    xHints.ai_family = FREERTOS_AF_INET6;
+        memset( &xHints, 0, sizeof xHints );
+        xHints.ai_family = FREERTOS_AF_INET6;
 
-    rc = FreeRTOS_getaddrinfo( pcHostName, NULL, &xHints, &pxResult );
+        rc = FreeRTOS_getaddrinfo( pcHostName, NULL, &xHints, &pxResult );
 
-    FreeRTOS_printf( ( "Lookup '%s': %d\n", pcHostName, rc ) );
+        FreeRTOS_printf( ( "Lookup '%s': %d\n", pcHostName, rc ) );
 
-    FreeRTOS_dnsclear();
-    xDNSResult = -2;
-    rc = FreeRTOS_getaddrinfo_a( pcHostName,
-                                 NULL,
-                                 &xHints,
-                                 &pxResult, /* An allocated struct, containing the results. */
-                                 vDNSEvent,
-                                 ( void * ) ulID,
-                                 pdMS_TO_TICKS( 1000U ) );
-    vTaskDelay( pdMS_TO_TICKS( 1000U ) );
-    rc = xDNSResult;
-    FreeRTOS_printf( ( "Lookup '%s': %d\n", pcHostName, rc ) );
-    /*      FreeRTOS_gethostbyname( pcHostName ); */
+        FreeRTOS_dnsclear();
+        xDNSResult = -2;
+        rc = FreeRTOS_getaddrinfo_a( pcHostName,
+                                    NULL,
+                                    &xHints,
+                                    &pxResult, /* An allocated struct, containing the results. */
+                                    vDNSEvent,
+                                    ( void * ) ulID,
+                                    pdMS_TO_TICKS( 1000U ) );
+        vTaskDelay( pdMS_TO_TICKS( 1000U ) );
+        rc = xDNSResult;
+        FreeRTOS_printf( ( "Lookup '%s': %d\n", pcHostName, rc ) );
+        /*      FreeRTOS_gethostbyname( pcHostName ); */
+    }
+    else
+    {
+        FreeRTOS_printf( ( "dns_test: Failed to generate a random Search ID\n" ) );
+    }
 }
 
 void showAddressInfo( struct freertos_addrinfo * pxAddrInfo )

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_IPv6_Demo/IPv6_Multi_WinSim_demo/main.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_IPv6_Demo/IPv6_Multi_WinSim_demo/main.c
@@ -968,7 +968,7 @@ static void dns_test( const char * pcHostName )
     }
     else
     {
-        FreeRTOS_printf( ( "dns_test: Failed to generate a random Search ID\n" ) );
+        FreeRTOS_printf( ( "dns_test: Failed to generate a random SearchID\n" ) );
     }
 }
 

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_IPv6_Demo/IPv6_Multi_WinSim_demo/main.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_IPv6_Demo/IPv6_Multi_WinSim_demo/main.c
@@ -955,12 +955,12 @@ static void dns_test( const char * pcHostName )
         FreeRTOS_dnsclear();
         xDNSResult = -2;
         rc = FreeRTOS_getaddrinfo_a( pcHostName,
-                                    NULL,
-                                    &xHints,
-                                    &pxResult, /* An allocated struct, containing the results. */
-                                    vDNSEvent,
-                                    ( void * ) ulID,
-                                    pdMS_TO_TICKS( 1000U ) );
+                                     NULL,
+                                     &xHints,
+                                     &pxResult, /* An allocated struct, containing the results. */
+                                     vDNSEvent,
+                                     ( void * ) ulID,
+                                     pdMS_TO_TICKS( 1000U ) );
         vTaskDelay( pdMS_TO_TICKS( 1000U ) );
         rc = xDNSResult;
         FreeRTOS_printf( ( "Lookup '%s': %d\n", pcHostName, rc ) );

--- a/FreeRTOS-Plus/Test/FreeRTOS-Cellular-Interface/Integration/Config/FreeRTOSIPConfig.h
+++ b/FreeRTOS-Plus/Test/FreeRTOS-Cellular-Interface/Integration/Config/FreeRTOSIPConfig.h
@@ -60,26 +60,26 @@ extern void vLoggingPrintf( const char * pcFormatString,
 
 /* Define the byte order of the target MCU (the MCU FreeRTOS+TCP is executing
  * on).  Valid options are pdFREERTOS_BIG_ENDIAN and pdFREERTOS_LITTLE_ENDIAN. */
-#define ipconfigBYTE_ORDER                         pdFREERTOS_LITTLE_ENDIAN
+#define ipconfigBYTE_ORDER                                    pdFREERTOS_LITTLE_ENDIAN
 
 /* If the network card/driver includes checksum offloading (IP/TCP/UDP checksums)
  * then set ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM to 1 to prevent the software
  * stack repeating the checksum calculations. */
-#define ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM     1
+#define ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM                1
 
 /* Several API's will block until the result is known, or the action has been
  * performed, for example FreeRTOS_send() and FreeRTOS_recv().  The timeouts can be
  * set per socket, using setsockopt().  If not set, the times below will be
  * used as defaults. */
-#define ipconfigSOCK_DEFAULT_RECEIVE_BLOCK_TIME    ( 2000 )
-#define ipconfigSOCK_DEFAULT_SEND_BLOCK_TIME       ( 5000 )
+#define ipconfigSOCK_DEFAULT_RECEIVE_BLOCK_TIME               ( 2000 )
+#define ipconfigSOCK_DEFAULT_SEND_BLOCK_TIME                  ( 5000 )
 
 /* Include support for LLMNR: Link-local Multicast Name Resolution
  * (non-Microsoft) */
-#define ipconfigUSE_LLMNR                          ( 0 )
+#define ipconfigUSE_LLMNR                                     ( 0 )
 
 /* Include support for NBNS: NetBIOS Name Service (Microsoft) */
-#define ipconfigUSE_NBNS                           ( 0 )
+#define ipconfigUSE_NBNS                                      ( 0 )
 
 /* Include support for DNS caching.  For TCP, having a small DNS cache is very
  * useful.  When a cache is present, ipconfigDNS_REQUEST_ATTEMPTS can be kept low
@@ -87,10 +87,10 @@ extern void vLoggingPrintf( const char * pcFormatString,
  * socket has been destroyed, the result will be stored into the cache.  The next
  * call to FreeRTOS_gethostbyname() will return immediately, without even creating
  * a socket. */
-#define ipconfigUSE_DNS_CACHE                      ( 1 )
-#define ipconfigDNS_CACHE_NAME_LENGTH              ( 64 )
-#define ipconfigDNS_CACHE_ENTRIES                  ( 4 )
-#define ipconfigDNS_REQUEST_ATTEMPTS               ( 2 )
+#define ipconfigUSE_DNS_CACHE                                 ( 1 )
+#define ipconfigDNS_CACHE_NAME_LENGTH                         ( 64 )
+#define ipconfigDNS_CACHE_ENTRIES                             ( 4 )
+#define ipconfigDNS_REQUEST_ATTEMPTS                          ( 2 )
 
 /* The IP stack executes it its own task (although any application task can make
  * use of its services through the published sockets API). ipconfigUDP_TASK_PRIORITY
@@ -101,14 +101,14 @@ extern void vLoggingPrintf( const char * pcFormatString,
  * FreeRTOSConfig.h, not FreeRTOSIPConfig.h. Consideration needs to be given as to
  * the priority assigned to the task executing the IP stack relative to the
  * priority assigned to tasks that use the IP stack. */
-#define ipconfigIP_TASK_PRIORITY                   ( configMAX_PRIORITIES - 2 )
+#define ipconfigIP_TASK_PRIORITY                              ( configMAX_PRIORITIES - 2 )
 
 /* The size, in words (not bytes), of the stack allocated to the FreeRTOS+TCP
  * task.  This setting is less important when the FreeRTOS Win32 simulator is used
  * as the Win32 simulator only stores a fixed amount of information on the task
  * stack.  FreeRTOS includes optional stack overflow detection, see:
  * https://www.FreeRTOS.org/Stacks-and-stack-overflow-checking.html */
-#define ipconfigIP_TASK_STACK_SIZE_WORDS           ( configMINIMAL_STACK_SIZE * 5 )
+#define ipconfigIP_TASK_STACK_SIZE_WORDS                      ( configMINIMAL_STACK_SIZE * 5 )
 
 /* If ipconfigUSE_NETWORK_EVENT_HOOK is set to 1 then FreeRTOS+TCP will call the
  * network event hook at the appropriate times.  If ipconfigUSE_NETWORK_EVENT_HOOK

--- a/FreeRTOS-Plus/Test/FreeRTOS-Cellular-Interface/Integration/Config/FreeRTOSIPConfig.h
+++ b/FreeRTOS-Plus/Test/FreeRTOS-Cellular-Interface/Integration/Config/FreeRTOSIPConfig.h
@@ -110,14 +110,6 @@ extern void vLoggingPrintf( const char * pcFormatString,
  * https://www.FreeRTOS.org/Stacks-and-stack-overflow-checking.html */
 #define ipconfigIP_TASK_STACK_SIZE_WORDS           ( configMINIMAL_STACK_SIZE * 5 )
 
-/* ipconfigRAND32() is called by the IP stack to generate random numbers for
- * things such as a DHCP transaction number or initial sequence number.  Random
- * number generation is performed via this macro to allow applications to use their
- * own random number generation method.  For example, it might be possible to
- * generate a random number by sampling noise on an analogue input. */
-extern UBaseType_t uxRand();
-#define ipconfigRAND32()    uxRand()
-
 /* If ipconfigUSE_NETWORK_EVENT_HOOK is set to 1 then FreeRTOS+TCP will call the
  * network event hook at the appropriate times.  If ipconfigUSE_NETWORK_EVENT_HOOK
  * is not set to 1 then the network event hook will never be called.  See

--- a/FreeRTOS-Plus/Test/FreeRTOS-Plus-TCP/Integration/Full-TCP-Networkless/Config/FreeRTOSIPConfig.h
+++ b/FreeRTOS-Plus/Test/FreeRTOS-Plus-TCP/Integration/Full-TCP-Networkless/Config/FreeRTOSIPConfig.h
@@ -113,14 +113,6 @@ extern void vLoggingPrintf( const char * pcFormatString,
  * http://www.freertos.org/Stacks-and-stack-overflow-checking.html */
 #define ipconfigIP_TASK_STACK_SIZE_WORDS           ( configMINIMAL_STACK_SIZE * 5 )
 
-/* ipconfigRAND32() is called by the IP stack to generate random numbers for
- * things such as a DHCP transaction number or initial sequence number.  Random
- * number generation is performed via this macro to allow applications to use their
- * own random number generation method.  For example, it might be possible to
- * generate a random number by sampling noise on an analogue input. */
-/*extern UBaseType_t rand(); */
-#define ipconfigRAND32()    rand()
-
 /* If ipconfigUSE_NETWORK_EVENT_HOOK is set to 1 then FreeRTOS+TCP will call the
  * network event hook at the appropriate times.  If ipconfigUSE_NETWORK_EVENT_HOOK
  * is not set to 1 then the network event hook will never be called.  See

--- a/FreeRTOS-Plus/Test/FreeRTOS-Plus-TCP/Integration/Full-TCP-Networkless/Config/FreeRTOSIPConfig.h
+++ b/FreeRTOS-Plus/Test/FreeRTOS-Plus-TCP/Integration/Full-TCP-Networkless/Config/FreeRTOSIPConfig.h
@@ -62,26 +62,26 @@ extern void vLoggingPrintf( const char * pcFormatString,
 
 /* Define the byte order of the target MCU (the MCU FreeRTOS+TCP is executing
  * on).  Valid options are pdFREERTOS_BIG_ENDIAN and pdFREERTOS_LITTLE_ENDIAN. */
-#define ipconfigBYTE_ORDER                         pdFREERTOS_LITTLE_ENDIAN
+#define ipconfigBYTE_ORDER                             pdFREERTOS_LITTLE_ENDIAN
 
 /* If the network card/driver includes checksum offloading (IP/TCP/UDP checksums)
  * then set ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM to 1 to prevent the software
  * stack repeating the checksum calculations. */
-#define ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM     1
+#define ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM         1
 
 /* Several API's will block until the result is known, or the action has been
  * performed, for example FreeRTOS_send() and FreeRTOS_recv().  The timeouts can be
  * set per socket, using setsockopt().  If not set, the times below will be
  * used as defaults. */
-#define ipconfigSOCK_DEFAULT_RECEIVE_BLOCK_TIME    ( 5000 )
-#define ipconfigSOCK_DEFAULT_SEND_BLOCK_TIME       ( 5000 )
+#define ipconfigSOCK_DEFAULT_RECEIVE_BLOCK_TIME        ( 5000 )
+#define ipconfigSOCK_DEFAULT_SEND_BLOCK_TIME           ( 5000 )
 
 /* Include support for LLMNR: Link-local Multicast Name Resolution
  * (non-Microsoft) */
-#define ipconfigUSE_LLMNR                          ( 0 )
+#define ipconfigUSE_LLMNR                              ( 0 )
 
 /* Include support for NBNS: NetBIOS Name Service (Microsoft) */
-#define ipconfigUSE_NBNS                           ( 1 )
+#define ipconfigUSE_NBNS                               ( 1 )
 
 /* Include support for DNS caching.  For TCP, having a small DNS cache is very
  * useful.  When a cache is present, ipconfigDNS_REQUEST_ATTEMPTS can be kept low
@@ -89,11 +89,11 @@ extern void vLoggingPrintf( const char * pcFormatString,
  * socket has been destroyed, the result will be stored into the cache.  The next
  * call to FreeRTOS_gethostbyname() will return immediately, without even creating
  * a socket. */
-#define ipconfigUSE_DNS_CACHE                      ( 1 )
-#define ipconfigDNS_CACHE_NAME_LENGTH              ( 254 )
-#define ipconfigDNS_CACHE_ENTRIES                  ( 4 )
-#define ipconfigDNS_CACHE_ADDRESSES_PER_ENTRY      ( 6 )
-#define ipconfigDNS_REQUEST_ATTEMPTS               ( 2 )
+#define ipconfigUSE_DNS_CACHE                          ( 1 )
+#define ipconfigDNS_CACHE_NAME_LENGTH                  ( 254 )
+#define ipconfigDNS_CACHE_ENTRIES                      ( 4 )
+#define ipconfigDNS_CACHE_ADDRESSES_PER_ENTRY          ( 6 )
+#define ipconfigDNS_REQUEST_ATTEMPTS                   ( 2 )
 
 /* The IP stack executes it its own task (although any application task can make
  * use of its services through the published sockets API). ipconfigUDP_TASK_PRIORITY
@@ -104,14 +104,14 @@ extern void vLoggingPrintf( const char * pcFormatString,
  * FreeRTOSConfig.h, not FreeRTOSIPConfig.h. Consideration needs to be given as to
  * the priority assigned to the task executing the IP stack relative to the
  * priority assigned to tasks that use the IP stack. */
-#define ipconfigIP_TASK_PRIORITY                   ( configMAX_PRIORITIES - 2 )
+#define ipconfigIP_TASK_PRIORITY                       ( configMAX_PRIORITIES - 2 )
 
 /* The size, in words (not bytes), of the stack allocated to the FreeRTOS+TCP
  * task.  This setting is less important when the FreeRTOS Win32 simulator is used
  * as the Win32 simulator only stores a fixed amount of information on the task
  * stack.  FreeRTOS includes optional stack overflow detection, see:
  * http://www.freertos.org/Stacks-and-stack-overflow-checking.html */
-#define ipconfigIP_TASK_STACK_SIZE_WORDS           ( configMINIMAL_STACK_SIZE * 5 )
+#define ipconfigIP_TASK_STACK_SIZE_WORDS               ( configMINIMAL_STACK_SIZE * 5 )
 
 /* If ipconfigUSE_NETWORK_EVENT_HOOK is set to 1 then FreeRTOS+TCP will call the
  * network event hook at the appropriate times.  If ipconfigUSE_NETWORK_EVENT_HOOK

--- a/FreeRTOS-Plus/Test/FreeRTOS-Plus-TCP/Integration/Full-TCP-Suite/Config/FreeRTOSIPConfig.h
+++ b/FreeRTOS-Plus/Test/FreeRTOS-Plus-TCP/Integration/Full-TCP-Suite/Config/FreeRTOSIPConfig.h
@@ -102,7 +102,7 @@
  * is not set to 1 then the network event hook will never be called. See:
  * https://www.FreeRTOS.org/FreeRTOS-Plus/FreeRTOS_Plus_UDP/API/vApplicationIPNetworkEventHook.shtml.
  */
-#define ipconfigUSE_NETWORK_EVENT_HOOK           1
+#define ipconfigUSE_NETWORK_EVENT_HOOK             1
 
 /* Sockets have a send block time attribute.  If FreeRTOS_sendto() is called but
  * a network buffer cannot be obtained then the calling task is held in the Blocked
@@ -116,7 +116,7 @@
  * ipconfigMAX_SEND_BLOCK_TIME_TICKS is specified in RTOS ticks.  A time in
  * milliseconds can be converted to a time in ticks by dividing the time in
  * milliseconds by portTICK_PERIOD_MS. */
-#define ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS    ( 5000U / portTICK_PERIOD_MS )
+#define ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS      ( 5000U / portTICK_PERIOD_MS )
 
 /* If ipconfigUSE_DHCP is 1 then FreeRTOS+TCP will attempt to retrieve an IP
  * address, netmask, DNS server address and gateway address from a DHCP server.  If
@@ -125,14 +125,14 @@
  * set to 1 if a valid configuration cannot be obtained from a DHCP server for any
  * reason.  The static configuration used is that passed into the stack by the
  * FreeRTOS_IPInit() function call. */
-#define ipconfigUSE_DHCP                         1
-#define ipconfigDHCP_REGISTER_HOSTNAME           1
-#define ipconfigDHCP_USES_UNICAST                1
+#define ipconfigUSE_DHCP                           1
+#define ipconfigDHCP_REGISTER_HOSTNAME             1
+#define ipconfigDHCP_USES_UNICAST                  1
 
 /* If ipconfigDHCP_USES_USER_HOOK is set to 1 then the application writer must
  * provide an implementation of the DHCP callback function,
  * xApplicationDHCPUserHook(). */
-#define ipconfigUSE_DHCP_HOOK                    0
+#define ipconfigUSE_DHCP_HOOK                      0
 
 /* When ipconfigUSE_DHCP is set to 1, DHCP requests will be sent out at
  * increasing time intervals until either a reply is received from a DHCP server

--- a/FreeRTOS-Plus/Test/FreeRTOS-Plus-TCP/Integration/Full-TCP-Suite/Config/FreeRTOSIPConfig.h
+++ b/FreeRTOS-Plus/Test/FreeRTOS-Plus-TCP/Integration/Full-TCP-Suite/Config/FreeRTOSIPConfig.h
@@ -97,14 +97,6 @@
  * https://www.FreeRTOS.org/Stacks-and-stack-overflow-checking.html. */
 #define ipconfigIP_TASK_STACK_SIZE_WORDS           ( configMINIMAL_STACK_SIZE * 5 )
 
-/* ipconfigRAND32() is called by the IP stack to generate random numbers for
- * things such as a DHCP transaction number or initial sequence number.  Random
- * number generation is performed via this macro to allow applications to use their
- * own random number generation method.  For example, it might be possible to
- * generate a random number by sampling noise on an analogue input. */
-extern uint32_t ulRand();
-#define ipconfigRAND32()    ulRand()
-
 /* If ipconfigUSE_NETWORK_EVENT_HOOK is set to 1 then FreeRTOS+TCP will call the
  * network event hook at the appropriate times.  If ipconfigUSE_NETWORK_EVENT_HOOK
  * is not set to 1 then the network event hook will never be called. See:

--- a/FreeRTOS-Plus/VisualStudio_StaticProjects/FreeRTOS+TCP/FreeRTOSIPConfig.h
+++ b/FreeRTOS-Plus/VisualStudio_StaticProjects/FreeRTOS+TCP/FreeRTOSIPConfig.h
@@ -113,14 +113,6 @@ extern void vLoggingPrintf( const char * pcFormatString,
  * https://www.FreeRTOS.org/Stacks-and-stack-overflow-checking.html */
 #define ipconfigIP_TASK_STACK_SIZE_WORDS           ( configMINIMAL_STACK_SIZE * 5U )
 
-/* ipconfigRAND32() is called by the IP stack to generate random numbers for
- * things such as a DHCP transaction number or initial sequence number.  Random
- * number generation is performed via this macro to allow applications to use their
- * own random number generation method.  For example, it might be possible to
- * generate a random number by sampling noise on an analogue input. */
-extern UBaseType_t uxRand();
-#define ipconfigRAND32()    uxRand()
-
 /* If ipconfigUSE_NETWORK_EVENT_HOOK is set to 1 then FreeRTOS+TCP will call the
  * network event hook at the appropriate times.  If ipconfigUSE_NETWORK_EVENT_HOOK
  * is not set to 1 then the network event hook will never be called.  See

--- a/FreeRTOS-Plus/VisualStudio_StaticProjects/FreeRTOS+TCP/FreeRTOSIPConfig.h
+++ b/FreeRTOS-Plus/VisualStudio_StaticProjects/FreeRTOS+TCP/FreeRTOSIPConfig.h
@@ -63,26 +63,26 @@ extern void vLoggingPrintf( const char * pcFormatString,
 
 /* Define the byte order of the target MCU (the MCU FreeRTOS+TCP is executing
  * on).  Valid options are pdFREERTOS_BIG_ENDIAN and pdFREERTOS_LITTLE_ENDIAN. */
-#define ipconfigBYTE_ORDER                         pdFREERTOS_LITTLE_ENDIAN
+#define ipconfigBYTE_ORDER                             pdFREERTOS_LITTLE_ENDIAN
 
 /* If the network card/driver includes checksum offloading (IP/TCP/UDP checksums)
  * then set ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM to 1 to prevent the software
  * stack repeating the checksum calculations. */
-#define ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM     1
+#define ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM         1
 
 /* Several API's will block until the result is known, or the action has been
  * performed, for example FreeRTOS_send() and FreeRTOS_recv().  The timeouts can be
  * set per socket, using setsockopt().  If not set, the times below will be
  * used as defaults. */
-#define ipconfigSOCK_DEFAULT_RECEIVE_BLOCK_TIME    ( 5000 )
-#define ipconfigSOCK_DEFAULT_SEND_BLOCK_TIME       ( 5000 )
+#define ipconfigSOCK_DEFAULT_RECEIVE_BLOCK_TIME        ( 5000 )
+#define ipconfigSOCK_DEFAULT_SEND_BLOCK_TIME           ( 5000 )
 
 /* Include support for LLMNR: Link-local Multicast Name Resolution
  * (non-Microsoft) */
-#define ipconfigUSE_LLMNR                          ( 0 )
+#define ipconfigUSE_LLMNR                              ( 0 )
 
 /* Include support for NBNS: NetBIOS Name Service (Microsoft) */
-#define ipconfigUSE_NBNS                           ( 0 )
+#define ipconfigUSE_NBNS                               ( 0 )
 
 /* Include support for DNS caching.  For TCP, having a small DNS cache is very
  * useful.  When a cache is present, ipconfigDNS_REQUEST_ATTEMPTS can be kept low
@@ -90,10 +90,10 @@ extern void vLoggingPrintf( const char * pcFormatString,
  * socket has been destroyed, the result will be stored into the cache.  The next
  * call to FreeRTOS_gethostbyname() will return immediately, without even creating
  * a socket. */
-#define ipconfigUSE_DNS_CACHE                      1
-#define ipconfigDNS_CACHE_NAME_LENGTH              ( 64U )
-#define ipconfigDNS_CACHE_ENTRIES                  ( 4U )
-#define ipconfigDNS_REQUEST_ATTEMPTS               ( 2U )
+#define ipconfigUSE_DNS_CACHE                          1
+#define ipconfigDNS_CACHE_NAME_LENGTH                  ( 64U )
+#define ipconfigDNS_CACHE_ENTRIES                      ( 4U )
+#define ipconfigDNS_REQUEST_ATTEMPTS                   ( 2U )
 
 /* The IP stack executes it its own task (although any application task can make
  * use of its services through the published sockets API). ipconfigUDP_TASK_PRIORITY
@@ -104,14 +104,14 @@ extern void vLoggingPrintf( const char * pcFormatString,
  * FreeRTOSConfig.h, not FreeRTOSIPConfig.h. Consideration needs to be given as to
  * the priority assigned to the task executing the IP stack relative to the
  * priority assigned to tasks that use the IP stack. */
-#define ipconfigIP_TASK_PRIORITY                   ( configMAX_PRIORITIES - 2U )
+#define ipconfigIP_TASK_PRIORITY                       ( configMAX_PRIORITIES - 2U )
 
 /* The size, in words (not bytes), of the stack allocated to the FreeRTOS+TCP
  * task.  This setting is less important when the FreeRTOS Win32 simulator is used
  * as the Win32 simulator only stores a fixed amount of information on the task
  * stack.  FreeRTOS includes optional stack overflow detection, see:
  * https://www.FreeRTOS.org/Stacks-and-stack-overflow-checking.html */
-#define ipconfigIP_TASK_STACK_SIZE_WORDS           ( configMINIMAL_STACK_SIZE * 5U )
+#define ipconfigIP_TASK_STACK_SIZE_WORDS               ( configMINIMAL_STACK_SIZE * 5U )
 
 /* If ipconfigUSE_NETWORK_EVENT_HOOK is set to 1 then FreeRTOS+TCP will call the
  * network event hook at the appropriate times.  If ipconfigUSE_NETWORK_EVENT_HOOK

--- a/FreeRTOS/Test/CBMC/patches/FreeRTOSIPConfig.h
+++ b/FreeRTOS/Test/CBMC/patches/FreeRTOSIPConfig.h
@@ -98,7 +98,7 @@
  * is not set to 1 then the network event hook will never be called. See:
  * https://www.FreeRTOS.org/FreeRTOS-Plus/FreeRTOS_Plus_UDP/API/vApplicationIPNetworkEventHook.shtml.
  */
-#define ipconfigUSE_NETWORK_EVENT_HOOK           1
+#define ipconfigUSE_NETWORK_EVENT_HOOK             1
 
 /* Sockets have a send block time attribute.  If FreeRTOS_sendto() is called but
  * a network buffer cannot be obtained then the calling task is held in the Blocked
@@ -112,7 +112,7 @@
  * ipconfigMAX_SEND_BLOCK_TIME_TICKS is specified in RTOS ticks.  A time in
  * milliseconds can be converted to a time in ticks by dividing the time in
  * milliseconds by portTICK_PERIOD_MS. */
-#define ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS    ( 5000U / portTICK_PERIOD_MS )
+#define ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS      ( 5000U / portTICK_PERIOD_MS )
 
 /* If ipconfigUSE_DHCP is 1 then FreeRTOS+TCP will attempt to retrieve an IP
  * address, netmask, DNS server address and gateway address from a DHCP server.  If
@@ -121,14 +121,14 @@
  * set to 1 if a valid configuration cannot be obtained from a DHCP server for any
  * reason.  The static configuration used is that passed into the stack by the
  * FreeRTOS_IPInit() function call. */
-#define ipconfigUSE_DHCP                         1
-#define ipconfigDHCP_REGISTER_HOSTNAME           1
-#define ipconfigDHCP_USES_UNICAST                1
+#define ipconfigUSE_DHCP                           1
+#define ipconfigDHCP_REGISTER_HOSTNAME             1
+#define ipconfigDHCP_USES_UNICAST                  1
 
 /* If ipconfigDHCP_USES_USER_HOOK is set to 1 then the application writer must
  * provide an implementation of the DHCP callback function,
  * xApplicationDHCPUserHook(). */
-#define ipconfigUSE_DHCP_HOOK                    0
+#define ipconfigUSE_DHCP_HOOK                      0
 
 /* When ipconfigUSE_DHCP is set to 1, DHCP requests will be sent out at
  * increasing time intervals until either a reply is received from a DHCP server

--- a/FreeRTOS/Test/CBMC/patches/FreeRTOSIPConfig.h
+++ b/FreeRTOS/Test/CBMC/patches/FreeRTOSIPConfig.h
@@ -93,14 +93,6 @@
  * https://www.FreeRTOS.org/Stacks-and-stack-overflow-checking.html. */
 #define ipconfigIP_TASK_STACK_SIZE_WORDS           ( configMINIMAL_STACK_SIZE * 5 )
 
-/* ipconfigRAND32() is called by the IP stack to generate random numbers for
- * things such as a DHCP transaction number or initial sequence number.  Random
- * number generation is performed via this macro to allow applications to use their
- * own random number generation method.  For example, it might be possible to
- * generate a random number by sampling noise on an analogue input. */
-extern uint32_t ulRand();
-#define ipconfigRAND32()    ulRand()
-
 /* If ipconfigUSE_NETWORK_EVENT_HOOK is set to 1 then FreeRTOS+TCP will call the
  * network event hook at the appropriate times.  If ipconfigUSE_NETWORK_EVENT_HOOK
  * is not set to 1 then the network event hook will never be called. See:


### PR DESCRIPTION
<!--- Title -->

Description
-----------
The macro's ipconfigRAND32() and configRAND32() are not in use anymore. In TCP V2.2.1 releases the ipconfigRAND32 macro was replaced by xApplicationGetRandomNumber().
Removing the instances of ipconfigRAND32 from the code.

Test Steps
-----------
Jenkins run

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [NA] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
[PR 782](https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/pull/782)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
