### PR TITLE
Demo/CORTEX_MPU_M3_MPS2_QEMU_GCC: optimize _sbrk()

### DIFF
--- a/FreeRTOS/Demo/CORTEX_MPU_M3_MPS2_QEMU_GCC/init/startup.c
+++ b/FreeRTOS/Demo/CORTEX_MPU_M3_MPS2_QEMU_GCC/init/startup.c
@@ -34,7 +34,7 @@
 extern void vPortSVCHandler( void );
 extern void xPortPendSVHandler( void );
 extern void xPortSysTickHandler( void );
-extern void uart_init();
+extern void uart_init( void );
 extern int main();
 
 extern uint32_t _estack, _sidata, _sdata, _edata, _sbss, _ebss;

--- a/FreeRTOS/Demo/CORTEX_MPU_M3_MPS2_QEMU_GCC/syscall.c
+++ b/FreeRTOS/Demo/CORTEX_MPU_M3_MPS2_QEMU_GCC/syscall.c
@@ -53,7 +53,7 @@ extern unsigned long g_ulBase;
 /**
  * @brief initializes the UART emulated hardware
  */
-void uart_init()
+void uart_init(void)
 {
     UART0_ADDR->BAUDDIV = 16;
     UART0_ADDR->CTRL = UART_CTRL_TX_EN;
@@ -85,7 +85,7 @@ FILE *const stdout = &__stdio;
 
 #else
 
-static void * heap_end = 0;
+static char * heap_end = ( char * ) &_heap_bottom;
 
 /**
  * @brief not used anywhere in the code
@@ -139,16 +139,9 @@ int _write( __attribute__( ( unused ) ) int file,
  */
 void * _sbrk( int incr )
 {
-    char * prev_heap_end;
+    void * prev_heap_end = heap_end;
 
-    if( heap_end == 0 )
-    {
-        heap_end = ( void * ) &_heap_bottom;
-    }
-
-    prev_heap_end = heap_end;
-
-    if( ( heap_end + incr ) > ( void * ) &_heap_top )
+    if( ( heap_end + incr ) > ( char * ) &_heap_top )
     {
         return ( void * ) -1;
     }
@@ -202,7 +195,7 @@ void _kill( pid_t pid,
     ( void ) sig;
 }
 
-int _getpid()
+int _getpid( void )
 {
     return 1;
 }


### PR DESCRIPTION
Optimize _sbrk() from runtime to compiletime initialization.
Fix compiler warnings by adjusting (void *) and (char *) types.

Complete function declarations for uart_init() and _getpid().

<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->

Test Steps
-----------
Compile/run this code on qemu.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
