### PR TITLE
[WIN32-MSVC Demo] Define TickType_t width based on the target platform(32bit/64bit).

### DIFF
--- a/FreeRTOS/Demo/WIN32-MSVC/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/WIN32-MSVC/FreeRTOSConfig.h
@@ -65,11 +65,11 @@
 #define configINITIAL_TICK_COUNT				( ( TickType_t ) 0 ) /* For test. */
 #define configSTREAM_BUFFER_TRIGGER_LEVEL_TEST_MARGIN 1 /* As there are a lot of tasks running. */
 
- /* Tick type width is defined based on the target platform.(32bit or 64bit) */
+ /* Tick type width is defined based on the target platform(32bit or 64bit). */
 #ifdef _M_X64
-    #define configTICK_TYPE_WIDTH_IN_BITS			TICK_TYPE_WIDTH_64_BITS
+    #define configTICK_TYPE_WIDTH_IN_BITS		TICK_TYPE_WIDTH_64_BITS
 #else
-    #define configTICK_TYPE_WIDTH_IN_BITS			TICK_TYPE_WIDTH_32_BITS
+    #define configTICK_TYPE_WIDTH_IN_BITS		TICK_TYPE_WIDTH_32_BITS
 #endif
 
 /* Software timer related configuration options. */

--- a/FreeRTOS/Demo/WIN32-MSVC/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/WIN32-MSVC/FreeRTOSConfig.h
@@ -49,7 +49,6 @@
 #define configTOTAL_HEAP_SIZE					( ( size_t ) ( 490 * 1024 ) ) /* This demo tests heap_5 so places multiple blocks within this total heap size.  See mainREGION_1_SIZE to mainREGION_3_SIZE definitions in main.c. */
 #define configMAX_TASK_NAME_LEN					( 12 )
 #define configUSE_TRACE_FACILITY				1
-#define configUSE_16_BIT_TICKS					0
 #define configIDLE_SHOULD_YIELD					1
 #define configUSE_MUTEXES						1
 #define configCHECK_FOR_STACK_OVERFLOW			0
@@ -65,6 +64,13 @@
 #define configSUPPORT_STATIC_ALLOCATION			1
 #define configINITIAL_TICK_COUNT				( ( TickType_t ) 0 ) /* For test. */
 #define configSTREAM_BUFFER_TRIGGER_LEVEL_TEST_MARGIN 1 /* As there are a lot of tasks running. */
+
+ /* Tick type width is defined based on the target platform.(32bit or 64bit) */
+#ifdef _M_X64
+    #define configTICK_TYPE_WIDTH_IN_BITS			TICK_TYPE_WIDTH_64_BITS
+#else
+    #define configTICK_TYPE_WIDTH_IN_BITS			TICK_TYPE_WIDTH_32_BITS
+#endif
 
 /* Software timer related configuration options. */
 #define configUSE_TIMERS						1

--- a/FreeRTOS/Demo/WIN32-MSVC/main.c
+++ b/FreeRTOS/Demo/WIN32-MSVC/main.c
@@ -133,7 +133,7 @@ void vApplicationStackOverflowHook( TaskHandle_t pxTask,
 void vApplicationTickHook( void );
 void vApplicationGetIdleTaskMemory( StaticTask_t ** ppxIdleTaskTCBBuffer,
                                     StackType_t ** ppxIdleTaskStackBuffer,
-                                    uint32_t * pulIdleTaskStackSize );
+                                    configSTACK_DEPTH_TYPE * puxIdleTaskStackSize );
 void vApplicationGetTimerTaskMemory( StaticTask_t ** ppxTimerTaskTCBBuffer,
                                      StackType_t ** ppxTimerTaskStackBuffer,
                                      uint32_t * pulTimerTaskStackSize );
@@ -417,7 +417,7 @@ static void prvInitialiseHeap( void )
  * used by the Idle task. */
 void vApplicationGetIdleTaskMemory( StaticTask_t ** ppxIdleTaskTCBBuffer,
                                     StackType_t ** ppxIdleTaskStackBuffer,
-                                    configSTACK_DEPTH_TYPE * pulIdleTaskStackSize )
+                                    configSTACK_DEPTH_TYPE * puxIdleTaskStackSize )
 {
 /* If the buffers to be provided to the Idle task are declared inside this
  * function then they must be declared static - otherwise they will be allocated on
@@ -435,7 +435,7 @@ void vApplicationGetIdleTaskMemory( StaticTask_t ** ppxIdleTaskTCBBuffer,
     /* Pass out the size of the array pointed to by *ppxIdleTaskStackBuffer.
      * Note that, as the array is necessarily of type StackType_t,
      * configMINIMAL_STACK_SIZE is specified in words, not bytes. */
-    *pulIdleTaskStackSize = configMINIMAL_STACK_SIZE;
+    *puxIdleTaskStackSize = configMINIMAL_STACK_SIZE;
 }
 /*-----------------------------------------------------------*/
 

--- a/FreeRTOS/Demo/WIN32-MSVC/main_full.c
+++ b/FreeRTOS/Demo/WIN32-MSVC/main_full.c
@@ -463,7 +463,7 @@ void vFullDemoIdleFunction( void )
 
     /* Exercise heap_5 a bit.  The malloc failed hook will trap failed
      * allocations so there is no need to test here. */
