### PR TITLE
Add support to build Posix Demo with Dynamic Allocation

### DIFF
--- a/FreeRTOS/Demo/Posix_GCC/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/Posix_GCC/FreeRTOSConfig.h
@@ -58,16 +58,23 @@
 #define configUSE_ALTERNATIVE_API                  0
 #define configUSE_QUEUE_SETS                       1
 #define configUSE_TASK_NOTIFICATIONS               1
-/* For static memory allocation , set configSUPPORT_STATIC_ALLOCATION to 1 .
- * Since heap_3.c is used in this demo, configSUPPORT_DYNAMIC_ALLOCATION value 
- * cannot be set to 0. The user can either leave it as it is defined, or remove 
- * the definition from the file.
+
+/* The following 2  memory allocation schemes are possible for this demo:
+ *
+ * 1. Dynamic Only.
+ *    #define configSUPPORT_STATIC_ALLOCATION  0
+ *    #define configSUPPORT_DYNAMIC_ALLOCATION 1
+ *
+ * 2. Static and Dynamic.
+ *    #define configSUPPORT_STATIC_ALLOCATION  1
+ *    #define configSUPPORT_DYNAMIC_ALLOCATION 1
+ *
+ * Static only configuration is not possible for this demo as it utilizes
+ * dynamic allocation.
  */
 #define configSUPPORT_STATIC_ALLOCATION            1
-/* For dynamic memory allocation , set configSUPPORT_STATIC_ALLOCATION to 0 
- * and configSUPPORT_DYNAMIC_ALLOCATION to 1.  
- */
 #define configSUPPORT_DYNAMIC_ALLOCATION           1
+
 #define configRECORD_STACK_HIGH_ADDRESS            1
 
 /* Software timer related configuration options.  The maximum possible task

--- a/FreeRTOS/Demo/Posix_GCC/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/Posix_GCC/FreeRTOSConfig.h
@@ -58,7 +58,16 @@
 #define configUSE_ALTERNATIVE_API                  0
 #define configUSE_QUEUE_SETS                       1
 #define configUSE_TASK_NOTIFICATIONS               1
+/* For static memory allocation , set configSUPPORT_STATIC_ALLOCATION to 1
+ * Since heap_3.c is used in this demo, configSUPPORT_DYNAMIC_ALLOCATION value 
+ * cannot be set to 0. The user can either leave it as it is defined, or remove 
+ * the definition from the file.
+ */
 #define configSUPPORT_STATIC_ALLOCATION            1
+/* For dynamic memory allocation , set configSUPPORT_STATIC_ALLOCATION to 0 and
+ * configSUPPORT_DYNAMIC_ALLOCATION to 1.  
+ */
+#define configSUPPORT_DYNAMIC_ALLOCATION           1
 #define configRECORD_STACK_HIGH_ADDRESS            1
 
 /* Software timer related configuration options.  The maximum possible task

--- a/FreeRTOS/Demo/Posix_GCC/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/Posix_GCC/FreeRTOSConfig.h
@@ -58,14 +58,14 @@
 #define configUSE_ALTERNATIVE_API                  0
 #define configUSE_QUEUE_SETS                       1
 #define configUSE_TASK_NOTIFICATIONS               1
-/* For static memory allocation , set configSUPPORT_STATIC_ALLOCATION to 1
+/* For static memory allocation , set configSUPPORT_STATIC_ALLOCATION to 1 .
  * Since heap_3.c is used in this demo, configSUPPORT_DYNAMIC_ALLOCATION value 
  * cannot be set to 0. The user can either leave it as it is defined, or remove 
  * the definition from the file.
  */
 #define configSUPPORT_STATIC_ALLOCATION            1
-/* For dynamic memory allocation , set configSUPPORT_STATIC_ALLOCATION to 0 and
- * configSUPPORT_DYNAMIC_ALLOCATION to 1.  
+/* For dynamic memory allocation , set configSUPPORT_STATIC_ALLOCATION to 0 
+ * and configSUPPORT_DYNAMIC_ALLOCATION to 1.  
  */
 #define configSUPPORT_DYNAMIC_ALLOCATION           1
 #define configRECORD_STACK_HIGH_ADDRESS            1

