### PR TITLE
Fix AWS Demo Build Configurations

### DIFF
--- a/FreeRTOS-Plus/Demo/AWS/Device_Defender_Windows_Simulator/Device_Defender_Demo/Device_Defender_Demo.vcxproj
+++ b/FreeRTOS-Plus/Demo/AWS/Device_Defender_Windows_Simulator/Device_Defender_Demo/Device_Defender_Demo.vcxproj
@@ -31,6 +31,7 @@
     <UseDebugLibraries>true</UseDebugLibraries>
     <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
+    <PreferredToolArchitecture>x86</PreferredToolArchitecture>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
@@ -38,6 +39,7 @@
     <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
+    <PreferredToolArchitecture>x86</PreferredToolArchitecture>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>

--- a/FreeRTOS-Plus/Demo/AWS/Device_Defender_Windows_Simulator/Device_Defender_Demo/defender_demo.sln
+++ b/FreeRTOS-Plus/Demo/AWS/Device_Defender_Windows_Simulator/Device_Defender_Demo/defender_demo.sln
@@ -1,4 +1,3 @@
-
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.31205.134
@@ -17,52 +16,52 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Statically Linked Libraries
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Win32 = Debug|Win32
 		Debug|x64 = Debug|x64
-		Debug|x86 = Debug|x86
+		Release|Win32 = Release|Win32
 		Release|x64 = Release|x64
-		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{6C548950-0BED-42EF-8039-95A2084A806D}.Debug|Win32.ActiveCfg = Debug|Win32
+		{6C548950-0BED-42EF-8039-95A2084A806D}.Debug|Win32.Build.0 = Debug|Win32
 		{6C548950-0BED-42EF-8039-95A2084A806D}.Debug|x64.ActiveCfg = Debug|x64
 		{6C548950-0BED-42EF-8039-95A2084A806D}.Debug|x64.Build.0 = Debug|x64
-		{6C548950-0BED-42EF-8039-95A2084A806D}.Debug|x86.ActiveCfg = Debug|Win32
-		{6C548950-0BED-42EF-8039-95A2084A806D}.Debug|x86.Build.0 = Debug|Win32
+		{6C548950-0BED-42EF-8039-95A2084A806D}.Release|Win32.ActiveCfg = Release|Win32
+		{6C548950-0BED-42EF-8039-95A2084A806D}.Release|Win32.Build.0 = Release|Win32
 		{6C548950-0BED-42EF-8039-95A2084A806D}.Release|x64.ActiveCfg = Release|x64
 		{6C548950-0BED-42EF-8039-95A2084A806D}.Release|x64.Build.0 = Release|x64
-		{6C548950-0BED-42EF-8039-95A2084A806D}.Release|x86.ActiveCfg = Release|Win32
-		{6C548950-0BED-42EF-8039-95A2084A806D}.Release|x86.Build.0 = Release|Win32
+		{C90E6CC5-818B-4C97-8876-0986D989387C}.Debug|Win32.ActiveCfg = Debug|Win32
+		{C90E6CC5-818B-4C97-8876-0986D989387C}.Debug|Win32.Build.0 = Debug|Win32
 		{C90E6CC5-818B-4C97-8876-0986D989387C}.Debug|x64.ActiveCfg = Debug|x64
 		{C90E6CC5-818B-4C97-8876-0986D989387C}.Debug|x64.Build.0 = Debug|x64
-		{C90E6CC5-818B-4C97-8876-0986D989387C}.Debug|x86.ActiveCfg = Debug|Win32
-		{C90E6CC5-818B-4C97-8876-0986D989387C}.Debug|x86.Build.0 = Debug|Win32
+		{C90E6CC5-818B-4C97-8876-0986D989387C}.Release|Win32.ActiveCfg = Release|Win32
+		{C90E6CC5-818B-4C97-8876-0986D989387C}.Release|Win32.Build.0 = Release|Win32
 		{C90E6CC5-818B-4C97-8876-0986D989387C}.Release|x64.ActiveCfg = Release|x64
 		{C90E6CC5-818B-4C97-8876-0986D989387C}.Release|x64.Build.0 = Release|x64
