### PR TITLE
Fix demo build issue , when configUSE_TRACE_FACILITY is disabled

### DIFF
--- a/FreeRTOS/Demo/Posix_GCC/CMakeLists.txt
+++ b/FreeRTOS/Demo/Posix_GCC/CMakeLists.txt
@@ -10,7 +10,7 @@ else()
     add_compile_options( -DTRACE_ON_ENTER=0 )
 endif()
 
-if( COVERAGE_TEST )
+if( ( COVERAGE_TEST ) OR ( NO_TRACING ) )
     set( COVERAGE_TEST 1 )
     add_compile_options( -DprojCOVERAGE_TEST=1 )
 else()

--- a/FreeRTOS/Demo/Posix_GCC/code_coverage_additions.c
+++ b/FreeRTOS/Demo/Posix_GCC/code_coverage_additions.c
@@ -142,7 +142,9 @@ static BaseType_t prvStaticAllocationsWithNullBuffers( void )
     return xReturn;
 }
 /*-----------------------------------------------------------*/
+
 #if( configUSE_TRACE_FACILITY == 1 )
+
     static BaseType_t prvTraceUtils( void )
     {
         EventGroupHandle_t xEventGroup;
@@ -202,8 +204,8 @@ static BaseType_t prvStaticAllocationsWithNullBuffers( void )
             xReturn = pdFAIL;
         }
 
-        /* Exercise the task trace utilities.  Value of 100 is arbitrary, just want
-        * to check the value that is set is also read back. */
+        /* Exercise the task trace utilities.  Value of 100 is arbitrary, just
+         * want to check the value that is set is also read back. */
         uxValue = 100;
         xTaskHandle = xTaskGetCurrentTaskHandle();
         vTaskSetTaskNumber( xTaskHandle, uxValue );
@@ -221,8 +223,8 @@ static BaseType_t prvStaticAllocationsWithNullBuffers( void )
         /* Timer trace util functions are exercised in prvTimerQuery(). */
 
 
-        /* Exercise the stream buffer utilities.  Try creating with a trigger level
-        * of 0, it should then get capped to 1. */
+        /* Exercise the stream buffer utilities.  Try creating with a trigger
+         * level of 0, it should then get capped to 1. */
         xStreamBuffer = xStreamBufferCreate( sizeof( uint32_t ), 0 );
 
         if( xStreamBuffer != NULL )
@@ -266,7 +268,8 @@ static BaseType_t prvStaticAllocationsWithNullBuffers( void )
 
         return xReturn;
     }
-#endif
+
+#endif /* #if( configUSE_TRACE_FACILITY == 1 ) */
 /*-----------------------------------------------------------*/
 
 static BaseType_t prvPeekTimeout( void )
@@ -302,7 +305,6 @@ static BaseType_t prvPeekTimeout( void )
 
     return xReturn;
 }
-
 /*-----------------------------------------------------------*/
 
 static BaseType_t prvQueueQueryFromISR( void )
@@ -371,7 +373,9 @@ static BaseType_t prvQueueQueryFromISR( void )
     return xReturn;
 }
 /*-----------------------------------------------------------*/
+
 #if( configUSE_TRACE_FACILITY == 1)
+
     static BaseType_t prvTaskQueryFunctions( void )
     {
         static TaskStatus_t xStatus, * pxStatusArray;
@@ -382,7 +386,7 @@ static BaseType_t prvQueueQueryFromISR( void )
         const uint32_t ulRunTimeTollerance = ( uint32_t ) 0xfff;
 
         /* Obtain task status with the stack high water mark and without the
-        * state. */
+         * state. */
         vTaskGetInfo( NULL, &xStatus, pdTRUE, eRunning );
 
         if( uxTaskGetStackHighWaterMark( NULL ) != xStatus.usStackHighWaterMark )
@@ -396,7 +400,7 @@ static BaseType_t prvQueueQueryFromISR( void )
         }
 
         /* Now obtain a task status without the high water mark but with the state,
-        * which in the case of the idle task should be Read. */
+         * which in the case of the idle task should be Read. */
         xTimerTask = xTimerGetTimerDaemonTaskHandle();
         vTaskSuspend( xTimerTask ); /* Should never suspend Timer task normally!. */
         vTaskGetInfo( xTimerTask, &xStatus, pdFALSE, eInvalid );
@@ -435,7 +439,7 @@ static BaseType_t prvQueueQueryFromISR( void )
         }
 
         /* Attempting to abort a delay in the idle task should be guaranteed to
-        * fail as the idle task should never block. */
+         * fail as the idle task should never block. */
         xIdleTask = xTaskGetIdleTaskHandle();
 
         if( xTaskAbortDelay( xIdleTask ) != pdFAIL )
