### PR TITLE
Fix SMP unit test for switch hook

### DIFF
--- a/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c
+++ b/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c
@@ -1802,6 +1802,7 @@ void test_coverage_xTaskRemoveFromEventList_remove_eq_priority_task( void )
     vFakePortGetCoreID_ExpectAndReturn( 0 ); /* Get prvYieldCore. */
     vFakePortGetCoreID_ExpectAndReturn( 0 ); /* Get portGET_CRITICAL_NESTING_COUNT. */
     vFakePortGetCoreID_ExpectAndReturn( 0 ); /* Get xYieldPendings. */
+    vFakePortGetCoreID_ExpectAndReturn( 0 ); /* portTASK_SWITCH_HOOK(). */
 
     /* API call. */
     xReturn = xTaskRemoveFromEventList( &xEventList );

--- a/manifest.yml
+++ b/manifest.yml
@@ -5,7 +5,7 @@ license: "MIT"
 
 dependencies:
   - name: "FreeRTOS-Kernel"
-    version: "dc09a3dd5"
+    version: "cd5c774b2"
     repository:
       type: "git"
       url: "https://github.com/FreeRTOS/FreeRTOS-Kernel.git"


### PR DESCRIPTION
<!--- Title -->

Description
-----------
The implementation cause one more `portGET_CORE_ID()` call. Update the unit test correspondingly.
```
                /* Macro to inject port specific behaviour immediately after
                 * switching tasks, such as setting an end of stack watchpoint
                 * or reconfiguring the MPU. */
                portTASK_SWITCH_HOOK( pxCurrentTCBs[ portGET_CORE_ID() ] );
```

Test Steps
-----------
Before this PR, there will be test failure.
```
/mnt/c/msys64/home/chinglee/kernel/unit-test/FreeRTOS/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c:1754:test_coverage_xTaskRemoveFromEventList_remove_eq_priority_task:FAIL:Function vFakePortGetCoreID.  Called more times than expected.
```

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
