### PR TITLE
Fix compilation issue for FreeRTOS Plus WolfSSL demo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Check Formatting
         uses: FreeRTOS/CI-CD-Github-Actions/formatting@main
         with:
-          exclude-dirs: ethernet, drivers, FreeRTOS/Demo
+          exclude-dirs: ethernet, drivers, FreeRTOS/Demo, FreeRTOS-Plus/Demo
 
   spell-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -31,5 +31,5 @@ jobs:
       uses: FreeRTOS/CI-CD-Github-Actions/formatting-bot@main
       continue-on-error: true
       with:
-        exclude-dirs: ethernet, drivers, FreeRTOS/Demo, FreeRTOS-Plus/Demo
+        exclude-dirs: ethernet, drivers, FreeRTOS/Demo
       

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -31,5 +31,5 @@ jobs:
       uses: FreeRTOS/CI-CD-Github-Actions/formatting-bot@main
       continue-on-error: true
       with:
-        exclude-dirs: ethernet, drivers, FreeRTOS/Demo
+        exclude-dirs: ethernet, drivers, FreeRTOS/Demo, FreeRTOS-Plus/Demo
       

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_WolfSSL_Windows_Simulator/FreeRTOS_Plus_WolfSSL_Windows_Simulator.vcxproj
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_WolfSSL_Windows_Simulator/FreeRTOS_Plus_WolfSSL_Windows_Simulator.vcxproj
@@ -21,13 +21,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug_with_Libslirp|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_WolfSSL_Windows_Simulator/FreeRTOS_Plus_WolfSSL_Windows_Simulator.vcxproj
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_WolfSSL_Windows_Simulator/FreeRTOS_Plus_WolfSSL_Windows_Simulator.vcxproj
@@ -160,10 +160,9 @@ xcopy /y /d "..\..\ThirdParty\glib\build\subprojects\pcre2-10.42\pcre2-8-0.dll" 
     <ClCompile Include="..\..\ThirdParty\wolfSSL\wolfcrypt\src\ge_low_mem.c" />
     <ClCompile Include="..\..\ThirdParty\wolfSSL\wolfcrypt\src\ge_operations.c" />
     <ClCompile Include="..\..\ThirdParty\wolfSSL\wolfcrypt\src\hash.c" />
-    <ClCompile Include="..\..\ThirdParty\wolfSSL\wolfcrypt\src\hc128.c" />
     <ClCompile Include="..\..\ThirdParty\wolfSSL\wolfcrypt\src\hmac.c" />
-    <ClCompile Include="..\..\ThirdParty\wolfSSL\wolfcrypt\src\idea.c" />
     <ClCompile Include="..\..\ThirdParty\wolfSSL\wolfcrypt\src\integer.c" />
+    <ClCompile Include="..\..\ThirdParty\wolfSSL\wolfcrypt\src\kdf.c" />
     <ClCompile Include="..\..\ThirdParty\wolfSSL\wolfcrypt\src\logging.c" />
     <ClCompile Include="..\..\ThirdParty\wolfSSL\wolfcrypt\src\md2.c" />
     <ClCompile Include="..\..\ThirdParty\wolfSSL\wolfcrypt\src\md4.c" />
@@ -174,7 +173,6 @@ xcopy /y /d "..\..\ThirdParty\glib\build\subprojects\pcre2-10.42\pcre2-8-0.dll" 
     <ClCompile Include="..\..\ThirdParty\wolfSSL\wolfcrypt\src\pkcs7.c" />
     <ClCompile Include="..\..\ThirdParty\wolfSSL\wolfcrypt\src\poly1305.c" />
     <ClCompile Include="..\..\ThirdParty\wolfSSL\wolfcrypt\src\pwdbased.c" />
-    <ClCompile Include="..\..\ThirdParty\wolfSSL\wolfcrypt\src\rabbit.c" />
     <ClCompile Include="..\..\ThirdParty\wolfSSL\wolfcrypt\src\random.c" />
     <ClCompile Include="..\..\ThirdParty\wolfSSL\wolfcrypt\src\ripemd.c" />
     <ClCompile Include="..\..\ThirdParty\wolfSSL\wolfcrypt\src\rsa.c" />

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_WolfSSL_Windows_Simulator/FreeRTOS_Plus_WolfSSL_Windows_Simulator.vcxproj.filters
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_WolfSSL_Windows_Simulator/FreeRTOS_Plus_WolfSSL_Windows_Simulator.vcxproj.filters
@@ -260,13 +260,7 @@
     <ClCompile Include="..\..\ThirdParty\wolfSSL\wolfcrypt\src\hash.c">
       <Filter>wolfSSL\wolfcrypt</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\ThirdParty\wolfSSL\wolfcrypt\src\hc128.c">
-      <Filter>wolfSSL\wolfcrypt</Filter>
-    </ClCompile>
     <ClCompile Include="..\..\ThirdParty\wolfSSL\wolfcrypt\src\hmac.c">
-      <Filter>wolfSSL\wolfcrypt</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\ThirdParty\wolfSSL\wolfcrypt\src\idea.c">
       <Filter>wolfSSL\wolfcrypt</Filter>
     </ClCompile>
     <ClCompile Include="..\..\ThirdParty\wolfSSL\wolfcrypt\src\integer.c">
@@ -300,9 +294,6 @@
       <Filter>wolfSSL\wolfcrypt</Filter>
     </ClCompile>
     <ClCompile Include="..\..\ThirdParty\wolfSSL\wolfcrypt\src\pwdbased.c">
-      <Filter>wolfSSL\wolfcrypt</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\ThirdParty\wolfSSL\wolfcrypt\src\rabbit.c">
       <Filter>wolfSSL\wolfcrypt</Filter>
     </ClCompile>
     <ClCompile Include="..\..\ThirdParty\wolfSSL\wolfcrypt\src\random.c">
@@ -379,6 +370,9 @@
     </ClCompile>
     <ClCompile Include="..\..\ThirdParty\wolfSSL\wolfcrypt\src\wolfmath.c">
       <Filter>wolfSSL\wolfcrypt</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ThirdParty\wolfSSL\wolfcrypt\src\kdf.c">
+      <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->
Fix compilation issue for FreeRTOS Plus WolfSSL demo by removing hc128.c, idea.c and rabbit.c which are not present in wolfSSL v5.6.4-stable and adding kdf.c

Test Steps
-----------
<!-- Describe the steps to reproduce. -->
Ran the [FreeRTOS Plus wolfSSL](https://github.com/FreeRTOS/FreeRTOS/tree/main/FreeRTOS-Plus/Demo/FreeRTOS_Plus_WolfSSL_Windows_Simulator) demo

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
