### PR TITLE
Make a couple of demos build using picolibc

### DIFF
--- a/FreeRTOS/Demo/CORTEX_MPU_M3_MPS2_QEMU_GCC/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_MPU_M3_MPS2_QEMU_GCC/FreeRTOSConfig.h
@@ -44,6 +44,10 @@ extern void vAssertCalled( void );
 #define configASSERT( x )    if( ( x ) == 0 ) vAssertCalled()
 #define configQUEUE_REGISTRY_SIZE                        20
 
+#ifdef PICOLIBC_TLS
+#define configUSE_PICOLIBC_TLS                           1
+#endif
+
 #define configUSE_PREEMPTION                             1
 #define configUSE_TIME_SLICING                           0
 #define configUSE_PORT_OPTIMISED_TASK_SELECTION          0

--- a/FreeRTOS/Demo/CORTEX_MPU_M3_MPS2_QEMU_GCC/Makefile
+++ b/FreeRTOS/Demo/CORTEX_MPU_M3_MPS2_QEMU_GCC/Makefile
@@ -63,6 +63,11 @@ else
     CFLAGS                +=     -O3
 endif
 
+ifeq ($(PICOLIBC), 1)
+    CFLAGS                +=     --specs=picolibc.specs -DPICOLIBC_INTEGER_PRINTF_SCANF
+   LDFLAGS                +=     --specs=picolibc.specs -DPICOLIBC_INTEGER_PRINTF_SCANF
+endif
+
 OBJ_FILES             :=    $(SOURCE_FILES:%.c=$(BUILD_DIR)/%.o)
 
 .PHONY: clean

--- a/FreeRTOS/Demo/CORTEX_MPU_M3_MPS2_QEMU_GCC/scripts/mps2_m3.ld
+++ b/FreeRTOS/Demo/CORTEX_MPU_M3_MPS2_QEMU_GCC/scripts/mps2_m3.ld
@@ -175,6 +175,26 @@ SECTIONS
         _edata = .;
     } > RAM AT > FLASH
 
+    .tdata : {
+        *(.tdata .tdata.*)
+    } >FLASH
+
+    .tbss (NOLOAD) : {
+         *(.tbss .tbss.* .gnu.linkonce.tb.*)
+         *(.tcommon)
+         PROVIDE( __tbss_end = . );
+         PROVIDE( __tls_end = . );
+    } >FLASH
+    PROVIDE( __tdata_source = LOADADDR(.tdata) );
+    PROVIDE( __tdata_source_end = LOADADDR(.tdata) + SIZEOF(.tdata) );
+    PROVIDE( __tdata_size = SIZEOF(.tdata) );
+    PROVIDE( __tbss_offset = ADDR(.tbss) - ADDR(.tdata) );
+    PROVIDE( __tbss_start = ADDR(.tbss) );
+    PROVIDE( __tbss_size = SIZEOF(.tbss) );
+    PROVIDE( __tls_size = __tls_end - ADDR(.tdata) );
+    PROVIDE( __tls_align = MAX(ALIGNOF(.tdata), ALIGNOF(.tbss)) );
+    PROVIDE( __arm32_tls_tcb_offset = MAX(8, __tls_align) );
+    PROVIDE( __arm64_tls_tcb_offset = MAX(16, __tls_align) );
 
     . = ALIGN(4);
     .bss :
@@ -195,8 +215,10 @@ SECTIONS
         PROVIDE ( end = . );
         PROVIDE ( _end = . );
         _heap_bottom = .;
+        __heap_start = .;
         . = . + _Min_Heap_Size;
         _heap_top = .;
+        __heap_end = .;
         . = . + _Min_Stack_Size;
         . = ALIGN(8);
        } >RAM

--- a/FreeRTOS/Demo/CORTEX_MPU_M3_MPS2_QEMU_GCC/syscall.c
+++ b/FreeRTOS/Demo/CORTEX_MPU_M3_MPS2_QEMU_GCC/syscall.c
@@ -50,8 +50,6 @@ extern unsigned long _heap_bottom;
 extern unsigned long _heap_top;
 extern unsigned long g_ulBase;
 
-static void * heap_end = 0;
-
 /**
  * @brief initializes the UART emulated hardware
  */
@@ -60,6 +58,34 @@ void uart_init()
     UART0_ADDR->BAUDDIV = 16;
     UART0_ADDR->CTRL = UART_CTRL_TX_EN;
 }