-		{C90E6CC5-818B-4C97-8876-0986D989387C}.Release|x86.ActiveCfg = Release|Win32
-		{C90E6CC5-818B-4C97-8876-0986D989387C}.Release|x86.Build.0 = Release|Win32
+		{72C209C4-49A4-4942-A201-44706C9D77EC}.Debug|Win32.ActiveCfg = Debug|Win32
+		{72C209C4-49A4-4942-A201-44706C9D77EC}.Debug|Win32.Build.0 = Debug|Win32
 		{72C209C4-49A4-4942-A201-44706C9D77EC}.Debug|x64.ActiveCfg = Debug|x64
 		{72C209C4-49A4-4942-A201-44706C9D77EC}.Debug|x64.Build.0 = Debug|x64
-		{72C209C4-49A4-4942-A201-44706C9D77EC}.Debug|x86.ActiveCfg = Debug|Win32
-		{72C209C4-49A4-4942-A201-44706C9D77EC}.Debug|x86.Build.0 = Debug|Win32
+		{72C209C4-49A4-4942-A201-44706C9D77EC}.Release|Win32.ActiveCfg = Release|Win32
+		{72C209C4-49A4-4942-A201-44706C9D77EC}.Release|Win32.Build.0 = Release|Win32
 		{72C209C4-49A4-4942-A201-44706C9D77EC}.Release|x64.ActiveCfg = Release|x64
 		{72C209C4-49A4-4942-A201-44706C9D77EC}.Release|x64.Build.0 = Release|x64
-		{72C209C4-49A4-4942-A201-44706C9D77EC}.Release|x86.ActiveCfg = Release|Win32
-		{72C209C4-49A4-4942-A201-44706C9D77EC}.Release|x86.Build.0 = Release|Win32
+		{BE362AC0-B10B-4276-B84E-6304652BA228}.Debug|Win32.ActiveCfg = Debug|Win32
+		{BE362AC0-B10B-4276-B84E-6304652BA228}.Debug|Win32.Build.0 = Debug|Win32
 		{BE362AC0-B10B-4276-B84E-6304652BA228}.Debug|x64.ActiveCfg = Debug|x64
 		{BE362AC0-B10B-4276-B84E-6304652BA228}.Debug|x64.Build.0 = Debug|x64
-		{BE362AC0-B10B-4276-B84E-6304652BA228}.Debug|x86.ActiveCfg = Debug|Win32
-		{BE362AC0-B10B-4276-B84E-6304652BA228}.Debug|x86.Build.0 = Debug|Win32
+		{BE362AC0-B10B-4276-B84E-6304652BA228}.Release|Win32.ActiveCfg = Release|Win32
+		{BE362AC0-B10B-4276-B84E-6304652BA228}.Release|Win32.Build.0 = Release|Win32
 		{BE362AC0-B10B-4276-B84E-6304652BA228}.Release|x64.ActiveCfg = Release|x64
 		{BE362AC0-B10B-4276-B84E-6304652BA228}.Release|x64.Build.0 = Release|x64
-		{BE362AC0-B10B-4276-B84E-6304652BA228}.Release|x86.ActiveCfg = Release|Win32
-		{BE362AC0-B10B-4276-B84E-6304652BA228}.Release|x86.Build.0 = Release|Win32
+		{E1016F3E-94E9-4864-9FD8-1D7C1FEFBFD7}.Debug|Win32.ActiveCfg = Debug|Win32
+		{E1016F3E-94E9-4864-9FD8-1D7C1FEFBFD7}.Debug|Win32.Build.0 = Debug|Win32
 		{E1016F3E-94E9-4864-9FD8-1D7C1FEFBFD7}.Debug|x64.ActiveCfg = Debug|x64
 		{E1016F3E-94E9-4864-9FD8-1D7C1FEFBFD7}.Debug|x64.Build.0 = Debug|x64
