### PR TITLE
Add support to build Posix Demo with Dynamic Allocation

### DIFF
--- a/FreeRTOS/Demo/Posix_GCC/CMakeLists.txt
+++ b/FreeRTOS/Demo/Posix_GCC/CMakeLists.txt
@@ -10,10 +10,19 @@ else()
     add_compile_options( -DTRACE_ON_ENTER=0 )
 endif()
 
-if( ( COVERAGE_TEST ) OR ( NO_TRACING ) )
+if( COVERAGE_TEST )
     set( COVERAGE_TEST 1 )
+    set( NO_TRACING 1 )
     add_compile_options( -DprojCOVERAGE_TEST=1 )
+    add_compile_options( -DprojENABLE_TRACING=0 )
 else()
+    if( NO_TRACING )
+        set( NO_TRACING 1 )
+        add_compile_options( -DprojENABLE_TRACING=0 )
+    else()
+        set( NO_TRACING 0 )
+        add_compile_options( -DprojENABLE_TRACING=1 )
+    endif()
     set( COVERAGE_TEST 0 )
     add_compile_options( -DprojCOVERAGE_TEST=0 )
 endif()
@@ -58,7 +67,7 @@ add_subdirectory( ${FREERTOS_KERNEL_PATH} ${CMAKE_CURRENT_BINARY_DIR}/FreeRTOS-K
 target_compile_options( freertos_kernel
     PRIVATE
         # Trace macro cast pointer to int to store memory management event
-        $<IF:${COVERAGE_TEST},,-Wno-pointer-to-int-cast>
+        $<IF:${NO_TRACING},,-Wno-pointer-to-int-cast>
 )
 
 file( GLOB FREERTOS_PLUS_TRACE_SOURCES ${FREERTOS_PLUS_TRACE_PATH}/*.c ${FREERTOS_PLUS_TRACE_PATH}/kernelports/FreeRTOS/*.c )
@@ -70,7 +79,7 @@ add_executable( posix_demo
                 main_blinky.c
                 main_full.c
                 run-time-stats-utils.c
-                $<$<NOT:${COVERAGE_TEST}>:${FREERTOS_PLUS_TRACE_SOURCES}>
+                $<$<NOT:${NO_TRACING}>:${FREERTOS_PLUS_TRACE_SOURCES}>
                 ${CMAKE_CURRENT_LIST_DIR}/../Common/Minimal/AbortDelay.c
                 ${CMAKE_CURRENT_LIST_DIR}/../Common/Minimal/BlockQ.c
                 ${CMAKE_CURRENT_LIST_DIR}/../Common/Minimal/blocktim.c

--- a/FreeRTOS/Demo/Posix_GCC/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/Posix_GCC/FreeRTOSConfig.h
@@ -160,7 +160,7 @@ extern void vAssertCalled( const char * const pcFileName,
 /* Include the FreeRTOS+Trace FreeRTOS trace macro definitions. */
     #if( projENABLE_TRACING == 1 )
         #include "trcRecorder.h"
-    #endif
+    #endif /* if ( projENABLE_TRACING == 1 ) */
 #endif /* if ( projCOVERAGE_TEST == 1 ) */
 
 /* networking definitions */

--- a/FreeRTOS/Demo/Posix_GCC/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/Posix_GCC/FreeRTOSConfig.h
@@ -58,7 +58,16 @@
 #define configUSE_ALTERNATIVE_API                  0
 #define configUSE_QUEUE_SETS                       1
 #define configUSE_TASK_NOTIFICATIONS               1
+/* For static memory allocation , set configSUPPORT_STATIC_ALLOCATION to 1
+ * Since heap_3.c is used in this demo, configSUPPORT_DYNAMIC_ALLOCATION value 
+ * cannot be set to 0. The user can either leave it as it is defined, or remove 
+ * the definition from the file.
+ */
 #define configSUPPORT_STATIC_ALLOCATION            1
+/* For dynamic memory allocation , set configSUPPORT_STATIC_ALLOCATION to 0 and
+ * configSUPPORT_DYNAMIC_ALLOCATION to 1.  
+ */
+#define configSUPPORT_DYNAMIC_ALLOCATION           1
 #define configRECORD_STACK_HIGH_ADDRESS            1
 
 /* Software timer related configuration options.  The maximum possible task

--- a/FreeRTOS/Demo/Posix_GCC/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/Posix_GCC/FreeRTOSConfig.h
@@ -128,6 +128,10 @@ extern void vAssertCalled( const char * const pcFileName,
     #error projCOVERAGE_TEST should be defined to 1 or 0 on the command line.
 #endif
 
+#ifndef projENABLE_TRACING
+    #error projENABLE_TRACING should be defined to 1 or 0 on the command line.
+#endif
+
 #if ( projCOVERAGE_TEST == 1 )
 
 /* Insert NOPs in empty decision paths to ensure both true and false paths
@@ -154,7 +158,9 @@ extern void vAssertCalled( const char * const pcFileName,
     #define configUSE_MALLOC_FAILED_HOOK    1
 
 /* Include the FreeRTOS+Trace FreeRTOS trace macro definitions. */
-    #include "trcRecorder.h"
+    #if( projENABLE_TRACING == 1 )
+        #include "trcRecorder.h"
+    #endif
 #endif /* if ( projCOVERAGE_TEST == 1 ) */
 
 /* networking definitions */

--- a/FreeRTOS/Demo/Posix_GCC/Makefile
+++ b/FreeRTOS/Demo/Posix_GCC/Makefile
@@ -75,8 +75,14 @@ endif
 
 ifeq ($(COVERAGE_TEST),1)
   CPPFLAGS              += -DprojCOVERAGE_TEST=1
+  CPPFLAGS              += -DprojENABLE_TRACING=0
   CFLAGS                += -Werror
 else
+  ifeq ($(NO_TRACING),1)
+    CPPFLAGS              += -DprojENABLE_TRACING=0
+  else
+    CPPFLAGS              += -DprojENABLE_TRACING=1
+  endif
   CPPFLAGS              += -DprojCOVERAGE_TEST=0
 # Trace library.
   SOURCE_FILES          += ${FREERTOS_PLUS_DIR}/Source/FreeRTOS-Plus-Trace/kernelports/FreeRTOS/trcKernelPort.c

--- a/FreeRTOS/Demo/Posix_GCC/Makefile
+++ b/FreeRTOS/Demo/Posix_GCC/Makefile
@@ -82,11 +82,11 @@ else
     CPPFLAGS              += -DprojENABLE_TRACING=0
   else
     CPPFLAGS              += -DprojENABLE_TRACING=1
+# Trace Library.
+    SOURCE_FILES          += ${FREERTOS_PLUS_DIR}/Source/FreeRTOS-Plus-Trace/kernelports/FreeRTOS/trcKernelPort.c
+    SOURCE_FILES          += $(wildcard ${FREERTOS_PLUS_DIR}/Source/FreeRTOS-Plus-Trace/*.c )
   endif
   CPPFLAGS              += -DprojCOVERAGE_TEST=0
-# Trace library.
-  SOURCE_FILES          += ${FREERTOS_PLUS_DIR}/Source/FreeRTOS-Plus-Trace/kernelports/FreeRTOS/trcKernelPort.c
-  SOURCE_FILES          += $(wildcard ${FREERTOS_PLUS_DIR}/Source/FreeRTOS-Plus-Trace/*.c )
 endif
 
 ifdef PROFILE

--- a/FreeRTOS/Demo/Posix_GCC/code_coverage_additions.c
+++ b/FreeRTOS/Demo/Posix_GCC/code_coverage_additions.c
@@ -86,61 +86,63 @@ static BaseType_t prvTimerQuery( void );
 
 /*-----------------------------------------------------------*/
 
-static BaseType_t prvStaticAllocationsWithNullBuffers( void )
-{
-    uintptr_t ulReturned = 0;
-    BaseType_t xReturn = pdPASS;
-    UBaseType_t uxDummy = 10;
+#if( configSUPPORT_STATIC_ALLOCATION == 1 )
+    static BaseType_t prvStaticAllocationsWithNullBuffers( void )
+    {
+        uintptr_t ulReturned = 0;
+        BaseType_t xReturn = pdPASS;
+        UBaseType_t uxDummy = 10;
 
-    /* Don't expect to create any of the objects as a NULL parameter is always
-     * passed in place of a required buffer.  Hence if all passes then none of the
-     |= will be against 0, and ulReturned will still be zero at the end of this
-     * function. */
-    ulReturned |= ( uintptr_t ) xEventGroupCreateStatic( NULL );
+        /* Don't expect to create any of the objects as a NULL parameter is always
+        * passed in place of a required buffer.  Hence if all passes then none of the
+        |= will be against 0, and ulReturned will still be zero at the end of this
+        * function. */
+        ulReturned |= ( uintptr_t ) xEventGroupCreateStatic( NULL );
 
-    /* Try creating a task twice, once with puxStackBuffer NULL, and once with
-     * pxTaskBuffer NULL. */
-    ulReturned |= ( uintptr_t ) xTaskCreateStatic( NULL,    /* Task to run, not needed as the task is not created. */
-                                                   "Dummy", /* Task name. */
-                                                   configMINIMAL_STACK_SIZE,
-                                                   NULL,
-                                                   tskIDLE_PRIORITY,
-                                                   NULL,
-                                                   ( StaticTask_t * ) &xReturn ); /* Dummy value just to pass a non NULL value in - won't get used. */
+        /* Try creating a task twice, once with puxStackBuffer NULL, and once with
+        * pxTaskBuffer NULL. */
+        ulReturned |= ( uintptr_t ) xTaskCreateStatic( NULL,    /* Task to run, not needed as the task is not created. */
+                                                    "Dummy", /* Task name. */
+                                                    configMINIMAL_STACK_SIZE,
+                                                    NULL,
+                                                    tskIDLE_PRIORITY,
+                                                    NULL,
+                                                    ( StaticTask_t * ) &xReturn ); /* Dummy value just to pass a non NULL value in - won't get used. */
 
-    ulReturned |= ( uintptr_t ) xTaskCreateStatic( NULL,                          /* Task to run, not needed as the task is not created. */
-                                                   "Dummy",                       /* Task name. */
-                                                   configMINIMAL_STACK_SIZE,
-                                                   NULL,
-                                                   tskIDLE_PRIORITY,
-                                                   ( StackType_t * ) &xReturn, /* Dummy value just to pass a non NULL value in - won't get used. */
-                                                   NULL );
-
-    ulReturned |= ( uintptr_t ) xQueueCreateStatic( uxDummy,
-                                                    uxDummy,
-                                                    ( uint8_t * ) &xReturn, /* Dummy value just to pass a non NULL value in - won't get used. */
+        ulReturned |= ( uintptr_t ) xTaskCreateStatic( NULL,                          /* Task to run, not needed as the task is not created. */
+                                                    "Dummy",                       /* Task name. */
+                                                    configMINIMAL_STACK_SIZE,
+                                                    NULL,
+                                                    tskIDLE_PRIORITY,
+                                                    ( StackType_t * ) &xReturn, /* Dummy value just to pass a non NULL value in - won't get used. */
                                                     NULL );
 
-    /* Try creating a stream buffer twice, once with pucStreamBufferStorageArea
-     * set to NULL, and once with pxStaticStreamBuffer set to NULL. */
-    ulReturned |= ( uintptr_t ) xStreamBufferCreateStatic( uxDummy,
-                                                           uxDummy,
-                                                           NULL,
-                                                           ( StaticStreamBuffer_t * ) &xReturn ); /* Dummy value just to pass a non NULL value in - won't get used. */
+        ulReturned |= ( uintptr_t ) xQueueCreateStatic( uxDummy,
+                                                        uxDummy,
+                                                        ( uint8_t * ) &xReturn, /* Dummy value just to pass a non NULL value in - won't get used. */
+                                                        NULL );
 
-    ulReturned |= ( uintptr_t ) xStreamBufferCreateStatic( uxDummy,
-                                                           uxDummy,
-                                                           ( uint8_t * ) &xReturn, /* Dummy value just to pass a non NULL value in - won't get used. */
-                                                           NULL );
+        /* Try creating a stream buffer twice, once with pucStreamBufferStorageArea
+        * set to NULL, and once with pxStaticStreamBuffer set to NULL. */
+        ulReturned |= ( uintptr_t ) xStreamBufferCreateStatic( uxDummy,
+                                                            uxDummy,
+                                                            NULL,
+                                                            ( StaticStreamBuffer_t * ) &xReturn ); /* Dummy value just to pass a non NULL value in - won't get used. */
 
-    if( ulReturned != 0 )
-    {
-        /* Something returned a non-NULL value. */
-        xReturn = pdFAIL;
+        ulReturned |= ( uintptr_t ) xStreamBufferCreateStatic( uxDummy,
+                                                            uxDummy,
+                                                            ( uint8_t * ) &xReturn, /* Dummy value just to pass a non NULL value in - won't get used. */
+                                                            NULL );
+
+        if( ulReturned != 0 )
+        {
+            /* Something returned a non-NULL value. */
+            xReturn = pdFAIL;
+        }
+
+        return xReturn;
     }
-
-    return xReturn;
-}
+#endif /* if( configSUPPORT_STATIC_ALLOCATION == 1 )*/
 /*-----------------------------------------------------------*/
 
 #if( configUSE_TRACE_FACILITY == 1 )
@@ -643,14 +645,18 @@ BaseType_t xRunCodeCoverageTestAdditions( void )
 {
     BaseType_t xReturn = pdPASS;
 
-    xReturn &= prvStaticAllocationsWithNullBuffers();
+    #if( configSUPPORT_STATIC_ALLOCATION == 1 )
+    {
+        xReturn &= prvStaticAllocationsWithNullBuffers();
+    }
+    #endif /* if( configSUPPORT_STATIC_ALLOCATION == 1 ) */
 
     #if( configUSE_TRACE_FACILITY == 1 )
     {
         xReturn &= prvTraceUtils();
         xReturn &= prvTaskQueryFunctions();
     }
-    #endif
+    #endif /* if( configUSE_TRACE_FACILITY == 1 ) */
 
     xReturn &= prvPeekTimeout();
     xReturn &= prvQueueQueryFromISR();

--- a/FreeRTOS/Demo/Posix_GCC/console.c
+++ b/FreeRTOS/Demo/Posix_GCC/console.c
@@ -39,7 +39,15 @@ StaticSemaphore_t xStdioMutexBuffer;
 
 void console_init( void )
 {
-    xStdioMutex = xSemaphoreCreateMutexStatic( &xStdioMutexBuffer );
+    #if( configSUPPORT_STATIC_ALLOCATION == 1 )
+    {
+        xStdioMutex = xSemaphoreCreateMutexStatic( &xStdioMutexBuffer );
+    }
+    #else /* if( configSUPPORT_STATIC_ALLOCATION == 1 ) */
+    {
+        xStdioMutex = xSemaphoreCreateMutex( );
+    }
+    #endif /* if( configSUPPORT_STATIC_ALLOCATION == 1 ) */
 }
 
 void console_print( const char * fmt,

--- a/FreeRTOS/Demo/Posix_GCC/main.c
+++ b/FreeRTOS/Demo/Posix_GCC/main.c
@@ -142,9 +142,9 @@ StackType_t uxTimerTaskStack[ configTIMER_TASK_STACK_DEPTH ];
 /* Notes if the trace is running or not. */
 #if ( projENABLE_TRACING == 0 )
     static BaseType_t xTraceRunning = pdFALSE;
-#else /* #if ( projENABLE_TRACING == 0 ) */
+#else /* if ( projENABLE_TRACING == 0 ) */
     static BaseType_t xTraceRunning = pdTRUE;
-#endif /* #if ( projENABLE_TRACING == 0 ) */
+#endif /* if ( projENABLE_TRACING == 0 ) */
 
 static clockid_t cid = CLOCK_THREAD_CPUTIME_ID;
 
@@ -167,7 +167,7 @@ int main( void )
 
         #if ( TRACE_ON_ENTER == 1 )
             printf( "\r\nThe trace will be dumped to disk if Enter is hit.\r\n" );
-        #endif /* #if ( TRACE_ON_ENTER == 1 ) */
+        #endif /* if ( TRACE_ON_ENTER == 1 ) */
     }
     #endif /* if ( projENABLE_TRACING == 1 ) */
 

--- a/FreeRTOS/Demo/Posix_GCC/main.c
+++ b/FreeRTOS/Demo/Posix_GCC/main.c
@@ -347,9 +347,8 @@ void vAssertCalled( const char * const pcFileName,
 }
 /*-----------------------------------------------------------*/
 
-static void prvSaveTraceFile( void )
-{
-    #if ( projENABLE_TRACING == 1 )
+#if ( projENABLE_TRACING == 1 )
+    static void prvSaveTraceFile( void )
     {
         FILE * pxOutputFile;
 
@@ -368,8 +367,7 @@ static void prvSaveTraceFile( void )
             printf( "\r\nFailed to create trace dump file\r\n" );
         }
     }
-    #endif /* if ( projENABLE_TRACING == 1 ) */
-}
+#endif /* if ( projENABLE_TRACING == 1 ) */
 /*-----------------------------------------------------------*/
 
 /* configUSE_STATIC_ALLOCATION is set to 1, so the application must provide an

--- a/FreeRTOS/Demo/Posix_GCC/main.c
+++ b/FreeRTOS/Demo/Posix_GCC/main.c
@@ -142,9 +142,9 @@ StackType_t uxTimerTaskStack[ configTIMER_TASK_STACK_DEPTH ];
 /* Notes if the trace is running or not. */
 #if ( projENABLE_TRACING == 0 )
     static BaseType_t xTraceRunning = pdFALSE;
-#else
+#else /* #if ( projENABLE_TRACING == 0 ) */
     static BaseType_t xTraceRunning = pdTRUE;
-#endif
+#endif /* #if ( projENABLE_TRACING == 0 ) */
 
 static clockid_t cid = CLOCK_THREAD_CPUTIME_ID;
 
@@ -167,7 +167,7 @@ int main( void )
 
         #if ( TRACE_ON_ENTER == 1 )
             printf( "\r\nThe trace will be dumped to disk if Enter is hit.\r\n" );
-        #endif
+        #endif /* #if ( TRACE_ON_ENTER == 1 ) */
     }
     #endif /* if ( projENABLE_TRACING == 1 ) */
 

--- a/FreeRTOS/Demo/Posix_GCC/main.c
+++ b/FreeRTOS/Demo/Posix_GCC/main.c
@@ -68,7 +68,7 @@
 /* Local includes. */
 #include "console.h"
 
-#if ( projCOVERAGE_TEST != 1 )
+#if ( projENABLE_TRACING == 1 )
     #include <trcRecorder.h>
 #endif
 
@@ -140,7 +140,7 @@ static void handle_sigint( int signal );
 StackType_t uxTimerTaskStack[ configTIMER_TASK_STACK_DEPTH ];
 
 /* Notes if the trace is running or not. */
-#if ( projCOVERAGE_TEST == 1 )
+#if ( projENABLE_TRACING == 0 )
     static BaseType_t xTraceRunning = pdFALSE;
 #else
     static BaseType_t xTraceRunning = pdTRUE;
@@ -155,8 +155,7 @@ int main( void )
     /* SIGINT is not blocked by the posix port */
     signal( SIGINT, handle_sigint );
 
-    /* Do not include trace code when performing a code coverage analysis. */
-    #if ( projCOVERAGE_TEST != 1 )
+    #if ( projENABLE_TRACING == 1 )
     {
         /* Initialise the trace recorder.  Use of the trace recorder is optional.
          * See http://www.FreeRTOS.org/trace for more information. */
@@ -170,7 +169,7 @@ int main( void )
             printf( "\r\nThe trace will be dumped to disk if Enter is hit.\r\n" );
         #endif
     }
-    #endif /* if ( projCOVERAGE_TEST != 1 ) */
+    #endif /* if ( projENABLE_TRACING == 1 ) */
 
     console_init();
     #if ( mainSELECTED_APPLICATION == BLINKY_DEMO )
@@ -355,8 +354,7 @@ void vAssertCalled( const char * const pcFileName,
 
 static void prvSaveTraceFile( void )
 {
-    /* Tracing is not used when code coverage analysis is being performed. */
-    #if ( projCOVERAGE_TEST != 1 )
+    #if ( projENABLE_TRACING == 1 )
     {
         FILE * pxOutputFile;
 
@@ -375,7 +373,7 @@ static void prvSaveTraceFile( void )
             printf( "\r\nFailed to create trace dump file\r\n" );
         }
     }
-    #endif /* if ( projCOVERAGE_TEST != 1 ) */
+    #endif /* if ( projENABLE_TRACING == 1 ) */
 }
 /*-----------------------------------------------------------*/
 

--- a/FreeRTOS/Demo/Posix_GCC/main.c
+++ b/FreeRTOS/Demo/Posix_GCC/main.c
@@ -139,13 +139,6 @@ static void handle_sigint( int signal );
  * in a different file. */
 StackType_t uxTimerTaskStack[ configTIMER_TASK_STACK_DEPTH ];
 
-/* Notes if the trace is running or not. */
-#if ( projENABLE_TRACING == 0 )
-    static BaseType_t xTraceRunning = pdFALSE;
-#else /* if ( projENABLE_TRACING == 0 ) */
-    static BaseType_t xTraceRunning = pdTRUE;
-#endif /* if ( projENABLE_TRACING == 0 ) */
-
 static clockid_t cid = CLOCK_THREAD_CPUTIME_ID;
 
 /*-----------------------------------------------------------*/
@@ -280,10 +273,11 @@ void traceOnEnter()
 
         if( xReturn > 0 )
         {
-            if( xTraceRunning == pdTRUE )
+            #if ( projENABLE_TRACING == 1 )
             {
                 prvSaveTraceFile();
             }
+            #endif /* if ( projENABLE_TRACING == 1 ) */
 
             /* clear the buffer */
             char buffer[ 1 ];
@@ -333,10 +327,11 @@ void vAssertCalled( const char * const pcFileName,
         {
             xPrinted = pdTRUE;
 
-            if( xTraceRunning == pdTRUE )
+            #if ( projENABLE_TRACING == 1 )
             {
                 prvSaveTraceFile();
             }
+            #endif /* if ( projENABLE_TRACING == 0 ) */
         }
 
         /* You can step out of this function to debug the assertion by using

--- a/FreeRTOS/Demo/Posix_GCC/main_full.c
+++ b/FreeRTOS/Demo/Posix_GCC/main_full.c
@@ -737,7 +737,7 @@ static void prvDemonstrateTaskStateAndHandleGetFunctions( void )
         xErrorCount++;
     }
 
-    #if( configUSE_TRACE_FACILITY == 1 )
+    #if( ( configUSE_TRACE_FACILITY == 1 ) && ( configSUPPORT_STATIC_ALLOCATION == 1 ) )
     {
         /* Also with the vTaskGetInfo() function. */
         vTaskGetInfo( xTimerTaskHandle, /* The task being queried. */
@@ -756,7 +756,7 @@ static void prvDemonstrateTaskStateAndHandleGetFunctions( void )
             xErrorCount++;
         }
     }
-    #endif /* #if( configUSE_TRACE_FACILITY == 1 ) */
+    #endif /* if( ( configUSE_TRACE_FACILITY == 1 ) && ( configSUPPORT_STATIC_ALLOCATION == 1 ) ) */
 
     /* Other tests that should only be performed once follow.  The test task
      * is not created on each iteration because to do so would cause the death


### PR DESCRIPTION
Description
-----------
This PR enables to compile the Posix Demo ( Blinky demo and full demo ) with support for dynamic allocation. 

For static allocation : 
```
#define configSUPPORT_STATIC_ALLOCATION              1
```
For dynamic allocation :
```
#define configSUPPORT_STATIC_ALLOCATION              1
#define configSUPPORT_DYNAMIC_ALLOCATION             1
```
Test Steps
-----------
To build the Blinky demo, the below steps are followed
```
cd FreeRTOS/Demo/Posix_GCC
mkdir build
cd build
cmake .. -DNO_TRACING=1 -DUSER_DEMO=BLINKY_DEMO
make
```

Before applying the patch, the following linker errors are found
```
/usr/bin/ld: CMakeFiles/posix_demo.dir/code_coverage_additions.c.o: in function `prvStaticAllocationsWithNullBuffers':
~/FreeRTOS/Demo/Posix_GCC/code_coverage_additions.c:99: undefined reference to `xEventGroupCreateStatic'
/usr/bin/ld: ~/FreeRTOS/Demo/Posix_GCC/code_coverage_additions.c:103: undefined reference to `xTaskCreateStatic'
/usr/bin/ld: ~/FreeRTOS/Demo/Posix_GCC/code_coverage_additions.c:111: undefined reference to `xTaskCreateStatic'
```
After applying the patch, the demo compiles and runs successfully.
```
Starting echo blinky demo
Message received from task
Message received from task
Message received from task
Message received from task
Message received from task
Message received from task
Message received from task
Message received from task
Message received from task
Message received from software timer
```
Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
[Forum Issue](https://forums.freertos.org/t/possible-to-build-posix-blinky-with-support-for-dynamic-allocation/19606)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
