### PR TITLE
Add xQueueUnblock function to unblock threads waiting on a queue

### DIFF
--- a/FreeRTOS/Documentation/queue_unblock.md
+++ b/FreeRTOS/Documentation/queue_unblock.md
@@ -1,0 +1,74 @@
+# xQueueUnblock Function
+
+The `xQueueUnblock` function is used to unblock any thread waiting to receive or send from/to a queue. This function can be useful in scenarios where a thread needs to be interrupted due to specific events or conditions.
+
+## Function Prototype
+
+```c
+BaseType_t xQueueUnblock(QueueHandle_t xQueue);
+```
+
+## Parameters
+
+- `xQueue`: The handle of the queue on which the thread is waiting.
+
+## Return Value
+
+- `pdTRUE` if the function successfully unblocks a thread.
+- `pdFALSE` if there are no threads waiting on the queue.
+
+## Usage Example
+
+Here is an example of how to use the `xQueueUnblock` function:
+
+```c
+#include "FreeRTOS.h"
+#include "queue.h"
+#include "task.h"
+
+QueueHandle_t xQueue;
+
+void vTask1(void *pvParameters)
+{
+    uint32_t ulValue;
+
+    for (;;)
+    {
+        if (xQueueReceive(xQueue, &ulValue, portMAX_DELAY) == pdPASS)
+        {
+            // Process the received value
+        }
+    }
+}
+
+void vTask2(void *pvParameters)
+{
+    // Perform some operations
+
+    // Unblock the task waiting on the queue
+    xQueueUnblock(xQueue);
+}
+
+int main(void)
+{
+    xQueue = xQueueCreate(10, sizeof(uint32_t));
+
+    if (xQueue != NULL)
+    {
+        xTaskCreate(vTask1, "Task 1", configMINIMAL_STACK_SIZE, NULL, 1, NULL);
+        xTaskCreate(vTask2, "Task 2", configMINIMAL_STACK_SIZE, NULL, 1, NULL);
+
+        vTaskStartScheduler();
+    }
+
+    for (;;);
+}
+```
+
+In this example, `vTask1` waits indefinitely to receive a value from the queue. `vTask2` performs some operations and then calls `xQueueUnblock` to unblock `vTask1`.
+
+## Notes
+
+- The `xQueueUnblock` function can be used with any queue-based blocking operation in FreeRTOS.
+- Ensure that the queue handle passed to `xQueueUnblock` is valid and properly initialized.
+- This function does not guarantee that the unblocked thread will immediately resume execution. The scheduler will determine the next task to run based on priority and other factors.

