### PR TITLE
Posix_GCC: update compiler options

### DIFF
--- a/FreeRTOS/Demo/Posix_GCC/CMakeLists.txt
+++ b/FreeRTOS/Demo/Posix_GCC/CMakeLists.txt
@@ -4,6 +4,14 @@ project( posix_demo )
 
 add_compile_options( -D_WINDOWS_ )
 
+add_compile_options( -g3 -O2 -Wall -Wextra -Wpedantic )
+
+#add_compile_options( -Wshadow )
+
+#add_compile_options( -fanalyzer )
+
+#add_compile_options( -flto )
+
 if( TRACE_ON_ENTER )
     add_compile_options( -DTRACE_ON_ENTER=1 )
 else()

--- a/FreeRTOS/Demo/Posix_GCC/CMakeLists.txt
+++ b/FreeRTOS/Demo/Posix_GCC/CMakeLists.txt
@@ -4,13 +4,7 @@ project( posix_demo )
 
 add_compile_options( -D_WINDOWS_ )
 
-add_compile_options( -g3 -O2 -Wall -Wextra -Wpedantic )
-
-#add_compile_options( -Wshadow )
-
-#add_compile_options( -fanalyzer )
-
-#add_compile_options( -flto )
+add_compile_options( -Wall -Wextra -Wpedantic )
 
 if( TRACE_ON_ENTER )
     add_compile_options( -DTRACE_ON_ENTER=1 )
@@ -40,6 +34,9 @@ if( PROFILE )
 else()
     set( CMAKE_BUILD_TYPE "debug" )
 endif()
+
+set(CMAKE_CXX_FLAGS_RELEASE "-O3")
+set(CMAKE_CXX_FLAGS_DEBUG "-O0 -g3")
 
 if( SANITIZE_ADDRESS )
     add_compile_options( -fsanitize=address -fsanitize=alignment )

--- a/FreeRTOS/Demo/Posix_GCC/main.c
+++ b/FreeRTOS/Demo/Posix_GCC/main.c
@@ -455,7 +455,7 @@ void handle_sigint( int signal )
         printf( "chdir into %s error is %d\n", BUILD, errno );
     }
 
-    exit( 2 );
+    _exit( 2 );
 }
 
 /*-----------------------------------------------------------*/


### PR DESCRIPTION
<!--- Title -->

Description
-----------

1. Add to CFLAGS
   - add `-O0` optimization for debug builds.
   - add `-O3` optimization for release builds. 
2. Update signal handler `handle_sigint()` to use
  `_exit()` instead of `exit()`. Normal exit() is not allowed
  within a signal handler.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
