### PR TITLE
Use CBMC version 5.95.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,6 +168,8 @@ jobs:
 
       - name: Set up CBMC runner
         uses: FreeRTOS/CI-CD-Github-Actions/set_up_cbmc_runner@main
+        with:
+          cbmc_version: "5.95.1"
 
       - name: Run CBMC
         uses: FreeRTOS/CI-CD-Github-Actions/run_cbmc@main


### PR DESCRIPTION
Description
-----------
The upcoming CBMC version 6 release includes changes that may affect existing proofs. This PR will make sure that FreeRTOS PRs are not negatively impacted by this release. After releasing CBMC version 6 we will issue a follow-up PR that will return FreeRTOS to using CBMC's latest release, and will include any changes to proofs that may be necessary to support the new version.

Test Steps
-----------
Tested in CI (no changes in behaviour at this point)

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
n/a


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
