### PR TITLE
[mainline update] Populate RSA key attributes in mbedtls context

### DIFF
--- a/FreeRTOS-Plus/Source/Application-Protocols/network_transport/mbedtls_pk_pkcs11.c
+++ b/FreeRTOS-Plus/Source/Application-Protocols/network_transport/mbedtls_pk_pkcs11.c
@@ -1062,24 +1062,22 @@ static CK_RV p11_rsa_ctx_init( mbedtls_pk_context * pk,
         xResult = CKR_FUNCTION_FAILED;
     }
 
-    /*
-     * TODO: corePKCS11 does not allow exporting RSA public attributes.
-     * This function should be updated to properly initialize the
-     * mbedtls_rsa_context when this is addressed.
-     */
+    CK_ATTRIBUTE pxAttrs[ 8 ] =
+    {
+        { .type = CKA_MODULUS,          .ulValueLen = sizeof( mbedtls_mpi ), .pValue = &( pxMbedRsaCtx->N ) },
+        { .type = CKA_PUBLIC_EXPONENT,  .ulValueLen = sizeof( mbedtls_mpi ), .pValue = &( pxMbedRsaCtx->E ) },
+        { .type = CKA_PRIME_1,          .ulValueLen = sizeof( mbedtls_mpi ), .pValue = &( pxMbedRsaCtx->P ) },
+        { .type = CKA_PRIME_2,          .ulValueLen = sizeof( mbedtls_mpi ), .pValue = &( pxMbedRsaCtx->Q ) },
+        { .type = CKA_PRIVATE_EXPONENT, .ulValueLen = sizeof( mbedtls_mpi ), .pValue = &( pxMbedRsaCtx->D ) },
+        { .type = CKA_EXPONENT_1,       .ulValueLen = sizeof( mbedtls_mpi ), .pValue = &( pxMbedRsaCtx->DP ) },
+        { .type = CKA_EXPONENT_2,       .ulValueLen = sizeof( mbedtls_mpi ), .pValue = &( pxMbedRsaCtx->DQ ) },
+        { .type = CKA_COEFFICIENT,      .ulValueLen = sizeof( mbedtls_mpi ), .pValue = &( pxMbedRsaCtx->QP ) },
+    };
 
-    /* CK_ATTRIBUTE pxAttrs[ 2 ] = */
-    /* { */
-    /*     { .type = CKA_MODULUS, .ulValueLen = 0, .pValue = NULL }, */
-    /*     { .type = CKA_PUBLIC_EXPONENT,  .ulValueLen = 0, .pValue = NULL }, */
-    /*     { .type = CKA_PRIME_1,  .ulValueLen = 0, .pValue = NULL }, */
-    /*     { .type = CKA_PRIME_2,  .ulValueLen = 0, .pValue = NULL }, */
-    /*     { .type = CKA_EXPONENT_1,  .ulValueLen = 0, .pValue = NULL }, */
-    /*     { .type = CKA_EXPONENT_2,  .ulValueLen = 0, .pValue = NULL }, */
-    /*     { .type = CKA_COEFFICIENT,  .ulValueLen = 0, .pValue = NULL }, */
-    /* }; */
-
-    ( void ) pxMbedRsaCtx;
+    xResult = pxFunctionList->C_GetAttributeValue( xSessionHandle,
+                                                   xPkHandle,
+                                                   pxAttrs,
+                                                   sizeof( pxAttrs ) / sizeof( CK_ATTRIBUTE ) );
 
     if( xResult == CKR_OK )
     {

--- a/FreeRTOS-Plus/Source/Application-Protocols/network_transport/mbedtls_pk_pkcs11.c
+++ b/FreeRTOS-Plus/Source/Application-Protocols/network_transport/mbedtls_pk_pkcs11.c
@@ -1064,11 +1064,11 @@ static CK_RV p11_rsa_ctx_init( mbedtls_pk_context * pk,
 
     CK_ATTRIBUTE pxAttrs[ 8 ] =
     {
-        { .type = CKA_MODULUS,          .ulValueLen = sizeof( mbedtls_mpi ), .pValue = &( pxMbedRsaCtx->N ) },
-        { .type = CKA_PUBLIC_EXPONENT,  .ulValueLen = sizeof( mbedtls_mpi ), .pValue = &( pxMbedRsaCtx->E ) },
-        { .type = CKA_PRIME_1,          .ulValueLen = sizeof( mbedtls_mpi ), .pValue = &( pxMbedRsaCtx->P ) },
-        { .type = CKA_PRIME_2,          .ulValueLen = sizeof( mbedtls_mpi ), .pValue = &( pxMbedRsaCtx->Q ) },
-        { .type = CKA_PRIVATE_EXPONENT, .ulValueLen = sizeof( mbedtls_mpi ), .pValue = &( pxMbedRsaCtx->D ) },
+        { .type = CKA_MODULUS,          .ulValueLen = sizeof( mbedtls_mpi ), .pValue = &( pxMbedRsaCtx->N )  },
+        { .type = CKA_PUBLIC_EXPONENT,  .ulValueLen = sizeof( mbedtls_mpi ), .pValue = &( pxMbedRsaCtx->E )  },
+        { .type = CKA_PRIME_1,          .ulValueLen = sizeof( mbedtls_mpi ), .pValue = &( pxMbedRsaCtx->P )  },
+        { .type = CKA_PRIME_2,          .ulValueLen = sizeof( mbedtls_mpi ), .pValue = &( pxMbedRsaCtx->Q )  },
+        { .type = CKA_PRIVATE_EXPONENT, .ulValueLen = sizeof( mbedtls_mpi ), .pValue = &( pxMbedRsaCtx->D )  },
         { .type = CKA_EXPONENT_1,       .ulValueLen = sizeof( mbedtls_mpi ), .pValue = &( pxMbedRsaCtx->DP ) },
         { .type = CKA_EXPONENT_2,       .ulValueLen = sizeof( mbedtls_mpi ), .pValue = &( pxMbedRsaCtx->DQ ) },
         { .type = CKA_COEFFICIENT,      .ulValueLen = sizeof( mbedtls_mpi ), .pValue = &( pxMbedRsaCtx->QP ) },


### PR DESCRIPTION
Description
-----------
Now that corePKCS11 allows exporting RSA public attributes, this PR updates the `p11_rsa_ctx_init` function to properly initialise the `mbedtls_rsa_context`. This is needed to make corePKCS11 demo work with TLSv1.3.

Test Steps
----------
Run the demo with AWS IoT TLSv1.3 endpoint.

Checklist
----------
- [x] I have tested my changes. No regression in existing tests.
- [NA] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
NA.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