-		{E1016F3E-94E9-4864-9FD8-1D7C1FEFBFD7}.Debug|x86.ActiveCfg = Debug|Win32
-		{E1016F3E-94E9-4864-9FD8-1D7C1FEFBFD7}.Debug|x86.Build.0 = Debug|Win32
+		{E1016F3E-94E9-4864-9FD8-1D7C1FEFBFD7}.Release|Win32.ActiveCfg = Release|Win32
+		{E1016F3E-94E9-4864-9FD8-1D7C1FEFBFD7}.Release|Win32.Build.0 = Release|Win32
 		{E1016F3E-94E9-4864-9FD8-1D7C1FEFBFD7}.Release|x64.ActiveCfg = Release|x64
 		{E1016F3E-94E9-4864-9FD8-1D7C1FEFBFD7}.Release|x64.Build.0 = Release|x64
-		{E1016F3E-94E9-4864-9FD8-1D7C1FEFBFD7}.Release|x86.ActiveCfg = Release|Win32
-		{E1016F3E-94E9-4864-9FD8-1D7C1FEFBFD7}.Release|x86.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/FreeRTOS-Plus/Demo/AWS/Device_Shadow_Windows_Simulator/Device_Shadow_Demo/Device_Shadow_Demo.vcxproj
+++ b/FreeRTOS-Plus/Demo/AWS/Device_Shadow_Windows_Simulator/Device_Shadow_Demo/Device_Shadow_Demo.vcxproj
@@ -31,6 +31,7 @@
     <UseDebugLibraries>true</UseDebugLibraries>
     <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
+    <PreferredToolArchitecture>x86</PreferredToolArchitecture>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
@@ -38,6 +39,7 @@
     <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
+    <PreferredToolArchitecture>x86</PreferredToolArchitecture>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>

--- a/FreeRTOS-Plus/Demo/AWS/Device_Shadow_Windows_Simulator/Device_Shadow_Demo/shadow_main_demo.sln
+++ b/FreeRTOS-Plus/Demo/AWS/Device_Shadow_Windows_Simulator/Device_Shadow_Demo/shadow_main_demo.sln
@@ -1,4 +1,3 @@
-
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.31205.134
@@ -17,52 +16,52 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Statically Linked Libraries
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Win32 = Debug|Win32
 		Debug|x64 = Debug|x64
-		Debug|x86 = Debug|x86
+		Release|Win32 = Release|Win32
 		Release|x64 = Release|x64
-		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{717F029B-ADE9-433A-9C05-3136171BEAEF}.Debug|Win32.ActiveCfg = Debug|Win32
+		{717F029B-ADE9-433A-9C05-3136171BEAEF}.Debug|Win32.Build.0 = Debug|Win32
 		{717F029B-ADE9-433A-9C05-3136171BEAEF}.Debug|x64.ActiveCfg = Debug|x64
 		{717F029B-ADE9-433A-9C05-3136171BEAEF}.Debug|x64.Build.0 = Debug|x64
-		{717F029B-ADE9-433A-9C05-3136171BEAEF}.Debug|x86.ActiveCfg = Debug|Win32
-		{717F029B-ADE9-433A-9C05-3136171BEAEF}.Debug|x86.Build.0 = Debug|Win32
+		{717F029B-ADE9-433A-9C05-3136171BEAEF}.Release|Win32.ActiveCfg = Release|Win32
+		{717F029B-ADE9-433A-9C05-3136171BEAEF}.Release|Win32.Build.0 = Release|Win32
 		{717F029B-ADE9-433A-9C05-3136171BEAEF}.Release|x64.ActiveCfg = Release|x64
 		{717F029B-ADE9-433A-9C05-3136171BEAEF}.Release|x64.Build.0 = Release|x64
