### PR TITLE
Demo/CORTEX_MPS2_QEMU_IAR_GCC cleanup

### DIFF
--- a/FreeRTOS/Demo/CORTEX_MPS2_QEMU_IAR_GCC/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_MPS2_QEMU_IAR_GCC/FreeRTOSConfig.h
@@ -131,4 +131,6 @@
 #define bktPRIMARY_PRIORITY      ( configMAX_PRIORITIES - 3 )
 #define bktSECONDARY_PRIORITY    ( configMAX_PRIORITIES - 4 )
 
+#define configENABLE_BACKWARD_COMPATIBILITY 0
+
 #endif /* FREERTOS_CONFIG_H */

--- a/FreeRTOS/Demo/CORTEX_MPS2_QEMU_IAR_GCC/build/gcc/Makefile
+++ b/FreeRTOS/Demo/CORTEX_MPS2_QEMU_IAR_GCC/build/gcc/Makefile
@@ -1,9 +1,8 @@
 OUTPUT_DIR := ./output
 IMAGE := RTOSDemo.out
-SUB_MAKEFILE_DIR = ./library-makefiles
 
 # The directory that contains the /source and /demo sub directories.
-FREERTOS_ROOT = ./../../../../
+FREERTOS_ROOT = ./../../../..
 
 CC = arm-none-eabi-gcc
 LD = arm-none-eabi-gcc
@@ -14,6 +13,9 @@ MAKE = make
 CFLAGS += $(INCLUDE_DIRS) -nostartfiles -ffreestanding -mthumb -mcpu=cortex-m3 \
 		  -Wall -Wextra -g3 -Os -ffunction-sections -fdata-sections \
 		  -MMD -MP -MF"$(@:%.o=%.d)" -MT $@
+
+#CFLAGS += -Wpedantic -Wshadow -fanalyzer
+#CFLAGS += -flto
 
 #
 # Kernel build.

--- a/FreeRTOS/Demo/CORTEX_MPS2_QEMU_IAR_GCC/build/gcc/startup_gcc.c
+++ b/FreeRTOS/Demo/CORTEX_MPS2_QEMU_IAR_GCC/build/gcc/startup_gcc.c
@@ -53,13 +53,13 @@ extern void TIMER1_Handler( void );
 /* Exception handlers. */
 static void HardFault_Handler( void ) __attribute__( ( naked ) );
 static void Default_Handler( void ) __attribute__( ( naked ) );
-void Reset_Handler( void );
+void Reset_Handler( void ) __attribute__( ( naked ) );
 
 extern int main( void );
 extern uint32_t _estack;
 
 /* Vector table. */
-const uint32_t* isr_vector[] __attribute__((section(".isr_vector"))) =
+const uint32_t* isr_vector[] __attribute__((section(".isr_vector"), used)) =
 {
     ( uint32_t * ) &_estack,
     ( uint32_t * ) &Reset_Handler,     // Reset                -15
@@ -68,15 +68,15 @@ const uint32_t* isr_vector[] __attribute__((section(".isr_vector"))) =
     ( uint32_t * ) &Default_Handler,   // MemManage_Handler    -12
     ( uint32_t * ) &Default_Handler,   // BusFault_Handler     -11
     ( uint32_t * ) &Default_Handler,   // UsageFault_Handler   -10
-    0, // reserved
-    0, // reserved
-    0, // reserved
+    0, // reserved   -9
+    0, // reserved   -8
+    0, // reserved   -7
     0, // reserved   -6
-    ( uint32_t * ) &vPortSVCHandler,    // SVC_Handler              -5
-    ( uint32_t * ) &Default_Handler,    // DebugMon_Handler         -4
-    0, // reserved
-    ( uint32_t * ) &xPortPendSVHandler, // PendSV handler    -2
-    ( uint32_t * ) &xPortSysTickHandler,// SysTick_Handler   -1
+    ( uint32_t * ) &vPortSVCHandler,    // SVC_Handler          -5
+    ( uint32_t * ) &Default_Handler,    // DebugMon_Handler     -4
+    0, // reserved   -3
+    ( uint32_t * ) &xPortPendSVHandler, // PendSV handler       -2
+    ( uint32_t * ) &xPortSysTickHandler,// SysTick_Handler      -1
     0,
     0,
     0,
@@ -86,7 +86,7 @@ const uint32_t* isr_vector[] __attribute__((section(".isr_vector"))) =
     0,
     0,
     ( uint32_t * ) TIMER0_Handler,     // Timer 0
-	( uint32_t * ) TIMER1_Handler,     // Timer 1
+    ( uint32_t * ) TIMER1_Handler,     // Timer 1
     0,
     0,
     0,
@@ -113,7 +113,7 @@ volatile uint32_t psr;/* Program status register. */
 /* Called from the hardfault handler to provide information on the processor
  * state at the time of the fault.
  */
-void prvGetRegistersFromStack( uint32_t *pulFaultStackAddress )
+__attribute__( ( used ) ) void prvGetRegistersFromStack( uint32_t *pulFaultStackAddress )
 {
     r0 = pulFaultStackAddress[ 0 ];
     r1 = pulFaultStackAddress[ 1 ];


### PR DESCRIPTION
Some small changes for Demo/CORTEX_MPS2_QEMU_IAR_GCC:
- FreeRTOSConfig.h: define configENABLE_BACKWARD_COMPATIBILITY to 0
- build/gcc/Makefile: remove unused SUB_MAKEFILE_DIR
- build/gcc/Makefile: no trailing slash(/) for FREERTOS_ROOT
- build/gcc/Makefile: commented out, but prepared:
   - CFLAGS += -Wpedantic -Wshadow -fanalyzer
   - CFLAGS += -flto
- build/gcc/startup_gcc.c:
   - "__attribute__( ( naked ) )" for Reset_Handler
   - "__attribute__( ( used ) )" for isr_vector and prvGetRegistersFromStack

<!--- Title -->

Description
-----------
See above.

Test Steps
-----------
Full and blinky demo still run ok.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
