### PR TITLE
Demo/Posix_GCC cleanup

### DIFF
--- a/FreeRTOS/Demo/Posix_GCC/main.c
+++ b/FreeRTOS/Demo/Posix_GCC/main.c
@@ -118,11 +118,13 @@ void vApplicationGetTimerTaskMemory( StaticTask_t ** ppxTimerTaskTCBBuffer,
                                      StackType_t ** ppxTimerTaskStackBuffer,
                                      uint32_t * pulTimerTaskStackSize );
 
+#if ( projENABLE_TRACING == 1 )
 /*
  * Writes trace data to a disk file when the trace recording is stopped.
  * This function will simply overwrite any trace files that already exist.
  */
 static void prvSaveTraceFile( void );
+#endif /* if ( projENABLE_TRACING == 1 ) */
 
 /*
  * Signal handler for Ctrl_C to cause the program to exit, and generate the
@@ -138,8 +140,6 @@ static void handle_sigint( int signal );
  * declared here, as a global, so it can be checked by a test that is implemented
  * in a different file. */
 StackType_t uxTimerTaskStack[ configTIMER_TASK_STACK_DEPTH ];
-
-static clockid_t cid = CLOCK_THREAD_CPUTIME_ID;
 
 /*-----------------------------------------------------------*/
 
@@ -425,6 +425,8 @@ void vApplicationGetTimerTaskMemory( StaticTask_t ** ppxTimerTaskTCBBuffer,
 void handle_sigint( int signal )
 {
     int xReturn;
+
+    (void) signal;
 
     xReturn = chdir( BUILD ); /* changing dir to place gmon.out inside build */
 

--- a/FreeRTOS/Demo/Posix_GCC/main_full.c
+++ b/FreeRTOS/Demo/Posix_GCC/main_full.c
@@ -269,7 +269,6 @@ static void prvCheckTask( void * pvParameters )
 {
     TickType_t xNextWakeTime;
     const TickType_t xCycleFrequency = pdMS_TO_TICKS( 10000UL );
-    HeapStats_t xHeapStats;
 
     /* Just to remove compiler warning. */
     ( void ) pvParameters;


### PR DESCRIPTION
Guard prvSaveTraceFile() function definition.

Remove "cid" as it is unused.

handle_sigint(): quiet compiler warning about unused param.

main_full.c: prvCheckTask(): Remove unused var "xHeapStats".

<!--- Title -->

Description
-----------

See above description.

Test Steps
-----------
Compile/run posix demo on Linux.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
