### PR TITLE
Fix WIN32-Mingw coverage test demo

### DIFF
--- a/FreeRTOS/Demo/WIN32-MingW/main_full.c
+++ b/FreeRTOS/Demo/WIN32-MingW/main_full.c
@@ -405,6 +405,16 @@ static void prvCheckTask( void * pvParameters )
 }
 /*-----------------------------------------------------------*/
 
+static void prvEndSchedulerTask( void * pvParameters )
+{
+    ( void ) pvParameters;
+
+    /* Calling vTaskEndScheduler in an application created task. */
+    vTaskEndScheduler();
+}
+
+/*-----------------------------------------------------------*/
+
 static void prvTestTask( void * pvParameters )
 {
     const unsigned long ulMSToSleep = 5;
@@ -428,6 +438,7 @@ void vFullDemoIdleFunction( void )
 {
     const unsigned long ulMSToSleep = 15;
     void * pvAllocated;
+    BaseType_t xReturn;
 
     /* Sleep to reduce CPU load, but don't sleep indefinitely in case there are
      * tasks waiting to be terminated by the idle task. */
@@ -484,7 +495,10 @@ void vFullDemoIdleFunction( void )
 
         if( ( xTaskGetTickCount() - configINITIAL_TICK_COUNT ) >= xMaxRunTime )
         {
-            vTaskEndScheduler();
+            /* Creating another task to end the scheduler to prevent deleting idle
+             * task itself in vTaskEndScheduler. */
+            xReturn = xTaskCreate( prvEndSchedulerTask, "TestEnd", configMINIMAL_STACK_SIZE, NULL, configMAX_PRIORITIES - 1, NULL );
+            configASSERT( xReturn == pdPASS );
         }
     }
     #endif /* if ( projCOVERAGE_TEST == 1 ) */


### PR DESCRIPTION
<!--- Title -->

Description
-----------
`vTaskEndScheduler` is called to end scheduler after a period of timer for code coverage test. FreeRTOS created tasks will be deleted in `vTaskEndScheduler`. Therefore, calling `vTaskEndScheduler` in idle task will end up deleting the idle task itself.

In this PR:
* Create another task to call the vTaskEndScheduler in WIN32-Mingw code coverage test.

Test Steps
-----------
```
make COVERAGE_TEST=1 -j8
./build/RTOSDemo.exe
```
The test should end after a period of time ( default setting 30 seconds ).

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] ~~I have modified and/or added unit-tests to cover the code changes in this Pull Request.~~

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
