### PR TITLE
Add missing header include in command pool

### DIFF
--- a/FreeRTOS-Plus/Demo/Common/coreMQTT_Agent_Interface/freertos_command_pool.c
+++ b/FreeRTOS-Plus/Demo/Common/coreMQTT_Agent_Interface/freertos_command_pool.c
@@ -43,7 +43,7 @@
 
 /* Demo config include. */
 #include "demo_config.h"
-
+#include "core_mqtt_config.h"
 /*-----------------------------------------------------------*/
 
 #define QUEUE_NOT_INITIALIZED    ( 0U )


### PR DESCRIPTION

<!--- Title -->

Description
-----------
This PR fixes a build error in OTA demos by adding a missing header in `FreeRTOS-Plus/Demo/Common/coreMQTT_Agent_Interface/freertos_command_pool.c`

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