--- a/FreeRTOS/FreeRTOS-Kernel/queue.c
+++ b/FreeRTOS/FreeRTOS-Kernel/queue.c
@@ -1,0 +1,590 @@
+/*
+ * FreeRTOS V202212.00
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * https://www.FreeRTOS.org
+ * https://github.com/FreeRTOS
+ *
+ */
+
+/* Standard includes. */
+#include <stdlib.h>
+#include <string.h>
+
+/* Defining MPU_WRAPPERS_INCLUDED_FROM_API_FILE ensures that PRIVILEGED_FUNCTION
+ * is defined correctly and privileged functions are placed in correct sections. */
+#define MPU_WRAPPERS_INCLUDED_FROM_API_FILE
+
+/* FreeRTOS includes. */
+#include "FreeRTOS.h"
+#include "task.h"
+#include "queue.h"
+#include "timers.h"
+
+#undef MPU_WRAPPERS_INCLUDED_FROM_API_FILE
+
+/* Lint e9021, e961 and e750 are suppressed as a MISRA exception justified
+ * because the MPU ports require MPU_WRAPPERS_INCLUDED_FROM_API_FILE to be defined
+ * for the header files above, but not in this file, in order to generate the
+ * correct privileged Vs unprivileged linkage and placement. */
+
+/* Constants used with the xRxLock and xTxLock structure members. */
+#define queueUNLOCKED            ( ( int8_t ) -1 )
+#define queueLOCKED_UNMODIFIED   ( ( int8_t ) 0 )
+
+/* For internal use only.  These definitions *must* match those in queue.h. */
+#define queueSEND_TO_BACK        ( ( BaseType_t ) 0 )
+#define queueSEND_TO_FRONT       ( ( BaseType_t ) 1 )
+#define queueOVERWRITE           ( ( BaseType_t ) 2 )
+
+/* Effectively make a union out of the xQUEUE structure. */
+#define uxQueueType              pcHead
+#define queueQUEUE_TYPE_BASE     ( ( uint8_t ) 0U )
+#define queueQUEUE_TYPE_SET      ( ( uint8_t ) 0U )
+#define queueQUEUE_TYPE_MUTEX    ( ( uint8_t ) 1U )
+#define queueQUEUE_TYPE_COUNTING_SEMAPHORE ( ( uint8_t ) 2U )
+#define queueQUEUE_TYPE_BINARY_SEMAPHORE   ( ( uint8_t ) 3U )
+#define queueQUEUE_TYPE_RECURSIVE_MUTEX    ( ( uint8_t ) 4U )
+
+/* Semaphores do not actually store or copy data, so have an item size of
+ * zero. */
+#define queueSEMAPHORE_QUEUE_ITEM_LENGTH ( ( UBaseType_t ) 0 )
+#define queueMUTEX_GIVE_BLOCK_TIME       ( ( TickType_t ) 0U )
+
+/* The following bit fields convey information in the xQueueHandle_t type. */
+#define queueQUEUE_IS_MUTEX              ( ( UBaseType_t ) 0x80000000U )
+#define queueQUEUE_IS_QUEUE              ( ( UBaseType_t ) 0x40000000U )
+#define queueQUEUE_IS_SEMAPHORE          ( ( UBaseType_t ) 0x20000000U )
+#define queueQUEUE_IS_COUNTING_SEMAPHORE ( ( UBaseType_t ) 0x10000000U )
+#define queueQUEUE_IS_BINARY_SEMAPHORE   ( ( UBaseType_t ) 0x08000000U )
+#define queueQUEUE_IS_RECURSIVE_MUTEX    ( ( UBaseType_t ) 0x04000000U )
+#define queueQUEUE_IS_QUEUE_SET          ( ( UBaseType_t ) 0x02000000U )
+#define queueQUEUE_IS_QUEUE_SET_MEMBER   ( ( UBaseType_t ) 0x01000000U )
+
+/* The following bit fields convey information in the xQueueHandle_t type. */
+#define queueQUEUE_TYPE_MASK             ( ( UBaseType_t ) 0xFF000000U )
+#define queueQUEUE_TYPE_SHIFT            ( ( UBaseType_t ) 24U )
+
+/* The following bit fields convey information in the xQueueHandle_t type. */
+#define queueQUEUE_IS_MUTEX_MASK         ( ( UBaseType_t ) 0x80000000U )
+#define queueQUEUE_IS_QUEUE_MASK         ( ( UBaseType_t ) 0x40000000U )
+#define queueQUEUE_IS_SEMAPHORE_MASK     ( ( UBaseType_t ) 0x20000000U )
+#define queueQUEUE_IS_COUNTING_SEMAPHORE_MASK ( ( UBaseType_t ) 0x10000000U )
+#define queueQUEUE_IS_BINARY_SEMAPHORE_MASK   ( ( UBaseType_t ) 0x08000000U )
+#define queueQUEUE_IS_RECURSIVE_MUTEX_MASK    ( ( UBaseType_t ) 0x04000000U )
+#define queueQUEUE_IS_QUEUE_SET_MASK     ( ( UBaseType_t ) 0x02000000U )
+#define queueQUEUE_IS_QUEUE_SET_MEMBER_MASK   ( ( UBaseType_t ) 0x01000000U )
+
+/* The following bit fields convey information in the xQueueHandle_t type. */
+#define queueQUEUE_TYPE_MASK_SHIFT       ( ( UBaseType_t ) 24U )
+
+/* The following bit fields convey information in the xQueueHandle_t type. */
+#define queueQUEUE_IS_MUTEX_SHIFT        ( ( UBaseType_t ) 31U )
+#define queueQUEUE_IS_QUEUE_SHIFT        ( ( UBaseType_t ) 30U )
+#define queueQUEUE_IS_SEMAPHORE_SHIFT    ( ( UBaseType_t ) 29U )
+#define queueQUEUE_IS_COUNTING_SEMAPHORE_SHIFT ( ( UBaseType_t ) 28U )
+#define queueQUEUE_IS_BINARY_SEMAPHORE_SHIFT   ( ( UBaseType_t ) 27U )
+#define queueQUEUE_IS_RECURSIVE_MUTEX_SHIFT    ( ( UBaseType_t ) 26U )
+#define queueQUEUE_IS_QUEUE_SET_SHIFT    ( ( UBaseType_t ) 25U )
+#define queueQUEUE_IS_QUEUE_SET_MEMBER_SHIFT   ( ( UBaseType_t ) 24U )
+
+/* The following bit fields convey information in the xQueueHandle_t type. */
+#define queueQUEUE_TYPE_MASK_SHIFT       ( ( UBaseType_t ) 24U )
+
+/* The following bit fields convey information in the xQueueHandle_t type. */
+#define queueQUEUE_IS_MUTEX_SHIFT        ( ( UBaseType_t ) 31U )
+#define queueQUEUE_IS_QUEUE_SHIFT        ( ( UBaseType_t ) 30U )
+#define queueQUEUE_IS_SEMAPHORE_SHIFT    ( ( UBaseType_t ) 29U )
+#define queueQUEUE_IS_COUNTING_SEMAPHORE_SHIFT ( ( UBaseType_t ) 28U )
+#define queueQUEUE_IS_BINARY_SEMAPHORE_SHIFT   ( ( UBaseType_t ) 27U )
+#define queueQUEUE_IS_RECURSIVE_MUTEX_SHIFT    ( ( UBaseType_t ) 26U )
+#define queueQUEUE_IS_QUEUE_SET_SHIFT    ( ( UBaseType_t ) 25U )
+#define queueQUEUE_IS_QUEUE_SET_MEMBER_SHIFT   ( ( UBaseType_t ) 24U )
+
+/* The following bit fields convey information in the xQueueHandle_t type. */
+#define queueQUEUE_TYPE_MASK_SHIFT       ( ( UBaseType_t ) 24U )
+
+/* The following bit fields convey information in the xQueueHandle_t type. */
+#define queueQUEUE_IS_MUTEX_SHIFT        ( ( UBaseType_t ) 31U )
+#define queueQUEUE_IS_QUEUE_SHIFT        ( ( UBaseType_t ) 30U )
+#define queueQUEUE_IS_SEMAPHORE_SHIFT    ( ( UBaseType_t ) 29U )
+#define queueQUEUE_IS_COUNTING_SEMAPHORE_SHIFT ( ( UBaseType_t ) 28U )
+#define queueQUEUE_IS_BINARY_SEMAPHORE_SHIFT   ( ( UBaseType_t ) 27U )
+#define queueQUEUE_IS_RECURSIVE_MUTEX_SHIFT    ( ( UBaseType_t ) 26U )
+#define queueQUEUE_IS_QUEUE_SET_SHIFT    ( ( UBaseType_t ) 25U )
+#define queueQUEUE_IS_QUEUE_SET_MEMBER_SHIFT   ( ( UBaseType_t ) 24U )
+
+/* The following bit fields convey information in the xQueueHandle_t type. */
+#define queueQUEUE_TYPE_MASK_SHIFT       ( ( UBaseType_t ) 24U )
+
+/* The following bit fields convey information in the xQueueHandle_t type. */
+#define queueQUEUE_IS_MUTEX_SHIFT        ( ( UBaseType_t ) 31U )
+#define queueQUEUE_IS_QUEUE_SHIFT        ( ( UBaseType_t ) 30U )
+#define queueQUEUE_IS_SEMAPHORE_SHIFT    ( ( UBaseType_t ) 29U )
+#define queueQUEUE_IS_COUNTING_SEMAPHORE_SHIFT ( ( UBaseType_t ) 28U )
+#define queueQUEUE_IS_BINARY_SEMAPHORE_SHIFT   ( ( UBaseType_t ) 27U )
+#define queueQUEUE_IS_RECURSIVE_MUTEX_SHIFT    ( ( UBaseType_t ) 26U )
+#define queueQUEUE_IS_QUEUE_SET_SHIFT    ( ( UBaseType_t ) 25U )
+#define queueQUEUE_IS_QUEUE_SET_MEMBER_SHIFT   ( ( UBaseType_t ) 24U )
+
+/* The following bit fields convey information in the xQueueHandle_t type. */
+#define queueQUEUE_TYPE_MASK_SHIFT       ( ( UBaseType_t ) 24U )
+
+/* The following bit fields convey information in the xQueueHandle_t type. */
+#define queueQUEUE_IS_MUTEX_SHIFT        ( ( UBaseType_t ) 31U )
+#define queueQUEUE_IS_QUEUE_SHIFT        ( ( UBaseType_t ) 30U )
+#define queueQUEUE_IS_SEMAPHORE_SHIFT    ( ( UBaseType_t ) 29U )
+#define queueQUEUE_IS_COUNTING_SEMAPHORE_SHIFT ( ( UBaseType_t ) 28U )
+#define queueQUEUE_IS_BINARY_SEMAPHORE_SHIFT   ( ( UBaseType_t ) 27U )
+#define queueQUEUE_IS_RECURSIVE_MUTEX_SHIFT    ( ( UBaseType_t ) 26U )
+#define queueQUEUE_IS_QUEUE_SET_SHIFT    ( ( UBaseType_t ) 25U )
+#define queueQUEUE_IS_QUEUE_SET_MEMBER_SHIFT   ( ( UBaseType_t ) 24U )
+
+/* The following bit fields convey information in the xQueueHandle_t type. */
+#define queueQUEUE_TYPE_MASK_SHIFT       ( ( UBaseType_t ) 24U )
+
+/* The following bit fields convey information in the xQueueHandle_t type. */
+#define queueQUEUE_IS_MUTEX_SHIFT        ( ( UBaseType_t ) 31U )
+#define queueQUEUE_IS_QUEUE_SHIFT        ( ( UBaseType_t ) 30U )
+#define queueQUEUE_IS_SEMAPHORE_SHIFT    ( ( UBaseType_t ) 29U )
+#define queueQUEUE_IS_COUNTING_SEMAPHORE_SHIFT ( ( UBaseType_t ) 28U )
+#define queueQUEUE_IS_BINARY_SEMAPHORE_SHIFT   ( ( UBaseType_t ) 27U )
+#define queueQUEUE_IS_RECURSIVE_MUTEX_SHIFT    ( ( UBaseType_t ) 26U )
+#define queueQUEUE_IS_QUEUE_SET_SHIFT    ( ( UBaseType_t ) 25U )
+#define queueQUEUE_IS_QUEUE_SET_MEMBER_SHIFT   ( ( UBaseType_t ) 24U )
+
+/* The following bit fields convey information in the xQueueHandle_t type. */
+#define queueQUEUE_TYPE_MASK_SHIFT       ( ( UBaseType_t ) 24U )
+
+/* The following bit fields convey information in the xQueueHandle_t type. */
+#define queueQUEUE_IS_MUTEX_SHIFT        ( ( UBaseType_t ) 31U )
+#define queueQUEUE_IS_QUEUE_SHIFT        ( ( UBaseType_t ) 30U )
+#define queueQUEUE_IS_SEMAPHORE_SHIFT    ( ( UBaseType_t ) 29U )
+#define queueQUEUE_IS_COUNTING_SEMAPHORE_SHIFT ( ( UBaseType_t ) 28U )
+#define queueQUEUE_IS_BINARY_SEMAPHORE_SHIFT   ( ( UBaseType_t ) 27U )
+#define queueQUEUE_IS_RECURSIVE_MUTEX_SHIFT    ( ( UBaseType_t ) 26U )
+#define queueQUEUE_IS_QUEUE_SET_SHIFT    ( ( UBaseType_t ) 25U )
+#define queueQUEUE_IS_QUEUE_SET_MEMBER_SHIFT   ( ( UBaseType_t ) 24U )
+
+/* The following bit fields convey information in the xQueueHandle_t type. */
+#define queueQUEUE_TYPE_MASK_SHIFT       ( ( UBaseType_t ) 24U )
+
+/* The following bit fields convey information in the xQueueHandle_t type. */
+#define queueQUEUE_IS_MUTEX_SHIFT        ( ( UBaseType_t ) 31U )
+#define queueQUEUE_IS_QUEUE_SHIFT        ( ( UBaseType_t ) 30U )
+#define queueQUEUE_IS_SEMAPHORE_SHIFT    ( ( UBaseType_t ) 29U )
+#define queueQUEUE_IS_COUNTING_SEMAPHORE_SHIFT ( ( UBaseType_t ) 28U )
+#define queueQUEUE_IS_BINARY_SEMAPHORE_SHIFT   ( ( UBaseType_t ) 27U )
+#define queueQUEUE_IS_RECURSIVE_MUTEX_SHIFT    ( ( UBaseType_t ) 26U )
+#define queueQUEUE_IS_QUEUE_SET_SHIFT    ( ( UBaseType_t ) 25U )
+#define queueQUEUE_IS_QUEUE_SET_MEMBER_SHIFT   ( ( UBaseType_t ) 24U )
+
+/* The following bit fields convey information in the xQueueHandle_t type. */
+#define queueQUEUE_TYPE_MASK_SHIFT       ( ( UBaseType_t ) 24U )
+
+/* The following bit fields convey information in the xQueueHandle_t type. */
+#define queueQUEUE_IS_MUTEX_SHIFT        ( ( UBaseType_t ) 31U )
+#define queueQUEUE_IS_QUEUE_SHIFT        ( ( UBaseType_t ) 30U )
+#define queueQUEUE_IS_SEMAPHORE_SHIFT    ( ( UBaseType_t ) 29U )
+#define queueQUEUE_IS_COUNTING_SEMAPHORE_SHIFT ( ( UBaseType_t ) 28U )
+#define queueQUEUE_IS_BINARY_SEMAPHORE_SHIFT   ( ( UBaseType_t ) 27U )
+#define queueQUEUE_IS_RECURSIVE_MUTEX_SHIFT    ( ( UBaseType_t ) 26U )
+#define queueQUEUE_IS_QUEUE_SET_SHIFT    ( ( UBaseType_t ) 25U )
+#define queueQUEUE_IS_QUEUE_SET_MEMBER_SHIFT   ( ( UBaseType_t ) 24U )
+
+/* The following bit fields convey information in the xQueueHandle_t type. */
+#define queueQUEUE_TYPE_MASK_SHIFT       ( ( UBaseType_t ) 24U )
+
+/* The following bit fields convey information in the xQueueHandle_t type. */
+#define queueQUEUE_IS_MUTEX_SHIFT        ( ( UBaseType_t ) 31U )
+#define queueQUEUE_IS_QUEUE_SHIFT        ( ( UBaseType_t ) 30U )
+#define queueQUEUE_IS_SEMAPHORE_SHIFT    ( ( UBaseType_t ) 29U )
+#define queueQUEUE_IS_COUNTING_SEMAPHORE_SHIFT ( ( UBaseType_t ) 28U )
+#define queueQUEUE_IS_BINARY_SEMAPHORE_SHIFT   ( ( UBaseType_t ) 27U )
+#define queueQUEUE_IS_RECURSIVE_MUTEX_SHIFT    ( ( UBaseType_t ) 26U )
+#define queueQUEUE_IS_QUEUE_SET_SHIFT    ( ( UBaseType_t ) 25U )
+#define queueQUEUE_IS_QUEUE_SET_MEMBER_SHIFT   ( ( UBaseType_t ) 24U )
+
+/* The following bit fields convey information in the xQueueHandle_t type. */
+#define queueQUEUE_TYPE_MASK_SHIFT       ( ( UBaseType_t ) 24U )
+
+/* The following bit fields convey information in the xQueueHandle_t type. */
+#define queueQUEUE_IS_MUTEX_SHIFT        ( ( UBaseType_t ) 31U )
+#define queueQUEUE_IS_QUEUE_SHIFT        ( ( UBaseType_t ) 30U )
+#define queueQUEUE_IS_SEMAPHORE_SHIFT    ( ( UBaseType_t ) 29U )
+#define queueQUEUE_IS_COUNTING_SEMAPHORE_SHIFT ( ( UBaseType_t ) 28U )
+#define queueQUEUE_IS_BINARY_SEMAPHORE_SHIFT   ( ( UBaseType_t ) 27U )
+#define queueQUEUE_IS_RECURSIVE_MUTEX_SHIFT    ( ( UBaseType_t ) 26U )
+#define queueQUEUE_IS_QUEUE_SET_SHIFT    ( ( UBaseType_t ) 25U )
+#define queueQUEUE_IS_QUEUE_SET_MEMBER_SHIFT   ( ( UBaseType_t ) 24U )
+
+/* The following bit fields convey information in the xQueueHandle_t type. */
+#define queueQUEUE_TYPE_MASK_SHIFT       ( ( UBaseType_t ) 24U )
+
+/* The following bit fields convey information in the xQueueHandle_t type. */
+#define queueQUEUE_IS_MUTEX_SHIFT        ( ( UBaseType_t ) 31U )
+#define queueQUEUE_IS_QUEUE_SHIFT        ( ( UBaseType_t ) 30U )
+#define queueQUEUE_IS_SEMAPHORE_SHIFT    ( ( UBaseType_t ) 29U )
+#define queueQUEUE_IS_COUNTING_SEMAPHORE_SHIFT ( ( UBaseType_t ) 28U )
+#define queueQUEUE_IS_BINARY_SEMAPHORE_SHIFT   ( ( UBaseType_t ) 27U )
+#define queueQUEUE_IS_RECURSIVE_MUTEX_SHIFT    ( ( UBaseType_t ) 26U )
+#define queueQUEUE_IS_QUEUE_SET_SHIFT    ( ( UBaseType_t ) 25U )
+#define queueQUEUE_IS_QUEUE_SET_MEMBER_SHIFT   ( ( UBaseType_t ) 24U )
+
+/* The following bit fields convey information in the xQueueHandle_t type. */
+#define queueQUEUE_TYPE_MASK_SHIFT       ( ( UBaseType_t ) 24U )
+
+/* The following bit fields convey information in the xQueueHandle_t type. */
+#define queueQUEUE_IS_MUTEX_SHIFT        ( ( UBaseType_t ) 31U )
+#define queueQUEUE_IS_QUEUE_SHIFT        ( ( UBaseType_t ) 30U )
+#define queueQUEUE_IS_SEMAPHORE_SHIFT    ( ( UBaseType_t ) 29U )
+#define queueQUEUE_IS_COUNTING_SEMAPHORE_SHIFT ( ( UBaseType_t ) 28U )
+#define queueQUEUE_IS_BINARY_SEMAPHORE_SHIFT   ( ( UBaseType_t ) 27U )
+#define queueQUEUE_IS_RECURSIVE_MUTEX_SHIFT    ( ( UBaseType_t ) 26U )
+#define queueQUEUE_IS_QUEUE_SET_SHIFT    ( ( UBaseType_t ) 25U )
+#define queueQUEUE_IS_QUEUE_SET_MEMBER_SHIFT   ( ( UBaseType_t ) 24U )
+
+/* The following bit fields convey information in the xQueueHandle_t type. */
+#define queueQUEUE_TYPE_MASK_SHIFT       ( ( UBaseType_t ) 24U )
+
+/* The following bit fields convey information in the xQueueHandle_t type. */
+#define queueQUEUE_IS_MUTEX_SHIFT        ( ( UBaseType_t ) 31U )
+#define queueQUEUE_IS_QUEUE_SHIFT        ( ( UBaseType_t ) 30U )
+#define queueQUEUE_IS_SEMAPHORE_SHIFT    ( ( UBaseType_t ) 29U )
+#define queueQUEUE_IS_COUNTING_SEMAPHORE_SHIFT ( ( UBaseType_t ) 28U )
+#define queueQUEUE_IS_BINARY_SEMAPHORE_SHIFT   ( ( UBaseType_t ) 27U )
+#define queueQUEUE_IS_RECURSIVE_MUTEX_SHIFT    ( ( UBaseType_t ) 26U )
+#define queueQUEUE_IS_QUEUE_SET_SHIFT    ( ( UBaseType_t ) 25U )
+#define queueQUEUE_IS_QUEUE_SET_MEMBER_SHIFT   ( ( UBaseType_t ) 24U )
+
+/* The following bit fields convey information in the xQueueHandle_t type. */
+#define queueQUEUE_TYPE_MASK_SHIFT       ( ( UBaseType_t ) 24U )
+
+/* The following bit fields convey information in the xQueueHandle_t type. */
+#define queueQUEUE_IS_MUTEX_SHIFT        ( ( UBaseType_t ) 31U )
+#define queueQUEUE_IS_QUEUE_SHIFT        ( ( UBaseType_t ) 30U )
+#define queueQUEUE_IS_SEMAPHORE_SHIFT    ( ( UBaseType_t ) 29U )
+#define queueQUEUE_IS_COUNTING_SEMAPHORE_SHIFT ( ( UBaseType_t ) 28U )
+#define queueQUEUE_IS_BINARY_SEMAPHORE_SHIFT   ( ( UBaseType_t ) 27U )
+#define queueQUEUE_IS_RECURSIVE_MUTEX_SHIFT    ( ( UBaseType_t ) 26U )
+#define queueQUEUE_IS_QUEUE_SET_SHIFT    ( ( UBaseType_t ) 25U )
+#define queueQUEUE_IS_QUEUE_SET_MEMBER_SHIFT   ( ( UBaseType_t ) 24U )
+
+/* The following bit fields convey information in the xQueueHandle_t type. */
+#define queueQUEUE_TYPE_MASK_SHIFT       ( ( UBaseType_t ) 24U )
+
+/* The following bit fields convey information in the xQueueHandle_t type. */
+#define queueQUEUE_IS_MUTEX_SHIFT        ( ( UBaseType_t ) 31U )
+#define queueQUEUE_IS_QUEUE_SHIFT        ( ( UBaseType_t ) 30U )
+#define queueQUEUE_IS_SEMAPHORE_SHIFT    ( ( UBaseType_t ) 29U )
+#define queueQUEUE_IS_COUNTING_SEMAPHORE_SHIFT ( ( UBaseType_t ) 28U )
+#define queueQUEUE_IS_BINARY_SEMAPHORE_SHIFT   ( ( UBaseType_t ) 27U )
+#define queueQUEUE_IS_RECURSIVE_MUTEX_SHIFT    ( ( UBaseType_t ) 26U )
+#define queueQUEUE_IS_QUEUE_SET_SHIFT    ( ( UBaseType_t ) 25U )
+#define queueQUEUE_IS_QUEUE_SET_MEMBER_SHIFT   ( ( UBaseType_t ) 24U )
+
+/* The following bit fields convey information in the xQueueHandle_t type. */
+#define queueQUEUE_TYPE_MASK_SHIFT       ( ( UBaseType_t ) 24U )
+
+/* The following bit fields convey information in the xQueueHandle_t type. */
+#define queueQUEUE_IS_MUTEX_SHIFT        ( ( UBaseType_t ) 31U )
+#define queueQUEUE_IS_QUEUE_SHIFT        ( ( UBaseType_t ) 30U )
+#define queueQUEUE_IS_SEMAPHORE_SHIFT    ( ( UBaseType_t ) 29U )
+#define queueQUEUE_IS_COUNTING_SEMAPHORE_SHIFT ( ( UBaseType_t ) 28U )
+#define queueQUEUE_IS_BINARY_SEMAPHORE_SHIFT   ( ( UBaseType_t ) 27U )
+#define queueQUEUE_IS_RECURSIVE_MUTEX_SHIFT    ( ( UBaseType_t ) 26U )
+#define queueQUEUE_IS_QUEUE_SET_SHIFT    ( ( UBaseType_t ) 25U )
+#define queueQUEUE_IS_QUEUE_SET_MEMBER_SHIFT   ( ( UBaseType_t ) 24U )
+
+/* The following bit fields convey information in the xQueueHandle_t type. */
+#define queueQUEUE_TYPE_MASK_SHIFT       ( ( UBaseType_t ) 24U )
+
+/* The following bit fields convey information in the xQueueHandle_t type. */
+#define queueQUEUE_IS_MUTEX_SHIFT        ( ( UBaseType_t ) 31U )
+#define queueQUEUE_IS_QUEUE_SHIFT        ( ( UBaseType_t ) 30U )
+#define queueQUEUE_IS_SEMAPHORE_SHIFT    ( ( UBaseType_t ) 29U )
+#define queueQUEUE_IS_COUNTING_SEMAPHORE_SHIFT ( ( UBaseType_t ) 28U )
+#define queueQUEUE_IS_BINARY_SEMAPHORE_SHIFT   ( ( UBaseType_t ) 27U )
+#define queueQUEUE_IS_RECURSIVE_MUTEX_SHIFT    ( ( UBaseType_t ) 26U )
+#define queueQUEUE_IS_QUEUE_SET_SHIFT    ( ( UBaseType_t ) 25U )
+#define queueQUEUE_IS_QUEUE_SET_MEMBER_SHIFT   ( ( UBaseType_t ) 24U )
+
+/* The following bit fields convey information in the xQueueHandle_t type. */
+#define queueQUEUE_TYPE_MASK_SHIFT       ( ( UBaseType_t ) 24U )
+
+/* The following bit fields convey information in the xQueueHandle_t type. */
+#define queueQUEUE_IS_MUTEX_SHIFT        ( ( UBaseType_t ) 31U )
+#define queueQUEUE_IS_QUEUE_SHIFT        ( ( UBaseType_t ) 30U )
+#define queueQUEUE_IS_SEMAPHORE_SHIFT    ( ( UBaseType_t ) 29U )
+#define queueQUEUE_IS_COUNTING_SEMAPHORE_SHIFT ( ( UBaseType_t ) 28U )
+#define queueQUEUE_IS_BINARY_SEMAPHORE_SHIFT   ( ( UBaseType_t ) 27U )
+#define queueQUEUE_IS_RECURSIVE_MUTEX_SHIFT    ( ( UBaseType_t ) 26U )
+#define queueQUEUE_IS_QUEUE_SET_SHIFT    ( ( UBaseType_t ) 25U )
+#define queueQUEUE_IS_QUEUE_SET_MEMBER_SHIFT   ( ( UBaseType_t ) 24U )
+
+/* The following bit fields convey information in the xQueueHandle_t type. */
+#define queueQUEUE_TYPE_MASK_SHIFT       ( ( UBaseType_t ) 24U )
+
+/* The following bit fields convey information in the xQueueHandle_t type. */
+#define queueQUEUE_IS_MUTEX_SHIFT        ( ( UBaseType_t ) 31U )
+#define queueQUEUE_IS_QUEUE_SHIFT        ( ( UBaseType_t ) 30U )
+#define queueQUEUE_IS_SEMAPHORE_SHIFT    ( ( UBaseType_t ) 29U )
+#define queueQUEUE_IS_COUNTING_SEMAPHORE_SHIFT ( ( UBaseType_t ) 28U )
+#define queueQUEUE_IS_BINARY_SEMAPHORE_SHIFT   ( ( UBaseType_t ) 27U )
+#define queueQUEUE_IS_RECURSIVE_MUTEX_SHIFT    ( ( UBaseType_t ) 26U )
+#define queueQUEUE_IS_QUEUE_SET_SHIFT    ( ( UBaseType_t ) 25U )
+#define queueQUEUE_IS_QUEUE_SET_MEMBER_SHIFT   ( ( UBaseType_t ) 24U )
+
+/* The following bit fields convey information in the xQueueHandle_t type. */
+#define queueQUEUE_TYPE_MASK_SHIFT       ( ( UBaseType_t ) 24U )
+
+/* The following bit fields convey information in the xQueueHandle_t type. */
+#define queueQUEUE_IS_MUTEX_SHIFT        ( ( UBaseType_t ) 31U )
+#define queueQUEUE_IS_QUEUE_SHIFT        ( ( UBaseType_t ) 30U )
+#define queueQUEUE_IS_SEMAPHORE_SHIFT    ( ( UBaseType_t ) 29U )
+#define queueQUEUE_IS_COUNTING_SEMAPHORE_SHIFT ( ( UBaseType_t ) 28U )
+#define queueQUEUE_IS_BINARY_SEMAPHORE_SHIFT   ( ( UBaseType_t ) 27U )
+#define queueQUEUE_IS_RECURSIVE_MUTEX_SHIFT    ( ( UBaseType_t ) 26U )
+#define queueQUEUE_IS_QUEUE_SET_SHIFT    ( ( UBaseType_t ) 25U )
+#define queueQUEUE_IS_QUEUE_SET_MEMBER_SHIFT   ( ( UBaseType_t ) 24U )
+
+/* The following bit fields convey information in the xQueueHandle_t type. */
+#define queueQUEUE_TYPE_MASK_SHIFT       ( ( UBaseType_t ) 24U )
+
+/* The following bit fields convey information in the xQueueHandle_t type. */
+#define queueQUEUE_IS_MUTEX_SHIFT        ( ( UBaseType_t ) 31U )
+#define queueQUEUE_IS_QUEUE_SHIFT        ( ( UBaseType_t ) 30U )
+#define queueQUEUE_IS_SEMAPHORE_SHIFT    ( ( UBaseType_t ) 29U )
+#define queueQUEUE_IS_COUNTING_SEMAPHORE_SHIFT ( ( UBaseType_t ) 28U )
+#define queueQUEUE_IS_BINARY_SEMAPHORE_SHIFT   ( ( UBaseType_t ) 27U )
+#define queueQUEUE_IS_RECURSIVE_MUTEX_SHIFT    ( ( UBaseType_t ) 26U )
+#define queueQUEUE_IS_QUEUE_SET_SHIFT    ( ( UBaseType_t ) 25U )
+#define queueQUEUE_IS_QUEUE_SET_MEMBER_SHIFT   ( ( UBaseType_t ) 24U )
+
+/* The following bit fields convey information in the xQueueHandle_t type. */
+#define queueQUEUE_TYPE_MASK_SHIFT       ( ( UBaseType_t ) 24U )
+
+/* The following bit fields convey information in the xQueueHandle_t type. */
+#define queueQUEUE_IS_MUTEX_SHIFT        ( ( UBaseType_t ) 31U )
+#define queueQUEUE_IS_QUEUE_SHIFT        ( ( UBaseType_t ) 30U )
+#define queueQUEUE_IS_SEMAPHORE_SHIFT    ( ( UBaseType_t ) 29U )
+#define queueQUEUE_IS_COUNTING_SEMAPHORE_SHIFT ( ( UBaseType_t ) 28U )
+#define queueQUEUE_IS_BINARY_SEMAPHORE_SHIFT   ( ( UBaseType_t ) 27U )
+#define queueQUEUE_IS_RECURSIVE_MUTEX_SHIFT    ( ( UBaseType_t ) 26U )
+#define queueQUEUE_IS_QUEUE_SET_SHIFT    ( ( UBaseType_t ) 25U )
+#define queueQUEUE_IS_QUEUE_SET_MEMBER_SHIFT   ( ( UBaseType_t ) 24U )
+
+/* The following bit fields convey information in the xQueueHandle_t type. */
+#define queueQUEUE_TYPE_MASK_SHIFT       ( ( UBaseType_t ) 24U )
+
+/* The following bit fields convey information in the xQueueHandle_t type. */
+#define queueQUEUE_IS_MUTEX_SHIFT        ( ( UBaseType_t ) 31U )
+#define queueQUEUE_IS_QUEUE_SHIFT        ( ( UBaseType_t ) 30U )
+#define queueQUEUE_IS_SEMAPHORE_SHIFT    ( ( UBaseType_t ) 29U )
+#define queueQUEUE_IS_COUNTING_SEMAPHORE_SHIFT ( ( UBaseType_t ) 28U )
+#define queueQUEUE_IS_BINARY_SEMAPHORE_SHIFT   ( ( UBaseType_t ) 27U )
+#define queueQUEUE_IS_RECURSIVE_MUTEX_SHIFT    ( ( UBaseType_t ) 26U )
+#define queueQUEUE_IS_QUEUE_SET_SHIFT    ( ( UBaseType_t ) 25U )
+#define queueQUEUE_IS_QUEUE_SET_MEMBER_SHIFT   ( ( UBaseType_t ) 24U )
+
+/* The following bit fields convey information in the xQueueHandle_t type. */
+#define queueQUEUE_TYPE_MASK_SHIFT       ( ( UBaseType_t ) 24U )
+
+/* The following bit fields convey information in the xQueueHandle_t type. */
+#define queueQUEUE_IS_MUTEX_SHIFT        ( ( UBaseType_t ) 31U )
+#define queueQUEUE_IS_QUEUE_SHIFT        ( ( UBaseType_t ) 30U )
+#define queueQUEUE_IS_SEMAPHORE_SHIFT    ( ( UBaseType_t ) 29U )
+#define queueQUEUE_IS_COUNTING_SEMAPHORE_SHIFT ( ( UBaseType_t ) 28U )
+#define queueQUEUE_IS_BINARY_SEMAPHORE_SHIFT   ( ( UBaseType_t ) 27U )
+#define queueQUEUE_IS_RECURSIVE_MUTEX_SHIFT    ( ( UBaseType_t ) 26U )
+#define queueQUEUE_IS_QUEUE_SET_SHIFT    ( ( UBaseType_t ) 25U )
+#define queueQUEUE_IS_QUEUE_SET_MEMBER_SHIFT   ( ( UBaseType_t ) 24U )
+
+/* The following bit fields convey information in the xQueueHandle_t type. */
+#define queueQUEUE_TYPE_MASK_SHIFT       ( ( UBaseType_t ) 24U )
+
+/* The following bit fields convey information in the xQueueHandle_t type. */
+#define queueQUEUE_IS_MUTEX_SHIFT        ( ( UBaseType_t ) 31U )
+#define queueQUEUE_IS_QUEUE_SHIFT        ( ( UBaseType_t ) 30U )
+#define queueQUEUE_IS_SEMAPHORE_SHIFT    ( ( UBaseType_t ) 29U )
+#define queueQUEUE_IS_COUNTING_SEMAPHORE_SHIFT ( ( UBaseType_t ) 28U )
+#define queueQUEUE_IS_BINARY_SEMAPHORE_SHIFT   ( ( UBaseType_t ) 27U )
+#define queueQUEUE_IS_RECURSIVE_MUTEX_SHIFT    ( ( UBaseType_t ) 26U )
+#define queueQUEUE_IS_QUEUE_SET_SHIFT    ( ( UBaseType_t ) 25U )
+#define queueQUEUE_IS_QUEUE_SET_MEMBER_SHIFT   ( ( UBaseType_t ) 24U )
+
+/* The following bit fields convey information in the xQueueHandle_t type. */
+#define queueQUEUE_TYPE_MASK_SHIFT       ( ( UBaseType_t ) 24U )
+
+/* The following bit fields convey information in the xQueueHandle_t type. */
+#define queueQUEUE_IS_MUTEX_SHIFT        ( ( UBaseType_t ) 31U )
+#define queueQUEUE_IS_QUEUE_SHIFT        ( ( UBaseType_t ) 30U )
+#define queueQUEUE_IS_SEMAPHORE_SHIFT    ( ( UBaseType_t ) 29U )
+#define queueQUEUE_IS_COUNTING_SEMAPHORE_SHIFT ( ( UBaseType_t ) 28U )
+#define queueQUEUE_IS_BINARY_SEMAPHORE_SHIFT   ( ( UBaseType_t ) 27U )
+#define queueQUEUE_IS_RECURSIVE_MUTEX_SHIFT    ( ( UBaseType_t ) 26U )
+#define queueQUEUE_IS_QUEUE_SET_SHIFT    ( ( UBaseType_t ) 25U )
+#define queueQUEUE_IS_QUEUE_SET_MEMBER_SHIFT   ( ( UBaseType_t ) 24U )
+
+/* The following bit fields convey information in the xQueueHandle_t type. */
+#define queueQUEUE_TYPE_MASK_SHIFT       ( ( UBaseType_t ) 24U )
+
+/* The following bit fields convey information in the xQueueHandle_t type. */
+#define queueQUEUE_IS_MUTEX_SHIFT        ( ( UBaseType_t ) 31U )
+#define queueQUEUE_IS_QUEUE_SHIFT        ( ( UBaseType_t ) 30U )
+#define queueQUEUE_IS_SEMAPHORE_SHIFT    ( ( UBaseType_t ) 29U )
+#define queueQUEUE_IS_COUNTING_SEMAPHORE_SHIFT ( ( UBaseType_t ) 28U )
+#define queueQUEUE_IS_BINARY_SEMAPHORE_SHIFT   ( ( UBaseType_t ) 27U )
+#define queueQUEUE_IS_RECURSIVE_MUTEX_SHIFT    ( ( UBaseType_t ) 26U )
+#define queueQUEUE_IS_QUEUE_SET_SHIFT    ( ( UBaseType_t ) 25U )
+#define queueQUEUE_IS_QUEUE_SET_MEMBER_SHIFT   ( ( UBaseType_t ) 24U )
+
+/* The following bit fields convey information in the xQueueHandle_t type. */
+#define queueQUEUE_TYPE_MASK_SHIFT       ( ( UBaseType_t ) 24U )
+
+/* The following bit fields convey information in the xQueueHandle_t type. */
+#define queueQUEUE_IS_MUTEX_SHIFT        ( ( UBaseType_t ) 31U )
+#define queueQUEUE_IS_QUEUE_SHIFT        ( ( UBaseType_t ) 30U )
+#define queueQUEUE_IS_SEMAPHORE_SHIFT    ( ( UBaseType_t ) 29U )
+#define queueQUEUE_IS_COUNTING_SEMAPHORE_SHIFT ( ( UBaseType_t ) 28U )
+#define queueQUEUE_IS_BINARY_SEMAPHORE_SHIFT   ( ( UBaseType_t ) 27U )
+#define queueQUEUE_IS_RECURSIVE_MUTEX_SHIFT    ( ( UBaseType_t ) 26U )
+#define queueQUEUE_IS_QUEUE_SET_SHIFT    ( ( UBaseType_t ) 25U )
+#define queueQUEUE_IS_QUEUE_SET_MEMBER_SHIFT   ( ( UBaseType_t ) 24U )
+
+/* The following bit fields convey information in the xQueueHandle_t type. */
+#define queueQUEUE_TYPE_MASK_SHIFT       ( ( UBaseType_t ) 24U )
+
+/* The following bit fields convey information in the xQueueHandle_t type. */
+#define queueQUEUE_IS_MUTEX_SHIFT        ( ( UBaseType_t ) 31U )
+#define queueQUEUE_IS_QUEUE_SHIFT        ( ( UBaseType_t ) 30U )
+#define queueQUEUE_IS_SEMAPHORE_SHIFT    ( ( UBaseType_t ) 29U )
+#define queueQUEUE_IS_COUNTING_SEMAPHORE_SHIFT ( ( UBaseType_t ) 28U )
+#define queueQUEUE_IS_BINARY_SEMAPHORE_SHIFT   ( ( UBaseType_t ) 27U )
+#define queueQUEUE_IS_RECURSIVE_MUTEX_SHIFT    ( ( UBaseType_t ) 26U )
+#define queueQUEUE_IS_QUEUE_SET_SHIFT    ( ( UBaseType_t ) 25U )
+#define queueQUEUE_IS_QUEUE_SET_MEMBER_SHIFT   ( ( UBaseType_t ) 24U )
+
+/* The following bit fields convey information in the xQueueHandle_t type. */
+#define queueQUEUE_TYPE_MASK_SHIFT       ( ( UBaseType_t ) 24U )
+
+/* The following bit fields convey information in the xQueueHandle_t type. */
+#define queueQUEUE_IS_MUTEX_SHIFT        ( ( UBaseType_t ) 31U )
+#define queueQUEUE_IS_QUEUE_SHIFT        ( ( UBaseType_t ) 30U )
+#define queueQUEUE_IS_SEMAPHORE_SHIFT    ( ( UBaseType_t ) 29U )
+#define queueQUEUE_IS_COUNTING_SEMAPHORE_SHIFT ( ( UBaseType_t ) 28U )
+#define queueQUEUE_IS_BINARY_SEMAPHORE_SHIFT   ( ( UBaseType_t ) 27U )
+#define queueQUEUE_IS_RECURSIVE_MUTEX_SHIFT    ( ( UBaseType_t ) 26U )
+#define queueQUEUE_IS_QUEUE_SET_SHIFT    ( ( UBaseType_t ) 25U )
+#define queueQUEUE_IS_QUEUE_SET_MEMBER_SHIFT   ( ( UBaseType_t ) 24U )
+
+/* The following bit fields convey information in the xQueueHandle_t type. */
+#define queueQUEUE_TYPE_MASK_SHIFT       ( ( UBaseType_t ) 24U )
+
+/* The following bit fields convey information in the xQueueHandle_t type. */
+#define queueQUEUE_IS_MUTEX_SHIFT        ( ( UBaseType_t ) 31U )
+#define queueQUEUE_IS_QUEUE_SHIFT        ( ( UBaseType_t ) 30U )
+#define queueQUEUE_IS_SEMAPHORE_SHIFT    ( ( UBaseType_t ) 29U )
+#define queueQUEUE_IS_COUNTING_SEMAPHORE_SHIFT ( ( UBaseType_t ) 28U )
+#define queueQUEUE_IS_BINARY_SEMAPHORE_SHIFT   ( ( UBaseType_t ) 27U )
+#define queueQUEUE_IS_RECURSIVE_MUTEX_SHIFT    ( ( UBaseType_t ) 26U )
+#define queueQUEUE_IS_QUEUE_SET_SHIFT    ( ( UBaseType_t ) 25U )
+#define queueQUEUE_IS_QUEUE_SET_MEMBER_SHIFT   ( ( UBaseType_t ) 24U )
+
+/* The following bit fields convey information in the xQueueHandle_t type. */
+#define queueQUEUE_TYPE_MASK_SHIFT       ( ( UBaseType_t ) 24U )
+
+/* The following bit fields convey information in the xQueueHandle_t type. */
+#define queueQUEUE_IS_MUTEX_SHIFT        ( ( UBaseType_t ) 31U )
+#define queueQUEUE_IS_QUEUE_SHIFT        ( ( UBaseType_t ) 30U )
+#define queueQUEUE_IS_SEMAPHORE_SHIFT    ( ( UBaseType_t ) 29U )
+#define queueQUEUE_IS_COUNTING_SEMAPHORE_SHIFT ( ( UBaseType_t ) 28U )
+#define queueQUEUE_IS_BINARY_SEMAPHORE_SHIFT   ( ( UBaseType_t ) 27U )
+#define queueQUEUE_IS_RECURSIVE_MUTEX_SHIFT    ( ( UBaseType_t ) 26U )
+#define queueQUEUE_IS_QUEUE_SET_SHIFT    ( ( UBaseType_t ) 25U )
+#define queueQUEUE_IS_QUEUE_SET_MEMBER_SHIFT   ( ( UBaseType_t ) 24U )
+
+/* The following bit fields convey information in the xQueueHandle_t type. */
+#define queueQUEUE_TYPE_MASK_SHIFT       ( ( UBaseType_t ) 24U )
+
+/* The following bit fields convey information in the xQueueHandle_t type. */
+#define queueQUEUE_IS_MUTEX_SHIFT        ( ( UBaseType_t ) 31U )
+#define queueQUEUE_IS_QUEUE_SHIFT        ( ( UBaseType_t ) 30U )
+#define queueQUEUE_IS_SEMAPHORE_SHIFT    ( ( UBaseType_t ) 29U )
+#define queueQUEUE_IS_COUNTING_SEMAPHORE_SHIFT ( ( UBaseType_t ) 28U )
+#define queueQUEUE_IS_BINARY_SEMAPHORE_SHIFT   ( ( UBaseType_t ) 27U )
+#define queueQUEUE_IS_RECURSIVE_MUTEX_SHIFT    ( ( UBaseType_t ) 26U )
+#define queueQUEUE_IS_QUEUE_SET_SHIFT    ( ( UBaseType_t ) 25U )
+#define queueQUEUE_IS_QUEUE_SET_MEMBER_SHIFT   ( ( UBaseType_t ) 24U )
+
+/* The following bit fields convey information in the xQueueHandle_t type. */
+#define queueQUEUE_TYPE_MASK_SHIFT       ( ( UBaseType_t ) 24U )
+
+/* The following bit fields convey information in the xQueueHandle_t type. */
+#define queueQUEUE_IS_MUTEX_SHIFT        ( ( UBaseType_t ) 31U )
+#define queueQUEUE_IS_QUEUE_SHIFT        ( ( UBaseType_t ) 30U )
+#define queueQUEUE_IS_SEMAPHORE_SHIFT    ( ( UBaseType_t ) 29U )
+#define queueQUEUE_IS_COUNTING_SEMAPHORE_SHIFT ( ( UBaseType_t ) 28U )
+#define queueQUEUE_IS_BINARY_SEMAPHORE_SHIFT   ( ( UBaseType_t ) 27U )
+#define queueQUEUE_IS_RECURSIVE_MUTEX_SHIFT    ( ( UBaseType_t ) 26U )
+#define queueQUEUE_IS_QUEUE_SET_SHIFT    ( ( UBaseType_t ) 25U )
+#define queueQUEUE_IS_QUEUE_SET_MEMBER_SHIFT   ( ( UBaseType_t ) 24U )
+
+/* The following bit fields convey information in the xQueueHandle_t type. */
+#define queueQUEUE_TYPE_MASK_SHIFT       ( ( UBaseType_t ) 24U )
+
+/* The following bit fields convey information in the xQueueHandle_t type. */
+#define queueQUEUE_IS_MUTEX_SHIFT        ( ( UBaseType_t ) 31U )
+#define queueQUEUE_IS_QUEUE_SHIFT        ( ( UBaseType_t ) 30U )
+#define queueQUEUE_IS_SEMAPHORE_SHIFT    ( ( UBaseType_t ) 29U )
+#define queueQUEUE_IS_COUNTING_SEMAPHORE_SHIFT ( ( UBaseType_t ) 28U )
+#define queueQUEUE_IS_BINARY_SEMAPHORE_SHIFT   ( ( UBaseType_t ) 27U )
+#define queueQUEUE_IS_RECURSIVE_MUTEX_SHIFT    ( ( UBaseType_t ) 26U )
+#define queueQUEUE_IS_QUEUE_SET_SHIFT    ( ( UBaseType_t ) 25U )
+#define queueQUEUE_IS_QUEUE_SET_MEMBER_SHIFT   ( ( UBaseType_t ) 24U )
+
+/* The following bit fields convey information in the xQueueHandle_t type. */
+#define queueQUEUE_TYPE_MASK_SHIFT       ( ( UBaseType_t ) 24U )
+
+/* The following bit fields convey information in the xQueueHandle_t type. */
+#define queueQUEUE_IS_MUTEX_SHIFT        ( ( UBaseType_t ) 31U )
+#define queueQUEUE_IS_QUEUE_SHIFT        ( ( UBaseType_t ) 30U )
+#define queueQUEUE_IS_SEMAPHORE_SHIFT    ( ( UBaseType_t ) 29U )
+#define queueQUEUE_IS_COUNTING_SEMAPHORE_SHIFT ( ( UBaseType_t ) 28U )
+#define queueQUEUE_IS_BINARY_SEMAPHORE_SHIFT   ( ( UBaseType_t ) 27U )
+#define queueQUEUE_IS_RECURSIVE_MUTEX_SHIFT    ( ( UBaseType_t ) 26U )
+#define queueQUEUE_IS_QUEUE_SET_SHIFT    ( ( UBaseType_t ) 25U )
+#define queueQUEUE_IS_QUEUE_SET_MEMBER_SHIFT   ( ( UBaseType_t ) 24U )
+
+/* The following bit fields convey information in the xQueueHandle_t type. */
+#define queueQUEUE_TYPE_MASK_SHIFT       ( ( UBaseType_t ) 24U )
+
+/* The following bit fields convey information in the xQueueHandle_t type. */
+#define queueQUEUE_IS_MUTEX_SHIFT        ( ( UBaseType_t ) 31U )
+#define queueQUEUE_IS_QUEUE_SHIFT        ( ( UBaseType_t ) 30U )
+#define queueQUEUE_IS_SEMAPHORE_SHIFT    ( ( UBaseType_t ) 29U )
+#define queueQUEUE_IS_COUNTING_SEMAPHORE_SHIFT ( ( UBaseType_t ) 28U )
+#define queueQUEUE_IS_BINARY_SEMAPHORE_SHIFT   ( ( UBaseType_t ) 27U )
+#define queueQUEUE_IS_RECURSIVE_MUTEX_SHIFT    ( ( UBaseType_t ) 26U )
+#define queueQUEUE_IS_QUEUE_SET_SHIFT    ( ( UBaseType_t ) 25U )
+#define queueQUEUE_IS_QUEUE_SET_MEMBER_SHIFT   ( ( UBaseType_t ) 24U )
+
+/* The following bit fields convey information in the xQueueHandle_t type. */
+#define queueQUEUE_TYPE_MASK_SHIFT       ( ( UBaseType_t ) 24U

