### PR TITLE
Add volatile qualifier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 [Oo]bj/
 [Ll]og/
 [Ll]ogs/
+[Bb]uild/
 
 # CodeWarrior temporary files
 *.tdt

--- a/FreeRTOS/Demo/RISC-V-Qemu-virt_GCC/ns16550.c
+++ b/FreeRTOS/Demo/RISC-V-Qemu-virt_GCC/ns16550.c
@@ -20,7 +20,7 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  *
  * https://www.FreeRTOS.org
- * https://www.github.com/FreeRTOS
+ * https://github.com/FreeRTOS
  *
  */
 

--- a/FreeRTOS/Demo/RISC-V-Qemu-virt_GCC/ns16550.c
+++ b/FreeRTOS/Demo/RISC-V-Qemu-virt_GCC/ns16550.c
@@ -54,17 +54,17 @@
 
 static uint8_t readb( uintptr_t addr )
 {
-	return *( (uint8_t *) addr );
+	return *( (volatile uint8_t *) addr );
 }
 
 static void writeb( uint8_t b, uintptr_t addr )
 {
-	*( (uint8_t *) addr ) = b;
+	*( (volatile uint8_t *) addr ) = b;
 }
 
 void vOutNS16550( struct device *dev, unsigned char c )
 {
-	volatile uintptr_t addr = dev->addr;
+	uintptr_t addr = dev->addr;
 
 	while ( (readb( addr + REG_LSR ) & LSR_THRE) == 0 ) {
 		/* busy wait */

--- a/FreeRTOS/Demo/RISC-V-Qemu-virt_GCC/ns16550.c
+++ b/FreeRTOS/Demo/RISC-V-Qemu-virt_GCC/ns16550.c
@@ -64,7 +64,7 @@ static void writeb( uint8_t b, uintptr_t addr )
 
 void vOutNS16550( struct device *dev, unsigned char c )
 {
-	uintptr_t addr = dev->addr;
+	volatile uintptr_t addr = dev->addr;
 
 	while ( (readb( addr + REG_LSR ) & LSR_THRE) == 0 ) {
 		/* busy wait */


### PR DESCRIPTION
Description
-----------
This is needed to ensure that the memory mapped address it always read.

Test Steps
-----------
Assembly before the change -
```asm
Disassembly of section .text.vOutNS16550:

00000000 <vOutNS16550>:
   0:   4118                    lw      a4,0(a0)
   2:   00574783                lbu     a5,5(a4)
   6:   0207f793                andi    a5,a5,32
   a:   e391                    bnez    a5,e <.L5>

0000000c <.L4>:
   c:   a001                    j       c <.L4>

0000000e <.L5>:
   e:   00b70023                sb      a1,0(a4)
  12:   8082                    ret
```

Assembly after the change -
```asm
Disassembly of section .text.vOutNS16550:

00000000 <vOutNS16550>:
   0:   4114                    lw      a3,0(a0)
   2:   00568713                addi    a4,a3,5

00000006 <.L2>:
   6:   00074783                lbu     a5,0(a4)
   a:   0207f793                andi    a5,a5,32
   e:   dfe5                    beqz    a5,6 <.L2>
  10:   00b68023                sb      a1,0(a3)
  14:   8082   
```

Checklist:
----------
- [x] I have tested my changes. No regression in existing tests.
- [NA] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
https://github.com/FreeRTOS/FreeRTOS/issues/1282


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