-		{717F029B-ADE9-433A-9C05-3136171BEAEF}.Release|x86.ActiveCfg = Release|Win32
-		{717F029B-ADE9-433A-9C05-3136171BEAEF}.Release|x86.Build.0 = Release|Win32
+		{C90E6CC5-818B-4C97-8876-0986D989387C}.Debug|Win32.ActiveCfg = Debug|Win32
+		{C90E6CC5-818B-4C97-8876-0986D989387C}.Debug|Win32.Build.0 = Debug|Win32
 		{C90E6CC5-818B-4C97-8876-0986D989387C}.Debug|x64.ActiveCfg = Debug|x64
 		{C90E6CC5-818B-4C97-8876-0986D989387C}.Debug|x64.Build.0 = Debug|x64
-		{C90E6CC5-818B-4C97-8876-0986D989387C}.Debug|x86.ActiveCfg = Debug|Win32
-		{C90E6CC5-818B-4C97-8876-0986D989387C}.Debug|x86.Build.0 = Debug|Win32
+		{C90E6CC5-818B-4C97-8876-0986D989387C}.Release|Win32.ActiveCfg = Release|Win32
+		{C90E6CC5-818B-4C97-8876-0986D989387C}.Release|Win32.Build.0 = Release|Win32
 		{C90E6CC5-818B-4C97-8876-0986D989387C}.Release|x64.ActiveCfg = Release|x64
 		{C90E6CC5-818B-4C97-8876-0986D989387C}.Release|x64.Build.0 = Release|x64
-		{C90E6CC5-818B-4C97-8876-0986D989387C}.Release|x86.ActiveCfg = Release|Win32
-		{C90E6CC5-818B-4C97-8876-0986D989387C}.Release|x86.Build.0 = Release|Win32
+		{72C209C4-49A4-4942-A201-44706C9D77EC}.Debug|Win32.ActiveCfg = Debug|Win32
+		{72C209C4-49A4-4942-A201-44706C9D77EC}.Debug|Win32.Build.0 = Debug|Win32
 		{72C209C4-49A4-4942-A201-44706C9D77EC}.Debug|x64.ActiveCfg = Debug|x64
 		{72C209C4-49A4-4942-A201-44706C9D77EC}.Debug|x64.Build.0 = Debug|x64
-		{72C209C4-49A4-4942-A201-44706C9D77EC}.Debug|x86.ActiveCfg = Debug|Win32
-		{72C209C4-49A4-4942-A201-44706C9D77EC}.Debug|x86.Build.0 = Debug|Win32
+		{72C209C4-49A4-4942-A201-44706C9D77EC}.Release|Win32.ActiveCfg = Release|Win32
+		{72C209C4-49A4-4942-A201-44706C9D77EC}.Release|Win32.Build.0 = Release|Win32
 		{72C209C4-49A4-4942-A201-44706C9D77EC}.Release|x64.ActiveCfg = Release|x64
 		{72C209C4-49A4-4942-A201-44706C9D77EC}.Release|x64.Build.0 = Release|x64
-		{72C209C4-49A4-4942-A201-44706C9D77EC}.Release|x86.ActiveCfg = Release|Win32
-		{72C209C4-49A4-4942-A201-44706C9D77EC}.Release|x86.Build.0 = Release|Win32
+		{BE362AC0-B10B-4276-B84E-6304652BA228}.Debug|Win32.ActiveCfg = Debug|Win32
+		{BE362AC0-B10B-4276-B84E-6304652BA228}.Debug|Win32.Build.0 = Debug|Win32
 		{BE362AC0-B10B-4276-B84E-6304652BA228}.Debug|x64.ActiveCfg = Debug|x64
 		{BE362AC0-B10B-4276-B84E-6304652BA228}.Debug|x64.Build.0 = Debug|x64
