### PR TITLE
Update GitPython version for untrusted search path on Windows.

### DIFF
--- a/.github/scripts/common/requirements.txt
+++ b/.github/scripts/common/requirements.txt
@@ -1,5 +1,5 @@
 Deprecated
-GitPython
+GitPython>=3.1.41
 PyGithub
 PyJWT
 PyYAML

--- a/.github/scripts/release-requirements.txt
+++ b/.github/scripts/release-requirements.txt
@@ -1,5 +1,5 @@
 Deprecated
-GitPython
+GitPython>=3.1.41
 PyGithub
 PyJWT
 PyYAML


### PR DESCRIPTION
<!--- Title -->
Update GitPython version for untrusted search path on Windows.

Description
-----------
<!--- Describe your changes in detail. -->
From [security dependabot alerts #16](https://github.com/FreeRTOS/FreeRTOS/security/dependabot/16), we should update GitPython version to 3.1.41 to fix untrusted search path under some conditions on Windows.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
