### PR TITLE
fix AbortDelay.c Test

### DIFF
--- a/FreeRTOS/Demo/Common/Minimal/AbortDelay.c
+++ b/FreeRTOS/Demo/Common/Minimal/AbortDelay.c
@@ -488,7 +488,9 @@
         uint8_t uxRxData;
 
         #if ( configSUPPORT_STATIC_ALLOCATION == 1 )
-            /* The variable used to hold the stream buffer structure. */
+            /* The variable used to hold the stream buffer structure.
+             * This control information is valid as long as xStreamBuffer
+             * is valid. */
             StaticStreamBuffer_t xStreamBufferStruct;
             {
                 /* Defines the memory that will actually hold the streams within the

--- a/FreeRTOS/Demo/Common/Minimal/AbortDelay.c
+++ b/FreeRTOS/Demo/Common/Minimal/AbortDelay.c
@@ -488,6 +488,7 @@
         uint8_t uxRxData;
 
         #if ( configSUPPORT_STATIC_ALLOCATION == 1 )
+
             /* The variable used to hold the stream buffer structure.
              * This control information is valid as long as xStreamBuffer
              * is valid. */

--- a/FreeRTOS/Demo/Common/Minimal/AbortDelay.c
+++ b/FreeRTOS/Demo/Common/Minimal/AbortDelay.c
@@ -488,14 +488,12 @@
         uint8_t uxRxData;
 
         #if ( configSUPPORT_STATIC_ALLOCATION == 1 )
+        /* The variable used to hold the stream buffer structure. */
+        StaticStreamBuffer_t xStreamBufferStruct;
         {
             /* Defines the memory that will actually hold the streams within the
              * stream buffer. */
             static uint8_t ucStorageBuffer[ sizeof( configMESSAGE_BUFFER_LENGTH_TYPE ) + 1 ];
-
-            /* The variable used to hold the stream buffer structure. */
-            StaticStreamBuffer_t xStreamBufferStruct;
-
 
             xStreamBuffer = xStreamBufferCreateStatic( sizeof( ucStorageBuffer ),
                                                        xTriggerLevelBytes,

--- a/FreeRTOS/Demo/Common/Minimal/AbortDelay.c
+++ b/FreeRTOS/Demo/Common/Minimal/AbortDelay.c
@@ -488,18 +488,18 @@
         uint8_t uxRxData;
 
         #if ( configSUPPORT_STATIC_ALLOCATION == 1 )
-        /* The variable used to hold the stream buffer structure. */
-        StaticStreamBuffer_t xStreamBufferStruct;
-        {
-            /* Defines the memory that will actually hold the streams within the
-             * stream buffer. */
-            static uint8_t ucStorageBuffer[ sizeof( configMESSAGE_BUFFER_LENGTH_TYPE ) + 1 ];
+            /* The variable used to hold the stream buffer structure. */
+            StaticStreamBuffer_t xStreamBufferStruct;
+            {
+                /* Defines the memory that will actually hold the streams within the
+                 * stream buffer. */
+                static uint8_t ucStorageBuffer[ sizeof( configMESSAGE_BUFFER_LENGTH_TYPE ) + 1 ];
 
-            xStreamBuffer = xStreamBufferCreateStatic( sizeof( ucStorageBuffer ),
-                                                       xTriggerLevelBytes,
-                                                       ucStorageBuffer,
-                                                       &xStreamBufferStruct );
-        }
+                xStreamBuffer = xStreamBufferCreateStatic( sizeof( ucStorageBuffer ),
+                                                           xTriggerLevelBytes,
+                                                           ucStorageBuffer,
+                                                           &xStreamBufferStruct );
+            }
         #else /* if ( configSUPPORT_STATIC_ALLOCATION == 1 ) */
         {
             xStreamBuffer = xStreamBufferCreate( sizeof( uint8_t ), xTriggerLevelBytes );


### PR DESCRIPTION
Fixing Issue with AbortDelay Tests in Release build.

Description
-----------
When xStreamBufferStruct gets out of scope it gets delete and results in an error down the line. This is fixed by moving the variable outside the inner scope. The variable does not need to be static because the Buffer is only used once and is deleted afterwards (per functioncall)

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