-		{BE362AC0-B10B-4276-B84E-6304652BA228}.Debug|x86.ActiveCfg = Debug|Win32
-		{BE362AC0-B10B-4276-B84E-6304652BA228}.Debug|x86.Build.0 = Debug|Win32
+		{BE362AC0-B10B-4276-B84E-6304652BA228}.Release|Win32.ActiveCfg = Release|Win32
+		{BE362AC0-B10B-4276-B84E-6304652BA228}.Release|Win32.Build.0 = Release|Win32
 		{BE362AC0-B10B-4276-B84E-6304652BA228}.Release|x64.ActiveCfg = Release|x64
 		{BE362AC0-B10B-4276-B84E-6304652BA228}.Release|x64.Build.0 = Release|x64
-		{BE362AC0-B10B-4276-B84E-6304652BA228}.Release|x86.ActiveCfg = Release|Win32
-		{BE362AC0-B10B-4276-B84E-6304652BA228}.Release|x86.Build.0 = Release|Win32
+		{E1016F3E-94E9-4864-9FD8-1D7C1FEFBFD7}.Debug|Win32.ActiveCfg = Debug|Win32
+		{E1016F3E-94E9-4864-9FD8-1D7C1FEFBFD7}.Debug|Win32.Build.0 = Debug|Win32
 		{E1016F3E-94E9-4864-9FD8-1D7C1FEFBFD7}.Debug|x64.ActiveCfg = Debug|x64
 		{E1016F3E-94E9-4864-9FD8-1D7C1FEFBFD7}.Debug|x64.Build.0 = Debug|x64
-		{E1016F3E-94E9-4864-9FD8-1D7C1FEFBFD7}.Debug|x86.ActiveCfg = Debug|Win32
-		{E1016F3E-94E9-4864-9FD8-1D7C1FEFBFD7}.Debug|x86.Build.0 = Debug|Win32
+		{E1016F3E-94E9-4864-9FD8-1D7C1FEFBFD7}.Release|Win32.ActiveCfg = Release|Win32
+		{E1016F3E-94E9-4864-9FD8-1D7C1FEFBFD7}.Release|Win32.Build.0 = Release|Win32
 		{E1016F3E-94E9-4864-9FD8-1D7C1FEFBFD7}.Release|x64.ActiveCfg = Release|x64
 		{E1016F3E-94E9-4864-9FD8-1D7C1FEFBFD7}.Release|x64.Build.0 = Release|x64
-		{E1016F3E-94E9-4864-9FD8-1D7C1FEFBFD7}.Release|x86.ActiveCfg = Release|Win32
-		{E1016F3E-94E9-4864-9FD8-1D7C1FEFBFD7}.Release|x86.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/FreeRTOS-Plus/Demo/AWS/Jobs_Windows_Simulator/Jobs_Demo/Jobs_Demo.vcxproj
+++ b/FreeRTOS-Plus/Demo/AWS/Jobs_Windows_Simulator/Jobs_Demo/Jobs_Demo.vcxproj
@@ -31,6 +31,7 @@
     <UseDebugLibraries>true</UseDebugLibraries>
     <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
+    <PreferredToolArchitecture>x86</PreferredToolArchitecture>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
@@ -38,6 +39,7 @@
     <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
+    <PreferredToolArchitecture>x86</PreferredToolArchitecture>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>

--- a/FreeRTOS-Plus/Demo/AWS/Jobs_Windows_Simulator/Jobs_Demo/jobs_demo.sln
+++ b/FreeRTOS-Plus/Demo/AWS/Jobs_Windows_Simulator/Jobs_Demo/jobs_demo.sln
@@ -1,4 +1,3 @@
-
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.31205.134
@@ -17,52 +16,52 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Statically Linked Libraries
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Win32 = Debug|Win32
 		Debug|x64 = Debug|x64
-		Debug|x86 = Debug|x86
+		Release|Win32 = Release|Win32
 		Release|x64 = Release|x64