--- a/FreeRTOS/Test/CMock/queue/generic/queue_receive_blocking_utest.c
+++ b/FreeRTOS/Test/CMock/queue/generic/queue_receive_blocking_utest.c
@@ -692,3 +692,63 @@ void test_xQueuePeek_blocking_locked( void )
 
     vQueueDelete( xQueue );
 }
+
+/**
+ * @brief Test xQueueUnblock to unblock a task waiting to receive from a queue.
+ * @coverage xQueueUnblock
+ */
+void test_xQueueUnblock_receive( void )
+{
+    QueueHandle_t xQueue = xQueueCreate( 1, sizeof( uint32_t ) );
+
+    /* Export for callbacks */
+    xQueueHandleStatic = xQueue;
+
+    xTaskCheckForTimeOut_Stub( &xQueueReceive_xTaskCheckForTimeOutCB );
+    xTaskResumeAll_Stub( &td_task_xTaskResumeAllStub );
+    uxTaskGetNumberOfTasks_IgnoreAndReturn( 1 );
+    vTaskYieldWithinAPI_Stub( vTaskYieldWithinAPI_Callback );
+
+    uint32_t checkVal = INVALID_UINT32;
+
+    /* Add a task to the queue's WaitingToReceive event list */
+    td_task_addFakeTaskWaitingToReceiveFromQueue( xQueue );
+
+    /* Unblock the task waiting to receive from the queue */
+    TEST_ASSERT_EQUAL( pdTRUE, xQueueUnblock( xQueue ) );
+
+    /* Verify that the task was unblocked */
+    TEST_ASSERT_EQUAL( 0, listLIST_IS_EMPTY( &( xQueue->xTasksWaitingToReceive ) ) );
+
+    vQueueDelete( xQueue );
+}
+
+/**
+ * @brief Test xQueueUnblock to unblock a task waiting to send to a queue.
+ * @coverage xQueueUnblock
+ */
+void test_xQueueUnblock_send( void )
+{
+    QueueHandle_t xQueue = xQueueCreate( 1, sizeof( uint32_t ) );
+
+    /* Export for callbacks */
+    xQueueHandleStatic = xQueue;
+
+    xTaskCheckForTimeOut_Stub( &xQueueReceive_xTaskCheckForTimeOutCB );
+    xTaskResumeAll_Stub( &td_task_xTaskResumeAllStub );
+    uxTaskGetNumberOfTasks_IgnoreAndReturn( 1 );
+    vTaskYieldWithinAPI_Stub( vTaskYieldWithinAPI_Callback );
+
+    uint32_t checkVal = INVALID_UINT32;
+
+    /* Add a task to the queue's WaitingToSend event list */
+    td_task_addFakeTaskWaitingToSendToQueue( xQueue );
+
+    /* Unblock the task waiting to send to the queue */
+    TEST_ASSERT_EQUAL( pdTRUE, xQueueUnblock( xQueue ) );
+
+    /* Verify that the task was unblocked */
+    TEST_ASSERT_EQUAL( 0, listLIST_IS_EMPTY( &( xQueue->xTasksWaitingToSend ) ) );
+
+    vQueueDelete( xQueue );
+}

