### PR TITLE
Fix HTTP_S3_Download compile warning

### DIFF
--- a/FreeRTOS-Plus/Demo/coreHTTP_Windows_Simulator/HTTP_S3_Download/DemoTasks/S3DownloadHTTPExample.c
+++ b/FreeRTOS-Plus/Demo/coreHTTP_Windows_Simulator/HTTP_S3_Download/DemoTasks/S3DownloadHTTPExample.c
@@ -476,7 +476,7 @@ static JSONStatus_t prvParseCredentials( HTTPResponse_t * pxResponse,
  * @return pdPASS on success, pdFAIL on failure.
  */
 static BaseType_t prvGetTemporaryCredentials( TransportInterface_t * pxTransportInterface,
-                                              const char * pcDateISO8601,
+                                              char * pcDateISO8601,
                                               size_t xDateISO8601Len,
                                               HTTPResponse_t * pxResponse,
                                               SigV4Credentials_t * pxSigvCreds );
@@ -579,6 +579,10 @@ void vStartSimpleHTTPDemo( void )
                  tskIDLE_PRIORITY,         /* Task priority, must be between 0 and configMAX_PRIORITIES - 1. */
                  NULL );                   /* Used to pass out a handle to the created task - not used in this case. */
 }
+
+/*-----------------------------------------------------------*/
+
+extern BaseType_t xPlatformIsNetworkUp( void );
 
 /*-----------------------------------------------------------*/
 
@@ -1177,7 +1181,7 @@ static BaseType_t prvDownloadS3ObjectFile( const TransportInterface_t * pxTransp
 }
 
 static BaseType_t prvGetTemporaryCredentials( TransportInterface_t * pxTransportInterface,
-                                              const char * pcDateISO8601,
+                                              char * pcDateISO8601,
                                               size_t xDateISO8601Len,
                                               HTTPResponse_t * pxResponse,
                                               SigV4Credentials_t * pxSigvCreds )


### PR DESCRIPTION
<!--- Title -->

Description
-----------
Fix HTTP_S3_Download compile warning
* Fix `xPlatformIsNetworkUp()` is undeclared warning
* Fix cast const type warning

Test Steps
-----------
Compile with VS 2019 should has no warning.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] ~~I have modified and/or added unit-tests to cover the code changes in this Pull Request.~~

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
