### PR TITLE
Fix unit test for passive idle task

### DIFF
--- a/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c
+++ b/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c
@@ -70,6 +70,7 @@ extern List_t xDelayedTaskList1;
 extern List_t xDelayedTaskList2;
 extern List_t * pxDelayedTaskList;
 extern List_t * pxOverflowDelayedTaskList;
+extern TaskHandle_t xIdleTaskHandles[ configNUMBER_OF_CORES ];
 
 /* ===========================  EXTERN FUNCTIONS  =========================== */
 extern void prvAddNewTaskToReadyList( TCB_t * pxNewTCB );
@@ -83,9 +84,13 @@ extern void prvCheckTasksWaitingTermination( void );
 extern void prvDeleteTCB( TCB_t * pxTCB );
 extern TCB_t * prvSearchForNameWithinSingleList( List_t * pxList,
                                                  const char pcNameToQuery[] );
+extern BaseType_t prvCreateIdleTasks( void );
 
 /* ==============================  Global VARIABLES ============================== */
 TaskHandle_t xTaskHandles[ configNUMBER_OF_CORES ] = { NULL };
+
+static StaticTask_t xIdleTaskTCBs[ configNUMBER_OF_CORES ];
+static StackType_t uxIdleTaskStacks[ configNUMBER_OF_CORES ][ configMINIMAL_STACK_SIZE ];
 
 /* ============================  Unity Fixtures  ============================ */
 /*! called before each testcase */
@@ -175,19 +180,24 @@ static void prvInitialiseTestStack( TCB_t * pxTCB,
 
     ( void ) pxTopOfStack;
 }
-
 /* ============================  FreeRTOS static allocate function  ============================ */
 
 void vApplicationGetIdleTaskMemory( StaticTask_t ** ppxIdleTaskTCBBuffer,
                                     StackType_t ** ppxIdleTaskStackBuffer,
-                                    uint32_t * pulIdleTaskStackSize,
-                                    BaseType_t xCoreId )
+                                    uint32_t * pulIdleTaskStackSize )
 {
-    static StaticTask_t xIdleTaskTCBs[ configNUMBER_OF_CORES ];
-    static StackType_t uxIdleTaskStacks[ configNUMBER_OF_CORES ][ configMINIMAL_STACK_SIZE ];
+    *ppxIdleTaskTCBBuffer = &( xIdleTaskTCBs[ 0 ] );
+    *ppxIdleTaskStackBuffer = &( uxIdleTaskStacks[ 0 ][ 0 ] );
+    *pulIdleTaskStackSize = configMINIMAL_STACK_SIZE;
+}
 
-    *ppxIdleTaskTCBBuffer = &( xIdleTaskTCBs[ xCoreId ] );
-    *ppxIdleTaskStackBuffer = &( uxIdleTaskStacks[ xCoreId ][ 0 ] );
+void vApplicationGetPassiveIdleTaskMemory( StaticTask_t ** ppxIdleTaskTCBBuffer,
+                                           StackType_t ** ppxIdleTaskStackBuffer,
+                                           uint32_t * pulIdleTaskStackSize,
+                                           BaseType_t xPassiveIdleTaskIndex )
+{
+    *ppxIdleTaskTCBBuffer = &( xIdleTaskTCBs[ xPassiveIdleTaskIndex + 1 ] );
+    *ppxIdleTaskStackBuffer = &( uxIdleTaskStacks[ xPassiveIdleTaskIndex + 1 ][ 0 ] );
     *pulIdleTaskStackSize = configMINIMAL_STACK_SIZE;
 }
 
@@ -4624,4 +4634,48 @@ void test_coverage_prvSearchForNameWithinSingleList_long_task_name( void )
 
     /* Validation. */
     TEST_ASSERT_EQUAL( NULL, pReturnedTCB );
