### PR TITLE
Remove redundant portGET_CORE_ID calls in SMP unit test

### DIFF
--- a/FreeRTOS/Test/CMock/smp/config_assert/config_assert_utest.c
+++ b/FreeRTOS/Test/CMock/smp/config_assert/config_assert_utest.c
@@ -281,9 +281,6 @@ void test_prvYieldForTask_assert_yieldpending_core_is_false( void )
     vFakePortGetCoreID_ExpectAndReturn( 0 );
     vFakePortGetCoreID_ExpectAndReturn( 1 );
     vFakePortGetCoreID_ExpectAndReturn( 1 );
-    vFakePortGetCoreID_ExpectAndReturn( 1 );
-    vFakePortGetCoreID_ExpectAndReturn( 0 );
-    vFakePortGetCoreID_ExpectAndReturn( 0 );
     vFakePortGetCoreID_ExpectAndReturn( 0 );
 
     EXPECT_ASSERT_BREAK( vTaskRemoveFromUnorderedEventList( &xEventListItem,


### PR DESCRIPTION
<!--- Title -->

Description
-----------
* Fix `test_prvYieldForTask_assert_yieldpending_core_is_false()` with this kernel PR https://github.com/FreeRTOS/FreeRTOS-Kernel/pull/1065. Remove redundant portGET_CORE_ID() calls due to optimization.

Test Steps
-----------
Run this PR with [kernel PR](https://github.com/FreeRTOS/FreeRTOS-Kernel/pull/1065). All the unit test cases should be passed.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
