### PR TITLE
Fix misusage of CMock in dir tasks.

### DIFF
--- a/FreeRTOS/Test/CMock/tasks/tasks.yml
+++ b/FreeRTOS/Test/CMock/tasks/tasks.yml
@@ -1,7 +1,7 @@
 :cmock:
   :mock_prefix: mock_
   :when_no_prototypes: :warn
-  :when_ptr: :smart
+  :when_ptr: :compare_ptr
   :treat_externs: :include
   :treat_inlines: :include
   :enforce_strict_ordering: TRUE
@@ -9,7 +9,6 @@
     - :ignore
     - :ignore_arg
     - :expect_any_args
-    - :array
     - :callback
     - :return_thru_ptr
   :callback_include_count: true # include a count arg when calling the callback

--- a/FreeRTOS/Test/CMock/tasks/tasks_1_utest.c
+++ b/FreeRTOS/Test/CMock/tasks/tasks_1_utest.c
@@ -1364,7 +1364,7 @@ void test_vTaskPrioritySet_success_gt_curr_prio( void )
     listGET_LIST_ITEM_VALUE_ExpectAnyArgsAndReturn( 0 );
     listSET_LIST_ITEM_VALUE_Expect( &( ptcb->xEventListItem ),
                                     configMAX_PRIORITIES - 5 );