+}
+
+/**
+ * @brief prvCreateIdleTasks - get static idle task memory.
+ *
+ * Verify get static idle task memory is correct.
+ *
+ * <b>Coverage</b>
+ * @code{c}
+ * #if ( configNUMBER_OF_CORES == 1 )
+ *     ...
+ * #else
+ * {
+ *     if( xCoreID == 0 )
+ *     {
+ *         vApplicationGetIdleTaskMemory( &pxIdleTaskTCBBuffer, &pxIdleTaskStackBuffer, &ulIdleTaskStackSize );
+ *     }
+ *     else
+ *     {
+ *         vApplicationGetPassiveIdleTaskMemory( &pxIdleTaskTCBBuffer, &pxIdleTaskStackBuffer, &ulIdleTaskStackSize, xCoreID - 1 );
+ *     }
+ * }
+ * #endif
+ * @endcode
+ * ( xCoreID == 0 ) both true and false.
+ */
+void test_coverage_prvCreateIdleTasks_get_static_memory( void )
+{
+    BaseType_t xReturn;
+    BaseType_t xCoreID;
+
+    /* API call. */
+    xReturn = prvCreateIdleTasks();
+
+    /* Validation. */
+    TEST_ASSERT_EQUAL( pdTRUE, xReturn );   /* Verify this function should return without error. */
+
+    /* Verify that the idle tasks TCB and stack buffer are provided by vApplicationGetIdleTaskMemory and
+     * vApplicationGetPassiveIdleTaskMemory. */
+    for( xCoreID = 0; xCoreID < configNUMBER_OF_CORES; xCoreID++ )
+    {
+        TEST_ASSERT_EQUAL( xIdleTaskHandles[ xCoreID ], &xIdleTaskTCBs[ xCoreID ] );
+        TEST_ASSERT_EQUAL( xIdleTaskHandles[ xCoreID ].pxStack, &uxIdleTaskStacks[ xCoreID ][ 0 ] );
+    }
 }

--- a/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c
+++ b/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c
@@ -4669,7 +4669,7 @@ void test_coverage_prvCreateIdleTasks_get_static_memory( void )
     xReturn = prvCreateIdleTasks();
 
     /* Validation. */
-    TEST_ASSERT_EQUAL( pdTRUE, xReturn );   /* Verify this function should return without error. */
+    TEST_ASSERT_EQUAL( pdTRUE, xReturn ); /* Verify this function should return without error. */
 
     /* Verify that the idle tasks TCB and stack buffer are provided by vApplicationGetIdleTaskMemory and
      * vApplicationGetPassiveIdleTaskMemory. */

--- a/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c
+++ b/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c
@@ -4676,6 +4676,6 @@ void test_coverage_prvCreateIdleTasks_get_static_memory( void )
     for( xCoreID = 0; xCoreID < configNUMBER_OF_CORES; xCoreID++ )
     {
         TEST_ASSERT_EQUAL( xIdleTaskHandles[ xCoreID ], &xIdleTaskTCBs[ xCoreID ] );
-        TEST_ASSERT_EQUAL( xIdleTaskHandles[ xCoreID ].pxStack, &uxIdleTaskStacks[ xCoreID ][ 0 ] );
+        TEST_ASSERT_EQUAL( xIdleTaskHandles[ xCoreID ]->pxStack, &uxIdleTaskStacks[ xCoreID ][ 0 ] );
     }
 }