-    pvAllocated = pvPortMalloc( ( rand() % 500 ) + 1 );
+    pvAllocated = pvPortMalloc( ( size_t )( rand() % 500 ) + 1 );
     vPortFree( pvAllocated );
 }
 /*-----------------------------------------------------------*/

--- a/FreeRTOS/Demo/WIN32-MSVC/main_full.c
+++ b/FreeRTOS/Demo/WIN32-MSVC/main_full.c
@@ -521,18 +521,18 @@ void vFullDemoTickHookFunction( void )
 static void prvPendedFunction( void * pvParameter1,
                                uint32_t ulParameter2 )
 {
-    static UBaseType_t ulLastParameter1 = 1000UL;
+    static UBaseType_t uxLastParameter1 = 1000UL;
     static uint32_t ulLastParameter2 = 0UL;
-    UBaseType_t ulParameter1;
+    UBaseType_t uxParameter1;
 
-    ulParameter1 = ( UBaseType_t ) pvParameter1;
+    uxParameter1 = ( UBaseType_t ) pvParameter1;
 
     /* Ensure the parameters are as expected. */
-    configASSERT( ulParameter1 == ( ulLastParameter1 + 1 ) );
+    configASSERT( uxParameter1 == ( uxLastParameter1 + 1 ) );
     configASSERT( ulParameter2 == ( ulLastParameter2 + 1 ) );
 
     /* Remember the parameters for the next time the function is called. */
-    ulLastParameter1 = ulParameter1;
+    uxLastParameter1 = uxParameter1;
     ulLastParameter2 = ulParameter2;
 }
 /*-----------------------------------------------------------*/
@@ -586,18 +586,18 @@ static void prvDemonstrateTimerQueryFunctions( void )
 
 static void prvDemonstratePendingFunctionCall( void )
 {
-    static UBaseType_t ulParameter1 = 1000UL;
+    static UBaseType_t uxParameter1 = 1000UL;
     static uint32_t ulParameter2 = 0UL;
     const TickType_t xDontBlock = 0; /* This is called from the idle task so must *not* attempt to block. */
 
     /* prvPendedFunction() just expects the parameters to be incremented by one
      * each time it is called. */
 
-    ulParameter1++;
+    uxParameter1++;
     ulParameter2++;
 
     /* Pend the function call, sending the parameters. */
-    xTimerPendFunctionCall( prvPendedFunction, ( void * ) ulParameter1, ulParameter2, xDontBlock );
+    xTimerPendFunctionCall( prvPendedFunction, ( void * ) uxParameter1, ulParameter2, xDontBlock );
 }
 /*-----------------------------------------------------------*/
 

--- a/FreeRTOS/Demo/WIN32-MSVC/main_full.c
+++ b/FreeRTOS/Demo/WIN32-MSVC/main_full.c
@@ -521,10 +521,11 @@ void vFullDemoTickHookFunction( void )
 static void prvPendedFunction( void * pvParameter1,
                                uint32_t ulParameter2 )
 {
-    static uint32_t ulLastParameter1 = 1000UL, ulLastParameter2 = 0UL;
-    uint32_t ulParameter1;
+    static UBaseType_t ulLastParameter1 = 1000UL;
+    static uint32_t ulLastParameter2 = 0UL;
+    UBaseType_t ulParameter1;
 
-    ulParameter1 = ( uint32_t ) pvParameter1;
+    ulParameter1 = ( UBaseType_t ) pvParameter1;
 
     /* Ensure the parameters are as expected. */
     configASSERT( ulParameter1 == ( ulLastParameter1 + 1 ) );
@@ -585,7 +586,8 @@ static void prvDemonstrateTimerQueryFunctions( void )
 
 static void prvDemonstratePendingFunctionCall( void )
 {
-    static uint32_t ulParameter1 = 1000UL, ulParameter2 = 0UL;
+    static UBaseType_t ulParameter1 = 1000UL;
+    static uint32_t ulParameter2 = 0UL;
     const TickType_t xDontBlock = 0; /* This is called from the idle task so must *not* attempt to block. */
 
     /* prvPendedFunction() just expects the parameters to be incremented by one


### PR DESCRIPTION
<!--- Title -->
[WIN32-MSVC Demo] Define TickType_t width based on the target platform(32bit/64bit).

Description
-----------
<!--- Describe your changes in detail. -->
This PR is the MSVC version of PR #1199. This PR improves MSVC Demo on x64.
1. Add automatic TickType_t width switching.
64bit TickType_t is used on x64 platform. 32bit TickType_t is used on Win32 platform.
2. Solve x64 unique compiler warnings.
64bit variable caused some compiler warnings because of their wider width. Those warnings are solved.

[Related forum topic]
This PR is derived from the following topic in the forum.
[64bit application on FreeRTOS windows port](https://forums.freertos.org/t/64bit-application-on-freertos-windows-port/19110)

[Limitation]
There are still x64 unique compiler warnings in TraceRecorder submodule which is out of the FreeRTOS.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->
1. Build WIN32-MSVC Demo(full demo) on x64 platform.
2. Confirm there is no extra warnings.
3. Run demo application.
4. Confirm it is running successfully.

Blinky demo is also tested.
Those tests are performed on also Win32 platform as regression tests.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->
MinGW version of this PR is #1199.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
