### PR TITLE
Fix corePKCS11 demo logging message

### DIFF
--- a/FreeRTOS-Plus/Demo/Common/Logging/windows/Logging_WinSim.c
+++ b/FreeRTOS-Plus/Demo/Common/Logging/windows/Logging_WinSim.c
@@ -341,6 +341,8 @@ void vLoggingPrintf( const char * pcFormat,
                                 ( unsigned long ) xTaskGetTickCount(),
                                 pcTaskName );
 
+            /* Print meta data for next message if this message is endedd with line
+             * break. */
             if( prvStrEndedWithLineBreak( pcFormat ) != pdFALSE )
             {
                 xAfterLineBreak = pdTRUE;
@@ -545,7 +547,7 @@ static DWORD WINAPI prvWin32LoggingThread( void * pvParameter )
         }
     }
 
-    /* Enable direct push to flush buffer after logging thread exit. */
+    /* Enable direct print after logging thread exit. */
     xDirectPrint = pdTRUE;
 
     return 0;

--- a/FreeRTOS-Plus/Demo/Common/Logging/windows/Logging_WinSim.c
+++ b/FreeRTOS-Plus/Demo/Common/Logging/windows/Logging_WinSim.c
@@ -149,6 +149,39 @@ static size_t ulSizeOfLoggingFile = 0ul;
 Socket_t xPrintSocket = FREERTOS_INVALID_SOCKET;
 struct freertos_sockaddr xPrintUDPAddress;
 
