### PR TITLE
Update Cortex R4F and Cortex R5F MPU Demos

### DIFF
--- a/.github/workflows/freertos_mpu_demo.yml
+++ b/.github/workflows/freertos_mpu_demo.yml
@@ -11,8 +11,8 @@ env:
   bashEnd:  \033[0m
 
 jobs:
-  Cortex-R4:
-    name: Texas Instruments RM46
+  Cortex-Rx-MPU-Demos:
+    name: TI-Hercules RM46 and RM57 MPU Demos
     runs-on: ubuntu-latest
     steps:
       - env:
@@ -20,7 +20,17 @@ jobs:
         name: ${{ env.stepName }}
         uses: actions/checkout@v4.1.1
         with:
-          submodules: false
+          submodules: true
+
+      - env:
+          stepName: Fetch FreeRTOS-Kernel
+        name: ${{ env.stepName }}
+        shell: bash
+        run: |
+          # ${{ env.stepName }}
+          echo -e "::group::${{ env.bashInfo }} ${{ env.stepName }} ${{ env.bashEnd }}"
+          git submodule update --checkout --init --depth 1 FreeRTOS/Source
+          echo -e "${{ env.bashPass }} ${{ env.stepName }} ${{ env.bashEnd }}"
 
       - env:
           stepName: Install GNU ARM Toolchain
@@ -31,6 +41,18 @@ jobs:
           echo -e "::group::${{ env.bashInfo }} ${{ env.stepName }} ${{ env.bashEnd }}"
           sudo apt-get -y update
           sudo apt-get -y install gcc-arm-none-eabi build-essential cmake git ninja-build python3-minimal
+          echo -e "::endgroup::"
+          echo -e "${{ env.bashPass }} ${{ env.stepName }} ${{ env.bashEnd }}"
+
+      - env:
+          stepName: Build CORTEX R5 MPU Demo
+        name: ${{ env.stepName }}
+        shell: bash
+        working-directory: FreeRTOS/Demo/CORTEX_MPU_R5F_TI_RM57_HERCULES_GCC
+        run: |
+          # ${{ env.stepName }}
+          echo -e "::group::${{ env.bashInfo }} ${{ env.stepName }} ${{ env.bashEnd }}"
+          cmake -S . -B build && make -j -C build all
           echo -e "::endgroup::"
           echo -e "${{ env.bashPass }} ${{ env.stepName }} ${{ env.bashEnd }}"
 
@@ -42,78 +64,6 @@ jobs:
         run: |
           # ${{ env.stepName }}
           echo -e "::group::${{ env.bashInfo }} ${{ env.stepName }} ${{ env.bashEnd }}"
-          set +e
-          cmake -S . -B build;
-          make -C build all;
-          exitStatus=$?
-          set -e
-          echo -e "::endgroup::"
-          if [ $exitStatus -eq 0 ]; then
-            echo -e "${{ env.bashPass }} ${{ env.stepName }} ${{ env.bashEnd }}"
-          else
-            echo -e "${{ env.bashFail }} ${{ env.stepName }} ${{ env.bashEnd }}"
-            exit 1
-          fi
-
-  Cortex-R5:
-    name: Texas Instruments RM57
-    runs-on: ubuntu-latest
-    steps:
-      - env:
-          stepName: Checkout Repository
-        name: ${{ env.stepName }}
-        uses: actions/checkout@v4.1.1
-        with:
-          submodules: false
-
-      - env:
-          stepName: Install GNU ARM Toolchain
-        name: Install GNU ARM Toolchain
-        shell: bash
-        run: |
-          # ${{ env.stepName }}
-          echo -e "::group::${{ env.bashInfo }} ${{ env.stepName }} ${{ env.bashEnd }}"
-          sudo apt-get -y update
-          sudo apt-get -y install gcc-arm-none-eabi build-essential cmake git ninja-build python3-minimal
+          cmake -S . -B build && make -j -C build all
           echo -e "::endgroup::"
           echo -e "${{ env.bashPass }} ${{ env.stepName }} ${{ env.bashEnd }}"
-
-      - env:
-          stepName: Fetch Kernel Submodule
-        name: ${{ env.stepName }}
-        shell: bash
-        run: |
-          # ${{ env.stepName }}
-          echo -e "::group:: ${{ env.bashInfo }} ${{ env.stepName }} ${{ env.bashEnd }}"
-          set +e
-          git submodule update --checkout --init --depth 1 FreeRTOS/Source FreeRTOS/Demo/ThirdParty/Community-Supported-Demos
-          exitStatus=$?
-          set -e
-          echo -e "::endgroup::"
-          if [ $exitStatus -eq 0 ]; then
-            echo -e "${{ env.bashPass }} ${{ env.stepName }} ${{ env.bashEnd }}"
-          else
-            echo -e "${{ env.bashFail }} ${{ env.stepName }} ${{ env.bashEnd }}"
-            exit 1
-          fi
-
-      - env:
-          stepName: Build CORTEX R5 MPU Demo
-        name: ${{ env.stepName }}
-        shell: bash
-        working-directory: FreeRTOS/Demo/CORTEX_MPU_R5F_TI_RM57_HERCULES_GCC
-        run: |
-          # ${{ env.stepName }}
-          echo -e "::group::${{ env.bashInfo }} ${{ env.stepName }} ${{ env.bashEnd }}"
-          set +e
-          cmake -S . -B build;
-          make -C build all;
-          exitStatus=$?
-          set -e
-          echo -e "::endgroup::"
-          if [ $exitStatus -eq 0 ]; then
-            echo -e "${{ env.bashPass }} ${{ env.stepName }} ${{ env.bashEnd }}"
-          else
-            echo -e "${{ env.bashFail }} ${{ env.stepName }} ${{ env.bashEnd }}"
-            exit 1
-          fi

--- a/FreeRTOS/Demo/CORTEX_MPU_R4F_TI_RM46_HERCULES_GCC/CMakeLists.txt
+++ b/FreeRTOS/Demo/CORTEX_MPU_R4F_TI_RM46_HERCULES_GCC/CMakeLists.txt
@@ -50,19 +50,22 @@ INCLUDE(FetchContent)
 FetchContent_Declare(
     FreeRTOS-Kernel
     GIT_REPOSITORY https://github.com/FreeRTOS/FreeRTOS-Kernel.git
-    GIT_TAG main
+    # Last tested FreeRTOS-Kernel Commit
+    GIT_TAG e8289dfee6e00660b5ad028e9f931ffb76c95840
     SOURCE_DIR "${DEMO_DIR}/../../Source"
     USES_TERMINAL_DOWNLOAD YES
     USES_TERMINAL_UPDATE   YES
-    BUILD_COMMAND "")
+    BUILD_COMMAND ""
+)
 