-		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{9A8FD41D-DD8D-42C0-825A-266AEBD15C99}.Debug|Win32.ActiveCfg = Debug|Win32
+		{9A8FD41D-DD8D-42C0-825A-266AEBD15C99}.Debug|Win32.Build.0 = Debug|Win32
 		{9A8FD41D-DD8D-42C0-825A-266AEBD15C99}.Debug|x64.ActiveCfg = Debug|x64
 		{9A8FD41D-DD8D-42C0-825A-266AEBD15C99}.Debug|x64.Build.0 = Debug|x64
-		{9A8FD41D-DD8D-42C0-825A-266AEBD15C99}.Debug|x86.ActiveCfg = Debug|Win32
-		{9A8FD41D-DD8D-42C0-825A-266AEBD15C99}.Debug|x86.Build.0 = Debug|Win32
+		{9A8FD41D-DD8D-42C0-825A-266AEBD15C99}.Release|Win32.ActiveCfg = Release|Win32
+		{9A8FD41D-DD8D-42C0-825A-266AEBD15C99}.Release|Win32.Build.0 = Release|Win32
 		{9A8FD41D-DD8D-42C0-825A-266AEBD15C99}.Release|x64.ActiveCfg = Release|x64
 		{9A8FD41D-DD8D-42C0-825A-266AEBD15C99}.Release|x64.Build.0 = Release|x64
-		{9A8FD41D-DD8D-42C0-825A-266AEBD15C99}.Release|x86.ActiveCfg = Release|Win32
-		{9A8FD41D-DD8D-42C0-825A-266AEBD15C99}.Release|x86.Build.0 = Release|Win32
+		{C90E6CC5-818B-4C97-8876-0986D989387C}.Debug|Win32.ActiveCfg = Debug|Win32
+		{C90E6CC5-818B-4C97-8876-0986D989387C}.Debug|Win32.Build.0 = Debug|Win32
 		{C90E6CC5-818B-4C97-8876-0986D989387C}.Debug|x64.ActiveCfg = Debug|x64
 		{C90E6CC5-818B-4C97-8876-0986D989387C}.Debug|x64.Build.0 = Debug|x64
-		{C90E6CC5-818B-4C97-8876-0986D989387C}.Debug|x86.ActiveCfg = Debug|Win32
-		{C90E6CC5-818B-4C97-8876-0986D989387C}.Debug|x86.Build.0 = Debug|Win32
+		{C90E6CC5-818B-4C97-8876-0986D989387C}.Release|Win32.ActiveCfg = Release|Win32
+		{C90E6CC5-818B-4C97-8876-0986D989387C}.Release|Win32.Build.0 = Release|Win32
 		{C90E6CC5-818B-4C97-8876-0986D989387C}.Release|x64.ActiveCfg = Release|x64
 		{C90E6CC5-818B-4C97-8876-0986D989387C}.Release|x64.Build.0 = Release|x64
-		{C90E6CC5-818B-4C97-8876-0986D989387C}.Release|x86.ActiveCfg = Release|Win32
-		{C90E6CC5-818B-4C97-8876-0986D989387C}.Release|x86.Build.0 = Release|Win32
+		{72C209C4-49A4-4942-A201-44706C9D77EC}.Debug|Win32.ActiveCfg = Debug|Win32
+		{72C209C4-49A4-4942-A201-44706C9D77EC}.Debug|Win32.Build.0 = Debug|Win32
 		{72C209C4-49A4-4942-A201-44706C9D77EC}.Debug|x64.ActiveCfg = Debug|x64
 		{72C209C4-49A4-4942-A201-44706C9D77EC}.Debug|x64.Build.0 = Debug|x64
-		{72C209C4-49A4-4942-A201-44706C9D77EC}.Debug|x86.ActiveCfg = Debug|Win32
-		{72C209C4-49A4-4942-A201-44706C9D77EC}.Debug|x86.Build.0 = Debug|Win32
+		{72C209C4-49A4-4942-A201-44706C9D77EC}.Release|Win32.ActiveCfg = Release|Win32
+		{72C209C4-49A4-4942-A201-44706C9D77EC}.Release|Win32.Build.0 = Release|Win32
 		{72C209C4-49A4-4942-A201-44706C9D77EC}.Release|x64.ActiveCfg = Release|x64
 		{72C209C4-49A4-4942-A201-44706C9D77EC}.Release|x64.Build.0 = Release|x64
