### PR TITLE
Riscv re-factoring

### DIFF
--- a/FreeRTOS/Demo/RISC-V_RV32_QEMU_VIRT_GCC/build/gcc/Makefile
+++ b/FreeRTOS/Demo/RISC-V_RV32_QEMU_VIRT_GCC/build/gcc/Makefile
@@ -13,7 +13,7 @@ MAKE = make
 GCC_VERSION = $(shell $(CC) --version | grep ^$(CC) | sed 's/^.* //g' | awk -F. '{ printf("%d%02d%02d"), $$1, $$2, $$3 }')
 GCC_VERSION_NEED_ZICSR = "110100"
 
-CFLAGS += $(INCLUDE_DIRS) -DportasmHANDLE_INTERRUPT=handle_trap -fmessage-length=0 \
+CFLAGS += $(INCLUDE_DIRS) -fmessage-length=0 \
           -mabi=ilp32 -mcmodel=medlow -ffunction-sections -fdata-sections \
           -Wno-unused-parameter -nostartfiles -g3 -Os
 

--- a/FreeRTOS/Demo/RISC-V_RV32_QEMU_VIRT_GCC/riscv-virt.c
+++ b/FreeRTOS/Demo/RISC-V_RV32_QEMU_VIRT_GCC/riscv-virt.c
@@ -1,6 +1,6 @@
 /*
  * FreeRTOS V202212.00
- * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
@@ -55,10 +55,4 @@ size_t i;
 	vOutNS16550( &dev, '\n' );
 
 	portEXIT_CRITICAL();
-}
-
-void handle_trap(void)
-{
-	while (1)
-		;
 }


### PR DESCRIPTION
* Refactor the trap handler macro Since `portasmHANDLE_INTERRUPT` is removed at FreeRTOS-kernel, Riscv re-factoring (#444) (commit: 9efca75d1e) We don't need this definition anymore
We also remove the unused function definition

* Styling the file header to pass the checker Remove an extra space

<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