--- a/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/multiple_priorities_no_timeslice_utest.c
+++ b/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/multiple_priorities_no_timeslice_utest.c
@@ -80,14 +80,26 @@ int suiteTearDown( int numFailures )
 
 void vApplicationGetIdleTaskMemory( StaticTask_t ** ppxIdleTaskTCBBuffer,
                                     StackType_t ** ppxIdleTaskStackBuffer,
-                                    uint32_t * pulIdleTaskStackSize,
-                                    BaseType_t xCoreId )
+                                    uint32_t * pulIdleTaskStackSize )
 {
-    static StaticTask_t xIdleTaskTCBs[ configNUMBER_OF_CORES ];
-    static StackType_t uxIdleTaskStacks[ configNUMBER_OF_CORES ][ configMINIMAL_STACK_SIZE ];
+    static StaticTask_t xIdleTaskTCB;
+    static StackType_t uxIdleTaskStack[ configMINIMAL_STACK_SIZE ];
 
-    *ppxIdleTaskTCBBuffer = &( xIdleTaskTCBs[ xCoreId ] );
-    *ppxIdleTaskStackBuffer = &( uxIdleTaskStacks[ xCoreId ][ 0 ] );
+    *ppxIdleTaskTCBBuffer = &( xIdleTaskTCB );
+    *ppxIdleTaskStackBuffer = &( uxIdleTaskStack[ 0 ] );
+    *pulIdleTaskStackSize = configMINIMAL_STACK_SIZE;
+}
+
+void vApplicationGetPassiveIdleTaskMemory( StaticTask_t ** ppxIdleTaskTCBBuffer,
+                                           StackType_t ** ppxIdleTaskStackBuffer,
+                                           uint32_t * pulIdleTaskStackSize,
+                                           BaseType_t xPassiveIdleTaskIndex )
+{
+    static StaticTask_t xIdleTaskTCBs[ configNUMBER_OF_CORES - 1 ];
+    static StackType_t uxIdleTaskStacks[ configNUMBER_OF_CORES - 1 ][ configMINIMAL_STACK_SIZE ];
+
+    *ppxIdleTaskTCBBuffer = &( xIdleTaskTCBs[ xPassiveIdleTaskIndex ] );
+    *ppxIdleTaskStackBuffer = &( uxIdleTaskStacks[ xPassiveIdleTaskIndex ][ 0 ] );
     *pulIdleTaskStackSize = configMINIMAL_STACK_SIZE;
 }
 


### PR DESCRIPTION
Fix unit test for passive idle task

Description
-----------
Fix unit test compilation error for passive idle task memory. TaskHandle_t is a pointer and operator `->` should be used.
The PR is to cover the changes in https://github.com/FreeRTOS/FreeRTOS-Kernel/pull/890.

Test Steps
-----------

1. Fetch kernel branch
```
cd FreeRTOS/FreeRTOS/Source
git remote add chinglee-iot https://github.com/chinglee-iot/FreeRTOS-Kernel
git fetch chinglee-iot
git checkout chinglee-iot/add-get-passive-idle-task-memory -b add-get-passive-idle-task-memory
```
2. Build and run the unit test
```
cd FreeRTOS/FreeRTOS/Test/CMock
make smp
```

There will be compilation error message before this PR.
```
/home/ubuntu/kernel/FreeRTOS/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c:4679:55: error: ‘xIdleTaskHandles[xCoreID]’ is a pointer; did you mean to use ‘->’?
 4679 |         TEST_ASSERT_EQUAL( xIdleTaskHandles[ xCoreID ].pxStack, &uxIdleTaskStacks[ xCoreID ][ 0 ] );
      |                                                       ^
/home/ubuntu/kernel/FreeRTOS/FreeRTOS/Test/CMock/CMock/vendor/unity/src/unity_internals.h:772:133: note: in definition of macro ‘UNITY_TEST_ASSERT_EQUAL_INT’
  772 | ne UNITY_TEST_ASSERT_EQUAL_INT(expected, actual, line, message)                             UnityAssertEqualNumber((UNITY_INT)(expected), (UNITY_INT)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT)
      |                                                                                                                                ^~~~~~~~

/home/ubuntu/kernel/FreeRTOS/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c:4679:9: note: in expansion of macro ‘TEST_ASSERT_EQUAL’
 4679 |         TEST_ASSERT_EQUAL( xIdleTaskHandles[ xCoreID ].pxStack, &uxIdleTaskStacks[ xCoreID ][ 0 ] );
      |         ^~~~~~~~~~~~~~~~~
```

After this PR, there should be no compilation error.

Test result
```
/home/ubuntu/kernel/FreeRTOS/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c:4663:test_coverage_prvCreateIdleTasks_get_static_memory:PASS

-----------------------
81 Tests 0 Failures 0 Ignored

```

Coverage rate
```
Overall coverage rate:
  lines......: 96.9% (3081 of 3180 lines)
  functions..: 99.6% (226 of 227 functions)
  branches...: 93.2% (1824 of 1957 branches)

```


Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