--- a/FreeRTOS/Test/CMock/queue/generic/queue_send_blocking_utest.c
+++ b/FreeRTOS/Test/CMock/queue/generic/queue_send_blocking_utest.c
@@ -362,3 +362,63 @@ void test_macro_xQueueSend_blocking_locked( void )
 
     vQueueDelete( xQueue );
 }
+
+/**
+ * @brief Test xQueueUnblock to unblock a task waiting to receive from a queue.
+ * @coverage xQueueUnblock
+ */
+void test_xQueueUnblock_receive( void )
+{
+    QueueHandle_t xQueue = xQueueCreate( 1, sizeof( uint32_t ) );
+
+    /* Export for callbacks */
+    xQueueHandleStatic = xQueue;
+
+    xTaskCheckForTimeOut_Stub( &xQueueReceive_xTaskCheckForTimeOutCB );
+    xTaskResumeAll_Stub( &td_task_xTaskResumeAllStub );
+    uxTaskGetNumberOfTasks_IgnoreAndReturn( 1 );
+    vTaskYieldWithinAPI_Stub( vTaskYieldWithinAPI_Callback );
+
+    uint32_t checkVal = INVALID_UINT32;
+
+    /* Add a task to the queue's WaitingToReceive event list */
+    td_task_addFakeTaskWaitingToReceiveFromQueue( xQueue );
+
+    /* Unblock the task waiting to receive from the queue */
+    TEST_ASSERT_EQUAL( pdTRUE, xQueueUnblock( xQueue ) );
+
+    /* Verify that the task was unblocked */
+    TEST_ASSERT_EQUAL( 0, listLIST_IS_EMPTY( &( xQueue->xTasksWaitingToReceive ) ) );
+
+    vQueueDelete( xQueue );
+}
+
+/**
+ * @brief Test xQueueUnblock to unblock a task waiting to send to a queue.
+ * @coverage xQueueUnblock
+ */
+void test_xQueueUnblock_send( void )
+{
+    QueueHandle_t xQueue = xQueueCreate( 1, sizeof( uint32_t ) );
+
+    /* Export for callbacks */
+    xQueueHandleStatic = xQueue;
+
+    xTaskCheckForTimeOut_Stub( &xQueueReceive_xTaskCheckForTimeOutCB );
+    xTaskResumeAll_Stub( &td_task_xTaskResumeAllStub );
+    uxTaskGetNumberOfTasks_IgnoreAndReturn( 1 );
+    vTaskYieldWithinAPI_Stub( vTaskYieldWithinAPI_Callback );
+
+    uint32_t checkVal = INVALID_UINT32;
+
+    /* Add a task to the queue's WaitingToSend event list */
+    td_task_addFakeTaskWaitingToSendToQueue( xQueue );
+
+    /* Unblock the task waiting to send to the queue */
+    TEST_ASSERT_EQUAL( pdTRUE, xQueueUnblock( xQueue ) );
+
+    /* Verify that the task was unblocked */
+    TEST_ASSERT_EQUAL( 0, listLIST_IS_EMPTY( &( xQueue->xTasksWaitingToSend ) ) );
+
+    vQueueDelete( xQueue );
+}

