### PR TITLE
[WIN32-MingW Demo] Modify project setting files to resolve compiler errors on Eclipse

### DIFF
--- a/FreeRTOS/Demo/WIN32-MingW/.cproject
+++ b/FreeRTOS/Demo/WIN32-MingW/.cproject
@@ -66,7 +66,7 @@
 						</toolChain>
 					</folderInfo>
 					<sourceEntries>
-						<entry excluding="FreeRTOS+Trace Recorder/streamports" flags="VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name=""/>
+						<entry excluding="FreeRTOS+Trace Recorder/extras|FreeRTOS+Trace Recorder/kernelports/Zephyr|FreeRTOS+Trace Recorder/kernelports/ThreadX|FreeRTOS+Trace Recorder/kernelports/ESP-IDF_FreeRTOS|FreeRTOS+Trace Recorder/kernelports/BareMetal|FreeRTOS_Source/examples|FreeRTOS+Trace Recorder/streamports" flags="VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name=""/>
 					</sourceEntries>
 				</configuration>
 			</storageModule>
@@ -139,7 +139,7 @@
 						</toolChain>
 					</folderInfo>
 					<sourceEntries>
-						<entry excluding="FreeRTOS+Trace Recorder|FreeRTOS+Trace Recorder/streamports" flags="VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name=""/>
+						<entry excluding="FreeRTOS_Source/examples|FreeRTOS+Trace Recorder|FreeRTOS+Trace Recorder/streamports" flags="VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name=""/>
 					</sourceEntries>
 				</configuration>
 			</storageModule>

--- a/FreeRTOS/Demo/WIN32-MingW/.cproject
+++ b/FreeRTOS/Demo/WIN32-MingW/.cproject
@@ -30,7 +30,8 @@
 								<option id="gnu.c.compiler.mingw.exe.debug.option.debugging.level.514946732" name="Debug Level" superClass="gnu.c.compiler.mingw.exe.debug.option.debugging.level" useByScannerDiscovery="false" value="gnu.c.debugging.level.max" valueType="enumerated"/>
 								<option id="gnu.c.compiler.option.include.paths.1474487302" name="Include paths (-I)" superClass="gnu.c.compiler.option.include.paths" useByScannerDiscovery="false" valueType="includePath">
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/FreeRTOS_Source/include}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/FreeRTOS+Trace Recorder/Include}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/FreeRTOS+Trace Recorder/include}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/FreeRTOS+Trace Recorder/kernelports/FreeRTOS/include}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/Trace_Recorder_Configuration}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/Standard_Demo_Tasks/Include}&quot;"/>
@@ -101,7 +102,8 @@
 								<option id="gnu.c.compiler.mingw.exe.debug.option.debugging.level.434354805" name="Debug Level" superClass="gnu.c.compiler.mingw.exe.debug.option.debugging.level" useByScannerDiscovery="false" value="gnu.c.debugging.level.max" valueType="enumerated"/>
 								<option id="gnu.c.compiler.option.include.paths.1988602727" name="Include paths (-I)" superClass="gnu.c.compiler.option.include.paths" useByScannerDiscovery="false" valueType="includePath">
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/FreeRTOS_Source/include}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/FreeRTOS+Trace Recorder/Include}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/FreeRTOS+Trace Recorder/include}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/FreeRTOS+Trace Recorder/kernelports/FreeRTOS/include}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/Trace_Recorder_Configuration}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/Standard_Demo_Tasks/Include}&quot;"/>

--- a/FreeRTOS/Demo/WIN32-MingW/.cproject
+++ b/FreeRTOS/Demo/WIN32-MingW/.cproject
@@ -67,7 +67,7 @@
 						</toolChain>
 					</folderInfo>
 					<sourceEntries>
-						<entry excluding="FreeRTOS+Trace Recorder/extras|FreeRTOS+Trace Recorder/kernelports/Zephyr|FreeRTOS+Trace Recorder/kernelports/ThreadX|FreeRTOS+Trace Recorder/kernelports/ESP-IDF_FreeRTOS|FreeRTOS+Trace Recorder/kernelports/BareMetal|FreeRTOS_Source/examples|FreeRTOS+Trace Recorder/streamports" flags="VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name=""/>
+						<entry flags="VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name=""/>
 					</sourceEntries>
 				</configuration>
 			</storageModule>
@@ -141,7 +141,7 @@
 						</toolChain>
 					</folderInfo>
 					<sourceEntries>
-						<entry excluding="FreeRTOS_Source/examples|FreeRTOS+Trace Recorder|FreeRTOS+Trace Recorder/streamports" flags="VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name=""/>
+						<entry excluding="FreeRTOS+Trace Recorder" flags="VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name=""/>
 					</sourceEntries>
 				</configuration>
 			</storageModule>

--- a/FreeRTOS/Demo/WIN32-MingW/.project
+++ b/FreeRTOS/Demo/WIN32-MingW/.project
@@ -47,39 +47,57 @@
 	</linkedResources>
 	<filteredResources>
 		<filter>
-			<id>1712588963851</id>
+			<id>1713338225157</id>
 			<name>FreeRTOS+Trace Recorder</name>
-			<type>10</type>
+			<type>9</type>
 			<matcher>
 				<id>org.eclipse.ui.ide.multiFilter</id>
-				<arguments>1.0-name-matches-false-false-ConfigurationTemplate</arguments>
+				<arguments>1.0-name-matches-false-false-include</arguments>
 			</matcher>
 		</filter>
 		<filter>
-			<id>1712588963861</id>
+			<id>1713338225174</id>
 			<name>FreeRTOS+Trace Recorder</name>
-			<type>10</type>
+			<type>9</type>
 			<matcher>
 				<id>org.eclipse.ui.ide.multiFilter</id>
