### PR TITLE
Fix MQTT wolfssl demo and add wolfssl config WOLFSSL_ALT_CERT_CHAINS

### DIFF
--- a/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Mutual_Auth_wolfSSL/user_settings.h
+++ b/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Mutual_Auth_wolfSSL/user_settings.h
@@ -103,6 +103,8 @@
 #define NO_MD4
 #define NO_PWDBASED
 
+#define WOLFSSL_ALT_CERT_CHAINS
+
 /*-- Debugging options  ------------------------------------------------------
  *
  * "DEBUG_WOLFSSL" definition enables log to output into stdout.

--- a/FreeRTOS-Plus/Source/Application-Protocols/network_transport/transport_wolfSSL.c
+++ b/FreeRTOS-Plus/Source/Application-Protocols/network_transport/transport_wolfSSL.c
@@ -143,11 +143,11 @@ static int wolfSSL_IORecvGlue( WOLFSSL * ssl,
     read = TCP_Sockets_Recv( xSocket, ( void * ) buf, ( size_t ) sz );
 
     if( ( read == 0 ) ||
-        ( read == -TCP_SOCKETS_ERRNO_EWOULDBLOCK ) )
+        ( read == TCP_SOCKETS_ERRNO_EWOULDBLOCK ) )
     {
         read = WOLFSSL_CBIO_ERR_WANT_READ;
     }
-    else if( read == -TCP_SOCKETS_ERRNO_ENOTCONN )
+    else if( read == TCP_SOCKETS_ERRNO_ENOTCONN )
     {
         read = WOLFSSL_CBIO_ERR_CONN_CLOSE;
     }
@@ -169,11 +169,11 @@ static int wolfSSL_IOSendGlue( WOLFSSL * ssl,
     Socket_t xSocket = ( Socket_t ) context;
     BaseType_t sent = TCP_Sockets_Send( xSocket, ( void * ) buf, ( size_t ) sz );
 
-    if( sent == -TCP_SOCKETS_ERRNO_EWOULDBLOCK )
+    if( sent == TCP_SOCKETS_ERRNO_EWOULDBLOCK )
     {
         sent = WOLFSSL_CBIO_ERR_WANT_WRITE;
     }
-    else if( sent == -TCP_SOCKETS_ERRNO_ENOTCONN )
+    else if( sent == TCP_SOCKETS_ERRNO_ENOTCONN )
     {
         sent = WOLFSSL_CBIO_ERR_CONN_CLOSE;
     }


### PR DESCRIPTION
<!--- Title -->

Description
-----------
This PR fixes the MQTT wolfSSL demo by fixing the incorrect error code handling in the wolfSSL sockets wrapper and updating the wolfSSL user config/setting by adding `WOLFSSL_ALT_CERT_CHAINS` config to allow loading intermediate CA's as trusted and ignoring no signer failures for CA's up the chain to root.

`WOLFSSL_ALT_CERT_CHAINS` - https://www.wolfssl.com/documentation/manuals/wolfssl/chapter02.html

Test Steps
-----------
Run the MQTT wolfSSL demo.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- ~[ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.~

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