-FetchContent_GetProperties(FreeRTOS-Kernel)
-if(NOT FreeRTOS-Kernel_POPULATED)
-    FetchContent_Populate(FreeRTOS-Kernel)
-endif()
+# Uncomment the following lines to use Fetch-Content to clone Kernel.
+# FetchContent_GetProperties(FreeRTOS-Kernel)
+# if(NOT FreeRTOS-Kernel_POPULATED)
+#     FetchContent_Populate(FreeRTOS-Kernel)
+# endif()
 
 # Get the absolute path to the FreeRTOS-Kernel Directory
-SET(FREERTOS_KERNEL_DIR_REL "${freertos-kernel_SOURCE_DIR}")
+SET(FREERTOS_KERNEL_DIR_REL "${DEMO_DIR}/../../Source")
 GET_FILENAME_COMPONENT(FREERTOS_KERNEL_DIR ${FREERTOS_KERNEL_DIR_REL} ABSOLUTE)
 
 # Get the absolute path to the Port Directory

--- a/FreeRTOS/Demo/CORTEX_MPU_R4F_TI_RM46_HERCULES_GCC/include/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_MPU_R4F_TI_RM46_HERCULES_GCC/include/FreeRTOSConfig.h
@@ -97,6 +97,7 @@ extern void vMainSetupTimerInterrupt( void );
     #define configUSE_CO_ROUTINES                                  0
     #define configUSE_MUTEXES                                      1U
     #define configUSE_RECURSIVE_MUTEXES                            1U
+    #define configUSE_EVENT_GROUPS                                 0U
     #define configCHECK_FOR_STACK_OVERFLOW                         0
     #define configUSE_QUEUE_SETS                                   1U
     #define configUSE_COUNTING_SEMAPHORES                          1U

--- a/FreeRTOS/Demo/CORTEX_MPU_R4F_TI_RM46_HERCULES_GCC/include/demo_tasks.h
+++ b/FreeRTOS/Demo/CORTEX_MPU_R4F_TI_RM46_HERCULES_GCC/include/demo_tasks.h
@@ -100,8 +100,7 @@
 #define demoIRQ_TASK_PRIORITY              ( configTIMER_TASK_PRIORITY + 2UL )
 
 /** @brief Priority at which the Notification Demo Task is created. */