@@ -444,15 +448,15 @@ static BaseType_t prvQueueQueryFromISR( void )
         }
 
         /* Create an array of task status objects large enough to hold information
-        * on the number of tasks at this time - note this may change at any time if
-        * higher priority tasks are executing and creating tasks. */
+         * on the number of tasks at this time - note this may change at any time if
+         * higher priority tasks are executing and creating tasks. */
         uxNumberOfTasks = uxTaskGetNumberOfTasks();
         pxStatusArray = ( TaskStatus_t * ) pvPortMalloc( uxNumberOfTasks * sizeof( TaskStatus_t ) );
 
         if( pxStatusArray != NULL )
         {
             /* Pass part of the array into uxTaskGetSystemState() to ensure it doesn't
-            * try using more space than there is available. */
+             * try using more space than there is available. */
             uxReturned = uxTaskGetSystemState( pxStatusArray, uxNumberOfTasks / ( UBaseType_t ) 2, NULL );
 
             if( uxReturned != ( UBaseType_t ) 0 )
@@ -461,7 +465,7 @@ static BaseType_t prvQueueQueryFromISR( void )
             }
 
             /* Now do the same but passing in the complete array size, this is done
-            * twice to check for a difference in the total run time. */
+             * twice to check for a difference in the total run time. */
             uxTaskGetSystemState( pxStatusArray, uxNumberOfTasks, &ulTotalRunTime1 );
             memset( ( void * ) pxStatusArray, 0xaa, uxNumberOfTasks * sizeof( TaskStatus_t ) );
             uxReturned = uxTaskGetSystemState( pxStatusArray, uxNumberOfTasks, &ulTotalRunTime2 );
@@ -471,7 +475,7 @@ static BaseType_t prvQueueQueryFromISR( void )
                 xReturn = pdFAIL;
             }
 
-            /* Basic santity check of array contents. */
+            /* Basic sanity check of array contents. */
             for( ux = 0; ux < uxReturned; ux++ )
             {
                 if( pxStatusArray[ ux ].eCurrentState >= ( UBaseType_t ) eInvalid )
@@ -494,7 +498,8 @@ static BaseType_t prvQueueQueryFromISR( void )
 
         return xReturn;
     }
-#endif
+
+#endif /* #if( configUSE_TRACE_FACILITY == 1) */
 /*-----------------------------------------------------------*/
 
 static BaseType_t prvDummyTagFunction( void * pvParameter )
@@ -611,16 +616,18 @@ static BaseType_t prvTimerQuery( void )
         {
             xReturn = pdFAIL;
         }
-    #if( configUSE_TRACE_FACILITY == 1)
-    {
+
+        #if( configUSE_TRACE_FACILITY == 1 )
+        {
             vTimerSetTimerNumber( xTimer, uxTimerNumber );
 
             if( uxTimerGetTimerNumber( xTimer ) != uxTimerNumber )
             {
                 xReturn = pdFAIL;
             }
-    }
-    #endif
+        }
+        #endif /* #if( configUSE_TRACE_FACILITY == 1 ) */
+
         xTimerDelete( xTimer, portMAX_DELAY );
     }
     else
@@ -637,12 +644,14 @@ BaseType_t xRunCodeCoverageTestAdditions( void )
     BaseType_t xReturn = pdPASS;
 
     xReturn &= prvStaticAllocationsWithNullBuffers();
+
     #if( configUSE_TRACE_FACILITY == 1 )
     {
         xReturn &= prvTraceUtils();
         xReturn &= prvTaskQueryFunctions();
     }
     #endif
+
     xReturn &= prvPeekTimeout();
     xReturn &= prvQueueQueryFromISR();
     xReturn &= prvTaskTags();

--- a/FreeRTOS/Demo/Posix_GCC/main_full.c
+++ b/FreeRTOS/Demo/Posix_GCC/main_full.c
@@ -736,25 +736,27 @@ static void prvDemonstrateTaskStateAndHandleGetFunctions( void )
         pcStatusMessage = "Error:  Returned timer task state was incorrect";
         xErrorCount++;
     }
