### PR TITLE
Add separate compile option for tracing functionality in Posix demo

### DIFF
--- a/FreeRTOS/Demo/Posix_GCC/CMakeLists.txt
+++ b/FreeRTOS/Demo/Posix_GCC/CMakeLists.txt
@@ -10,10 +10,19 @@ else()
     add_compile_options( -DTRACE_ON_ENTER=0 )
 endif()
 
-if( ( COVERAGE_TEST ) OR ( NO_TRACING ) )
+if( COVERAGE_TEST )
     set( COVERAGE_TEST 1 )
+    set( NO_TRACING 1 )
     add_compile_options( -DprojCOVERAGE_TEST=1 )
+    add_compile_options( -DprojENABLE_TRACING=0 )
 else()
+    if( NO_TRACING )
+        set( NO_TRACING 1 )
+        add_compile_options( -DprojENABLE_TRACING=0 )
+    else()
+        set( NO_TRACING 0 )
+        add_compile_options( -DprojENABLE_TRACING=1 )
+    endif()
     set( COVERAGE_TEST 0 )
     add_compile_options( -DprojCOVERAGE_TEST=0 )
 endif()
@@ -58,7 +67,7 @@ add_subdirectory( ${FREERTOS_KERNEL_PATH} ${CMAKE_CURRENT_BINARY_DIR}/FreeRTOS-K
 target_compile_options( freertos_kernel
     PRIVATE
         # Trace macro cast pointer to int to store memory management event
-        $<IF:${COVERAGE_TEST},,-Wno-pointer-to-int-cast>
+        $<IF:${NO_TRACING},,-Wno-pointer-to-int-cast>
 )
 
 file( GLOB FREERTOS_PLUS_TRACE_SOURCES ${FREERTOS_PLUS_TRACE_PATH}/*.c ${FREERTOS_PLUS_TRACE_PATH}/kernelports/FreeRTOS/*.c )
@@ -70,7 +79,7 @@ add_executable( posix_demo
                 main_blinky.c
                 main_full.c
                 run-time-stats-utils.c
-                $<$<NOT:${COVERAGE_TEST}>:${FREERTOS_PLUS_TRACE_SOURCES}>
+                $<$<NOT:${NO_TRACING}>:${FREERTOS_PLUS_TRACE_SOURCES}>
                 ${CMAKE_CURRENT_LIST_DIR}/../Common/Minimal/AbortDelay.c
                 ${CMAKE_CURRENT_LIST_DIR}/../Common/Minimal/BlockQ.c
                 ${CMAKE_CURRENT_LIST_DIR}/../Common/Minimal/blocktim.c

--- a/FreeRTOS/Demo/Posix_GCC/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/Posix_GCC/FreeRTOSConfig.h
@@ -160,7 +160,7 @@ extern void vAssertCalled( const char * const pcFileName,
 /* Include the FreeRTOS+Trace FreeRTOS trace macro definitions. */
     #if( projENABLE_TRACING == 1 )
         #include "trcRecorder.h"
-    #endif
+    #endif /* if ( projENABLE_TRACING == 1 ) */
 #endif /* if ( projCOVERAGE_TEST == 1 ) */
 
 /* networking definitions */

--- a/FreeRTOS/Demo/Posix_GCC/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/Posix_GCC/FreeRTOSConfig.h
@@ -128,6 +128,10 @@ extern void vAssertCalled( const char * const pcFileName,
     #error projCOVERAGE_TEST should be defined to 1 or 0 on the command line.
 #endif
 
+#ifndef projENABLE_TRACING
+    #error projENABLE_TRACING should be defined to 1 or 0 on the command line.
+#endif
+
 #if ( projCOVERAGE_TEST == 1 )
 
 /* Insert NOPs in empty decision paths to ensure both true and false paths
@@ -154,7 +158,9 @@ extern void vAssertCalled( const char * const pcFileName,
     #define configUSE_MALLOC_FAILED_HOOK    1
 
 /* Include the FreeRTOS+Trace FreeRTOS trace macro definitions. */
-    #include "trcRecorder.h"
+    #if( projENABLE_TRACING == 1 )
+        #include "trcRecorder.h"
+    #endif
 #endif /* if ( projCOVERAGE_TEST == 1 ) */
 
 /* networking definitions */

--- a/FreeRTOS/Demo/Posix_GCC/Makefile
+++ b/FreeRTOS/Demo/Posix_GCC/Makefile
@@ -75,8 +75,14 @@ endif
 
 ifeq ($(COVERAGE_TEST),1)
   CPPFLAGS              += -DprojCOVERAGE_TEST=1
+  CPPFLAGS              += -DprojENABLE_TRACING=0
   CFLAGS                += -Werror
 else
+  ifeq ($(NO_TRACING),1)
+    CPPFLAGS              += -DprojENABLE_TRACING=0
+  else
+    CPPFLAGS              += -DprojENABLE_TRACING=1
+  endif
   CPPFLAGS              += -DprojCOVERAGE_TEST=0
 # Trace library.
   SOURCE_FILES          += ${FREERTOS_PLUS_DIR}/Source/FreeRTOS-Plus-Trace/kernelports/FreeRTOS/trcKernelPort.c

--- a/FreeRTOS/Demo/Posix_GCC/main.c
+++ b/FreeRTOS/Demo/Posix_GCC/main.c
@@ -142,9 +142,9 @@ StackType_t uxTimerTaskStack[ configTIMER_TASK_STACK_DEPTH ];
 /* Notes if the trace is running or not. */
 #if ( projENABLE_TRACING == 0 )
     static BaseType_t xTraceRunning = pdFALSE;
-#else /* #if ( projENABLE_TRACING == 0 ) */
+#else /* if ( projENABLE_TRACING == 0 ) */
     static BaseType_t xTraceRunning = pdTRUE;
-#endif /* #if ( projENABLE_TRACING == 0 ) */
+#endif /* if ( projENABLE_TRACING == 0 ) */
 
 static clockid_t cid = CLOCK_THREAD_CPUTIME_ID;
 
@@ -167,7 +167,7 @@ int main( void )
 
         #if ( TRACE_ON_ENTER == 1 )
             printf( "\r\nThe trace will be dumped to disk if Enter is hit.\r\n" );
-        #endif /* #if ( TRACE_ON_ENTER == 1 ) */
+        #endif /* if ( TRACE_ON_ENTER == 1 ) */
     }
     #endif /* if ( projENABLE_TRACING == 1 ) */
 

--- a/FreeRTOS/Demo/Posix_GCC/main.c
+++ b/FreeRTOS/Demo/Posix_GCC/main.c
@@ -347,9 +347,8 @@ void vAssertCalled( const char * const pcFileName,
 }
 /*-----------------------------------------------------------*/
 
-static void prvSaveTraceFile( void )
-{
-    #if ( projENABLE_TRACING == 1 )
+#if ( projENABLE_TRACING == 1 )
+    static void prvSaveTraceFile( void )
     {
         FILE * pxOutputFile;
 
@@ -368,8 +367,7 @@ static void prvSaveTraceFile( void )
             printf( "\r\nFailed to create trace dump file\r\n" );
         }
     }
-    #endif /* if ( projENABLE_TRACING == 1 ) */
-}
+#endif /* if ( projENABLE_TRACING == 1 ) */
 /*-----------------------------------------------------------*/
 
 /* configUSE_STATIC_ALLOCATION is set to 1, so the application must provide an

--- a/FreeRTOS/Demo/Posix_GCC/main.c
+++ b/FreeRTOS/Demo/Posix_GCC/main.c
@@ -142,9 +142,9 @@ StackType_t uxTimerTaskStack[ configTIMER_TASK_STACK_DEPTH ];
 /* Notes if the trace is running or not. */
 #if ( projENABLE_TRACING == 0 )
     static BaseType_t xTraceRunning = pdFALSE;
-#else
+#else /* #if ( projENABLE_TRACING == 0 ) */
     static BaseType_t xTraceRunning = pdTRUE;
-#endif
+#endif /* #if ( projENABLE_TRACING == 0 ) */
 
 static clockid_t cid = CLOCK_THREAD_CPUTIME_ID;
 
@@ -167,7 +167,7 @@ int main( void )
 
         #if ( TRACE_ON_ENTER == 1 )
             printf( "\r\nThe trace will be dumped to disk if Enter is hit.\r\n" );
-        #endif
+        #endif /* #if ( TRACE_ON_ENTER == 1 ) */
     }
     #endif /* if ( projENABLE_TRACING == 1 ) */
 

