### PR TITLE
Fix one typical misusage of CMock.

### DIFF
--- a/FreeRTOS/Test/CMock/tasks/tasks.yml
+++ b/FreeRTOS/Test/CMock/tasks/tasks.yml
@@ -1,6 +1,7 @@
 :cmock:
   :mock_prefix: mock_
   :when_no_prototypes: :warn
+  :when_ptr: :smart
   :treat_externs: :include
   :treat_inlines: :include
   :enforce_strict_ordering: TRUE

--- a/FreeRTOS/Test/CMock/tasks/tasks_1_utest.c
+++ b/FreeRTOS/Test/CMock/tasks/tasks_1_utest.c
@@ -2626,8 +2626,8 @@ void test_vTaskResume_success_task_event_list_orphan( void )
     /* back */
     uxListRemove_ExpectAndReturn( &ptcb->xStateListItem, pdTRUE );
     /* prvAddTaskToReadyList*/
-    listINSERT_END_Expect( &pxReadyTasksLists[ create_task_priority ],
-                           &ptcb->xStateListItem );
+    listINSERT_END_ExpectWithArray( &pxReadyTasksLists[ 3 ], 0,
+                           &ptcb->xStateListItem, 0 );
     /* API Call */
     vTaskResume( task_handle ); /* not current tcb */
     /* Validations */

--- a/FreeRTOS/Test/CMock/tasks/tasks_1_utest.c
+++ b/FreeRTOS/Test/CMock/tasks/tasks_1_utest.c
@@ -2627,7 +2627,7 @@ void test_vTaskResume_success_task_event_list_orphan( void )
     uxListRemove_ExpectAndReturn( &ptcb->xStateListItem, pdTRUE );
     /* prvAddTaskToReadyList*/
     listINSERT_END_ExpectWithArray( &pxReadyTasksLists[ 3 ], 0,
-                           &ptcb->xStateListItem, 0 );
+                                    &ptcb->xStateListItem, 0 );
     /* API Call */
     vTaskResume( task_handle ); /* not current tcb */
     /* Validations */


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->
CMock has three policies when dealing with pointer:
1. compare_ptr : compare the pointer itself;
2. compare_data : compare the data which is pointed by pointer;
3. smart : compare the pointer itself, or compare the data; 

By default, CMock use compare_data policy.

Most test cases in FreeRTOS need to compare the pointer itself, and we haven't use CMock properly.
For example, one test case of vTaskResume is wrong, and because CMock compares the data pointed by pointer currently, so the error didn't exposed.

There are so many misusage need to fix, it will take a lot of work. I'm here to fix one typical misusage first.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
