### PR TITLE
Add back mtCOVERAGE_TEST_MARKER in stream_buffer unit test

### DIFF
--- a/FreeRTOS/Test/CMock/stream_buffer/api/FreeRTOSConfig.h
+++ b/FreeRTOS/Test/CMock/stream_buffer/api/FreeRTOSConfig.h
@@ -128,6 +128,8 @@ void vConfigureTimerForRunTimeStats( void );    /* Prototype of function that in
         }                                             \
     } while( 0 )
 
+#define mtCOVERAGE_TEST_MARKER() __asm volatile ( "NOP" )
+
 #define configINCLUDE_MESSAGE_BUFFER_AMP_DEMO    0
 #if ( configINCLUDE_MESSAGE_BUFFER_AMP_DEMO == 1 )
     extern void vGenerateCoreBInterrupt( void * xUpdatedMessageBuffer );

--- a/FreeRTOS/Test/CMock/stream_buffer/api/FreeRTOSConfig.h
+++ b/FreeRTOS/Test/CMock/stream_buffer/api/FreeRTOSConfig.h
@@ -128,7 +128,7 @@ void vConfigureTimerForRunTimeStats( void );    /* Prototype of function that in
         }                                             \
     } while( 0 )
 
-#define mtCOVERAGE_TEST_MARKER() __asm volatile ( "NOP" )
+#define mtCOVERAGE_TEST_MARKER()    __asm volatile ( "NOP" )
 
 #define configINCLUDE_MESSAGE_BUFFER_AMP_DEMO    0
 #if ( configINCLUDE_MESSAGE_BUFFER_AMP_DEMO == 1 )

--- a/FreeRTOS/Test/CMock/stream_buffer/callback/FreeRTOSConfig.h
+++ b/FreeRTOS/Test/CMock/stream_buffer/callback/FreeRTOSConfig.h
@@ -129,7 +129,7 @@ void vConfigureTimerForRunTimeStats( void );    /* Prototype of function that in
         }                                             \
     } while( 0 )
 
-#define mtCOVERAGE_TEST_MARKER() __asm volatile ( "NOP" )
+#define mtCOVERAGE_TEST_MARKER()              __asm volatile ( "NOP" )
 
 extern void vDefaultSendCompletedStub( void * xStreamBuffer );
 #define sbSEND_COMPLETED( pxStreamBuffer )    vDefaultSendCompletedStub( pxStreamBuffer )

--- a/FreeRTOS/Test/CMock/stream_buffer/callback/FreeRTOSConfig.h
+++ b/FreeRTOS/Test/CMock/stream_buffer/callback/FreeRTOSConfig.h
@@ -129,6 +129,8 @@ void vConfigureTimerForRunTimeStats( void );    /* Prototype of function that in
         }                                             \
     } while( 0 )
 
+#define mtCOVERAGE_TEST_MARKER() __asm volatile ( "NOP" )
+
 extern void vDefaultSendCompletedStub( void * xStreamBuffer );
 #define sbSEND_COMPLETED( pxStreamBuffer )    vDefaultSendCompletedStub( pxStreamBuffer )
 


### PR DESCRIPTION
Add back mtCOVERAGE_TEST_MARKER in stream_buffer unit test

Description
-----------
Add back `mtCOVERAGE_TEST_MARKER` in stream_buffer unit test. The marker is removed in [SMP unit test PR](https://github.com/FreeRTOS/FreeRTOS/pull/1047).

Test Steps
-----------
N/A

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] ~~I have modified and/or added unit-tests to cover the code changes in this Pull Request.~~

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
