### PR TITLE
Add test cases to cover prvCreateIdleTasks for SMP

### DIFF
--- a/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c
+++ b/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c
@@ -70,6 +70,7 @@ extern List_t xDelayedTaskList1;
 extern List_t xDelayedTaskList2;
 extern List_t * pxDelayedTaskList;
 extern List_t * pxOverflowDelayedTaskList;
+extern TaskHandle_t xIdleTaskHandles[ configNUMBER_OF_CORES ];
 
 /* ===========================  EXTERN FUNCTIONS  =========================== */
 extern void prvAddNewTaskToReadyList( TCB_t * pxNewTCB );
@@ -83,9 +84,13 @@ extern void prvCheckTasksWaitingTermination( void );
 extern void prvDeleteTCB( TCB_t * pxTCB );
 extern TCB_t * prvSearchForNameWithinSingleList( List_t * pxList,
                                                  const char pcNameToQuery[] );
+extern BaseType_t prvCreateIdleTasks( void );
 
 /* ==============================  Global VARIABLES ============================== */
 TaskHandle_t xTaskHandles[ configNUMBER_OF_CORES ] = { NULL };
+
+static StaticTask_t xIdleTaskTCBs[ configNUMBER_OF_CORES ];
+static StackType_t uxIdleTaskStacks[ configNUMBER_OF_CORES ][ configMINIMAL_STACK_SIZE ];
 
 /* ============================  Unity Fixtures  ============================ */
 /*! called before each testcase */
@@ -175,19 +180,24 @@ static void prvInitialiseTestStack( TCB_t * pxTCB,
 
     ( void ) pxTopOfStack;
 }
-
 /* ============================  FreeRTOS static allocate function  ============================ */
 
 void vApplicationGetIdleTaskMemory( StaticTask_t ** ppxIdleTaskTCBBuffer,
                                     StackType_t ** ppxIdleTaskStackBuffer,
-                                    uint32_t * pulIdleTaskStackSize,
-                                    BaseType_t xCoreId )
+                                    uint32_t * pulIdleTaskStackSize )
 {
-    static StaticTask_t xIdleTaskTCBs[ configNUMBER_OF_CORES ];
-    static StackType_t uxIdleTaskStacks[ configNUMBER_OF_CORES ][ configMINIMAL_STACK_SIZE ];
+    *ppxIdleTaskTCBBuffer = &( xIdleTaskTCBs[ 0 ] );
+    *ppxIdleTaskStackBuffer = &( uxIdleTaskStacks[ 0 ][ 0 ] );
+    *pulIdleTaskStackSize = configMINIMAL_STACK_SIZE;
+}
 
-    *ppxIdleTaskTCBBuffer = &( xIdleTaskTCBs[ xCoreId ] );
-    *ppxIdleTaskStackBuffer = &( uxIdleTaskStacks[ xCoreId ][ 0 ] );
+void vApplicationGetPassiveIdleTaskMemory( StaticTask_t ** ppxIdleTaskTCBBuffer,
+                                           StackType_t ** ppxIdleTaskStackBuffer,
+                                           uint32_t * pulIdleTaskStackSize,
+                                           BaseType_t xPassiveIdleTaskIndex )
+{
+    *ppxIdleTaskTCBBuffer = &( xIdleTaskTCBs[ xPassiveIdleTaskIndex + 1 ] );
+    *ppxIdleTaskStackBuffer = &( uxIdleTaskStacks[ xPassiveIdleTaskIndex + 1 ][ 0 ] );
     *pulIdleTaskStackSize = configMINIMAL_STACK_SIZE;
 }
 
@@ -4624,4 +4634,48 @@ void test_coverage_prvSearchForNameWithinSingleList_long_task_name( void )
 
     /* Validation. */
     TEST_ASSERT_EQUAL( NULL, pReturnedTCB );
+}
+
+/**
+ * @brief prvCreateIdleTasks - get static idle task memory.
+ *
+ * Verify get static idle task memory is correct.
+ *
+ * <b>Coverage</b>
+ * @code{c}
+ * #if ( configNUMBER_OF_CORES == 1 )
+ *     ...
+ * #else
+ * {
+ *     if( xCoreID == 0 )
+ *     {
+ *         vApplicationGetIdleTaskMemory( &pxIdleTaskTCBBuffer, &pxIdleTaskStackBuffer, &ulIdleTaskStackSize );
+ *     }
+ *     else
+ *     {
+ *         vApplicationGetPassiveIdleTaskMemory( &pxIdleTaskTCBBuffer, &pxIdleTaskStackBuffer, &ulIdleTaskStackSize, xCoreID - 1 );
+ *     }
+ * }
+ * #endif
+ * @endcode
+ * ( xCoreID == 0 ) both true and false.
+ */
+void test_coverage_prvCreateIdleTasks_get_static_memory( void )
+{
+    BaseType_t xReturn;
+    BaseType_t xCoreID;
+
+    /* API call. */
+    xReturn = prvCreateIdleTasks();
+
+    /* Validation. */
+    TEST_ASSERT_EQUAL( pdTRUE, xReturn );   /* Verify this function should return without error. */
+
+    /* Verify that the idle tasks TCB and stack buffer are provided by vApplicationGetIdleTaskMemory and
+     * vApplicationGetPassiveIdleTaskMemory. */
+    for( xCoreID = 0; xCoreID < configNUMBER_OF_CORES; xCoreID++ )
+    {
+        TEST_ASSERT_EQUAL( xIdleTaskHandles[ xCoreID ], &xIdleTaskTCBs[ xCoreID ] );
+        TEST_ASSERT_EQUAL( xIdleTaskHandles[ xCoreID ].pxStack, &uxIdleTaskStacks[ xCoreID ][ 0 ] );
+    }
 }

