### PR TITLE
Update corePKCS11 submodule pointer

### DIFF
--- a/FreeRTOS-Plus/Demo/corePKCS11_MQTT_Mutual_Auth_Windows_Simulator/PKCS11_Mqtt_MutualAuthDemo.c
+++ b/FreeRTOS-Plus/Demo/corePKCS11_MQTT_Mutual_Auth_Windows_Simulator/PKCS11_Mqtt_MutualAuthDemo.c
@@ -417,6 +417,16 @@ static void prvMQTTDemoTask( void * pvParameters )
     {
         LogInfo( ( "---------STARTING DEMO---------\r\n" ) );
         /****************************** Connect. ******************************/
+        /* Wait for Networking */
+        if( xPlatformIsNetworkUp() == pdFALSE )
+        {
+            LogInfo( ( "Waiting for the network link up event..." ) );
+
+            while( xPlatformIsNetworkUp() == pdFALSE )
+            {
+                vTaskDelay( pdMS_TO_TICKS( 1000U ) );
+            }
+        }
 
         /* Establish a TLS connection with the MQTT broker. This example connects
          * to the MQTT broker as specified by democonfigMQTT_BROKER_ENDPOINT and

--- a/FreeRTOS-Plus/Demo/corePKCS11_MQTT_Mutual_Auth_Windows_Simulator/PKCS11_Mqtt_MutualAuthDemo.c
+++ b/FreeRTOS-Plus/Demo/corePKCS11_MQTT_Mutual_Auth_Windows_Simulator/PKCS11_Mqtt_MutualAuthDemo.c
@@ -416,6 +416,7 @@ static void prvMQTTDemoTask( void * pvParameters )
     for( ; ; )
     {
         LogInfo( ( "---------STARTING DEMO---------\r\n" ) );
+
         /****************************** Connect. ******************************/
         /* Wait for Networking */
         if( xPlatformIsNetworkUp() == pdFALSE )

--- a/FreeRTOS-Plus/Demo/corePKCS11_MQTT_Mutual_Auth_Windows_Simulator/PKCS11_Mqtt_MutualAuthDemo.c
+++ b/FreeRTOS-Plus/Demo/corePKCS11_MQTT_Mutual_Auth_Windows_Simulator/PKCS11_Mqtt_MutualAuthDemo.c
@@ -304,6 +304,10 @@ static MQTTStatus_t prvProcessLoopWithTimeout( MQTTContext_t * pMqttContext,
 
 /*-----------------------------------------------------------*/
 
+extern BaseType_t xPlatformIsNetworkUp( void );
+
+/*-----------------------------------------------------------*/
+
 /* @brief Static buffer used to hold MQTT messages being sent and received. */
 static uint8_t ucSharedBuffer[ democonfigNETWORK_BUFFER_SIZE ];
 

--- a/FreeRTOS-Plus/Demo/corePKCS11_MQTT_Mutual_Auth_Windows_Simulator/main.c
+++ b/FreeRTOS-Plus/Demo/corePKCS11_MQTT_Mutual_Auth_Windows_Simulator/main.c
@@ -52,6 +52,8 @@
 
 extern void vPlatformInitIpStack( void );
 
+extern void vStartPKCSMutualAuthDemo( void );
+
 /*-----------------------------------------------------------*/
 
 int main( void )

--- a/FreeRTOS-Plus/Source/Application-Protocols/network_transport/mbedtls_pk_pkcs11.c
+++ b/FreeRTOS-Plus/Source/Application-Protocols/network_transport/mbedtls_pk_pkcs11.c
@@ -849,7 +849,7 @@ static int p11_ecdsa_check_pair( const void * pvPub,
         };
         unsigned char pucTestSignature[ MBEDTLS_ECDSA_MAX_SIG_LEN( 256 ) ] = { 0 };
         size_t uxSigLen = 0;
-        lResult = p11_ecdsa_sign( pxMbedtlsPkCtx, MBEDTLS_MD_SHA256,
+        lResult = p11_ecdsa_sign( ( mbedtls_pk_context * ) pxMbedtlsPkCtx, MBEDTLS_MD_SHA256,
                                   pucTestHash, sizeof( pucTestHash ),
                                   pucTestSignature, sizeof( pucTestSignature ), &uxSigLen,
                                   NULL, NULL );
@@ -883,7 +883,7 @@ static size_t p11_rsa_get_bitlen( const mbedtls_pk_context * pxMbedtlsPkCtx )
 
     configASSERT( mbedtls_rsa_info.get_bitlen );
 
-    return mbedtls_rsa_info.get_bitlen( pxMbedtlsPkCtx );
+    return mbedtls_rsa_info.get_bitlen( ( mbedtls_pk_context * ) pxMbedtlsPkCtx );
 }
 
 /*-----------------------------------------------------------*/
@@ -1009,8 +1009,8 @@ static int p11_rsa_check_pair( const void * pvPub,
 {
     configASSERT( mbedtls_rsa_info.check_pair_func );
 
-    return mbedtls_rsa_info.check_pair_func( pvPub,
-                                             pxMbedtlsPkCtx,
+    return mbedtls_rsa_info.check_pair_func( ( void * ) pvPub,
+                                             ( mbedtls_pk_context * ) pxMbedtlsPkCtx,
                                              lFRng,
                                              pvPRng );
 }
@@ -1112,7 +1112,7 @@ static void p11_rsa_debug( const mbedtls_pk_context * pxMbedtlsPkCtx,
 {
     configASSERT( mbedtls_rsa_info.debug_func );
 
-    mbedtls_rsa_info.debug_func( pxMbedtlsPkCtx, pxItems );
+    mbedtls_rsa_info.debug_func( ( mbedtls_pk_context * ) pxMbedtlsPkCtx, pxItems );
 }
 
 /*-----------------------------------------------------------*/

--- a/FreeRTOS-Plus/Source/Application-Protocols/network_transport/transport_mbedtls_pkcs11.c
+++ b/FreeRTOS-Plus/Source/Application-Protocols/network_transport/transport_mbedtls_pkcs11.c
@@ -569,7 +569,7 @@ static CK_RV readCertificateIntoContext( SSLContext_t * pSslContext,
 
     /* Get the handle of the certificate. */
     xResult = xFindObjectWithLabelAndClass( pSslContext->xP11Session,
-                                            pcLabelName,
+                                            ( char * ) pcLabelName,
                                             strnlen( pcLabelName,
                                                      pkcs11configMAX_LABEL_LENGTH ),
                                             xClass,
@@ -643,7 +643,6 @@ static CK_RV initializeClientKeys( SSLContext_t * pxCtx,
     CK_RV xResult = CKR_OK;
     CK_SLOT_ID * pxSlotIds = NULL;
     CK_ULONG xCount = 0;
-    CK_ATTRIBUTE xTemplate[ 2 ];
     mbedtls_pk_type_t xKeyAlgo = ( mbedtls_pk_type_t ) ~0;
 
     /* Get the PKCS #11 module/token slot count. */
@@ -686,7 +685,7 @@ static CK_RV initializeClientKeys( SSLContext_t * pxCtx,
     {
         /* Get the handle of the device private key. */
         xResult = xFindObjectWithLabelAndClass( pxCtx->xP11Session,
-                                                pcLabelName,
+                                                ( char * ) pcLabelName,
                                                 strnlen( pcLabelName,
                                                          pkcs11configMAX_LABEL_LENGTH ),
                                                 CKO_PRIVATE_KEY,

--- a/FreeRTOS-Plus/VisualStudio_StaticProjects/corePKCS11/corePKCS11.vcxproj
+++ b/FreeRTOS-Plus/VisualStudio_StaticProjects/corePKCS11/corePKCS11.vcxproj
@@ -56,7 +56,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>WIN32;WIN32_LEAN_AND_MEAN;MBEDTLS_CONFIG_FILE="mbedtls_config_v3.5.1.h";_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>..\..\Source\corePKCS11\source\include;..\..\Source\corePKCS11\source\portable\os;..\..\Source\corePKCS11\source\portable\os\freertos_winsim;..\..\Source\corePKCS11\source\dependency\3rdparty\mbedtls_utils;..\..\Source\corePKCS11\source\dependency\3rdparty\pkcs11;..\..\Source\corePKCS11\source\dependency\3rdparty\pkcs11\published\2-40-errata-1;.\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\Source\corePKCS11\source\include;..\..\Source\corePKCS11\source\portable\os;..\..\Source\corePKCS11\source\portable\os\freertos_winsim;..\..\Source\corePKCS11\source\dependency\3rdparty\mbedtls_utils;..\..\Source\corePKCS11\source\dependency\3rdparty\pkcs11\published\2-40-errata-1;.\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <Link>

--- a/FreeRTOS-Plus/VisualStudio_StaticProjects/corePKCS11/corePKCS11.vcxproj
+++ b/FreeRTOS-Plus/VisualStudio_StaticProjects/corePKCS11/corePKCS11.vcxproj
@@ -56,7 +56,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>WIN32;WIN32_LEAN_AND_MEAN;MBEDTLS_CONFIG_FILE="mbedtls_config_v3.5.1.h";_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>..\..\Source\corePKCS11\source\include;..\..\Source\corePKCS11\source\portable\os;..\..\Source\corePKCS11\source\portable\os\freertos_winsim;..\..\Source\corePKCS11\source\dependency\3rdparty\mbedtls_utils;..\..\Source\corePKCS11\source\dependency\3rdparty\pkcs11;..\..\Source\corePKCS11\source\dependency\3rdparty\pkcs11\published/2-40-errata-1;.\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\Source\corePKCS11\source\include;..\..\Source\corePKCS11\source\portable\os;..\..\Source\corePKCS11\source\portable\os\freertos_winsim;..\..\Source\corePKCS11\source\dependency\3rdparty\mbedtls_utils;..\..\Source\corePKCS11\source\dependency\3rdparty\pkcs11;..\..\Source\corePKCS11\source\dependency\3rdparty\pkcs11\published\2-40-errata-1;.\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <Link>
@@ -70,7 +70,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>MBEDTLS_CONFIG_FILE="mbedtls_config_v3.5.1.h";WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>..\..\Source\corePKCS11\source\include;..\..\Source\corePKCS11\source\portable\os;..\..\Source\corePKCS11\source\portable\os\freertos_winsim;..\..\Source\corePKCS11\source\dependency\3rdparty\mbedtls_utils;..\..\Source\corePKCS11\source\dependency\3rdparty\pkcs11;.\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\Source\corePKCS11\source\include;..\..\Source\corePKCS11\source\portable\os;..\..\Source\corePKCS11\source\portable\os\freertos_winsim;..\..\Source\corePKCS11\source\dependency\3rdparty\mbedtls_utils;..\..\Source\corePKCS11\source\dependency\3rdparty\pkcs11\published\2-40-errata-1;.\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <Link>

--- a/FreeRTOS-Plus/VisualStudio_StaticProjects/corePKCS11/corePKCS11.vcxproj
+++ b/FreeRTOS-Plus/VisualStudio_StaticProjects/corePKCS11/corePKCS11.vcxproj
@@ -43,11 +43,11 @@
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <PublicIncludeDirectories>..\..\Source\corePKCS11\source\include;..\..\Source\corePKCS11\source\dependency\3rdparty\mbedtls_utils;..\..\Source\corePKCS11\source\dependency\3rdparty\pkcs11;.\</PublicIncludeDirectories>
+    <PublicIncludeDirectories>..\..\Source\corePKCS11\source\include;..\..\Source\corePKCS11\source\dependency\3rdparty\mbedtls_utils;..\..\Source\corePKCS11\source\dependency\3rdparty\pkcs11\published\2-40-errata-1;.\</PublicIncludeDirectories>
     <AllProjectIncludesArePublic>true</AllProjectIncludesArePublic>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug_with_Libslirp|Win32'">
-    <PublicIncludeDirectories>..\..\Source\corePKCS11\source\include;..\..\Source\corePKCS11\source\dependency\3rdparty\mbedtls_utils;..\..\Source\corePKCS11\source\dependency\3rdparty\pkcs11;.\</PublicIncludeDirectories>
+    <PublicIncludeDirectories>..\..\Source\corePKCS11\source\include;..\..\Source\corePKCS11\source\dependency\3rdparty\mbedtls_utils;..\..\Source\corePKCS11\source\dependency\3rdparty\pkcs11\published\2-40-errata-1;.\</PublicIncludeDirectories>
     <AllProjectIncludesArePublic>true</AllProjectIncludesArePublic>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
@@ -56,7 +56,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>WIN32;WIN32_LEAN_AND_MEAN;MBEDTLS_CONFIG_FILE="mbedtls_config_v3.5.1.h";_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>..\..\Source\corePKCS11\source\include;..\..\Source\corePKCS11\source\portable\os;..\..\Source\corePKCS11\source\portable\os\freertos_winsim;..\..\Source\corePKCS11\source\dependency\3rdparty\mbedtls_utils;..\..\Source\corePKCS11\source\dependency\3rdparty\pkcs11;.\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\Source\corePKCS11\source\include;..\..\Source\corePKCS11\source\portable\os;..\..\Source\corePKCS11\source\portable\os\freertos_winsim;..\..\Source\corePKCS11\source\dependency\3rdparty\mbedtls_utils;..\..\Source\corePKCS11\source\dependency\3rdparty\pkcs11;..\..\Source\corePKCS11\source\dependency\3rdparty\pkcs11\published/2-40-errata-1;.\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <Link>

--- a/manifest.yml
+++ b/manifest.yml
@@ -54,7 +54,7 @@ dependencies:
       path: "FreeRTOS-Plus/Source/Application-Protocols/coreMQTT-Agent"
 
   - name: "corePKCS11"
-    version: "cb865c1"
+    version: "59875a9"
     repository:
       type: "git"
       url: "https://github.com/FreeRTOS/corePKCS11.git"


### PR DESCRIPTION
<!--- Title -->

Description
-----------
In this PR:
* Update corePKCS11 submodule pointer
* Fix corePKCS11_MQTT_Mutual_Auth_Windows_Simulator demo to wait for network up
* Fix compiler warning in corePKCS11 demos

Test Steps
-----------
N/A

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] ~~I have modified and/or added unit-tests to cover the code changes in this Pull Request.~~

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
