### PR TITLE
Fix coreHTTP demo compile warning

### DIFF
--- a/FreeRTOS-Plus/Demo/coreHTTP_Windows_Simulator/HTTP_Mutual_Auth/DemoTasks/MutualAuthHTTPExample.c
+++ b/FreeRTOS-Plus/Demo/coreHTTP_Windows_Simulator/HTTP_Mutual_Auth/DemoTasks/MutualAuthHTTPExample.c
@@ -200,6 +200,10 @@ static BaseType_t prvSendHttpRequest( const TransportInterface_t * pxTransportIn
 
 /*-----------------------------------------------------------*/
 
+extern BaseType_t xPlatformIsNetworkUp( void );
+
+/*-----------------------------------------------------------*/
+
 /*
  * @brief Create the task that demonstrates the HTTP API Demo over a
  * mutually-authenticated network connection with an HTTP server.

--- a/FreeRTOS-Plus/Demo/coreHTTP_Windows_Simulator/HTTP_Plaintext/DemoTasks/PlainTextHTTPExample.c
+++ b/FreeRTOS-Plus/Demo/coreHTTP_Windows_Simulator/HTTP_Plaintext/DemoTasks/PlainTextHTTPExample.c
@@ -260,6 +260,10 @@ static BaseType_t prvSendHttpRequest( const TransportInterface_t * pxTransportIn
 
 /*-----------------------------------------------------------*/
 
+extern BaseType_t xPlatformIsNetworkUp( void );
+
+/*-----------------------------------------------------------*/
+
 /*
  * @brief Create the task that demonstrates the HTTP API Demo over a
  * mutually-authenticated network connection with an HTTP server.

--- a/FreeRTOS-Plus/Demo/coreHTTP_Windows_Simulator/HTTP_S3_Download_Multithreaded/DemoTasks/S3DownloadMultithreadedHTTPExample.c
+++ b/FreeRTOS-Plus/Demo/coreHTTP_Windows_Simulator/HTTP_S3_Download_Multithreaded/DemoTasks/S3DownloadMultithreadedHTTPExample.c
@@ -429,6 +429,10 @@ static BaseType_t prvDownloadLoop( void );
 
 /*-----------------------------------------------------------*/
 
+extern BaseType_t xPlatformIsNetworkUp( void );
+
+/*-----------------------------------------------------------*/
+
 /*
  * @brief Create task to demonstrate the HTTP API over a server-authenticated
  * network connection with a server.

--- a/FreeRTOS-Plus/Demo/coreHTTP_Windows_Simulator/HTTP_S3_Upload/DemoTasks/S3UploadHTTPExample.c
+++ b/FreeRTOS-Plus/Demo/coreHTTP_Windows_Simulator/HTTP_S3_Upload/DemoTasks/S3UploadHTTPExample.c
@@ -295,6 +295,10 @@ static BaseType_t prvVerifyS3ObjectFileSize( const TransportInterface_t * pxTran
 
 /*-----------------------------------------------------------*/
 
+extern BaseType_t xPlatformIsNetworkUp( void );
+
+/*-----------------------------------------------------------*/
+
 /*
  * @brief Create the task that demonstrates the HTTP API Demo over a
  * server-authenticated network connection with an HTTP server.


### PR DESCRIPTION
<!--- Title -->

Description
-----------
Fix `xPlatformIsNetworkUp` is not declared compile warning.

Test Steps
-----------
Compile coreHTTP demos including:
* HTTP_Mutual_Auth
* HTTP_Plaintext
* HTTP_S3_Download
* HTTP_S3_Download_Multithreaded
* HTTP_S3_Upload

Should not have any error.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] ~~I have modified and/or added unit-tests to cover the code changes in this Pull Request.~~

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
