### PR TITLE
Update FreeRTOS.h for portSWITCH_TASK_HOOK in unit test

### DIFF
--- a/FreeRTOS/Test/CMock/tasks/tasks_freertos/FreeRTOS.h
+++ b/FreeRTOS/Test/CMock/tasks/tasks_freertos/FreeRTOS.h
@@ -23,6 +23,10 @@
  * https://github.com/FreeRTOS
  *
  */
+/*
+ * The purpose of this file is to cover configASSERT. struct xSTATIC_TCB is updated to
+ * cause configASSERT. The rest of this file should be the same as FreeRTOS.h.
+ */ 
 
 #ifndef INC_FREERTOS_H
 #define INC_FREERTOS_H
@@ -240,14 +244,6 @@
 
 #ifndef INCLUDE_xTaskGetIdleTaskHandle
     #define INCLUDE_xTaskGetIdleTaskHandle    0
-#endif
-
-#ifndef traceENTER_xTaskGetIdleTaskHandleForCore
-    #define traceENTER_xTaskGetIdleTaskHandleForCore( xCoreID )
-#endif
-
-#ifndef traceRETURN_xTaskGetIdleTaskHandleForCore
-    #define traceRETURN_xTaskGetIdleTaskHandleForCore( xIdleTaskHandle )
 #endif
 
 #ifndef INCLUDE_xTaskAbortDelay
@@ -522,6 +518,10 @@
 
 #ifndef portSETUP_TCB
     #define portSETUP_TCB( pxTCB )    ( void ) ( pxTCB )
+#endif
+
+#ifndef portTASK_SWITCH_HOOK
+    #define portTASK_SWITCH_HOOK( pxTCB )    ( void ) ( pxTCB )
 #endif
 
 #ifndef configQUEUE_REGISTRY_SIZE
@@ -1892,14 +1892,20 @@
     #ifndef traceENTER_xTaskGetIdleTaskHandle
         #define traceENTER_xTaskGetIdleTaskHandle()
     #endif
-#else
-    #ifndef traceENTER_xTaskGetIdleTaskHandle
-        #define traceENTER_xTaskGetIdleTaskHandle( xCoreID )
+#endif
+
+#if ( configNUMBER_OF_CORES == 1 )
+    #ifndef traceRETURN_xTaskGetIdleTaskHandle
+        #define traceRETURN_xTaskGetIdleTaskHandle( xIdleTaskHandle )
     #endif
 #endif
 
-#ifndef traceRETURN_xTaskGetIdleTaskHandle
-    #define traceRETURN_xTaskGetIdleTaskHandle( xIdleTaskHandle )
+#ifndef traceENTER_xTaskGetIdleTaskHandleForCore
+    #define traceENTER_xTaskGetIdleTaskHandleForCore( xCoreID )
+#endif
+
+#ifndef traceRETURN_xTaskGetIdleTaskHandleForCore
+    #define traceRETURN_xTaskGetIdleTaskHandleForCore( xIdleTaskHandle )
 #endif
 
 #ifndef traceENTER_vTaskStepTick
@@ -2126,12 +2132,12 @@
     #define traceRETURN_xTaskGetCurrentTaskHandle( xReturn )
 #endif
 
-#ifndef traceENTER_xTaskGetCurrentTaskHandleCPU
-    #define traceENTER_xTaskGetCurrentTaskHandleCPU( xCoreID )
+#ifndef traceENTER_xTaskGetCurrentTaskHandleForCore
+    #define traceENTER_xTaskGetCurrentTaskHandleForCore( xCoreID )
 #endif
 
-#ifndef traceRETURN_xTaskGetCurrentTaskHandleCPU
-    #define traceRETURN_xTaskGetCurrentTaskHandleCPU( xReturn )
+#ifndef traceRETURN_xTaskGetCurrentTaskHandleForCore
+    #define traceRETURN_xTaskGetCurrentTaskHandleForCore( xReturn )
 #endif
 
 #ifndef traceENTER_xTaskGetSchedulerState

--- a/manifest.yml
+++ b/manifest.yml
@@ -5,7 +5,7 @@ license: "MIT"
 
 dependencies:
   - name: "FreeRTOS-Kernel"
-    version: "dc09a3dd5"
+    version: "cd5c774b2"
     repository:
       type: "git"
       url: "https://github.com/FreeRTOS/FreeRTOS-Kernel.git"


### PR DESCRIPTION
Update FreeRTOS.h for portSWITCH_TASK_HOOK in unit test

Description
-----------
Add missing port macro portSWITCH_TASK_HOOK in unit test.

Test Steps
-----------
Before this PR, there will be compilation error in unit test.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
https://github.com/FreeRTOS/FreeRTOS-Kernel/pull/867


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