+
+#ifdef __PICOLIBC__
+
+#include <stdio.h>
+
+/**
+ * @brief  Write byte to the UART channel to be displayed on the command line
+ *         with qemu
+ * @param [in] c     byte to send
+ * @param [in] file  ignored
+ * @returns the character written (cast to unsigned so it is not an error value)
+ */
+
+int
+_uart_putc(char c, FILE *file)
+{
+    (void) file;
+    UART_DR( UART0_ADDR ) = c;
+    return (unsigned char) c;
+}
+
+static FILE __stdio = FDEV_SETUP_STREAM(_uart_putc, NULL, NULL, _FDEV_SETUP_WRITE);
+
+FILE *const stdout = &__stdio;
+
+#else
+
+static void * heap_end = 0;
 
 /**
  * @brief not used anywhere in the code
@@ -180,6 +206,8 @@ int _getpid()
 {
     return 1;
 }
+
+#endif
 
 #ifdef __cplusplus
 }

--- a/FreeRTOS/Demo/RISC-V-Qemu-virt_GCC/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/RISC-V-Qemu-virt_GCC/FreeRTOSConfig.h
@@ -45,6 +45,10 @@
 #define configMTIME_BASE_ADDRESS		( CLINT_ADDR + CLINT_MTIME )
 #define configMTIMECMP_BASE_ADDRESS		( CLINT_ADDR + CLINT_MTIMECMP )
 
+#ifdef PICOLIBC_TLS
+#define configUSE_PICOLIBC_TLS			1
+#endif
+
 #define configUSE_PREEMPTION			1
 #define configUSE_IDLE_HOOK				0
 #define configUSE_TICK_HOOK				1

--- a/FreeRTOS/Demo/RISC-V-Qemu-virt_GCC/Makefile
+++ b/FreeRTOS/Demo/RISC-V-Qemu-virt_GCC/Makefile
@@ -43,6 +43,11 @@ else
     CFLAGS += -O2
 endif
 
+ifeq ($(PICOLIBC), 1)
+    CFLAGS += --specs=picolibc.specs -DPICOLIBC_INTEGER_PRINTF_SCANF
+   LDFLAGS += --specs=picolibc.specs -DPICOLIBC_INTEGER_PRINTF_SCANF
+endif
+
 SRCS = main.c main_blinky.c riscv-virt.c ns16550.c \
 	$(DEMO_SOURCE_DIR)/EventGroupsDemo.c \
 	$(DEMO_SOURCE_DIR)/TaskNotify.c \

--- a/FreeRTOS/Demo/RISC-V-Qemu-virt_GCC/fake_rom.lds
+++ b/FreeRTOS/Demo/RISC-V-Qemu-virt_GCC/fake_rom.lds
@@ -81,6 +81,25 @@ SECTIONS
 		_edata = .;
 	} >ram AT>rom
 
+	.tdata : {
+		*(.tdata .tdata.*)
+	} >rom AT>rom
+
+	.tbss (NOLOAD) : {
+		*(.tbss .tbss.* .gnu.linkonce.tb.*)
+		*(.tcommon)
+		PROVIDE( __tbss_end = . );
+		PROVIDE( __tls_end = . );
+	} >rom AT>rom
+	PROVIDE( __tdata_source = LOADADDR(.tdata) );
+	PROVIDE( __tdata_source_end = LOADADDR(.tdata) + SIZEOF(.tdata) );
+	PROVIDE( __tdata_size = SIZEOF(.tdata) );
+	PROVIDE( __tbss_offset = ADDR(.tbss) - ADDR(.tdata) );
+	PROVIDE( __tbss_start = ADDR(.tbss) );
+	PROVIDE( __tbss_size = SIZEOF(.tbss) );
+	PROVIDE( __tls_size = __tls_end - ADDR(.tdata) );
+	PROVIDE( __tls_align = MAX(ALIGNOF(.tdata), ALIGNOF(.tbss)) );
+
 	.bss.align :
 	{
 		. = ALIGN(4);


### PR DESCRIPTION
Picolibc Demos
-----------
This PR allows a couple of qemu-based demos to be built using picolibc rather than newlib. This includes
the MPU demo for the MPS2-AN385 and the RISC-V demo for the virt platform. For both tests, this required adding compiler and linker flags to direct the GCC toolchain to picolibc and enabling Picolibc TLS support. For the MPS2-AN385 demo, this also includes replacing the newlib-specific syscall interface with one for picolibc.

Building the Demos
-----------
```
$ cd Demo/CORTEX_MPU_M3_MPS2_QEMU_GCC
$ make PICOLIBC=1
$ qemu-system-arm -machine mps2-an385 -monitor null -semihosting --semihosting-config enable=on,target=native -kernel ./build/RTOSDemo.axf -serial stdio -nographic
$ cd ../RISC-V-Qemu-virt_GCC
$ make PICOLIBC=1
$ qemu-system-riscv32 -nographic -machine virt -net none -chardev stdio,id=con,mux=on -serial chardev:con -mon chardev=con,mode=readline -bios none -kernel ./build/RTOSDemo.axf
```

Checklist:
----------
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