--- a/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c
+++ b/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c
@@ -4669,7 +4669,7 @@ void test_coverage_prvCreateIdleTasks_get_static_memory( void )
     xReturn = prvCreateIdleTasks();
 
     /* Validation. */
-    TEST_ASSERT_EQUAL( pdTRUE, xReturn );   /* Verify this function should return without error. */
+    TEST_ASSERT_EQUAL( pdTRUE, xReturn ); /* Verify this function should return without error. */
 
     /* Verify that the idle tasks TCB and stack buffer are provided by vApplicationGetIdleTaskMemory and
      * vApplicationGetPassiveIdleTaskMemory. */

--- a/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/multiple_priorities_no_timeslice_utest.c
+++ b/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/multiple_priorities_no_timeslice_utest.c
@@ -80,14 +80,26 @@ int suiteTearDown( int numFailures )
 
 void vApplicationGetIdleTaskMemory( StaticTask_t ** ppxIdleTaskTCBBuffer,
                                     StackType_t ** ppxIdleTaskStackBuffer,
-                                    uint32_t * pulIdleTaskStackSize,
-                                    BaseType_t xCoreId )
+                                    uint32_t * pulIdleTaskStackSize )
 {
-    static StaticTask_t xIdleTaskTCBs[ configNUMBER_OF_CORES ];
-    static StackType_t uxIdleTaskStacks[ configNUMBER_OF_CORES ][ configMINIMAL_STACK_SIZE ];
+    static StaticTask_t xIdleTaskTCB;
+    static StackType_t uxIdleTaskStack[ configMINIMAL_STACK_SIZE ];
 
-    *ppxIdleTaskTCBBuffer = &( xIdleTaskTCBs[ xCoreId ] );
-    *ppxIdleTaskStackBuffer = &( uxIdleTaskStacks[ xCoreId ][ 0 ] );
+    *ppxIdleTaskTCBBuffer = &( xIdleTaskTCB );
+    *ppxIdleTaskStackBuffer = &( uxIdleTaskStack[ 0 ] );
+    *pulIdleTaskStackSize = configMINIMAL_STACK_SIZE;
+}
+
+void vApplicationGetPassiveIdleTaskMemory( StaticTask_t ** ppxIdleTaskTCBBuffer,
+                                           StackType_t ** ppxIdleTaskStackBuffer,
+                                           uint32_t * pulIdleTaskStackSize,
+                                           BaseType_t xPassiveIdleTaskIndex )
+{
+    static StaticTask_t xIdleTaskTCBs[ configNUMBER_OF_CORES - 1 ];
+    static StackType_t uxIdleTaskStacks[ configNUMBER_OF_CORES - 1 ][ configMINIMAL_STACK_SIZE ];
+
+    *ppxIdleTaskTCBBuffer = &( xIdleTaskTCBs[ xPassiveIdleTaskIndex ] );
+    *ppxIdleTaskStackBuffer = &( uxIdleTaskStacks[ xPassiveIdleTaskIndex ][ 0 ] );
     *pulIdleTaskStackSize = configMINIMAL_STACK_SIZE;
 }
 


### PR DESCRIPTION
Description
-----------
This PR is to cover changes in https://github.com/FreeRTOS/FreeRTOS-Kernel/pull/890
* Add test cases to cover `vApplicationGetIdleTaskMemory` and `vApplicationGetPassiveIdleTaskMemory` in `prvCreateIdleTasks`.

Test Steps
-----------
Run SMP unit test covg_multiple_priorities_no_timeslice.

```
./FreeRTOS/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c:4665:test_coverage_prvCreateIdleTasks_get_static_memory:PASS

-----------------------
81 Tests 0 Failures 0 Ignored
```

Filename | -- | --  | Line Coverage | --  | Functions | --  | Branches | -- 
-- | -- | -- | -- | -- | -- | -- | -- | -- 
event_groups.c |   |   | 94.4 % | 186 / 197 | 100.0 % | 16 / 16 | 72.0 % | 72 / 100
list.c |   |   | 100.0 % | 41 / 41 | 100.0 % | 5 / 5 | 100.0 % | 6 / 6
queue.c |   |   | 93.1 % | 772 / 829 | 100.0 % | 49 / 49 | 97.0 % | 456 / 470
stream_buffer.c |   |   | 98.5 % | 324 / 329 | 100.0 % | 26 / 26 | 95.0 % | 190 / 200
tasks.c |   |   | 98.3 % | 1511 / 1537 | 99.0 % | 99 / 100 | 92.9 % | 1024 / 1102
timers.c |   |   | 100.0 % | 244 / 244 | 100.0 % | 30 / 30 | 96.2 % | 76 / 79

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
