### PR TITLE
Update CMakeLists.txt for Posix GCC Demo

### DIFF
--- a/FreeRTOS/Demo/Posix_GCC/CMakeLists.txt
+++ b/FreeRTOS/Demo/Posix_GCC/CMakeLists.txt
@@ -42,7 +42,8 @@ target_include_directories( freertos_config
     INTERFACE
         ./
         ./Trace_Recorder_Configuration
-        ${FREERTOS_PLUS_TRACE_PATH}/Include
+        ${FREERTOS_PLUS_TRACE_PATH}/include
+        ${FREERTOS_PLUS_TRACE_PATH}/kernelports/FreeRTOS/include
 )
 
 # Select the heap port
@@ -60,7 +61,7 @@ target_compile_options( freertos_kernel
         $<IF:${COVERAGE_TEST},,-Wno-pointer-to-int-cast>
 )
 
-file( GLOB FREERTOS_PLUS_TRACE_SOURCES ${FREERTOS_PLUS_TRACE_PATH}/*.c )
+file( GLOB FREERTOS_PLUS_TRACE_SOURCES ${FREERTOS_PLUS_TRACE_PATH}/*.c ${FREERTOS_PLUS_TRACE_PATH}/kernelports/FreeRTOS/*.c )
 
 add_executable( posix_demo
                 code_coverage_additions.c


### PR DESCRIPTION
Description
-----------
This PR updates CMakeLists.txt to compile Posix Demo successfully, with tracing enabled.

Test Steps
-----------
```
cd ./FreeRTOS/FreeRTOS/Demo/Posix_GCC
cmake -B build -S .
cd build
make
```

Before applying the patch 
```
FreeRTOS/Demo/Posix_GCC/./FreeRTOSConfig.h:157:14: fatal error: trcRecorder.h: No such file or directory
  157 |     #include "trcRecorder.h"
      |              ^~~~~~~~~~~~~~~
```
After applying the patch, it compiles successfully.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
[Forum issue](https://forums.freertos.org/t/trcrecorder-h-no-such-file-or-directory-when-using-cmakelists-txt/19146)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
