### PR TITLE
Update User Mode Networking debug command for QEMU Demo

### DIFF
--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Echo_Qemu_mps2/Readme_UserNetworking.md
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Echo_Qemu_mps2/Readme_UserNetworking.md
@@ -129,7 +129,7 @@ is running `sudo nc -l 7` or `netcat -l 7` or `nc -l -p 7` depending on your OS)
 
 2. Start QEMU in the paused state waiting for GDB connection:
 ```shell
-   sudo qemu-system-arm -machine mps2-an385 -cpu cortex-m3 \
+   sudo qemu-system-arm -machine mps2-an385 -cpu cortex-m3 -s -S \
    -kernel ./build/freertos_tcp_mps2_demo.axf \
    -monitor null -semihosting -semihosting-config enable=on,target=native -serial stdio -nographic \
    -netdev user,id=mynet0, -net nic,model=lan9118,netdev=mynet0 \


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->
Update debug command for User Mode Networking of QEMU demo to correctly start QEMU in the paused state waiting for GDB connection.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.