-				<arguments>1.0-name-matches-false-false-streamports</arguments>
+				<arguments>1.0-name-matches-false-false-kernelports</arguments>
 			</matcher>
 		</filter>
 		<filter>
-			<id>1712588963870</id>
+			<id>1713338225189</id>
 			<name>FreeRTOS+Trace Recorder</name>
-			<type>10</type>
+			<type>9</type>
 			<matcher>
 				<id>org.eclipse.ui.ide.multiFilter</id>
-				<arguments>1.0-name-matches-false-false-extras</arguments>
+				<arguments>1.0-name-matches-false-false-config</arguments>
 			</matcher>
 		</filter>
 		<filter>
-			<id>1712588889456</id>
+			<id>1713338266068</id>
 			<name>FreeRTOS_Source</name>
-			<type>10</type>
+			<type>5</type>
 			<matcher>
 				<id>org.eclipse.ui.ide.multiFilter</id>
-				<arguments>1.0-name-matches-false-false-examples</arguments>
+				<arguments>1.0-name-matches-false-false-*.c</arguments>
+			</matcher>
+		</filter>
+		<filter>
+			<id>1713338266079</id>
+			<name>FreeRTOS_Source</name>
+			<type>9</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-include</arguments>
+			</matcher>
+		</filter>
+		<filter>
+			<id>1713338266087</id>
+			<name>FreeRTOS_Source</name>
+			<type>9</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-portable</arguments>
 			</matcher>
 		</filter>
 		<filter>

--- a/FreeRTOS/Demo/WIN32-MingW/.project
+++ b/FreeRTOS/Demo/WIN32-MingW/.project
@@ -47,12 +47,39 @@
 	</linkedResources>
 	<filteredResources>
 		<filter>
-			<id>1387372952208</id>
+			<id>1712588963851</id>
 			<name>FreeRTOS+Trace Recorder</name>
 			<type>10</type>
 			<matcher>
 				<id>org.eclipse.ui.ide.multiFilter</id>
 				<arguments>1.0-name-matches-false-false-ConfigurationTemplate</arguments>
+			</matcher>
+		</filter>
+		<filter>
+			<id>1712588963861</id>
+			<name>FreeRTOS+Trace Recorder</name>
+			<type>10</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-streamports</arguments>
+			</matcher>
+		</filter>
+		<filter>
+			<id>1712588963870</id>
+			<name>FreeRTOS+Trace Recorder</name>
+			<type>10</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-extras</arguments>
+			</matcher>
+		</filter>
+		<filter>
+			<id>1712588889456</id>
+			<name>FreeRTOS_Source</name>
+			<type>10</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-examples</arguments>
 			</matcher>
 		</filter>
 		<filter>
@@ -290,7 +317,16 @@
 			</matcher>
 		</filter>
 		<filter>
-			<id>0</id>
+			<id>1712588912887</id>
+			<name>FreeRTOS+Trace Recorder/kernelports</name>
+			<type>9</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-FreeRTOS</arguments>
+			</matcher>
+		</filter>
+		<filter>
+			<id>1712588782478</id>
 			<name>FreeRTOS_Source/portable</name>
 			<type>9</type>
 			<matcher>
@@ -299,7 +335,7 @@
 			</matcher>
 		</filter>
 		<filter>
-			<id>0</id>
+			<id>1712588782487</id>
 			<name>FreeRTOS_Source/portable</name>
 			<type>9</type>
 			<matcher>
@@ -308,7 +344,7 @@
 			</matcher>
 		</filter>
 		<filter>
-			<id>1418321226214</id>
+			<id>1712588808334</id>
 			<name>FreeRTOS_Source/portable/MemMang</name>
 			<type>5</type>
 			<matcher>


### PR DESCRIPTION
<!--- Title -->
[WIN32-MingW Demo] Modify project settings file to resolve compiler error on Eclipse

Description
-----------
<!--- Describe your changes in detail. -->
Before this change, WIN32-MingW Demo cannot be built on Eclipse because of several compiler errors.
The reason of those errors is some mismatches between Eclipse project files(`.cproject` and `.project`) and actual source file structures.
This PR includes modifications of those project files to resolve compiler errors.
This PR consists of the following two modifications.

1. Add resource filters.
The following directories are excluded from build by Resource Filter to avoid conflicts of multiple duplicate symbols.
`FreeRTOS/Source/example`
`FreeRTOS+Trace Recorder/extras`
`FreeRTOS+Trace Recorder/kernelports`   (except for `kernelports/FreeRTOS` which is included to build.)
`FreeRTOS+Trace Recorder/streamports`
The last one (streamports) is not new exclusion. It is changed from the "Excluded from Build" directive recoded in `.cproject` file to the "Resource Filter" directive recorded in `.project` file to be consistent with other directories.

2. Modify include pathes.
Directory name is modifiled. (`Include` -> `include`)
New directory is added. (`FreeRTOS+Trace Recorder/kernelports/FreeRTOS/include`)

These modifications have been discussed on the following Forum topic.
[WIN32-MingW Demo cannot be built on Eclipse](https://forums.freertos.org/t/win32-mingw-demo-cannot-be-built-on-eclipse/19734)

Test Steps
-----------
<!-- Describe the steps to reproduce. -->
1. Launch Eclipse and open workspace which includes WIN32-MingW demo project.
2. Build demo project and confirm no compiler error is reported.
3. Run and confirm demo is running successfully.

Step 2 and 3 have been confirmed on the following configurations.
Compiler: MinGW32 and MinGW64.
Debug configuration: Blinky demo and full demo
Debug_CodeCoverage configuration: full demo

On Debug_CodeCoverage configuration, code coverage score is also checked. No regression has been found.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
