### PR TITLE
Update unit tests due to task notification changes

### DIFF
--- a/FreeRTOS/Test/CMock/smp/config_assert/config_assert_utest.c
+++ b/FreeRTOS/Test/CMock/smp/config_assert/config_assert_utest.c
@@ -595,6 +595,7 @@ void test_prvGetExpectedIdleTime_assert_nextUnblock_lt_xTickCount( void )
 
     /* vTaskSuspendAll */
     vFakePortAssertIfISR_Expect();
+    vFakePortGetCoreID_ExpectAndReturn( 0 );
     ulFakePortSetInterruptMask_ExpectAndReturn( 0 );
     vFakePortGetTaskLock_Expect();
     vFakePortGetISRLock_Expect();

--- a/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice_mock/covg_multiple_priorities_no_timeslice_mock_utest.c
+++ b/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice_mock/covg_multiple_priorities_no_timeslice_mock_utest.c
@@ -636,46 +636,6 @@ void test_coverage_vTaskPreemptionDisable_null_handle( void )
 }
 
 /**
- * @brief This test ensures that when we call vTaskSuspendAll and we task of the
- *        current core has a critical nesting count of 1 only the scheduler is
- *        suspended
- *
- * <b>Coverage</b>
- * @code{c}
- * vTaskSuspendAll();
- *
- * if( portGET_CRITICAL_NESTING_COUNT() == 0U )
- *
- * @endcode
- *
- * configNUMBER_OF_CORES > 1
- */
-void test_coverage_vTaskSuspendAll_critical_nesting_ne_zero( void )
-{
-    TCB_t xTask = { 0 };
-
-    xTask.uxCriticalNesting = 1;
-    pxCurrentTCBs[ 0 ] = &xTask;
-    xSchedulerRunning = pdTRUE;
-    uxSchedulerSuspended = 0U;
-
-    /* Test Expectations */
-    vFakePortAssertIfISR_Expect();
-    ulFakePortSetInterruptMask_ExpectAndReturn( 0 );
-    vFakePortGetTaskLock_Expect();
-    vFakePortGetCoreID_ExpectAndReturn( 0 );
-    vFakePortGetISRLock_Expect();
-    vFakePortReleaseISRLock_Expect();
-    vFakePortClearInterruptMask_Expect( 0 );
-
-    /* API Call */
-    vTaskSuspendAll();
-
-    /* Test Verifications */
-    TEST_ASSERT_EQUAL( 1, uxSchedulerSuspended );
-}
-
-/**
  * @brief This test ensures that when we call prvGetExpectedIdleTime and the top
  *        ready priority is greater than the idle task, we return zero,
  *        as a suggestion to sleep
@@ -856,12 +816,17 @@ void test_coverage_prvGetExpectedIdleTime_ready_list_eq_1( void )
 
     /* vTaskSuspendAll */
     vFakePortAssertIfISR_Expect();
+    vFakePortGetCoreID_ExpectAndReturn( 0 );
     ulFakePortSetInterruptMask_ExpectAndReturn( 0 );
     vFakePortGetTaskLock_Expect();
+    /* prvCheckForRunStateChange */
+    vFakePortAssertIfISR_Expect();
+    vFakePortGetCoreID_ExpectAndReturn( 0 );
+    /* End of prvCheckForRunStateChange */
     vFakePortGetISRLock_Expect();
     vFakePortReleaseISRLock_Expect();
     vFakePortClearInterruptMask_Expect( 0 );
-
+    /* End of vTaskSuspendAll */
 
     ulFakePortSetInterruptMask_ExpectAndReturn( 0 );
     vFakePortGetCoreID_ExpectAndReturn( 0 );
@@ -957,11 +922,16 @@ void test_coverage_prvGetExpectedIdleTime_ready_list_eq_2( void )
 
     /* vTaskSuspendAll */
     vFakePortAssertIfISR_Stub( port_assert_if_isr_cb );
+    vFakePortGetCoreID_ExpectAndReturn( 0 );
     ulFakePortSetInterruptMask_ExpectAndReturn( 0 );
     vFakePortGetTaskLock_Expect();
+    /* prvCheckForRunStateChange */
+    vFakePortGetCoreID_ExpectAndReturn( 0 );
+    /* End of prvCheckForRunStateChange */
     vFakePortGetISRLock_Expect();
     vFakePortReleaseISRLock_Expect();
     vFakePortClearInterruptMask_Expect( 0 );
+    /* End of vTaskSuspendAll */
 
 
     ulFakePortSetInterruptMask_ExpectAndReturn( 0 );

--- a/FreeRTOS/Test/CMock/tasks/tasks_1_utest.c
+++ b/FreeRTOS/Test/CMock/tasks/tasks_1_utest.c
@@ -4928,6 +4928,8 @@ void test_ulTaskGenericNotifyTake_success( void )
     task_handle = create_task();
     task_handle->ulNotifiedValue[ uxIndexToWait ] = 0;
     /* Expectations */
