### PR TITLE
Update for vTaskSuspend unit test

### DIFF
--- a/FreeRTOS/Test/CMock/smp/config_assert/config_assert_utest.c
+++ b/FreeRTOS/Test/CMock/smp/config_assert/config_assert_utest.c
@@ -410,19 +410,27 @@ void test_vTaskDelete_assert_scheduler_suspended_eq_1( void )
 }
 
 /**
- * @brief This test ensures that the code asserts when a task is suspended while
- *        the scheduler is suspended
+ * @brief vTaskSuspend - scheduler suspended assertion.
+ *
+ * This test ensures that the code asserts when a task is suspended while
+ * the scheduler is suspended
  *
  * <b>Coverage</b>
  * @code{c}
- * vTaskDelete( xTaskToDelete );
- *
- * configASSERT( uxSchedulerSuspended == 0 );
- *
+ * if( xSchedulerRunning != pdFALSE )
+ * {
+ *     if( pxTCB->xTaskRunState == ( BaseType_t ) portGET_CORE_ID() )
+ *     {
+ *         configASSERT( uxSchedulerSuspended == 0 );
+ *         vTaskYieldWithinAPI();
+ *     }
+ *     else
+ *     {
+ *         prvYieldCore( pxTCB->xTaskRunState );
+ *     }
+ * }
  * @endcode
- *
- * configNUMBER_OF_CORES > 1
- * INCLUDE_vTaskSuspend
+ * configASSERT( uxSchedulerSuspended == 0 ) is triggered.
  */
 void test_vTaskSuspend_assert_schedulersuspended_ne_zero( void )
 {
@@ -438,7 +446,15 @@ void test_vTaskSuspend_assert_schedulersuspended_ne_zero( void )
     uxListRemove_ExpectAnyArgsAndReturn( pdTRUE );
     listLIST_ITEM_CONTAINER_ExpectAnyArgsAndReturn( NULL );
     vListInsertEnd_ExpectAnyArgs();
+    vFakePortExitCriticalSection_Expect();
+
+    /* Reset the next expected unblock time if scheduler is running. */
+    vFakePortEnterCriticalSection_Expect();
     listLIST_IS_EMPTY_ExpectAnyArgsAndReturn( pdTRUE );
+    vFakePortExitCriticalSection_Expect();
+
+    /* Check task run state in critical section. */
+    vFakePortEnterCriticalSection_Expect();
     vFakePortGetCoreID_ExpectAndReturn( 1 );
 
     EXPECT_ASSERT_BREAK( vTaskSuspend( xTaskToSuspend ) );

--- a/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice_mock/covg_multiple_priorities_no_timeslice_mock_utest.c
+++ b/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice_mock/covg_multiple_priorities_no_timeslice_mock_utest.c
@@ -239,6 +239,10 @@ void test_coverage_vTaskSuspend_scheduler_running_false( void )
     vListInsertEnd_ExpectAnyArgs();
     vFakePortExitCriticalSection_Expect();
 
+    /* Enter critical section to check task run state. */
+    vFakePortEnterCriticalSection_Expect();
+    vFakePortExitCriticalSection_Expect();
+
     /* API call. */
     vTaskSuspend( &xTaskTCBs[ 0 ] );
 
@@ -277,6 +281,10 @@ void test_coverage_vTaskSuspend_running_state_below_range( void )
     vListInsertEnd_ExpectAnyArgs();
     vFakePortExitCriticalSection_Expect();
 
+    /* Enter critical section to check task run state. */
+    vFakePortEnterCriticalSection_Expect();
+    vFakePortExitCriticalSection_Expect();
+
     /* API call. */
     vTaskSuspend( &xTaskTCBs[ 0 ] );
 
@@ -312,6 +320,10 @@ void test_coverage_vTaskSuspend_running_state_above_range( void )
     uxListRemove_ExpectAnyArgsAndReturn( pdTRUE );
     listLIST_ITEM_CONTAINER_ExpectAnyArgsAndReturn( NULL );
     vListInsertEnd_ExpectAnyArgs();
+    vFakePortExitCriticalSection_Expect();
+
+    /* Enter critical section to check task run state. */
+    vFakePortEnterCriticalSection_Expect();
     vFakePortExitCriticalSection_Expect();
 
     /* API call. */


### PR DESCRIPTION
Update for vTaskSuspend unit test

Description
-----------
This PR fix the unit test in https://github.com/FreeRTOS/FreeRTOS-Kernel/pull/959

Test Steps
-----------
Before this PR there will have the following failed test cases:
>FreeRTOS/FreeRTOS/Test/CMock/smp/config_assert/config_assert_utest.c:427:test_vTaskSuspend_assert_schedulersuspended_ne_zero:FAIL:Function vFakePortExitCriticalSection.  Called more times than expected.
FreeRTOS/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice_mock/covg_multiple_priorities_no_timeslice_mock_utest.c:225:test_coverage_vTaskSuspend_scheduler_running_false:FAIL:Function vFakePortEnterCriticalSection.  Called more times than expected.
FreeRTOS/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice_mock/covg_multiple_priorities_no_timeslice_mock_utest.c:225:test_coverage_vTaskSuspend_scheduler_running_false:FAIL:Function vFakePortEnterCriticalSection.  Called more times than expected.
FreeRTOS/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice_mock/covg_multiple_priorities_no_timeslice_mock_utest.c:225:test_coverage_vTaskSuspend_scheduler_running_false:FAIL:Function vFakePortEnterCriticalSection.  Called more times than expected.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
