### PR TITLE
Fix build: unique names required for v4 upload-artifact task (#1274)

### DIFF
--- a/.github/workflows/kernel-unit-tests.yml
+++ b/.github/workflows/kernel-unit-tests.yml
@@ -30,12 +30,12 @@ jobs:
     - name: Archive code coverage data
       uses: actions/upload-artifact@v4
       with:
-        name: coverage-data
+        name: submodule-coverage-data
         path: FreeRTOS/Test/CMock/build/cmock_test*
     - name: Archive code coverage html report
       uses: actions/upload-artifact@v4
       with:
-        name: coverage-report
+        name: submodule-coverage-report
         path: FreeRTOS/Test/CMock/build/coverage
   run-upstream:
     name: FreeRTOS-Kernel Main Branch
@@ -71,10 +71,10 @@ jobs:
     - name: Archive code coverage data
       uses: actions/upload-artifact@v4
       with:
-        name: coverage-data
+        name: main-branch-coverage-data
         path: FreeRTOS/Test/CMock/build/cmock_test*
     - name: Archive code coverage html report
       uses: actions/upload-artifact@v4
       with:
-        name: coverage-report
+        name: main-branch-coverage-report
         path: FreeRTOS/Test/CMock/build/coverage


### PR DESCRIPTION
Fixes kernel unit test build broken since 9245b4aaa due to duplicate coverage artifact names.

Description
-----------
Change the artifact names for the unit test build.

Test Steps
-----------
Wait for the kernel unit tests to run on GitHub Actions and check that they pass.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
See #1274


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