+/* The logging thread handle. */
+HANDLE hLoggingThread = NULL;
+
+/* Windows event used to stop the logging thread and flush the logging buffer. */
+static void * pvLoggingThreadExitEvent = NULL;
+
+/*-----------------------------------------------------------*/
+
+static BaseType_t prvStrEndedWithLineBreak( const char* pcStr )
+{
+    BaseType_t xReturn;
+    size_t uxStrLen = strlen( pcStr );
+
+    if( uxStrLen < 2 )
+    {
+        xReturn = pdFALSE;
+    }
+    else if( pcStr[ uxStrLen - 2 ] != '\r' )
+    {
+        xReturn = pdFALSE;
+    }
+    else if( pcStr[ uxStrLen - 1 ] != '\n' )
+    {
+        xReturn = pdFALSE;
+    }
+    else
+    {
+        xReturn = pdTRUE;
+    }
+
+    return xReturn;
+}
+
 /*-----------------------------------------------------------*/
 
 void vLoggingInit( BaseType_t xLogToStdout,
@@ -162,8 +195,6 @@ void vLoggingInit( BaseType_t xLogToStdout,
 
     #if ( ( ipconfigHAS_DEBUG_PRINTF == 1 ) || ( ipconfigHAS_PRINTF == 1 ) )
     {
-        HANDLE Win32Thread;
-
         /* Record which output methods are to be used. */
         xStdoutLoggingUsed = xLogToStdout;
         xDiskFileLoggingUsed = xLogToFile;
@@ -212,8 +243,11 @@ void vLoggingInit( BaseType_t xLogToStdout,
             /* Create the Windows event. */
             pvLoggingThreadEvent = CreateEvent( NULL, FALSE, TRUE, L"StdoutLoggingEvent" );
 
+            /* Create logging thread exit event to notify the logging thread. */
+            pvLoggingThreadExitEvent = CreateEvent(NULL, FALSE, TRUE, L"LoggingThreadExitEvent");
+
             /* Create the thread itself. */
-            Win32Thread = CreateThread(
+            hLoggingThread = CreateThread(
                 NULL,                  /* Pointer to thread security attributes. */
                 0,                     /* Initial thread stack size, in bytes. */
                 prvWin32LoggingThread, /* Pointer to thread function. */
@@ -222,9 +256,9 @@ void vLoggingInit( BaseType_t xLogToStdout,
                 NULL );
 
             /* Use the cores that are not used by the FreeRTOS tasks. */
-            SetThreadAffinityMask( Win32Thread, ~0x01u );
-            SetThreadPriorityBoost( Win32Thread, TRUE );
-            SetThreadPriority( Win32Thread, THREAD_PRIORITY_IDLE );
+            SetThreadAffinityMask( hLoggingThread, ~0x01u );
+            SetThreadPriorityBoost( hLoggingThread, TRUE );
+            SetThreadPriority( hLoggingThread, THREAD_PRIORITY_IDLE );
         }
     }
     #else /* if ( ( ipconfigHAS_DEBUG_PRINTF == 1 ) || ( ipconfigHAS_PRINTF == 1 ) ) */
@@ -298,19 +332,35 @@ void vLoggingPrintf( const char * pcFormat,
             pcTaskName = pcNoTask;
         }
 
+        /* Print meta data only after line break. Meta data won't be printed in string
+         * contains line break only. */
         if( ( xAfterLineBreak == pdTRUE ) && ( strcmp( pcFormat, "\r\n" ) != 0 ) )
         {
             xLength = snprintf( cPrintString, dlMAX_PRINT_STRING_LENGTH, "%lu %lu [%s] ",
                                 xMessageNumber++,
                                 ( unsigned long ) xTaskGetTickCount(),
                                 pcTaskName );
-            xAfterLineBreak = pdFALSE;
+
+            if( prvStrEndedWithLineBreak( pcFormat ) != pdFALSE )
+            {
+                xAfterLineBreak = pdTRUE;
+            }
+            else
+            {
+                xAfterLineBreak = pdFALSE;
+            }
         }
         else
         {
             xLength = 0;
             memset( cPrintString, 0x00, dlMAX_PRINT_STRING_LENGTH );
-            xAfterLineBreak = pdTRUE;
+
+            /* Continue to print without meta data if string is not ended with line
+             * break. */
+            if( prvStrEndedWithLineBreak( pcFormat ) != pdFALSE )
+            {
+                xAfterLineBreak = pdTRUE;
+            }
         }
 
         xLength2 = vsnprintf( cPrintString + xLength, dlMAX_PRINT_STRING_LENGTH - xLength, pcFormat, args );
@@ -487,7 +537,18 @@ static DWORD WINAPI prvWin32LoggingThread( void * pvParameter )
 
         /* Write out all waiting messages. */
         prvLoggingFlushBuffer();
+
+        /* Check if the exit event is signaled. */
+        if( WaitForSingleObject( pvLoggingThreadExitEvent, 0 ) == WAIT_OBJECT_0 )
+        {
+            break;
+        }
     }
+
+    /* Enable direct push to flush buffer after logging thread exit. */
+    xDirectPrint = pdTRUE;
+
+    return 0;
 }
 /*-----------------------------------------------------------*/
 
@@ -552,5 +613,17 @@ static void prvLogToFile( const char * pcMessage,
 void vPlatformInitLogging( void )
 {
     vLoggingInit( pdTRUE, pdFALSE, pdFALSE, 0U, 0U );
+}
+/*-----------------------------------------------------------*/
+
+void vPlatformStopLoggingThreadAndFlush( void )
+{
+#if ( ( ipconfigHAS_DEBUG_PRINTF == 1 ) || ( ipconfigHAS_PRINTF == 1 ) )
+    SetEvent( pvLoggingThreadExitEvent );
+
+    WaitForSingleObject( hLoggingThread, INFINITE );
+
+    prvLoggingFlushBuffer();
+#endif
 }
 /*-----------------------------------------------------------*/

--- a/FreeRTOS-Plus/Demo/Common/Logging/windows/Logging_WinSim.c
+++ b/FreeRTOS-Plus/Demo/Common/Logging/windows/Logging_WinSim.c
@@ -160,7 +160,7 @@ static void * pvLoggingThreadExitEvent = NULL;
 static BaseType_t prvStrEndedWithLineBreak( const char * pcStr )
 {
     BaseType_t xReturn;
-    size_t uxStrLen = strlen( pcStr );
+    size_t uxStrLen = strnlen( pcStr, dlMAX_PRINT_STRING_LENGTH );
 
     if( uxStrLen < 2 )
     {

--- a/FreeRTOS-Plus/Demo/Common/Logging/windows/Logging_WinSim.c
+++ b/FreeRTOS-Plus/Demo/Common/Logging/windows/Logging_WinSim.c
@@ -157,7 +157,7 @@ static void * pvLoggingThreadExitEvent = NULL;
 
 /*-----------------------------------------------------------*/
 
-static BaseType_t prvStrEndedWithLineBreak( const char* pcStr )
+static BaseType_t prvStrEndedWithLineBreak( const char * pcStr )
 {
     BaseType_t xReturn;
     size_t uxStrLen = strlen( pcStr );
@@ -244,7 +244,7 @@ void vLoggingInit( BaseType_t xLogToStdout,
             pvLoggingThreadEvent = CreateEvent( NULL, FALSE, TRUE, L"StdoutLoggingEvent" );
 
             /* Create logging thread exit event to notify the logging thread. */
-            pvLoggingThreadExitEvent = CreateEvent(NULL, FALSE, TRUE, L"LoggingThreadExitEvent");
+            pvLoggingThreadExitEvent = CreateEvent( NULL, FALSE, TRUE, L"LoggingThreadExitEvent" );
 
             /* Create the thread itself. */
             hLoggingThread = CreateThread(
@@ -618,12 +618,12 @@ void vPlatformInitLogging( void )
 
 void vPlatformStopLoggingThreadAndFlush( void )
 {
-#if ( ( ipconfigHAS_DEBUG_PRINTF == 1 ) || ( ipconfigHAS_PRINTF == 1 ) )
-    SetEvent( pvLoggingThreadExitEvent );
+    #if ( ( ipconfigHAS_DEBUG_PRINTF == 1 ) || ( ipconfigHAS_PRINTF == 1 ) )
+        SetEvent( pvLoggingThreadExitEvent );
 
-    WaitForSingleObject( hLoggingThread, INFINITE );
+        WaitForSingleObject( hLoggingThread, INFINITE );
 
-    prvLoggingFlushBuffer();
-#endif
+        prvLoggingFlushBuffer();
+    #endif /* #if ( ( ipconfigHAS_DEBUG_PRINTF == 1 ) || ( ipconfigHAS_PRINTF == 1 ) ) */
 }
 /*-----------------------------------------------------------*/

--- a/FreeRTOS-Plus/Demo/Common/Logging/windows/Logging_WinSim.c
+++ b/FreeRTOS-Plus/Demo/Common/Logging/windows/Logging_WinSim.c
@@ -150,7 +150,7 @@ Socket_t xPrintSocket = FREERTOS_INVALID_SOCKET;
 struct freertos_sockaddr xPrintUDPAddress;
 
 /* The logging thread handle. */
-HANDLE hLoggingThread = NULL;
+HANDLE pvLoggingThread = NULL;
 
 /* Windows event used to stop the logging thread and flush the logging buffer. */
 static void * pvLoggingThreadExitEvent = NULL;
@@ -247,7 +247,7 @@ void vLoggingInit( BaseType_t xLogToStdout,
             pvLoggingThreadExitEvent = CreateEvent( NULL, FALSE, TRUE, L"LoggingThreadExitEvent" );
 
             /* Create the thread itself. */
-            hLoggingThread = CreateThread(
+            pvLoggingThread = CreateThread(
                 NULL,                  /* Pointer to thread security attributes. */
                 0,                     /* Initial thread stack size, in bytes. */
                 prvWin32LoggingThread, /* Pointer to thread function. */
@@ -256,9 +256,9 @@ void vLoggingInit( BaseType_t xLogToStdout,
                 NULL );
 
             /* Use the cores that are not used by the FreeRTOS tasks. */
-            SetThreadAffinityMask( hLoggingThread, ~0x01u );
-            SetThreadPriorityBoost( hLoggingThread, TRUE );
-            SetThreadPriority( hLoggingThread, THREAD_PRIORITY_IDLE );
+            SetThreadAffinityMask( pvLoggingThread, ~0x01u );
+            SetThreadPriorityBoost( pvLoggingThread, TRUE );
+            SetThreadPriority( pvLoggingThread, THREAD_PRIORITY_IDLE );
         }
     }
     #else /* if ( ( ipconfigHAS_DEBUG_PRINTF == 1 ) || ( ipconfigHAS_PRINTF == 1 ) ) */
@@ -623,7 +623,7 @@ void vPlatformStopLoggingThreadAndFlush( void )
     #if ( ( ipconfigHAS_DEBUG_PRINTF == 1 ) || ( ipconfigHAS_PRINTF == 1 ) )
         SetEvent( pvLoggingThreadExitEvent );
 
-        WaitForSingleObject( hLoggingThread, INFINITE );
+        WaitForSingleObject( pvLoggingThread, INFINITE );
 
         prvLoggingFlushBuffer();
     #endif /* #if ( ( ipconfigHAS_DEBUG_PRINTF == 1 ) || ( ipconfigHAS_PRINTF == 1 ) ) */

--- a/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/main.c
+++ b/FreeRTOS-Plus/Demo/corePKCS11_Windows_Simulator/main.c
@@ -51,6 +51,11 @@
 
 /*-----------------------------------------------------------*/
 
+extern void vPlatformInitLogging( void );
+extern void vPlatformStopLoggingThreadAndFlush( void );
+
+/*-----------------------------------------------------------*/
+
 static void prvPKCS11DemoTask( void * pvParameters )
 {
     configPRINTF( ( "---------STARTING DEMO---------\r\n" ) );
@@ -68,6 +73,7 @@ static void prvPKCS11DemoTask( void * pvParameters )
     #endif
     configPRINTF( ( "---------Finished DEMO---------\r\n" ) );
 
+    vPlatformStopLoggingThreadAndFlush();
     exit( 0 );
 }
 

--- a/FreeRTOS-Plus/VisualStudio_StaticProjects/FreeRTOS-Kernel/freertos_hooks_winsim.c
+++ b/FreeRTOS-Plus/VisualStudio_StaticProjects/FreeRTOS-Kernel/freertos_hooks_winsim.c
@@ -50,6 +50,10 @@
 
 /*-----------------------------------------------------------*/
 
+extern void vPlatformStopLoggingThreadAndFlush( void );
+
+/*-----------------------------------------------------------*/
+
 void vAssertCalled( const char * pcFile,
                     uint32_t ulLine )
 {
@@ -59,6 +63,10 @@ void vAssertCalled( const char * pcFile,
 
     ( void ) pcFileName;
     ( void ) ulLineNumber;
+
+    /* Stop the windows logging thread and flush the log buffer. This function does
+     * nothing if the logging is not initialized before. */
+    vPlatformStopLoggingThreadAndFlush();
 
     printf( "vAssertCalled( %s, %u )\n", pcFile, ulLine );
 


### PR DESCRIPTION
Fix corePKCS11 demo logging message

Description
-----------
The demo log has the following problem
1. Log is not flushed to console before exit.

2. Log without line break is not printed correctly.
```c
    configPRINTF( ( "AA" ) );
    configPRINTF( ( "BB" ) );
    configPRINTF( ( "CC" ) );
    configPRINTF( ( "\r\n" ) );
```
Current result:
> 105 43 [PKCS11 Demo] AABB106 43 [PKCS11 Demo] CC

Expected result:
> 59 34 [PKCS11 Demo] AABBCC

3. Two lines of log with line break is not printed correctly
```c
    configPRINTF( ( "AA\r\n" ) );
    configPRINTF( ( "BB\r\n" ) );
```
Current result:
> 83 43 [PKCS11 Demo] AA
> BB

Expected result:
> 59 32 [PKCS11 Demo] AA
> 60 32 [PKCS11 Demo] BB

In this PR:
* Add new API `vPlatformStopLoggingThreadAndFlush()` to flush demo log before demo exit
* Fix logging line break problem


Test Steps
-----------
Original log
```
0 1 [PKCS11 Demo] ---------STARTING DEMO---------

Starting PKCS #11 Management and Random Number Generation Demo.
1 1 [PKCS11 Demo] Cryptoki Major Version: 2 Minor Version 40
Generated random number: ca
2 8 [PKCS11 Demo] Generated random number: 87
Generated random number: a8
3 8 [PKCS11 Demo] Generated random number: de
Generated random number: 12
4 8 [PKCS11 Demo] Generated random number: bb
Generated random number: c6
5 8 [PKCS11 Demo] Generated random number: 6c
Generated random number: 24
6 8 [PKCS11 Demo] Generated random number: 1c
Finished PKCS #11 Management and Random Number Generation Demo.
7 8 [PKCS11 Demo]
Starting PKCS #11 Mechanisms and Digest Demo.
This Cryptoki library supports signing messages with RSA private keys.
8 9 [PKCS11 Demo] This Cryptoki library supports verifying messages with RSA public keys.
This Cryptoki library supports signing messages with ECDSA private keys.
9 9 [PKCS11 Demo] This Cryptoki library supports verifying messages with ECDSA public keys.
The Cryptoki library supports the SHA-256 algorithm.
10 9 [PKCS11 Demo] Known message: Hello world!
Hash of known message using SHA256:
11 9 [PKCS11 Demo] c05312 9 [PKCS11 Demo] 5e4b13 9 [PKCS11 Demo] e2b714 9 [PKCS11 Demo] 9ffd15 9 [PKCS11 Demo] 932916 9 [
PKCS11 Demo] 13517 9 [PKCS11 Demo] 436b18 9 [PKCS11 Demo] f88919 9 [PKCS11 Demo] 314e20 9 [PKCS11 Demo] 4a3f21 9 [PKCS11
Demo] aec022 9 [PKCS11 Demo] 5ecf23 9 [PKCS11 Demo] fcbb24 9 [PKCS11 Demo] 7df325 9 [PKCS11 Demo] 1ad926 9 [PKCS11 Demo]
e51a
27 9 [PKCS11 Demo] Finished PKCS #11 Mechanisms and Digest Demo.

Starting PKCS #11 Objects Demo.
28 9 [PKCS11 Demo] ---------Importing Objects---------
Importing RSA Certificate...
29 11 [PKCS11 Demo] Creating x509 certificate with label: Device Cert
corePKCS11_Certificate.dat has been created in the Visual Studio Solution directory
30 12 [PKCS11 Demo] Finished Importing RSA Certificate.
---------Finished Importing Objects---------
31 12 [PKCS11 Demo] ---------Generating Objects---------
Creating private key with label: Device Priv TLS Key
32 13 [PKCS11 Demo] Creating public key with label: Device Pub TLS Key
corePKCS11_Key.dat has been created in the Visual Studio Solution directory
33 19 [PKCS11 Demo] Extracting public key bytes...
Public Key in Hex Format, 91 bytes:
34 20 [PKCS11 Demo] 3059 3013 0607 2a86 48ce 3d02 0106 082a
35 20 [PKCS11 Demo] 8648 ce3d 0301 0703 4200 0425 27f4 baf7
36 20 [PKCS11 Demo] 1012 5210 5aed 0667 82b3 0923 de6e 7506
37 20 [PKCS11 Demo] 00f8 7733 19e6 3fa4 850c da84 4229 3ce1
38 20 [PKCS11 Demo] af05 970c 5a6d 2767 c9fe 01a0 c178 9b67
39 20 [PKCS11 Demo] 596b f01e 1e03 51f7 2c8c 15
40 20 [PKCS11 Demo] ---------Finished Generating Objects---------
Finished PKCS #11 Objects Demo.
41 20 [PKCS11 Demo]
Starting PKCS #11 Sign and Verify Demo.
Signing known message:
 Hello world
42 49 [PKCS11 Demo] The signature of the digest was verified with the public key and can be trusted.
Verifying with public key.
43 50 [PKCS11 Demo] Public Key in Hex Format, 91 bytes:
3059 3013 0607 2a86 48ce 3d02 0106 082a
44 50 [PKCS11 Demo] 8648 ce3d 0301 0703 4200 0425 27f4 baf7
45 50 [PKCS11 Demo] 1012 5210 5aed 0667 82b3 0923 de6e 7506
46 50 [PKCS11 Demo] 00f8 7733 19e6 3fa4 850c da84 4229 3ce1
47 50 [PKCS11 Demo] af05 970c 5a6d 2767 c9fe 01a0 c178 9b67
48 50 [PKCS11 Demo] 596b f01e 1e03 51f7 2c8c 15
49 51 [PKCS11 Demo] Created signature:
3050 51 [PKCS11 Demo] 450251 51 [PKCS11 Demo] 203b52 51 [PKCS11 Demo] 284553 51 [PKCS11 Demo] 0dfa

```

After this PR, the corePKCS11 demo log is fixed.
```
0 1 [PKCS11 Demo] ---------STARTING DEMO---------
1 2 [PKCS11 Demo]
Starting PKCS #11 Management and Random Number Generation Demo.
2 2 [PKCS11 Demo] Cryptoki Major Version: 2 Minor Version 40
3 5 [PKCS11 Demo] Generated random number: f3
4 5 [PKCS11 Demo] Generated random number: 8c
5 5 [PKCS11 Demo] Generated random number: ac
6 5 [PKCS11 Demo] Generated random number: 7
7 5 [PKCS11 Demo] Generated random number: c3
8 5 [PKCS11 Demo] Generated random number: bf
9 5 [PKCS11 Demo] Generated random number: 47
10 5 [PKCS11 Demo] Generated random number: 74
11 6 [PKCS11 Demo] Generated random number: 9a
12 6 [PKCS11 Demo] Generated random number: c9
13 6 [PKCS11 Demo] Finished PKCS #11 Management and Random Number Generation Demo.
14 6 [PKCS11 Demo]
Starting PKCS #11 Mechanisms and Digest Demo.
15 6 [PKCS11 Demo] This Cryptoki library supports signing messages with RSA private keys.
16 6 [PKCS11 Demo] This Cryptoki library supports verifying messages with RSA public keys.
17 6 [PKCS11 Demo] This Cryptoki library supports signing messages with ECDSA private keys.
18 7 [PKCS11 Demo] This Cryptoki library supports verifying messages with ECDSA public keys.
19 7 [PKCS11 Demo] The Cryptoki library supports the SHA-256 algorithm.
20 7 [PKCS11 Demo] Known message: Hello world!
21 7 [PKCS11 Demo] Hash of known message using SHA256:
22 7 [PKCS11 Demo] c0535e4be2b79ffd9329135436bf889314e4a3faec05ecffcbb7df31ad9e51a
23 8 [PKCS11 Demo] Finished PKCS #11 Mechanisms and Digest Demo.
24 8 [PKCS11 Demo]
Starting PKCS #11 Objects Demo.
25 8 [PKCS11 Demo] ---------Importing Objects---------
26 8 [PKCS11 Demo] Importing RSA Certificate...
27 9 [PKCS11 Demo] Creating x509 certificate with label: Device Cert
28 9 [PKCS11 Demo] corePKCS11_Certificate.dat has been created in the Visual Studio Solution directory
29 9 [PKCS11 Demo] Finished Importing RSA Certificate.
30 9 [PKCS11 Demo] ---------Finished Importing Objects---------
31 9 [PKCS11 Demo] ---------Generating Objects---------
32 10 [PKCS11 Demo] Creating private key with label: Device Priv TLS Key
33 10 [PKCS11 Demo] Creating public key with label: Device Pub TLS Key
34 16 [PKCS11 Demo] corePKCS11_Key.dat has been created in the Visual Studio Solution directory
35 16 [PKCS11 Demo] Extracting public key bytes...
36 16 [PKCS11 Demo] Public Key in Hex Format, 91 bytes:
37 16 [PKCS11 Demo] 3059 3013 0607 2a86 48ce 3d02 0106 082a
38 17 [PKCS11 Demo] 8648 ce3d 0301 0703 4200 0408 8549 cd72
39 17 [PKCS11 Demo] 6963 0031 97d3 9b3a 8109 4468 517d 19d9
40 17 [PKCS11 Demo] 6d8d 7dce ca29 e324 7fbe 96a3 2d93 b3f0
41 17 [PKCS11 Demo] 20c0 c8a8 26e6 8151 d2fa 36dc 3b0d e0d9
42 17 [PKCS11 Demo] 5608 9770 c551 4192 b148 ea
43 17 [PKCS11 Demo] ---------Finished Generating Objects---------
Finished PKCS #11 Objects Demo.
44 17 [PKCS11 Demo]
Starting PKCS #11 Sign and Verify Demo.
45 17 [PKCS11 Demo] Signing known message:
 Hello world
46 33 [PKCS11 Demo] The signature of the digest was verified with the public key and can be trusted.
47 33 [PKCS11 Demo] Verifying with public key.
48 34 [PKCS11 Demo] Public Key in Hex Format, 91 bytes:
49 35 [PKCS11 Demo] 3059 3013 0607 2a86 48ce 3d02 0106 082a
50 35 [PKCS11 Demo] 8648 ce3d 0301 0703 4200 0408 8549 cd72
51 35 [PKCS11 Demo] 6963 0031 97d3 9b3a 8109 4468 517d 19d9
52 35 [PKCS11 Demo] 6d8d 7dce ca29 e324 7fbe 96a3 2d93 b3f0
53 35 [PKCS11 Demo] 20c0 c8a8 26e6 8151 d2fa 36dc 3b0d e0d9
54 35 [PKCS11 Demo] 5608 9770 c551 4192 b148 ea
55 35 [PKCS11 Demo] Created signature:
56 35 [PKCS11 Demo] 3046022100b3853dbdae3327c63e78d7af7cf55e32fc0aa4dde25b8622ad04cb3b45098004022100d1f87a47d8067a66ec0e6
1baa9e20f1c4260e1fe71832881
57 37 [PKCS11 Demo] Finished PKCS #11 Sign and Verify Demo.
58 37 [PKCS11 Demo] ---------Finished DEMO---------

```

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