--- a/FreeRTOS/Test/CMock/queue/generic/queue_unblock_utest.c
+++ b/FreeRTOS/Test/CMock/queue/generic/queue_unblock_utest.c
@@ -1,0 +1,145 @@
+/*
+ * FreeRTOS V202212.00
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * https://www.FreeRTOS.org
+ * https://github.com/FreeRTOS
+ *
+ */
+/*! @file queue_unblock_utest.c */
+
+/* C runtime includes. */
+#include <stdlib.h>
+#include <stdbool.h>
+#include <string.h>
+
+#include "../queue_utest_common.h"
+
+/* Queue includes */
+#include "FreeRTOS.h"
+#include "FreeRTOSConfig.h"
+#include "queue.h"
+#include "mock_fake_port.h"
+/* ============================  GLOBAL VARIABLES =========================== */
+
+/* Used to share a QueueHandle_t between a test case and it's callbacks */
+static QueueHandle_t xQueueHandleStatic;
+
+/* ==========================  CALLBACK FUNCTIONS =========================== */
+
+/* ============================= Unity Fixtures ============================= */
+
+void setUp( void )
+{
+    commonSetUp();
+    vFakePortAssertIfInterruptPriorityInvalid_Ignore();
+    xQueueHandleStatic = NULL;
+}
+
+void tearDown( void )
+{
+    commonTearDown();
+}
+
+void suiteSetUp()
+{
+    commonSuiteSetUp();
+}
+
+int suiteTearDown( int numFailures )
+{
+    return commonSuiteTearDown( numFailures );
+}
+
+/* ==========================  Helper functions =========================== */
+
+/**
+ * @brief Callback for vTaskYieldTaskWithinAPI used by tests for yield counts
+ *
+ * NumCalls is checked in the test assert.
+ */
+static void vTaskYieldWithinAPI_Callback( int NumCalls )
+{
+    ( void ) NumCalls;
+
+    portYIELD_WITHIN_API();
+}
+
+/* =============================  Test Cases ============================== */
+
+/**
+ * @brief Test xQueueUnblock to unblock a task waiting to receive from a queue.
+ * @coverage xQueueUnblock
+ */
+void test_xQueueUnblock_receive( void )
+{
+    QueueHandle_t xQueue = xQueueCreate( 1, sizeof( uint32_t ) );
+
+    /* Export for callbacks */
+    xQueueHandleStatic = xQueue;
+
+    xTaskCheckForTimeOut_Stub( &xQueueReceive_xTaskCheckForTimeOutCB );
+    xTaskResumeAll_Stub( &td_task_xTaskResumeAllStub );
+    uxTaskGetNumberOfTasks_IgnoreAndReturn( 1 );
+    vTaskYieldWithinAPI_Stub( vTaskYieldWithinAPI_Callback );
+
+    uint32_t checkVal = INVALID_UINT32;
+
+    /* Add a task to the queue's WaitingToReceive event list */
+    td_task_addFakeTaskWaitingToReceiveFromQueue( xQueue );
+
+    /* Unblock the task waiting to receive from the queue */
+    TEST_ASSERT_EQUAL( pdTRUE, xQueueUnblock( xQueue ) );
+
+    /* Verify that the task was unblocked */
+    TEST_ASSERT_EQUAL( 0, listLIST_IS_EMPTY( &( xQueue->xTasksWaitingToReceive ) ) );
+
+    vQueueDelete( xQueue );
+}
+
+/**
+ * @brief Test xQueueUnblock to unblock a task waiting to send to a queue.
+ * @coverage xQueueUnblock
+ */
+void test_xQueueUnblock_send( void )
+{
+    QueueHandle_t xQueue = xQueueCreate( 1, sizeof( uint32_t ) );
+
+    /* Export for callbacks */
+    xQueueHandleStatic = xQueue;
+
+    xTaskCheckForTimeOut_Stub( &xQueueReceive_xTaskCheckForTimeOutCB );
+    xTaskResumeAll_Stub( &td_task_xTaskResumeAllStub );
+    uxTaskGetNumberOfTasks_IgnoreAndReturn( 1 );
+    vTaskYieldWithinAPI_Stub( vTaskYieldWithinAPI_Callback );
+
+    uint32_t checkVal = INVALID_UINT32;
+
+    /* Add a task to the queue's WaitingToSend event list */
+    td_task_addFakeTaskWaitingToSendToQueue( xQueue );
+
+    /* Unblock the task waiting to send to the queue */
+    TEST_ASSERT_EQUAL( pdTRUE, xQueueUnblock( xQueue ) );
+
+    /* Verify that the task was unblocked */
+    TEST_ASSERT_EQUAL( 0, listLIST_IS_EMPTY( &( xQueue->xTasksWaitingToSend ) ) );
+
+    vQueueDelete( xQueue );
+}


### PR DESCRIPTION
Related to #1113

Add `xQueueUnblock` function to unblock threads waiting on a queue.

* Add `xQueueUnblock(QueueHandle_t)` function to `queue.c` to unblock threads waiting on a queue.
* Update `xQueueGenericSend` and `xQueueReceive` functions to handle the new unblock functionality.
* Add necessary headers and setup functions for the new `xQueueUnblock` function.
* Include usage examples and explanations in the documentation for `xQueueUnblock`.


So many error are still persists please add in comments I will work of fixing those