-#define demoNOTIFICATION_TASK_PRIORITY \
-    ( configTIMER_TASK_PRIORITY + 1UL ) | portPRIVILEGE_BIT
+#define demoNOTIFICATION_TASK_PRIORITY     ( configTIMER_TASK_PRIORITY + 1UL )
 
 /* ------------------------------- Register Test Tasks ------------------------------- */
 
@@ -172,7 +171,6 @@ PRIVILEGED_FUNCTION void vIRQDemoHandler( void );
 #define portRTI_CLEARINTENA_REG  ( *( ( volatile uint32_t * ) 0xFFFFFC84UL ) )
 #define portRTI_INTFLAG_REG      ( *( ( volatile uint32_t * ) 0xFFFFFC88UL ) )
 #define portEND_OF_INTERRUPT_REG ( ( ( volatile uint32_t * ) configEOI_ADDRESS ) )
-
 
 /* Registers used by the Vectored Interrupt Manager */
 typedef void ( *ISRFunction_t )( void );

--- a/FreeRTOS/Demo/CORTEX_MPU_R5F_TI_RM57_HERCULES_GCC/CMakeLists.txt
+++ b/FreeRTOS/Demo/CORTEX_MPU_R5F_TI_RM57_HERCULES_GCC/CMakeLists.txt
@@ -50,19 +50,23 @@ INCLUDE(FetchContent)
 FetchContent_Declare(
     FreeRTOS-Kernel
     GIT_REPOSITORY https://github.com/FreeRTOS/FreeRTOS-Kernel.git
-    GIT_TAG main
+    # Last tested FreeRTOS-Kernel Commit
+    GIT_TAG e8289dfee6e00660b5ad028e9f931ffb76c95840
     SOURCE_DIR "${DEMO_DIR}/../../Source"
     USES_TERMINAL_DOWNLOAD YES
     USES_TERMINAL_UPDATE   YES
-    BUILD_COMMAND "")
+    BUILD_COMMAND ""
+)
 
-FetchContent_GetProperties(FreeRTOS-Kernel)
-if(NOT FreeRTOS-Kernel_POPULATED)
-    FetchContent_Populate(FreeRTOS-Kernel)
-endif()
+# Uncomment the following lines to use Fetch-Content to clone Kernel.
+# FetchContent_GetProperties(FreeRTOS-Kernel)
+# if(NOT FreeRTOS-Kernel_POPULATED)
+#     FetchContent_Populate(FreeRTOS-Kernel)
+# endif()
+
 
 # Get the absolute path to the FreeRTOS-Kernel Directory
-SET(FREERTOS_KERNEL_DIR_REL "${freertos-kernel_SOURCE_DIR}")
+SET(FREERTOS_KERNEL_DIR_REL "${DEMO_DIR}/../../Source")
 GET_FILENAME_COMPONENT(FREERTOS_KERNEL_DIR ${FREERTOS_KERNEL_DIR_REL} ABSOLUTE)
 
 # Get the absolute path to the Port Directory

--- a/FreeRTOS/Demo/CORTEX_MPU_R5F_TI_RM57_HERCULES_GCC/include/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_MPU_R5F_TI_RM57_HERCULES_GCC/include/FreeRTOSConfig.h
@@ -97,6 +97,7 @@ extern void vMainSetupTimerInterrupt( void );
     #define configUSE_CO_ROUTINES                                  0
     #define configUSE_MUTEXES                                      1U
     #define configUSE_RECURSIVE_MUTEXES                            1U
+    #define configUSE_EVENT_GROUPS                                 0U
     #define configCHECK_FOR_STACK_OVERFLOW                         0
     #define configUSE_QUEUE_SETS                                   1U
     #define configUSE_COUNTING_SEMAPHORES                          1U

--- a/FreeRTOS/Demo/CORTEX_MPU_R5F_TI_RM57_HERCULES_GCC/include/demo_tasks.h
+++ b/FreeRTOS/Demo/CORTEX_MPU_R5F_TI_RM57_HERCULES_GCC/include/demo_tasks.h
@@ -100,8 +100,7 @@
 #define demoIRQ_TASK_PRIORITY              ( configTIMER_TASK_PRIORITY + 2UL )
 
 /** @brief Priority at which the Notification Demo Task is created. */
