### PR TITLE
Compile demo for RV32

### DIFF
--- a/FreeRTOS/Demo/RISC-V_RV32_QEMU_VIRT_GCC/build/gcc/Makefile
+++ b/FreeRTOS/Demo/RISC-V_RV32_QEMU_VIRT_GCC/build/gcc/Makefile
@@ -4,9 +4,9 @@ IMAGE := RTOSDemo.elf
 # The directory that contains the /source and /demo sub directories.
 FREERTOS_ROOT = ./../../../..
 
-CC = riscv64-unknown-elf-gcc
-LD = riscv64-unknown-elf-gcc
-SIZE = riscv64-unknown-elf-size
+CC = riscv32-unknown-elf-gcc
+LD = riscv32-unknown-elf-gcc
+SIZE = riscv32-unknown-elf-size
 MAKE = make
 
 # Generate GCC_VERSION in number format


### PR DESCRIPTION
Compile demo for RV32

Description
-----------
Noticed an RV32 demo was using the 64-bit compiler, just updated the paths. 
Updated Makefile operates as expected and builds elf file.

Test Steps
-----------
`build -C build/gcc`

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
