### PR TITLE
CORTEX_MPU_M3_MPS2_QEMU_GCC: remove unused defines

### DIFF
--- a/FreeRTOS/Demo/CORTEX_MPU_M3_MPS2_QEMU_GCC/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_MPU_M3_MPS2_QEMU_GCC/FreeRTOSConfig.h
@@ -72,7 +72,6 @@ extern void vAssertCalled( void );
 #define configUSE_COUNTING_SEMAPHORES                    1
 #define configSUPPORT_DYNAMIC_ALLOCATION                 1
 #define configSUPPORT_STATIC_ALLOCATION                  1
-#define configNUM_TX_DESCRIPTORS                         15
 #define configSTREAM_BUFFER_TRIGGER_LEVEL_TEST_MARGIN    2
 #define configCHECK_FOR_STACK_OVERFLOW                   2
 #define configALLOW_UNPRIVILEGED_CRITICAL_SECTIONS       0
@@ -133,10 +132,5 @@ unsigned long ulGetRunTimeCounterValue( void ); /* Prototype of function that re
  |      9 connected. */
 extern void vLoggingPrintf( const char * pcFormatString,
                             ... );
-
-#ifdef HEAP3
-    #define xPortGetMinimumEverFreeHeapSize    ( x )
-    #define xPortGetFreeHeapSize               ( x )
-#endif
 
 #endif /* FREERTOS_CONFIG_H */


### PR DESCRIPTION
From CORTEX_MPU_M3_MPS2_QEMU_GCC remove unused configNUM_TX_DESCRIPTORS define and remove HEAP3 from as heap_4.c is used.

<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
