### PR TITLE
Remove the configASSERT test for prvCheckForRunStateChange

### DIFF
--- a/FreeRTOS/Test/CMock/smp/config_assert/config_assert_utest.c
+++ b/FreeRTOS/Test/CMock/smp/config_assert/config_assert_utest.c
@@ -623,40 +623,6 @@ void test_vTaskStepTick_assert_scheduler_not_suspended( void )
 }
 
 /**
- * @brief prvCheckForRunStateChange - task state not changed.
- *
- * When the task is able to run after calling portENABLE_INTERRUPTS. The task state
- * is supposed to be changed to run state. This test cover the assertion of this scenario.
- *
- * <b>Coverage</b>
- * @code{c}
- * configASSERT( pxThisTCB->xTaskRunState != taskTASK_YIELDING );
- * @endcode
- */
-void test_prvCheckForRunStateChange_assert_task_state_not_changed( void )
-{
-    TCB_t xTaskTCB = { NULL };
-
-    pxCurrentTCBs[ 0 ] = &xTaskTCB;
-    xTaskTCB.uxCriticalNesting = 0;
-    xTaskTCB.xTaskRunState = taskTASK_YIELDING;
-    uxSchedulerSuspended = 1;
-
-    /* Expection. */
-    vFakePortAssertIfISR_Expect();
-    vFakePortGetCoreID_ExpectAndReturn( 0 );
-    vFakePortGetCoreID_ExpectAndReturn( 0 );
-    vFakePortReleaseTaskLock_Expect();
-    vFakePortEnableInterrupts_Expect();
-
-    /* API Call. */
-    EXPECT_ASSERT_BREAK( prvCheckForRunStateChange() );
-
-    /* Test Verifications */
-    validate_and_clear_assertions();
-}
-
-/**
  * @brief vTaskStepTick - assert if scheduler suspended.
  *
  * <b>Coverage</b>


### PR DESCRIPTION
<!--- Title -->

Description
-----------
This PR address the kernel PR https://github.com/FreeRTOS/FreeRTOS-Kernel/pull/1093 to remove the configASSERT test.

Test Steps
-----------
Remove the following test case due to this configASSERT is remove in implementation.
```
/home/runner/work/FreeRTOS-Kernel/FreeRTOS-Kernel/FreeRTOS/Test/CMock/smp/config_assert/config_assert_utest.c:636:test_prvCheckForRunStateChange_assert_task_state_not_changed:FAIL:Function vFakePortDisableInterrupts.  Called more times than expected.
/home/runner/work/FreeRTOS-Kernel/FreeRTOS-Kernel/FreeRTOS/Test/CMock/smp/config_assert/config_assert_utest.c:667:test_vTaskStepTick_assert_tick_to_jump_eq_0:PASS
/home/runner/work/FreeRTOS-Kernel/FreeRTOS-Kernel/FreeRTOS/Test/CMock/smp/config_assert
```

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
https://github.com/FreeRTOS/FreeRTOS-Kernel/pull/1093


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
