### PR TITLE
Demo/CORTEX_MPU_M3_MPS2_QEMU_GCC/syscall.c: remove unused g_ulBase

### DIFF
--- a/FreeRTOS/Demo/CORTEX_MPU_M3_MPS2_QEMU_GCC/syscall.c
+++ b/FreeRTOS/Demo/CORTEX_MPU_M3_MPS2_QEMU_GCC/syscall.c
@@ -45,11 +45,6 @@ typedef struct UART_t
 #define UART_CTRL_TX_EN      ( 1 << 0 )
 #define UART_CTRL_RX_EN      ( 1 << 1 )
 
-
-extern unsigned long _heap_bottom;
-extern unsigned long _heap_top;
-extern unsigned long g_ulBase;
-
 /**
  * @brief initializes the UART emulated hardware
  */
@@ -84,6 +79,9 @@ static FILE __stdio = FDEV_SETUP_STREAM(_uart_putc, NULL, NULL, _FDEV_SETUP_WRIT
 FILE *const stdout = &__stdio;
 
 #else
+
+extern unsigned long _heap_bottom;
+extern unsigned long _heap_top;
 
 static char * heap_end = ( char * ) &_heap_bottom;
 
@@ -150,6 +148,7 @@ void * _sbrk( int incr )
 
     return prev_heap_end;
 }
+
 void _close( int fd )
 {
     ( void ) fd;


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->
In FreeRTOS/Demo/CORTEX_MPU_M3_MPS2_QEMU_GCC/syscall.c the extern definition of g_ulBase ist not used, so remove it. Also move _heap_bottom and _heap_top to where they are used in syscall.c.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