-#define demoNOTIFICATION_TASK_PRIORITY \
-    ( configTIMER_TASK_PRIORITY + 1UL ) | portPRIVILEGE_BIT
+#define demoNOTIFICATION_TASK_PRIORITY     ( configTIMER_TASK_PRIORITY + 1UL )
 
 /* ------------------------------- Register Test Tasks ------------------------------- */
 

--- a/manifest.yml
+++ b/manifest.yml
@@ -5,7 +5,7 @@ license: "MIT"
 
 dependencies:
   - name: "FreeRTOS-Kernel"
-    version: "625b24a10"
+    version: "e8289dfee"
     repository:
       type: "git"
       url: "https://github.com/FreeRTOS/FreeRTOS-Kernel.git"


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->
By default use the submodule for the FreeRTOS-Kernel in the repo to remove a dependency circle.
Add in a line stating to remove commented out lines to instead clone down the last tested commit of the kernel.
Make the notification tasks unprivileged now that the missing MPU permission check was added.
Update the FreeRTOS-Kernel submodule to use the latest FreeRTOS-Kernel.
Set `configUSE_EVENT_GROUPS` to 0 in the CORTEX_MPU_R4/5F Demos.
Currently if `configUSE_EVENT_GROUPS` is not set to 0 it is [defaulted to 1 in FreeRTOS.h](https://github.com/FreeRTOS/FreeRTOS-Kernel/blob/7c910499ecf13bc3f5d881814f319704279b5c13/include/FreeRTOS.h#L321-L323)

```
#ifndef configUSE_EVENT_GROUPS
    #define configUSE_EVENT_GROUPS    1
#endif
```

This causes the inclusion of the event group functions in [mpu_wrappers_v2.c](). However FreeRTOS.h cannot be included into [mpu_wrappers_v2_asm.S](https://github.com/FreeRTOS/FreeRTOS-Kernel/blob/main/portable/GCC/ARM_CRx_MPU/mpu_wrappers_v2_asm.S#L35). This leads to [mpu_wrappers_v2_asm.S](https://github.com/FreeRTOS/FreeRTOS-Kernel/blob/main/portable/GCC/ARM_CRx_MPU/mpu_wrappers_v2_asm.S#L204) not compiling the needed MPU Wrapper functions:
```
#if ( configUSE_EVENT_GROUPS == 1 )

    .extern MPU_xEventGroupWaitBitsImpl
    .align 4
    .global MPU_xEventGroupWaitBitsEntry
    .type MPU_xEventGroupWaitBitsEntry, function
    MPU_xEventGroupWaitBitsEntry:
        INVOKE_SYSTEM_CALL #SYSTEM_CALL_xEventGroupWaitBits, MPU_xEventGroupWaitBitsImpl

    /* ----------------------------------------------------------------------------------- */

 < REST_OF_EVENT_GROUP_FUNCTIONS>
 
 #endif /* if ( configUSE_EVENT_GROUPS == 1 ) */
 ```
 
 This leads to the error seen on the CI-CD build being done by https://github.com/FreeRTOS/FreeRTOS-Kernel/pull/1018, which can be seen [here](https://github.com/FreeRTOS/FreeRTOS-Kernel/actions/runs/8471513369/job/23215284813#step:7:292):

```
 /usr/lib/gcc/arm-none-eabi/10.3.1/../../../arm-none-eabi/bin/ld: CMakeFiles/FREERTOS_KERNEL.dir/home/runner/work/FreeRTOS-Kernel/FreeRTOS-Kernel/FreeRTOS/Source/portable/Common/mpu_wrappers_v2.c.obj: in function `MPU_xEventGroupWaitBits':
/home/runner/work/FreeRTOS-Kernel/FreeRTOS-Kernel/FreeRTOS/Source/portable/Common/mpu_wrappers_v2.c:3892: undefined reference to `MPU_xEventGroupWaitBitsEntry'
collect2: error: ld returned 1 exit status
```
Test Steps
-----------
<!-- Describe the steps to reproduce. -->
Made changes, ran demos with changes on both the RM57 Launchpad and the RM46 Launchpad

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have tested my changes. No regression in existing tests.
- [X] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->
https://github.com/FreeRTOS/FreeRTOS-Kernel/pull/1016
https://github.com/FreeRTOS/FreeRTOS-Kernel/pull/1018

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
