### PR TITLE
Cortex M3 MPS2: fix alignment warning from assembler

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
         if: success() && ( github.ref == 'refs/heads/main' || github.ref == 'refs/heads/release-candidate' )
         env:
           GIT_SHA:
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: doxygen.zip-${{ github.sha }}
           path: ./freertos/doxygen.zip
@@ -144,7 +144,7 @@ jobs:
           Upload memory size report as artifact (for main and
           release-candidate ONLY)
         if: success() && ( github.ref == 'refs/heads/main' || github.ref == 'refs/heads/release-candidate' )
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: freertos-memory-estimates
           path: ./freertos_lts_memory_estimates.json

--- a/.github/workflows/kernel-unit-tests.yml
+++ b/.github/workflows/kernel-unit-tests.yml
@@ -28,12 +28,12 @@ jobs:
           make -C FreeRTOS/Test/CMock lcovhtml
           lcov --config-file FreeRTOS/Test/CMock/lcovrc --summary FreeRTOS/Test/CMock/build/cmock_test.info > FreeRTOS/Test/CMock/build/cmock_test_summary.txt
     - name: Archive code coverage data
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: coverage-data
         path: FreeRTOS/Test/CMock/build/cmock_test*
     - name: Archive code coverage html report
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: coverage-report
         path: FreeRTOS/Test/CMock/build/coverage
@@ -69,12 +69,12 @@ jobs:
           make -C FreeRTOS/Test/CMock lcovhtml
           lcov --config-file FreeRTOS/Test/CMock/lcovrc --summary FreeRTOS/Test/CMock/build/cmock_test.info > FreeRTOS/Test/CMock/build/cmock_test_summary.txt
     - name: Archive code coverage data
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: coverage-data
         path: FreeRTOS/Test/CMock/build/cmock_test*
     - name: Archive code coverage html report
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: coverage-report
         path: FreeRTOS/Test/CMock/build/coverage

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Echo_Qemu_mps2/startup.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Echo_Qemu_mps2/startup.c
@@ -133,9 +133,8 @@ void Default_Handler2( void )
         " mrseq r0, msp                                             \n"
         " mrsne r0, psp                                             \n"
         " ldr r1, [r0, #24]                                         \n"
-        " ldr r2, handler2_address_const                            \n"
+        " ldr r2, =prvGetRegistersFromStack                         \n"
         " bx r2                                                     \n"
-        " handler2_address_const: .word prvGetRegistersFromStack    \n"
     );
 }
 

--- a/FreeRTOS/Demo/CORTEX_MPS2_QEMU_IAR_GCC/build/gcc/startup_gcc.c
+++ b/FreeRTOS/Demo/CORTEX_MPS2_QEMU_IAR_GCC/build/gcc/startup_gcc.c
@@ -142,9 +142,8 @@ void HardFault_Handler( void )
         " mrseq r0, msp                                             \n"
         " mrsne r0, psp                                             \n"
         " ldr r1, [r0, #24]                                         \n"
-        " ldr r2, handler2_address_const                            \n"
+        " ldr r2, =prvGetRegistersFromStack                         \n"
         " bx r2                                                     \n"
-        " handler2_address_const: .word prvGetRegistersFromStack    \n"
     );
 }
 

--- a/FreeRTOS/Demo/CORTEX_MPU_M3_MPS2_QEMU_GCC/init/startup.c
+++ b/FreeRTOS/Demo/CORTEX_MPU_M3_MPS2_QEMU_GCC/init/startup.c
@@ -134,9 +134,8 @@ void HardFault_Handler( void )
         " mrseq r0, msp                                             \n"
         " mrsne r0, psp                                             \n"
         " ldr r1, [r0, #24]                                         \n"
-        " ldr r2, handler2_address_const                            \n"
+        " ldr r2, =prvGetRegistersFromStack                         \n"
         " bx r2                                                     \n"
-        " handler2_address_const: .word prvGetRegistersFromStack    \n"
     );
 }
 
@@ -149,9 +148,8 @@ void MemMang_Handler( void )
         " ite eq                                                             \n"
         " mrseq r0, msp                                                      \n"
         " mrsne r0, psp                                                      \n"
-        " ldr r1, handler3_address_const                                      \n"
+        " ldr r1, =vHandleMemoryFault                                        \n"
         " bx r1                                                              \n"
-        " handler3_address_const: .word vHandleMemoryFault                    \n"
     );
 }
 
@@ -163,9 +161,8 @@ void BusFault_Handler( void )
         " ite eq                                                             \n"
         " mrseq r0, msp                                                      \n"
         " mrsne r0, psp                                                      \n"
-        " ldr r1, handler4_address_const                                      \n"
+        " ldr r1, =vHandleMemoryFault                                        \n"
         " bx r1                                                              \n"
-        " handler4_address_const: .word vHandleMemoryFault                    \n"
     );
 }
 
@@ -177,9 +174,8 @@ void UsageFault_Handler( void )
         " ite eq                                                             \n"
         " mrseq r0, msp                                                      \n"
         " mrsne r0, psp                                                      \n"
-        " ldr r1, handler5_address_const                                      \n"
+        " ldr r1, =vHandleMemoryFault                                        \n"
         " bx r1                                                              \n"
-        " handler5_address_const: .word vHandleMemoryFault                    \n"
     );
 }
 
@@ -191,9 +187,8 @@ void Debug_Handler( void )
         " ite eq                                                             \n"
         " mrseq r0, msp                                                      \n"
         " mrsne r0, psp                                                      \n"
-        " ldr r1, handler6_address_const                                      \n"
+        " ldr r1, =vHandleMemoryFault                                        \n"
         " bx r1                                                              \n"
-        " handler6_address_const: .word vHandleMemoryFault                    \n"
     );
 }
 


### PR DESCRIPTION
Fix assembler alignment warnings for Cortex M3 MPS2:
Warning: section does not have enough alignment to ensure safe PC-relative loads

Description
-----------
<!--- Describe your changes in detail. -->

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
