### PR TITLE
Fix unit test for vTaskEndShceduler

### DIFF
--- a/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice_mock/covg_multiple_priorities_no_timeslice_mock_utest.c
+++ b/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice_mock/covg_multiple_priorities_no_timeslice_mock_utest.c
@@ -501,56 +501,6 @@ void test_coverage_prvYieldCore_runstate_eq_yielding( void )
 }
 
 /**
- * @brief vTaskDelete - scheduler not running.
- *
- * This test ensures that if vTaskDelete is called and the scheduler is
- * not running, the core is not yielded, but it is removed from the
- * stateList, the eventList and inserted in the taskwaitingtermination
- * list, the uxdeletedtaskwaiting for cleanup is increased and the
- * uxtasknumber is increased
- *
- * <b>Coverage</b>
- * @code{c}
- * if( ( xSchedulerRunning != pdFALSE ) &&
- *     ( taskTASK_IS_RUNNING( pxTCB ) == pdTRUE ) )
- * ...
- * @endcode
- * ( xSchedulerRunning != pdFALSE ) is false.
- */
-void test_coverage_vTaskDelete_scheduler_not_running( void )
-{
-    TCB_t * pxTask = NULL;
-    TaskHandle_t xTaskToDelete;
-
-    pxTask = pvPortMalloc( sizeof( TCB_t ) );
-
-    pxTask->xTaskRunState = 1; /* running on core 1 */
-    xTaskToDelete = pxTask;
-    pxCurrentTCBs[ 0 ] = pxTask;
-    pxTask->pxStack = pvPortMalloc( 100 );
-
-    xSchedulerRunning = pdFALSE;
-
-    uxTaskNumber = 1;
-    uxCurrentNumberOfTasks = 1;
-
-    /* Test Expectations */
-    vFakePortEnterCriticalSection_Expect();
-    uxListRemove_ExpectAnyArgsAndReturn( 0 );
-    listLIST_ITEM_CONTAINER_ExpectAnyArgsAndReturn( NULL );
-    listLIST_IS_EMPTY_ExpectAnyArgsAndReturn( pdTRUE );
-
-    vFakePortExitCriticalSection_Expect();
-
-    /* API Call */
-    vTaskDelete( xTaskToDelete );
-
-    /* Test Verifications */
-    TEST_ASSERT_EQUAL( 0, uxCurrentNumberOfTasks );
-    TEST_ASSERT_EQUAL( 2, uxTaskNumber );
-}
-
-/**
  * @brief This test ensures that if xTask Delete is called and the scheuler is
  *        running while the task runstate is more that the configNUMBER_OF_CORES,
  *        the core is not yielded, but it is removed from the

--- a/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice_mock/covg_multiple_priorities_no_timeslice_mock_utest.c
+++ b/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice_mock/covg_multiple_priorities_no_timeslice_mock_utest.c
@@ -503,7 +503,7 @@ void test_coverage_prvYieldCore_runstate_eq_yielding( void )
 /**
  * @brief vTaskDelete - scheduler not running.
  *
- * This test ensures that if vTaskDelete is called and the scheuler is
+ * This test ensures that if vTaskDelete is called and the scheduler is
  * not running, the core is not yielded, but it is removed from the
  * stateList, the eventList and inserted in the taskwaitingtermination
  * list, the uxdeletedtaskwaiting for cleanup is increased and the
@@ -519,35 +519,34 @@ void test_coverage_prvYieldCore_runstate_eq_yielding( void )
  */
 void test_coverage_vTaskDelete_scheduler_not_running( void )
 {
-    TCB_t task;
+    TCB_t * pxTask = NULL;
     TaskHandle_t xTaskToDelete;
 
-    task.xTaskRunState = 1; /* running on core 1 */
-    xTaskToDelete = &task;
-    pxCurrentTCBs[ 0 ] = &task;
+    pxTask = pvPortMalloc( sizeof( TCB_t ) );
+
+    pxTask->xTaskRunState = 1; /* running on core 1 */
+    xTaskToDelete = pxTask;
+    pxCurrentTCBs[ 0 ] = pxTask;
+    pxTask->pxStack = pvPortMalloc( 100 );
 
     xSchedulerRunning = pdFALSE;
 
-    uxDeletedTasksWaitingCleanUp = 0;
     uxTaskNumber = 1;
+    uxCurrentNumberOfTasks = 1;
 
     /* Test Expectations */
     vFakePortEnterCriticalSection_Expect();
     uxListRemove_ExpectAnyArgsAndReturn( 0 );
     listLIST_ITEM_CONTAINER_ExpectAnyArgsAndReturn( NULL );
-
-    /* if task != taskTaskNOT_RUNNING */
-    vListInsertEnd_ExpectAnyArgs();
-    vPortCurrentTaskDying_ExpectAnyArgs();
+    listLIST_IS_EMPTY_ExpectAnyArgsAndReturn( pdTRUE );
 
     vFakePortExitCriticalSection_Expect();
-
 
     /* API Call */
     vTaskDelete( xTaskToDelete );
 
     /* Test Verifications */
-    TEST_ASSERT_EQUAL( 1, uxDeletedTasksWaitingCleanUp );
+    TEST_ASSERT_EQUAL( 0, uxCurrentNumberOfTasks );
     TEST_ASSERT_EQUAL( 2, uxTaskNumber );
 }
 


### PR DESCRIPTION
Fix unit test for vTaskEndShceduler

Description
-----------
This PR fixes the unit test to address kernel change https://github.com/FreeRTOS/FreeRTOS-Kernel/pull/962

### In this PR
* Update kernel unit test for vTaskEndScheduler.
* test_coverage_vTaskDelete_scheduler_not_running is removed due to the line to be covered is removed.

Test Steps
-----------
There will have the following unit test errors:
> tasks_1_utest.c:887:test_vTaskDelete_success_current_task:FAIL:Function listLIST_IS_EMPTY.  Called more times than expected.
tasks_1_utest.c:905:test_vTaskDelete_success_current_task_ready_empty:FAIL:Function listLIST_IS_EMPTY.  Called more times than expected.
tasks_1_utest.c:924:test_vTaskDelete_success_current_task_ready_empty_null_task:FAIL:Function listLIST_IS_EMPTY.  Called more times than expected.
tasks_1_utest.c:1123:test_vTaskEndScheduler_success:FAIL:Function xTimerGetTimerDaemonTaskHandle.  Called more times than expected.
tasks_1_utest.c:4428:test_xTaskGetSchedulerState_not_running:FAIL:Function xTimerGetTimerDaemonTaskHandle.  Called more times than expected.



Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