+    /* xTaskResumeAll */
+    listLIST_IS_EMPTY_ExpectAndReturn( &xPendingReadyList, pdTRUE );
     /* API Call */
     ret_gen_notify_take = ulTaskGenericNotifyTake( uxIndexToWait,
                                                    pdFALSE,
@@ -4948,6 +4950,8 @@ void test_ulTaskGenericNotifyTake_success2( void )
     task_handle = create_task();
     task_handle->ulNotifiedValue[ uxIndexToWait ] = 2;
     /* Expectations */
+    /* xTaskResumeAll */
+    listLIST_IS_EMPTY_ExpectAndReturn( &xPendingReadyList, pdTRUE );
     /* API Call */
     ret_gen_notify_take = ulTaskGenericNotifyTake( uxIndexToWait,
                                                    pdFALSE,
@@ -4968,6 +4972,8 @@ void test_ulTaskGenericNotifyTake_success_clear_count( void )
     task_handle = create_task();
     task_handle->ulNotifiedValue[ uxIndexToWait ] = 5;
     /* Expectations */
+    /* xTaskResumeAll */
+    listLIST_IS_EMPTY_ExpectAndReturn( &xPendingReadyList, pdTRUE );
     /* API Call */
     ret_gen_notify_take = ulTaskGenericNotifyTake( uxIndexToWait,
                                                    pdTRUE,
@@ -4993,7 +4999,8 @@ void test_ulTaskGenericNotifyTake_success_yield( void )
     uxListRemove_ExpectAndReturn( &ptcb->xStateListItem, 1 );
     listSET_LIST_ITEM_VALUE_Expect( &ptcb->xStateListItem, xTickCount + 9 );
     vListInsert_Expect( pxDelayedTaskList, &ptcb->xStateListItem );
-    listLIST_IS_EMPTY_ExpectAnyArgsAndReturn( pdTRUE );
+    /* xTaskResumeAll */
+    listLIST_IS_EMPTY_ExpectAndReturn( &xPendingReadyList, pdTRUE );
     /* API Call */
     ret_gen_notify_take = ulTaskGenericNotifyTake( uxIndexToWait,
                                                    pdFALSE,
@@ -5607,16 +5614,21 @@ void test_xTaskGenericNotifyWait_success_notif_received( void )
 
     TaskHandle_t task_handle;
 
+    /* Setup */
     task_handle = create_task();
     ptcb = task_handle;
     ptcb->ucNotifyState[ uxIndexToWait ] = 2; /* taskNOTIFICATION_RECEIVED */
     ptcb->ulNotifiedValue[ uxIndexToWait ] = 5;
-
+    /* Expectations */
+    /* xTaskResumeAll */
+    listLIST_IS_EMPTY_ExpectAndReturn( &xPendingReadyList, pdTRUE );
+    /* API Call */
     ret = xTaskGenericNotifyWait( uxIndexToWait,
                                   ulBitsToClearOnEntry,
                                   ulBitsToClearOnExit,
                                   &pullNotificationValue,
                                   xTicksToWait );
+    /* Validations */
     TEST_ASSERT_EQUAL( pdTRUE, ret );
     TEST_ASSERT_EQUAL( 5, pullNotificationValue );
     ASSERT_PORT_YIELD_WITHIN_API_NOT_CALLED();
@@ -5667,12 +5679,14 @@ void test_xTaskGenericNotifyWait_success_notif_not_received_no_wait( void )
 
     TaskHandle_t task_handle;
 
+    /* Setup */
     task_handle = create_task();
     ptcb = task_handle;
     ptcb->ucNotifyState[ uxIndexToWait ] = 1; /* taskWAITING_NOTIFICATION */
     ptcb->ulNotifiedValue[ uxIndexToWait ] = 5;
     /* Expectations */
-
+    /* xTaskResumeAll */
+    listLIST_IS_EMPTY_ExpectAndReturn( &xPendingReadyList, pdTRUE );
     /* API Call */
     ret = xTaskGenericNotifyWait( uxIndexToWait,
                                   ulBitsToClearOnEntry,
@@ -5695,12 +5709,14 @@ void test_xTaskGenericNotifyWait_success_notif_not_received_pull_null( void )
 
     TaskHandle_t task_handle;
 
+    /* Setup */
     task_handle = create_task();
     ptcb = task_handle;
     ptcb->ucNotifyState[ uxIndexToWait ] = 1; /* taskWAITING_NOTIFICATION */
     ptcb->ulNotifiedValue[ uxIndexToWait ] = 5;
     /* Expectations */
-
+    /* xTaskResumeAll */
+    listLIST_IS_EMPTY_ExpectAndReturn( &xPendingReadyList, pdTRUE );
     /* API Call */
     ret = xTaskGenericNotifyWait( uxIndexToWait,
                                   ulBitsToClearOnEntry,


### PR DESCRIPTION
<!--- Title -->

Description
-----------

https://github.com/FreeRTOS/FreeRTOS-Kernel/pull/982 made some changes to task notification functions and `vTaskSuspendAll()`. This PR updates the CMock unit tests according to those changes.

Test Steps
-----------

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------

See https://github.com/FreeRTOS/FreeRTOS-Kernel/pull/982

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