-    listIS_CONTAINED_WITHIN_ExpectAndReturn( &pxReadyTasksLists[ 5 ],
+    listIS_CONTAINED_WITHIN_ExpectAndReturn( &pxReadyTasksLists[ 4 ],
                                              &( ptcb->xStateListItem ),
                                              pdTRUE );
     uxListRemove_ExpectAndReturn( &( ptcb->xStateListItem ), 0 );
@@ -1396,13 +1396,13 @@ void test_vTaskPrioritySet_success_gt_curr_prio_curr_tcb( void )
 
     listGET_LIST_ITEM_VALUE_ExpectAnyArgsAndReturn( 0 );
     listSET_LIST_ITEM_VALUE_Expect( &( ptcb->xEventListItem ), 2 );
-    listIS_CONTAINED_WITHIN_ExpectAndReturn( &pxReadyTasksLists[ 5 ],
+    listIS_CONTAINED_WITHIN_ExpectAndReturn( &pxReadyTasksLists[ 3 ],
                                              &( ptcb->xStateListItem ),
                                              pdTRUE );
     uxListRemove_ExpectAndReturn( &( ptcb->xStateListItem ), 0 );
     /* port Reset ready priority */
     /* add task to ready list */
-    listINSERT_END_Expect( &( pxReadyTasksLists[ 5 ] ),
+    listINSERT_END_Expect( &( pxReadyTasksLists[ 7 ] ),
                            &( ptcb->xStateListItem ) );
 
     TEST_ASSERT_EQUAL( 3, ptcb->uxBasePriority );
@@ -1461,11 +1461,11 @@ void test_vTaskPrioritySet_success_gt_max_prio( void )
 
     /* expectations */
     listGET_LIST_ITEM_VALUE_ExpectAnyArgsAndReturn( 0x80000000UL );
-    listIS_CONTAINED_WITHIN_ExpectAndReturn( &pxReadyTasksLists[ 5 ],
+    listIS_CONTAINED_WITHIN_ExpectAndReturn( &pxReadyTasksLists[ 3 ],
                                              &( ptcb->xStateListItem ),
                                              pdTRUE );
     uxListRemove_ExpectAndReturn( &( ptcb->xStateListItem ), 0 );
-    listINSERT_END_Expect( &( pxReadyTasksLists[ 5 ] ),
+    listINSERT_END_Expect( &( pxReadyTasksLists[ configMAX_PRIORITIES - 1 ] ),
                            &( ptcb->xStateListItem ) );
 
     /* API call */
@@ -1486,11 +1486,11 @@ void test_vTaskPrioritySet_success_call_current_null( void )
 
     /* expectations */
     listGET_LIST_ITEM_VALUE_ExpectAnyArgsAndReturn( 0x80000000UL );
-    listIS_CONTAINED_WITHIN_ExpectAndReturn( &pxReadyTasksLists[ 5 ],
+    listIS_CONTAINED_WITHIN_ExpectAndReturn( &pxReadyTasksLists[ 3 ],
                                              &( ptcb->xStateListItem ),
                                              pdTRUE );
     uxListRemove_ExpectAndReturn( &( ptcb->xStateListItem ), 0 );
-    listINSERT_END_Expect( &( pxReadyTasksLists[ 5 ] ),
+    listINSERT_END_Expect( &( pxReadyTasksLists[ 4 ] ),
                            &( ptcb->xStateListItem ) );
 
     /* API call */
@@ -1537,11 +1537,11 @@ void test_vTaskPrioritySet_success_lt_curr_prio_curr_task( void )
     listGET_LIST_ITEM_VALUE_ExpectAnyArgsAndReturn( 0 );
     listSET_LIST_ITEM_VALUE_Expect( &( ptcb->xEventListItem ),
                                     configMAX_PRIORITIES - 2 );
-    listIS_CONTAINED_WITHIN_ExpectAndReturn( &pxReadyTasksLists[ 5 ],
+    listIS_CONTAINED_WITHIN_ExpectAndReturn( &pxReadyTasksLists[ 3 ],
                                              &( ptcb->xStateListItem ),
                                              pdTRUE );
     uxListRemove_ExpectAndReturn( &( ptcb->xStateListItem ), 1 );
-    listINSERT_END_Expect( &( pxReadyTasksLists[ 5 ] ),
+    listINSERT_END_Expect( &( pxReadyTasksLists[ 2 ] ),
                            &( ptcb->xStateListItem ) );
     /* API call */
     vTaskPrioritySet( taskHandle, 2 );
@@ -1569,7 +1569,7 @@ void test_vTaskPrioritySet_success_lt_curr_prio_not_curr_task( void )
     listGET_LIST_ITEM_VALUE_ExpectAnyArgsAndReturn( 0 );
     listSET_LIST_ITEM_VALUE_Expect( &( ptcb->xEventListItem ),
                                     configMAX_PRIORITIES - 2 );
-    listIS_CONTAINED_WITHIN_ExpectAndReturn( &pxReadyTasksLists[ 5 ],
+    listIS_CONTAINED_WITHIN_ExpectAndReturn( &pxReadyTasksLists[ 3 ],
                                              &( ptcb->xStateListItem ),
                                              pdFALSE );
     /* API call */
@@ -1607,7 +1607,7 @@ void test_vTaskPrioritySet_success_gt_curr_prio_diff_base( void )
     listGET_LIST_ITEM_VALUE_ExpectAnyArgsAndReturn( 0 );
     listSET_LIST_ITEM_VALUE_Expect( &( ptcb->xEventListItem ),
                                     configMAX_PRIORITIES - 5 );
-    listIS_CONTAINED_WITHIN_ExpectAndReturn( &pxReadyTasksLists[ 5 ],
+    listIS_CONTAINED_WITHIN_ExpectAndReturn( &pxReadyTasksLists[ 4 ],
                                              &( ptcb->xStateListItem ),
                                              pdFALSE );
     /* API call */
@@ -1646,7 +1646,7 @@ void test_vTaskPrioritySet_success_lt_curr_prio_diff_base( void )
     listGET_LIST_ITEM_VALUE_ExpectAnyArgsAndReturn( 0 );
     listSET_LIST_ITEM_VALUE_Expect( &( ptcb->xEventListItem ),
                                     configMAX_PRIORITIES - 5 );
-    listIS_CONTAINED_WITHIN_ExpectAndReturn( &pxReadyTasksLists[ 5 ],
+    listIS_CONTAINED_WITHIN_ExpectAndReturn( &pxReadyTasksLists[ 6 ],
                                              &( ptcb->xStateListItem ),
                                              pdFALSE );
     /* API call */
@@ -1832,7 +1832,7 @@ void test_vTaskDelay_success_gt_0_yield_called( void )
     uxListRemove_ExpectAndReturn( &ptcb->xStateListItem, 1 );
     listSET_LIST_ITEM_VALUE_Expect( &ptcb->xStateListItem,
                                     xTickCount + delay );
-    vListInsert_Expect( pxOverflowDelayedTaskList, &ptcb->xStateListItem );
+    vListInsert_Expect( pxDelayedTaskList, &ptcb->xStateListItem );
 
     /* xTaskResumeAll */
     listLIST_IS_EMPTY_ExpectAnyArgsAndReturn( pdTRUE );
@@ -1854,7 +1854,7 @@ void test_vTaskDelay_success_gt_0_yield_not_called( void )
     uxListRemove_ExpectAndReturn( &ptcb->xStateListItem, pdTRUE );
     listSET_LIST_ITEM_VALUE_Expect( &ptcb->xStateListItem,
                                     xTickCount + delay );
-    vListInsert_Expect( pxOverflowDelayedTaskList, &ptcb->xStateListItem );
+    vListInsert_Expect( pxDelayedTaskList, &ptcb->xStateListItem );
 
     /* xTaskResumeAll */
 
@@ -1868,7 +1868,7 @@ void test_vTaskDelay_success_gt_0_yield_not_called( void )
     /* back to xTaskResumeAll */
     listLIST_IS_EMPTY_ExpectAndReturn( &xPendingReadyList, pdTRUE );
     /* prvResetNextTaskUnblockTime */
-    listLIST_IS_EMPTY_ExpectAndReturn( &xPendingReadyList, pdTRUE );
+    listLIST_IS_EMPTY_ExpectAndReturn( pxDelayedTaskList, pdTRUE );
 
     /* API Call */
     vTaskDelay( delay );
@@ -1900,7 +1900,7 @@ void test_vTaskDelay_success_gt_0_already_yielded( void )
     uxListRemove_ExpectAndReturn( &ptcb->xStateListItem, pdTRUE );
     listSET_LIST_ITEM_VALUE_Expect( &ptcb->xStateListItem,
                                     xTickCount + delay );
-    vListInsert_Expect( pxOverflowDelayedTaskList, &ptcb->xStateListItem );
+    vListInsert_Expect( pxDelayedTaskList, &ptcb->xStateListItem );
 
     /* xTaskResumeAll */
     listLIST_IS_EMPTY_ExpectAndReturn( &xPendingReadyList, pdFALSE );
@@ -1913,7 +1913,7 @@ void test_vTaskDelay_success_gt_0_already_yielded( void )
     /* back to xTaskResumeAll */
     listLIST_IS_EMPTY_ExpectAndReturn( &xPendingReadyList, pdTRUE );
     /* prvResetNextTaskUnblockTime */
-    listLIST_IS_EMPTY_ExpectAndReturn( &xPendingReadyList, pdTRUE );
+    listLIST_IS_EMPTY_ExpectAndReturn( pxDelayedTaskList, pdTRUE );
 
     /* API Call */
     vTaskDelay( delay );
@@ -2198,7 +2198,7 @@ void test_xTaskDelayUntil_success_gt_tickCount_should_delay( void )
     TEST_ASSERT_EQUAL( pxCurrentTCB, ptcb );
     uxListRemove_ExpectAndReturn( &pxCurrentTCB->xStateListItem, 0 );
     listSET_LIST_ITEM_VALUE_Expect( &pxCurrentTCB->xStateListItem, 3 );
-    vListInsert_Expect( pxOverflowDelayedTaskList, &ptcb->xStateListItem );
+    vListInsert_Expect( pxDelayedTaskList, &ptcb->xStateListItem );
     /* xTaskResumeAll */
     listLIST_IS_EMPTY_ExpectAndReturn( &xPendingReadyList, pdTRUE );
 
@@ -2241,7 +2241,7 @@ void test_xTaskDelayUntil_success_lt_tickCount( void )
     /* prvResetNextTaskUnblockTime */
     uxListRemove_ExpectAndReturn( &pxCurrentTCB->xStateListItem, 0 );
     listSET_LIST_ITEM_VALUE_Expect( &pxCurrentTCB->xStateListItem, 500 + ( ( previousWakeTime + 5 ) - xTickCount ) );
-    vListInsert_Expect( pxOverflowDelayedTaskList, &ptcb->xStateListItem );
+    vListInsert_Expect( pxDelayedTaskList, &ptcb->xStateListItem );
     /* xTaskResumeAll */
     listLIST_IS_EMPTY_ExpectAndReturn( &xPendingReadyList, pdFALSE );
     listGET_OWNER_OF_HEAD_ENTRY_ExpectAndReturn( &xPendingReadyList, ptcb );
@@ -2253,7 +2253,7 @@ void test_xTaskDelayUntil_success_lt_tickCount( void )
     /* back to xTaskResumeAll */
     listLIST_IS_EMPTY_ExpectAndReturn( &xPendingReadyList, pdTRUE );
     /* prvResetNextTaskUnblockTime */
-    listLIST_IS_EMPTY_ExpectAndReturn( &xPendingReadyList, pdTRUE );
+    listLIST_IS_EMPTY_ExpectAndReturn( pxDelayedTaskList, pdTRUE );
     /* API Call */
     ret_xtask_delay = xTaskDelayUntil( &previousWakeTime, 5 );
     /* Validations */
@@ -2284,7 +2284,7 @@ void test_xTaskDelayUntil_success_lt_tickCount1( void )
     /* back to xTaskResumeAll */
     listLIST_IS_EMPTY_ExpectAndReturn( &xPendingReadyList, pdTRUE );
     /* prvResetNextTaskUnblockTime */
-    listLIST_IS_EMPTY_ExpectAndReturn( &xPendingReadyList, pdTRUE );
+    listLIST_IS_EMPTY_ExpectAndReturn( pxDelayedTaskList, pdTRUE );
     /* API Call */
     ret_xtask_delay = xTaskDelayUntil( &previousWakeTime, xTimeIncrement );
     /* Validations */
@@ -2321,7 +2321,7 @@ void test_xTaskDelayUntil_success_lt_tickCount2( void )
     /* back to xTaskResumeAll */
     listLIST_IS_EMPTY_ExpectAndReturn( &xPendingReadyList, pdTRUE );
     /* prvResetNextTaskUnblockTime */
-    listLIST_IS_EMPTY_ExpectAndReturn( &xPendingReadyList, pdTRUE );
+    listLIST_IS_EMPTY_ExpectAndReturn( pxDelayedTaskList, pdTRUE );
     /* API Call */
     ret_xtask_delay = xTaskDelayUntil( &previousWakeTime, xTimeIncrement );
     /* Validations */
@@ -2370,7 +2370,7 @@ void test_xTaskDelayUntil_success_yield_already( void )
     /* back to xTaskResumeAll */
     listLIST_IS_EMPTY_ExpectAndReturn( &xPendingReadyList, pdTRUE );
     /* prvResetNextTaskUnblockTime */
-    listLIST_IS_EMPTY_ExpectAndReturn( &xPendingReadyList, pdTRUE );
+    listLIST_IS_EMPTY_ExpectAndReturn( pxDelayedTaskList, pdTRUE );
     /* API Call */
     ret_xtask_delay = xTaskDelayUntil( &previousWakeTime, xTimeIncrement );
     /* Validations */
@@ -2626,8 +2626,8 @@ void test_vTaskResume_success_task_event_list_orphan( void )
     /* back */
     uxListRemove_ExpectAndReturn( &ptcb->xStateListItem, pdTRUE );
     /* prvAddTaskToReadyList*/
-    listINSERT_END_ExpectWithArray( &pxReadyTasksLists[ 3 ], 0,
-                                    &ptcb->xStateListItem, 0 );
+    listINSERT_END_Expect( &pxReadyTasksLists[ 3 ],
+                           &ptcb->xStateListItem );
     /* API Call */
     vTaskResume( task_handle ); /* not current tcb */
     /* Validations */
@@ -2835,7 +2835,7 @@ void test_xTaskResumeFromISR_success_curr_prio_lt_suspended_task( void )
     /* back */
     uxListRemove_ExpectAndReturn( &ptcb->xStateListItem, pdTRUE );
     /* prvAddTaskToReadyList */
-    listINSERT_END_Expect( &pxReadyTasksLists[ create_task_priority ],
+    listINSERT_END_Expect( &pxReadyTasksLists[ 3 ],
                            &ptcb->xStateListItem );
     /* API Call */
     ret_task_resume = xTaskResumeFromISR( task_handle );
@@ -3142,7 +3142,7 @@ void test_xTaskIncrementTick_success_tickCount_overlow( void )
     /* taskSWITCH_DELAYED_LISTS */
     listLIST_IS_EMPTY_ExpectAndReturn( pxDelayedTaskList, pdTRUE );
     /* back */
-    listLIST_IS_EMPTY_ExpectAndReturn( pxDelayedTaskList, pdTRUE );
+    listLIST_IS_EMPTY_ExpectAndReturn( pxOverflowDelayedTaskList, pdTRUE );
     listCURRENT_LIST_LENGTH_ExpectAndReturn( &pxReadyTasksLists[ pxCurrentTCB->uxPriority ],
                                              2 );
     /* API Call */
@@ -3195,7 +3195,7 @@ void test_xTaskIncrementTick_success_switch( void )
     /* Expectations */
     /* taskSWITCH_DELAYED_LISTS(); */
     listLIST_IS_EMPTY_ExpectAndReturn( pxDelayedTaskList, pdTRUE );
-    listLIST_IS_EMPTY_ExpectAndReturn( pxDelayedTaskList, pdTRUE );
+    listLIST_IS_EMPTY_ExpectAndReturn( pxOverflowDelayedTaskList, pdTRUE );
     listCURRENT_LIST_LENGTH_ExpectAndReturn( &pxReadyTasksLists[ ptcb->uxPriority ],
                                              3 );
 
@@ -3428,7 +3428,7 @@ void test_xTaskIncrementTick_success_unblock_tasks3( void )
     listINSERT_END_Expect( &pxReadyTasksLists[ task_handle->uxPriority ],
                            &task_handle->xStateListItem );
     listLIST_IS_EMPTY_ExpectAndReturn( pxDelayedTaskList, pdTRUE );
-    listCURRENT_LIST_LENGTH_ExpectAndReturn( &pxReadyTasksLists[ task_handle->uxPriority ], 1 );
+    listCURRENT_LIST_LENGTH_ExpectAndReturn( &pxReadyTasksLists[ 3 ], 1 );
 
     /* API Call */
     ret_task_incrementtick = xTaskIncrementTick();
@@ -3477,7 +3477,7 @@ void test_xTaskAbortDelay_success( void )
     uxListRemove_ExpectAndReturn( &tcb->xStateListItem, pdTRUE );
     listLIST_ITEM_CONTAINER_ExpectAndReturn( &ptcb->xEventListItem, NULL );
     /* prvAddTaskToReadyList */
-    listINSERT_END_Expect( &pxReadyTasksLists[ create_task_priority ],
+    listINSERT_END_Expect( &pxReadyTasksLists[ 4 ],
                            &ptcb->xStateListItem );
     /* xTaskResumeAll */
     listLIST_IS_EMPTY_ExpectAndReturn( &xPendingReadyList, pdTRUE );
@@ -3527,7 +3527,7 @@ void test_xTaskAbortDelay_success_notdelayed( void )
                                              pxDelayedTaskList );
     uxListRemove_ExpectAndReturn( &ptcb->xEventListItem, pdTRUE );
     /* prvAddTaskToReadyList */
-    listINSERT_END_Expect( &pxReadyTasksLists[ create_task_priority ],
+    listINSERT_END_Expect( &pxReadyTasksLists[ 6 ],
                            &ptcb->xStateListItem );
     /* xTaskResumeAll */
     listLIST_IS_EMPTY_ExpectAndReturn( &xPendingReadyList, pdTRUE );
@@ -3853,7 +3853,7 @@ void test_vTaskPlaceOnEventListRestricted_max_wait( void )
     /* prvAddCurrentTaskToDelayedList */
     uxListRemove_ExpectAndReturn( &ptcb->xStateListItem, 1 );
     listSET_LIST_ITEM_VALUE_Expect( &ptcb->xStateListItem, ( xTickCount + portMAX_DELAY ) );
-    vListInsert_Expect( pxDelayedTaskList, &ptcb->xStateListItem );
+    vListInsert_Expect( pxOverflowDelayedTaskList, &ptcb->xStateListItem );
     /* API Call */
     vTaskPlaceOnEventListRestricted( &eventList, portMAX_DELAY, pdFALSE );
 }
@@ -3989,7 +3989,7 @@ void test_vTaskRemoveFromUnorderedEventList_yielding( void )
     /*uxListRemove_ExpectAndReturn( &ptcb->xStateListItem, pdTRUE ); */
     listREMOVE_ITEM_Expect( &( ptcb->xStateListItem ) );
     /* prvAddTaskToReadyList */
-    listINSERT_END_Expect( &pxReadyTasksLists[ create_task_priority ],
+    listINSERT_END_Expect( &pxReadyTasksLists[ 3 ],
                            &ptcb->xStateListItem );
 
     /* API Call */
@@ -4551,7 +4551,7 @@ void test_xTaskPriorityInherit_success2( void )
                                              &mutex_holder->xStateListItem, pdTRUE );
     uxListRemove_ExpectAndReturn( &mutex_holder->xStateListItem, 0 );
     /* prvAddTaskToReadyList */
-    listINSERT_END_Expect( &pxReadyTasksLists[ mutex_holder->uxPriority ],
+    listINSERT_END_Expect( &pxReadyTasksLists[ pxCurrentTCB->uxPriority ],
                            &mutex_holder->xStateListItem );
     /* API Call */
     ret_prio_inherit = xTaskPriorityInherit( mutex_holder );
@@ -4582,7 +4582,7 @@ void test_xTaskPriorityInherit_success3( void )
                                              &mutex_holder->xStateListItem, pdTRUE );
     uxListRemove_ExpectAndReturn( &mutex_holder->xStateListItem, 1 );
     /* prvAddTaskToReadyList */
-    listINSERT_END_Expect( &pxReadyTasksLists[ mutex_holder->uxPriority ],
+    listINSERT_END_Expect( &pxReadyTasksLists[ pxCurrentTCB->uxPriority ],
                            &mutex_holder->xStateListItem );
     /* API Call */
     ret_prio_inherit = xTaskPriorityInherit( mutex_holder );
@@ -4634,7 +4634,7 @@ void test_xTaskPriorityDisinherit_success_base_ne_current_priority( void )
     listSET_LIST_ITEM_VALUE_Expect( &mutex_holder->xEventListItem,
                                     configMAX_PRIORITIES - mutex_holder->uxBasePriority );
     /* prvAddTaskToReadyList */
-    listINSERT_END_Expect( &pxReadyTasksLists[ mutex_holder->uxPriority ],
+    listINSERT_END_Expect( &pxReadyTasksLists[ mutex_holder->uxBasePriority ],
                            &mutex_holder->xStateListItem );
     /* API Call */
     ret_prio_disinherit = xTaskPriorityDisinherit( mutex_holder );
@@ -4662,7 +4662,7 @@ void test_xTaskPriorityDisinherit_success_base_ne_current_priority2( void )
     listSET_LIST_ITEM_VALUE_Expect( &mutex_holder->xEventListItem,
                                     configMAX_PRIORITIES - mutex_holder->uxBasePriority );
     /* prvAddTaskToReadyList */
-    listINSERT_END_Expect( &pxReadyTasksLists[ mutex_holder->uxPriority ],
+    listINSERT_END_Expect( &pxReadyTasksLists[ mutex_holder->uxBasePriority ],
                            &mutex_holder->xStateListItem );
     /* API Call */
     ret_prio_disinherit = xTaskPriorityDisinherit( mutex_holder );
@@ -4808,7 +4808,7 @@ void test_vTaskPriorityDisinheritAfterTimeout_success5()
                                              pdTRUE );
     uxListRemove_ExpectAndReturn( &mutex_holder->xStateListItem, 1 );
     /* prvAddTaskToReadyList */
-    listINSERT_END_Expect( &pxReadyTasksLists[ mutex_holder->uxPriority ],
+    listINSERT_END_Expect( &pxReadyTasksLists[ mutex_holder->uxBasePriority ],
                            &mutex_holder->xStateListItem );
     /* API Call */
     vTaskPriorityDisinheritAfterTimeout( mutex_holder,
@@ -4835,7 +4835,7 @@ void test_vTaskPriorityDisinheritAfterTimeout_success6()
                                              pdTRUE );
     uxListRemove_ExpectAndReturn( &mutex_holder->xStateListItem, 0 );
     /* prvAddTaskToReadyList */
-    listINSERT_END_Expect( &pxReadyTasksLists[ mutex_holder->uxPriority ],
+    listINSERT_END_Expect( &pxReadyTasksLists[ create_task_priority + 2 ],
                            &mutex_holder->xStateListItem );
     /* API Call */
     vTaskPriorityDisinheritAfterTimeout( mutex_holder,
@@ -5599,7 +5599,7 @@ void test_xTaskGenericNotifyWait_success_notif_not_received( void )
     uxListRemove_ExpectAndReturn( &ptcb->xStateListItem, 0 );
     listSET_LIST_ITEM_VALUE_Expect( &ptcb->xStateListItem,
                                     xTickCount + xTicksToWait );
-    vListInsert_Expect( pxOverflowDelayedTaskList, &ptcb->xStateListItem );
+    vListInsert_Expect( pxDelayedTaskList, &ptcb->xStateListItem );
     listLIST_IS_EMPTY_ExpectAnyArgsAndReturn( pdTRUE );
 
     /* API Call */
@@ -5689,7 +5689,7 @@ void test_xTaskGenericNotifyWait_success_notif_received_while_waiting( void )
     uxListRemove_ExpectAndReturn( &ptcb->xStateListItem, 0 );
     listSET_LIST_ITEM_VALUE_Expect( &ptcb->xStateListItem,
                                     xTickCount + xTicksToWait );
-    vListInsert_Expect( pxOverflowDelayedTaskList, &ptcb->xStateListItem );
+    vListInsert_Expect( pxDelayedTaskList, &ptcb->xStateListItem );
     listLIST_IS_EMPTY_ExpectAnyArgsAndReturn( pdTRUE );
     py_operation = &notif_received;
 
@@ -5722,7 +5722,7 @@ void test_vTaskGenericNotifyGiveFromISR_success( void )
     /*uxListRemove_ExpectAndReturn( &task_to_notify->xStateListItem, pdTRUE ); */
     listREMOVE_ITEM_Expect( &( task_to_notify->xStateListItem ) );
     /* prvAddTaskToReadyList */
-    listINSERT_END_Expect( &xPendingReadyList, &task_to_notify->xEventListItem );
+    listINSERT_END_Expect( &( pxReadyTasksLists[ task_to_notify->uxPriority ] ), &task_to_notify->xStateListItem );
 
     /* API Call */
     vTaskGenericNotifyGiveFromISR( task_to_notify,

--- a/FreeRTOS/Test/CMock/tasks/tasks_2_utest.c
+++ b/FreeRTOS/Test/CMock/tasks/tasks_2_utest.c
@@ -699,7 +699,7 @@ void test_vTaskPrioritySet_success_gt_curr_prio( void )
     listGET_LIST_ITEM_VALUE_ExpectAnyArgsAndReturn( 0 );
     listSET_LIST_ITEM_VALUE_Expect( &( ptcb->xEventListItem ),
                                     configMAX_PRIORITIES - 5 );
-    listIS_CONTAINED_WITHIN_ExpectAndReturn( &pxReadyTasksLists[ 5 ],
+    listIS_CONTAINED_WITHIN_ExpectAndReturn( &pxReadyTasksLists[ 4 ],
                                              &( ptcb->xStateListItem ),
                                              pdTRUE );
     uxListRemove_ExpectAndReturn( &( ptcb->xStateListItem ), 0 );


### PR DESCRIPTION
<!--- Title -->
Change CMock pointer policy of tasks from `smart` to `compare_ptr`.

Description
-----------
<!--- Describe your changes in detail. -->
Just like the previous [PR#1112](https://github.com/FreeRTOS/FreeRTOS/pull/1112) said,  we need to compare the pointer itself instead of compare the data pointed by the pointer.
CMock has two policies which can achieve it:

1. `smart` : with this policy, we need to change all the `xxx_Expect` to `xxx_ExpectWithArray`, and add an extra argument  for every pointer;
2. `compare_ptr` : with this policy, we don't need to change `xxx_Expect`, but we need to remove the CMock plugins `array`(because they are conflict options, and we haven't use feature `array`).

To minimize the change, I chose policy 2 `compare_ptr` here.
And I fixed the errors of test cases found by this change.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->
`cd ./FreeRTOS/Test/CMock`
`make -C tasks/ lcov`

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