-#if( configUSE_TRACE_FACILITY == 1 )
-{
-    /* Also with the vTaskGetInfo() function. */
-    vTaskGetInfo( xTimerTaskHandle, /* The task being queried. */
-                  &xTaskInfo,       /* The structure into which information on the task will be written. */
-                  pdTRUE,           /* Include the task's high watermark in the structure. */
-                  eInvalid );       /* Include the task state in the structure. */
-}
-#endif
-    /* Check the information returned by vTaskGetInfo() is as expected. */
-    if( ( xTaskInfo.eCurrentState != eBlocked ) ||
-        ( strcmp( xTaskInfo.pcTaskName, "Tmr Svc" ) != 0 ) ||
-        ( xTaskInfo.uxCurrentPriority != configTIMER_TASK_PRIORITY ) ||
-        ( xTaskInfo.pxStackBase != uxTimerTaskStack ) ||
-        ( xTaskInfo.xHandle != xTimerTaskHandle ) )
+
+    #if( configUSE_TRACE_FACILITY == 1 )
     {
-        pcStatusMessage = "Error:  vTaskGetInfo() returned incorrect information about the timer task";
-        xErrorCount++;
+        /* Also with the vTaskGetInfo() function. */
+        vTaskGetInfo( xTimerTaskHandle, /* The task being queried. */
+                      &xTaskInfo,       /* The structure into which information on the task will be written. */
+                      pdTRUE,           /* Include the task's high watermark in the structure. */
+                      eInvalid );       /* Include the task state in the structure. */
+
+        /* Check the information returned by vTaskGetInfo() is as expected. */
+        if( ( xTaskInfo.eCurrentState != eBlocked ) ||
+            ( strcmp( xTaskInfo.pcTaskName, "Tmr Svc" ) != 0 ) ||
+            ( xTaskInfo.uxCurrentPriority != configTIMER_TASK_PRIORITY ) ||
+            ( xTaskInfo.pxStackBase != uxTimerTaskStack ) ||
+            ( xTaskInfo.xHandle != xTimerTaskHandle ) )
+        {
+            pcStatusMessage = "Error:  vTaskGetInfo() returned incorrect information about the timer task";
+            xErrorCount++;
+        }
     }
+    #endif /* #if( configUSE_TRACE_FACILITY == 1 ) */
 
     /* Other tests that should only be performed once follow.  The test task
      * is not created on each iteration because to do so would cause the death

--- a/FreeRTOS/Demo/Posix_GCC/main_full.c
+++ b/FreeRTOS/Demo/Posix_GCC/main_full.c
@@ -736,13 +736,15 @@ static void prvDemonstrateTaskStateAndHandleGetFunctions( void )
         pcStatusMessage = "Error:  Returned timer task state was incorrect";
         xErrorCount++;
     }
-
+#if( configUSE_TRACE_FACILITY == 1 )
+{
     /* Also with the vTaskGetInfo() function. */
     vTaskGetInfo( xTimerTaskHandle, /* The task being queried. */
                   &xTaskInfo,       /* The structure into which information on the task will be written. */
                   pdTRUE,           /* Include the task's high watermark in the structure. */
                   eInvalid );       /* Include the task state in the structure. */
-
+}
+#endif
     /* Check the information returned by vTaskGetInfo() is as expected. */
     if( ( xTaskInfo.eCurrentState != eBlocked ) ||
         ( strcmp( xTaskInfo.pcTaskName, "Tmr Svc" ) != 0 ) ||


### PR DESCRIPTION
Description
-----------
This PR fixes the build issue when trying to compile FreeRTOS Posix Blinky GCC [Demo](https://github.com/FreeRTOS/FreeRTOS/tree/main/FreeRTOS/Demo/Posix_GCC) without the configUSE_TRACE_FACILITY enabled. This PR adds a new compile option in CMake file `-DNO_TRACING` to allow users the option to disable tracing from cmake directly. By default, `-DNO_TRACING` is set to 0, and the tracing is enabled. 

Test Steps
-----------
```
cd FreeRTOS/Demo/Posix_GCC
mkdir build
cd build
cmake .. -DNO_TRACING=1
make
```

Before applying the patch, the following error is found
```
/home/ubuntu/Temp/FreeRTOS/FreeRTOS/Demo/Posix_GCC/main.c: In function ‘prvSaveTraceFile’:
/home/ubuntu/Temp/FreeRTOS/FreeRTOS/Demo/Posix_GCC/main.c:370:21: error: ‘RecorderDataPtr’ undeclared (first use in this function); did you mean ‘TraceRecorderData_t’?
  370 |             fwrite( RecorderDataPtr, sizeof( RecorderDataType ), 1, pxOutputFile );
      |                     ^~~~~~~~~~~~~~~
      |                     TraceRecorderData_t
/home/ubuntu/Temp/FreeRTOS/FreeRTOS/Demo/Posix_GCC/main.c:370:21: note: each undeclared identifier is reported only once for each function it appears in
/home/ubuntu/Temp/FreeRTOS/FreeRTOS/Demo/Posix_GCC/main.c:370:46: error: ‘RecorderDataType’ undeclared (first use in this function)
  370 |             fwrite( RecorderDataPtr, sizeof( RecorderDataType ), 1, pxOutputFile );
      |                                              ^~~~~~~~~~~~~~~~
```
After applying the patch, the blinky demo compiles and runs successfully.
```
Starting echo blinky demo
Message received from task
Message received from task
Message received from task
Message received from task
Message received from task
Message received from task
Message received from task
Message received from task
Message received from task
Message received from software timer
```
![image (10)](https://github.com/FreeRTOS/FreeRTOS/assets/118818625/74220cbf-c9bb-4df6-ab0e-bf0b37d51ba6)

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
[Forum issue](https://forums.freertos.org/t/possible-to-build-posix-blinky-without-configuse-trace-facility/19432)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