--- a/FreeRTOS/Demo/Posix_GCC/main.c
+++ b/FreeRTOS/Demo/Posix_GCC/main.c
@@ -68,7 +68,7 @@
 /* Local includes. */
 #include "console.h"
 
-#if ( projCOVERAGE_TEST != 1 )
+#if ( projENABLE_TRACING == 1 )
     #include <trcRecorder.h>
 #endif
 
@@ -140,7 +140,7 @@ static void handle_sigint( int signal );
 StackType_t uxTimerTaskStack[ configTIMER_TASK_STACK_DEPTH ];
 
 /* Notes if the trace is running or not. */
-#if ( projCOVERAGE_TEST == 1 )
+#if ( projENABLE_TRACING == 0 )
     static BaseType_t xTraceRunning = pdFALSE;
 #else
     static BaseType_t xTraceRunning = pdTRUE;
@@ -155,8 +155,7 @@ int main( void )
     /* SIGINT is not blocked by the posix port */
     signal( SIGINT, handle_sigint );
 
-    /* Do not include trace code when performing a code coverage analysis. */
-    #if ( projCOVERAGE_TEST != 1 )
+    #if ( projENABLE_TRACING == 1 )
     {
         /* Initialise the trace recorder.  Use of the trace recorder is optional.
          * See http://www.FreeRTOS.org/trace for more information. */
@@ -170,7 +169,7 @@ int main( void )
             printf( "\r\nThe trace will be dumped to disk if Enter is hit.\r\n" );
         #endif
     }