-		{72C209C4-49A4-4942-A201-44706C9D77EC}.Release|x86.ActiveCfg = Release|Win32
-		{72C209C4-49A4-4942-A201-44706C9D77EC}.Release|x86.Build.0 = Release|Win32
+		{E1016F3E-94E9-4864-9FD8-1D7C1FEFBFD7}.Debug|Win32.ActiveCfg = Debug|Win32
+		{E1016F3E-94E9-4864-9FD8-1D7C1FEFBFD7}.Debug|Win32.Build.0 = Debug|Win32
 		{E1016F3E-94E9-4864-9FD8-1D7C1FEFBFD7}.Debug|x64.ActiveCfg = Debug|x64
 		{E1016F3E-94E9-4864-9FD8-1D7C1FEFBFD7}.Debug|x64.Build.0 = Debug|x64
-		{E1016F3E-94E9-4864-9FD8-1D7C1FEFBFD7}.Debug|x86.ActiveCfg = Debug|Win32
-		{E1016F3E-94E9-4864-9FD8-1D7C1FEFBFD7}.Debug|x86.Build.0 = Debug|Win32
+		{E1016F3E-94E9-4864-9FD8-1D7C1FEFBFD7}.Release|Win32.ActiveCfg = Release|Win32
+		{E1016F3E-94E9-4864-9FD8-1D7C1FEFBFD7}.Release|Win32.Build.0 = Release|Win32
 		{E1016F3E-94E9-4864-9FD8-1D7C1FEFBFD7}.Release|x64.ActiveCfg = Release|x64
 		{E1016F3E-94E9-4864-9FD8-1D7C1FEFBFD7}.Release|x64.Build.0 = Release|x64
-		{E1016F3E-94E9-4864-9FD8-1D7C1FEFBFD7}.Release|x86.ActiveCfg = Release|Win32
-		{E1016F3E-94E9-4864-9FD8-1D7C1FEFBFD7}.Release|x86.Build.0 = Release|Win32
+		{BE362AC0-B10B-4276-B84E-6304652BA228}.Debug|Win32.ActiveCfg = Debug|Win32
+		{BE362AC0-B10B-4276-B84E-6304652BA228}.Debug|Win32.Build.0 = Debug|Win32
 		{BE362AC0-B10B-4276-B84E-6304652BA228}.Debug|x64.ActiveCfg = Debug|x64
 		{BE362AC0-B10B-4276-B84E-6304652BA228}.Debug|x64.Build.0 = Debug|x64
-		{BE362AC0-B10B-4276-B84E-6304652BA228}.Debug|x86.ActiveCfg = Debug|Win32
-		{BE362AC0-B10B-4276-B84E-6304652BA228}.Debug|x86.Build.0 = Debug|Win32
+		{BE362AC0-B10B-4276-B84E-6304652BA228}.Release|Win32.ActiveCfg = Release|Win32
+		{BE362AC0-B10B-4276-B84E-6304652BA228}.Release|Win32.Build.0 = Release|Win32
 		{BE362AC0-B10B-4276-B84E-6304652BA228}.Release|x64.ActiveCfg = Release|x64
 		{BE362AC0-B10B-4276-B84E-6304652BA228}.Release|x64.Build.0 = Release|x64
-		{BE362AC0-B10B-4276-B84E-6304652BA228}.Release|x86.ActiveCfg = Release|Win32
-		{BE362AC0-B10B-4276-B84E-6304652BA228}.Release|x86.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
<!--- Title -->

Description
-----------
Change the AWS Demos to use the `Win32` target instead of `x64` target by default

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