--- a/FreeRTOS/Demo/Posix_GCC/Makefile
+++ b/FreeRTOS/Demo/Posix_GCC/Makefile
@@ -82,7 +82,7 @@ else
     CPPFLAGS              += -DprojENABLE_TRACING=0
   else
     CPPFLAGS              += -DprojENABLE_TRACING=1
-# Trace Library.
+    # Trace Library.
     SOURCE_FILES          += ${FREERTOS_PLUS_DIR}/Source/FreeRTOS-Plus-Trace/kernelports/FreeRTOS/trcKernelPort.c
     SOURCE_FILES          += $(wildcard ${FREERTOS_PLUS_DIR}/Source/FreeRTOS-Plus-Trace/*.c )
   endif

--- a/FreeRTOS/Demo/Posix_GCC/Makefile
+++ b/FreeRTOS/Demo/Posix_GCC/Makefile
@@ -82,11 +82,11 @@ else
     CPPFLAGS              += -DprojENABLE_TRACING=0
   else
     CPPFLAGS              += -DprojENABLE_TRACING=1
+# Trace Library.
+    SOURCE_FILES          += ${FREERTOS_PLUS_DIR}/Source/FreeRTOS-Plus-Trace/kernelports/FreeRTOS/trcKernelPort.c
+    SOURCE_FILES          += $(wildcard ${FREERTOS_PLUS_DIR}/Source/FreeRTOS-Plus-Trace/*.c )
   endif
   CPPFLAGS              += -DprojCOVERAGE_TEST=0
-# Trace library.
-  SOURCE_FILES          += ${FREERTOS_PLUS_DIR}/Source/FreeRTOS-Plus-Trace/kernelports/FreeRTOS/trcKernelPort.c
-  SOURCE_FILES          += $(wildcard ${FREERTOS_PLUS_DIR}/Source/FreeRTOS-Plus-Trace/*.c )
 endif
 
 ifdef PROFILE

--- a/FreeRTOS/Demo/Posix_GCC/code_coverage_additions.c
+++ b/FreeRTOS/Demo/Posix_GCC/code_coverage_additions.c
@@ -86,61 +86,63 @@ static BaseType_t prvTimerQuery( void );
 
 /*-----------------------------------------------------------*/
 
-static BaseType_t prvStaticAllocationsWithNullBuffers( void )
-{
-    uintptr_t ulReturned = 0;
-    BaseType_t xReturn = pdPASS;
-    UBaseType_t uxDummy = 10;
+#if( configSUPPORT_STATIC_ALLOCATION == 1 )
+    static BaseType_t prvStaticAllocationsWithNullBuffers( void )
+    {
+        uintptr_t ulReturned = 0;
+        BaseType_t xReturn = pdPASS;
+        UBaseType_t uxDummy = 10;
 
-    /* Don't expect to create any of the objects as a NULL parameter is always
-     * passed in place of a required buffer.  Hence if all passes then none of the
-     |= will be against 0, and ulReturned will still be zero at the end of this
-     * function. */
-    ulReturned |= ( uintptr_t ) xEventGroupCreateStatic( NULL );
+        /* Don't expect to create any of the objects as a NULL parameter is always
+        * passed in place of a required buffer.  Hence if all passes then none of the
+        |= will be against 0, and ulReturned will still be zero at the end of this
+        * function. */
+        ulReturned |= ( uintptr_t ) xEventGroupCreateStatic( NULL );
 
-    /* Try creating a task twice, once with puxStackBuffer NULL, and once with
-     * pxTaskBuffer NULL. */
-    ulReturned |= ( uintptr_t ) xTaskCreateStatic( NULL,    /* Task to run, not needed as the task is not created. */
-                                                   "Dummy", /* Task name. */
-                                                   configMINIMAL_STACK_SIZE,
-                                                   NULL,
-                                                   tskIDLE_PRIORITY,
-                                                   NULL,
-                                                   ( StaticTask_t * ) &xReturn ); /* Dummy value just to pass a non NULL value in - won't get used. */
+        /* Try creating a task twice, once with puxStackBuffer NULL, and once with
+        * pxTaskBuffer NULL. */
+        ulReturned |= ( uintptr_t ) xTaskCreateStatic( NULL,    /* Task to run, not needed as the task is not created. */
+                                                    "Dummy", /* Task name. */
+                                                    configMINIMAL_STACK_SIZE,
+                                                    NULL,
+                                                    tskIDLE_PRIORITY,
+                                                    NULL,
+                                                    ( StaticTask_t * ) &xReturn ); /* Dummy value just to pass a non NULL value in - won't get used. */
 
-    ulReturned |= ( uintptr_t ) xTaskCreateStatic( NULL,                          /* Task to run, not needed as the task is not created. */
-                                                   "Dummy",                       /* Task name. */
-                                                   configMINIMAL_STACK_SIZE,
-                                                   NULL,
-                                                   tskIDLE_PRIORITY,
-                                                   ( StackType_t * ) &xReturn, /* Dummy value just to pass a non NULL value in - won't get used. */
-                                                   NULL );
-
-    ulReturned |= ( uintptr_t ) xQueueCreateStatic( uxDummy,
-                                                    uxDummy,
-                                                    ( uint8_t * ) &xReturn, /* Dummy value just to pass a non NULL value in - won't get used. */
+        ulReturned |= ( uintptr_t ) xTaskCreateStatic( NULL,                          /* Task to run, not needed as the task is not created. */
+                                                    "Dummy",                       /* Task name. */
+                                                    configMINIMAL_STACK_SIZE,
+                                                    NULL,
+                                                    tskIDLE_PRIORITY,
+                                                    ( StackType_t * ) &xReturn, /* Dummy value just to pass a non NULL value in - won't get used. */
                                                     NULL );
 
-    /* Try creating a stream buffer twice, once with pucStreamBufferStorageArea
-     * set to NULL, and once with pxStaticStreamBuffer set to NULL. */
-    ulReturned |= ( uintptr_t ) xStreamBufferCreateStatic( uxDummy,
-                                                           uxDummy,
-                                                           NULL,
-                                                           ( StaticStreamBuffer_t * ) &xReturn ); /* Dummy value just to pass a non NULL value in - won't get used. */
+        ulReturned |= ( uintptr_t ) xQueueCreateStatic( uxDummy,
+                                                        uxDummy,
+                                                        ( uint8_t * ) &xReturn, /* Dummy value just to pass a non NULL value in - won't get used. */
+                                                        NULL );
 
-    ulReturned |= ( uintptr_t ) xStreamBufferCreateStatic( uxDummy,
-                                                           uxDummy,
-                                                           ( uint8_t * ) &xReturn, /* Dummy value just to pass a non NULL value in - won't get used. */
-                                                           NULL );
+        /* Try creating a stream buffer twice, once with pucStreamBufferStorageArea
+        * set to NULL, and once with pxStaticStreamBuffer set to NULL. */
+        ulReturned |= ( uintptr_t ) xStreamBufferCreateStatic( uxDummy,
+                                                            uxDummy,
+                                                            NULL,
+                                                            ( StaticStreamBuffer_t * ) &xReturn ); /* Dummy value just to pass a non NULL value in - won't get used. */
 
-    if( ulReturned != 0 )
-    {
-        /* Something returned a non-NULL value. */
-        xReturn = pdFAIL;
+        ulReturned |= ( uintptr_t ) xStreamBufferCreateStatic( uxDummy,
+                                                            uxDummy,
+                                                            ( uint8_t * ) &xReturn, /* Dummy value just to pass a non NULL value in - won't get used. */
+                                                            NULL );
+
+        if( ulReturned != 0 )
+        {
+            /* Something returned a non-NULL value. */
+            xReturn = pdFAIL;
+        }
+
+        return xReturn;
     }
-
-    return xReturn;
-}
+#endif /* if( configSUPPORT_STATIC_ALLOCATION == 1 )*/
 /*-----------------------------------------------------------*/
 
 #if( configUSE_TRACE_FACILITY == 1 )
@@ -643,14 +645,18 @@ BaseType_t xRunCodeCoverageTestAdditions( void )
 {
     BaseType_t xReturn = pdPASS;
 
-    xReturn &= prvStaticAllocationsWithNullBuffers();
+    #if( configSUPPORT_STATIC_ALLOCATION == 1 )
+    {
+        xReturn &= prvStaticAllocationsWithNullBuffers();
+    }
+    #endif /* if( configSUPPORT_STATIC_ALLOCATION == 1 ) */
 
     #if( configUSE_TRACE_FACILITY == 1 )
     {
         xReturn &= prvTraceUtils();
         xReturn &= prvTaskQueryFunctions();
     }
-    #endif
+    #endif /* if( configUSE_TRACE_FACILITY == 1 ) */
 
     xReturn &= prvPeekTimeout();
     xReturn &= prvQueueQueryFromISR();

--- a/FreeRTOS/Demo/Posix_GCC/code_coverage_additions.c
+++ b/FreeRTOS/Demo/Posix_GCC/code_coverage_additions.c
@@ -87,6 +87,7 @@ static BaseType_t prvTimerQuery( void );
 /*-----------------------------------------------------------*/
 
 #if( configSUPPORT_STATIC_ALLOCATION == 1 )
+
     static BaseType_t prvStaticAllocationsWithNullBuffers( void )
     {
         uintptr_t ulReturned = 0;
@@ -94,28 +95,28 @@ static BaseType_t prvTimerQuery( void );
         UBaseType_t uxDummy = 10;
 
         /* Don't expect to create any of the objects as a NULL parameter is always
-        * passed in place of a required buffer.  Hence if all passes then none of the
-        |= will be against 0, and ulReturned will still be zero at the end of this
-        * function. */
+         * passed in place of a required buffer.  Hence if all passes then none of the
+         * |= will be against 0, and ulReturned will still be zero at the end of this
+         * function. */
         ulReturned |= ( uintptr_t ) xEventGroupCreateStatic( NULL );
 
         /* Try creating a task twice, once with puxStackBuffer NULL, and once with
-        * pxTaskBuffer NULL. */
+         * pxTaskBuffer NULL. */
         ulReturned |= ( uintptr_t ) xTaskCreateStatic( NULL,    /* Task to run, not needed as the task is not created. */
-                                                    "Dummy", /* Task name. */
-                                                    configMINIMAL_STACK_SIZE,
-                                                    NULL,
-                                                    tskIDLE_PRIORITY,
-                                                    NULL,
-                                                    ( StaticTask_t * ) &xReturn ); /* Dummy value just to pass a non NULL value in - won't get used. */
+                                                       "Dummy", /* Task name. */
+                                                       configMINIMAL_STACK_SIZE,
+                                                       NULL,
+                                                       tskIDLE_PRIORITY,
+                                                       NULL,
+                                                       ( StaticTask_t * ) &xReturn ); /* Dummy value just to pass a non NULL value in - won't get used. */
 
         ulReturned |= ( uintptr_t ) xTaskCreateStatic( NULL,                          /* Task to run, not needed as the task is not created. */
-                                                    "Dummy",                       /* Task name. */
-                                                    configMINIMAL_STACK_SIZE,
-                                                    NULL,
-                                                    tskIDLE_PRIORITY,
-                                                    ( StackType_t * ) &xReturn, /* Dummy value just to pass a non NULL value in - won't get used. */
-                                                    NULL );
+                                                       "Dummy",                       /* Task name. */
+                                                       configMINIMAL_STACK_SIZE,
+                                                       NULL,
+                                                       tskIDLE_PRIORITY,
+                                                       ( StackType_t * ) &xReturn, /* Dummy value just to pass a non NULL value in - won't get used. */
+                                                       NULL );
 
         ulReturned |= ( uintptr_t ) xQueueCreateStatic( uxDummy,
                                                         uxDummy,
@@ -123,16 +124,16 @@ static BaseType_t prvTimerQuery( void );
                                                         NULL );
 
         /* Try creating a stream buffer twice, once with pucStreamBufferStorageArea
-        * set to NULL, and once with pxStaticStreamBuffer set to NULL. */
+         * set to NULL, and once with pxStaticStreamBuffer set to NULL. */
         ulReturned |= ( uintptr_t ) xStreamBufferCreateStatic( uxDummy,
-                                                            uxDummy,
-                                                            NULL,
-                                                            ( StaticStreamBuffer_t * ) &xReturn ); /* Dummy value just to pass a non NULL value in - won't get used. */
+                                                               uxDummy,
+                                                               NULL,
+                                                               ( StaticStreamBuffer_t * ) &xReturn ); /* Dummy value just to pass a non NULL value in - won't get used. */
 
         ulReturned |= ( uintptr_t ) xStreamBufferCreateStatic( uxDummy,
-                                                            uxDummy,
-                                                            ( uint8_t * ) &xReturn, /* Dummy value just to pass a non NULL value in - won't get used. */
-                                                            NULL );
+                                                               uxDummy,
+                                                               ( uint8_t * ) &xReturn, /* Dummy value just to pass a non NULL value in - won't get used. */
+                                                               NULL );
 
         if( ulReturned != 0 )
         {
@@ -142,7 +143,8 @@ static BaseType_t prvTimerQuery( void );
 
         return xReturn;
     }
-#endif /* if( configSUPPORT_STATIC_ALLOCATION == 1 )*/
+
+#endif /* if( configSUPPORT_STATIC_ALLOCATION == 1 ) */
 /*-----------------------------------------------------------*/
 
 #if( configUSE_TRACE_FACILITY == 1 )

--- a/FreeRTOS/Demo/Posix_GCC/console.c
+++ b/FreeRTOS/Demo/Posix_GCC/console.c
@@ -39,7 +39,15 @@ StaticSemaphore_t xStdioMutexBuffer;
 
 void console_init( void )
 {
-    xStdioMutex = xSemaphoreCreateMutexStatic( &xStdioMutexBuffer );
+    #if( configSUPPORT_STATIC_ALLOCATION == 1 )
+    {
+        xStdioMutex = xSemaphoreCreateMutexStatic( &xStdioMutexBuffer );
+    }
+    #else /* if( configSUPPORT_STATIC_ALLOCATION == 1 ) */
+    {
+        xStdioMutex = xSemaphoreCreateMutex( );
+    }
+    #endif /* if( configSUPPORT_STATIC_ALLOCATION == 1 ) */
 }
 
 void console_print( const char * fmt,

--- a/FreeRTOS/Demo/Posix_GCC/main_full.c
+++ b/FreeRTOS/Demo/Posix_GCC/main_full.c
@@ -737,7 +737,7 @@ static void prvDemonstrateTaskStateAndHandleGetFunctions( void )
         xErrorCount++;
     }
 
-    #if( configUSE_TRACE_FACILITY == 1 )
+    #if( ( configUSE_TRACE_FACILITY == 1 ) && ( configSUPPORT_STATIC_ALLOCATION == 1 ) )
     {
         /* Also with the vTaskGetInfo() function. */
         vTaskGetInfo( xTimerTaskHandle, /* The task being queried. */
@@ -756,7 +756,7 @@ static void prvDemonstrateTaskStateAndHandleGetFunctions( void )
             xErrorCount++;
         }
     }
-    #endif /* #if( configUSE_TRACE_FACILITY == 1 ) */
+    #endif /* if( ( configUSE_TRACE_FACILITY == 1 ) && ( configSUPPORT_STATIC_ALLOCATION == 1 ) ) */
 
     /* Other tests that should only be performed once follow.  The test task
      * is not created on each iteration because to do so would cause the death

--- a/FreeRTOS/Demo/Posix_GCC/main_full.c
+++ b/FreeRTOS/Demo/Posix_GCC/main_full.c
@@ -737,7 +737,7 @@ static void prvDemonstrateTaskStateAndHandleGetFunctions( void )
         xErrorCount++;
     }
 
-    #if( ( configUSE_TRACE_FACILITY == 1 ) && ( configSUPPORT_STATIC_ALLOCATION == 1 ) )
+    #if( configUSE_TRACE_FACILITY == 1 )
     {
         /* Also with the vTaskGetInfo() function. */
         vTaskGetInfo( xTimerTaskHandle, /* The task being queried. */
@@ -749,14 +749,16 @@ static void prvDemonstrateTaskStateAndHandleGetFunctions( void )
         if( ( xTaskInfo.eCurrentState != eBlocked ) ||
             ( strcmp( xTaskInfo.pcTaskName, "Tmr Svc" ) != 0 ) ||
             ( xTaskInfo.uxCurrentPriority != configTIMER_TASK_PRIORITY ) ||
-            ( xTaskInfo.pxStackBase != uxTimerTaskStack ) ||
+            #if( configSUPPORT_STATIC_ALLOCATION == 1 )
+                ( xTaskInfo.pxStackBase != uxTimerTaskStack ) ||
+            #endif
             ( xTaskInfo.xHandle != xTimerTaskHandle ) )
         {
             pcStatusMessage = "Error:  vTaskGetInfo() returned incorrect information about the timer task";
             xErrorCount++;
         }
     }
-    #endif /* if( ( configUSE_TRACE_FACILITY == 1 ) && ( configSUPPORT_STATIC_ALLOCATION == 1 ) ) */
+    #endif /* #if( configUSE_TRACE_FACILITY == 1 ) */
 
     /* Other tests that should only be performed once follow.  The test task
      * is not created on each iteration because to do so would cause the death


### PR DESCRIPTION
Description
-----------
This PR enables to compile the Posix Demo ( Blinky demo and full demo ) with support for dynamic allocation.

For static allocation :
```
#define configSUPPORT_STATIC_ALLOCATION              1
```
For dynamic allocation :

```
#define configSUPPORT_STATIC_ALLOCATION              1
#define configSUPPORT_DYNAMIC_ALLOCATION             1
```

Test Steps
-----------
To build the Blinky demo, the below steps are followed
```
cd FreeRTOS/Demo/Posix_GCC
mkdir build
cd build
cmake .. -DNO_TRACING=1 -DUSER_DEMO=BLINKY_DEMO
make
```

Before applying the patch, the following linker errors are found
```
/usr/bin/ld: CMakeFiles/posix_demo.dir/code_coverage_additions.c.o: in function `prvStaticAllocationsWithNullBuffers':
~/FreeRTOS/Demo/Posix_GCC/code_coverage_additions.c:99: undefined reference to `xEventGroupCreateStatic'
/usr/bin/ld: ~/FreeRTOS/Demo/Posix_GCC/code_coverage_additions.c:103: undefined reference to `xTaskCreateStatic'
/usr/bin/ld: ~/FreeRTOS/Demo/Posix_GCC/code_coverage_additions.c:111: undefined reference to `xTaskCreateStatic'
```

After applying the patch, the demo compiles and runs successfully.
```
Starting echo blinky demo
Message received from task
Message received from task
Message received from task
Message received from task
Message received from task
Message received from task
Message received from task
Message received from task
Message received from task
Message received from software timer
```

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
[Forum issue](https://forums.freertos.org/t/possible-to-build-posix-blinky-with-support-for-dynamic-allocation/19606)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