-    #endif /* if ( projCOVERAGE_TEST != 1 ) */
+    #endif /* if ( projENABLE_TRACING == 1 ) */
 
     console_init();
     #if ( mainSELECTED_APPLICATION == BLINKY_DEMO )
@@ -355,8 +354,7 @@ void vAssertCalled( const char * const pcFileName,
 
 static void prvSaveTraceFile( void )
 {
-    /* Tracing is not used when code coverage analysis is being performed. */
-    #if ( projCOVERAGE_TEST != 1 )
+    #if ( projENABLE_TRACING == 1 )
     {
         FILE * pxOutputFile;
 
@@ -375,7 +373,7 @@ static void prvSaveTraceFile( void )
             printf( "\r\nFailed to create trace dump file\r\n" );
         }
     }
-    #endif /* if ( projCOVERAGE_TEST != 1 ) */
+    #endif /* if ( projENABLE_TRACING == 1 ) */
 }
 /*-----------------------------------------------------------*/
 

--- a/FreeRTOS/Demo/Posix_GCC/main.c
+++ b/FreeRTOS/Demo/Posix_GCC/main.c
@@ -139,13 +139,6 @@ static void handle_sigint( int signal );
  * in a different file. */
 StackType_t uxTimerTaskStack[ configTIMER_TASK_STACK_DEPTH ];
 
-/* Notes if the trace is running or not. */
-#if ( projENABLE_TRACING == 0 )
-    static BaseType_t xTraceRunning = pdFALSE;
-#else /* if ( projENABLE_TRACING == 0 ) */
-    static BaseType_t xTraceRunning = pdTRUE;
-#endif /* if ( projENABLE_TRACING == 0 ) */
-
 static clockid_t cid = CLOCK_THREAD_CPUTIME_ID;
 
 /*-----------------------------------------------------------*/
@@ -280,10 +273,11 @@ void traceOnEnter()
 
         if( xReturn > 0 )
         {
-            if( xTraceRunning == pdTRUE )
+            #if ( projENABLE_TRACING == 1 )
             {
                 prvSaveTraceFile();
             }
+            #endif /* if ( projENABLE_TRACING == 1 ) */
 
             /* clear the buffer */
             char buffer[ 1 ];
@@ -333,10 +327,11 @@ void vAssertCalled( const char * const pcFileName,
         {
             xPrinted = pdTRUE;
 
-            if( xTraceRunning == pdTRUE )
+            #if ( projENABLE_TRACING == 1 )
             {
                 prvSaveTraceFile();
             }
+            #endif /* if ( projENABLE_TRACING == 0 ) */
         }
 
         /* You can step out of this function to debug the assertion by using


### PR DESCRIPTION
Description
-----------
The PR #1189 added a new compile option in CMake file `-DNO_TRACING` to allow users to disable tracing. The earlier implementation always enabled coverage when tracing is turned off by specifying `-DNO_TRACING`.  This PR decouples the tracing and coverage so that those can be enabled/disabled separately. The following combinations are now possible:

1. Coverage = ON, Tracing = OFF [Tracing cannot be turned on with coverage.]
1. Coverage = OFF, Tracing = ON
1. Coverage = OFF, Tracing = OFF

Test Steps
-----------
```
cd FreeRTOS/Demo/Posix_GCC
mkdir build
cd build
cmake .. -DNO_TRACING=0 [ enable tracing ] 
cmake .. -DNO_TRACING=1 [ disable tracing ] 
cmake .. -DCOVERAGE_TEST=0 [ enable coverage ]
cmake .. -DCOVERAGE_TEST=1 [ disable coverage ]
make
```

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
#1189 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
