### PR TITLE
Remove no new core added coverage test for coreAffinitySet

### DIFF
--- a/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c
+++ b/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c
@@ -1338,62 +1338,6 @@ void test_coverage_vTaskCoreAffinitySet_null_task_handle( void )
 }
 
 /**
- * @brief vTaskCoreAffinitySet - no new core for task which is not running.
- *
- * Set core mask for a not running task. The new core mask doesn't enable the task
- * to run on any new core. Verify the core mask set is correct.
- *
- * <b>Coverage</b>
- * @code{c}
- * if( taskTASK_IS_RUNNING( pxTCB ) == pdTRUE )
- * {
- *     ...
- * }
- * else
- * {
- *     if( ( uxPrevNotAllowedCores & uxCoreAffinityMask ) != 0U )
- *     {
- *         prvYieldForTask( pxTCB );
- *     }
- * }
- * @endcode
- * ( taskTASK_IS_RUNNING( pxTCB ) == pdTRUE ) is false.
- * ( ( uxPrevNotAllowedCores & uxCoreAffinityMask ) != 0U ) is false.
- */
-void test_coverage_vTaskCoreAffinitySet_task_not_running_no_new_core( void )
-{
-    TCB_t xTaskTCB = { NULL };
-    UBaseType_t uxCoreAffinityMask;
-    UBaseType_t uxNewCoreAffinityMask;
-
-    /* Setup the variables and structure. */
-    /* This task is allowed to run on core 0 and core 1 only. */
-    uxCoreAffinityMask = ( 1U << 0 ) | ( 1U << 1 );
-    vCreateStaticTestTaskAffinity( &xTaskTCB,
-                                   uxCoreAffinityMask,
-                                   tskIDLE_PRIORITY,
-                                   configNUMBER_OF_CORES,
-                                   pdFALSE );
-    xSchedulerRunning = pdTRUE;
-
-    /* Expectations. */
-    vFakePortEnterCriticalSection_StubWithCallback( NULL );
-    vFakePortExitCriticalSection_StubWithCallback( NULL );
-    vFakePortCheckIfInISR_StopIgnore();
-
-    vFakePortEnterCriticalSection_Expect();
-    vFakePortExitCriticalSection_Expect();
-
-    /* API call. */
-    /* No new core is enabled for this task. */
-    uxNewCoreAffinityMask = ( 1U << 0 );
-    vTaskCoreAffinitySet( &xTaskTCB, uxNewCoreAffinityMask );
-
-    /* Validations. */
-    TEST_ASSERT_EQUAL( uxNewCoreAffinityMask, xTaskTCB.uxCoreAffinityMask );
-}
-
-/**
  * @brief prvYieldForTask - running task with xTaskRunState equals to configNUMBER_OF_CORES.
  *
  * Yield for a task of equal priority. No other task should be requested to yield.


### PR DESCRIPTION


<!--- Title -->

Description
-----------
* Remove no new core added coverage test for coreAffinitySet. Due to implementation change in this PR https://github.com/FreeRTOS/FreeRTOS-Kernel/pull/1123, the covered line is removed. This unit test is no longer required.

Test Steps
-----------
Run the unit test should have no error.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
https://github.com/FreeRTOS/FreeRTOS-Kernel/pull/1123
https://github.com/FreeRTOS/FreeRTOS-Kernel/issues/1086


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
