### PR TITLE
Enable release from forks

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -43,6 +43,7 @@ jobs:
           ACTOR: ${{ github.actor }}
           COMMIT_ID: ${{ github.event.inputs.commit_id }}
           VERSION_NUMBER: ${{ github.event.inputs.version_number }}
+          GITHUB_ORG: ${{ github.repository_owner }}
         run: |
           # Configure repo for push
           git config --global user.name "$ACTOR"
@@ -50,5 +51,5 @@ jobs:
 
           # Run the release script
           pip install -r ./tools/.github/scripts/release-requirements.txt
-          ./tools/.github/scripts/release.py FreeRTOS --core-repo-path=local_core --core-commit="$COMMIT_ID" --new-core-version="$VERSION_NUMBER"
+          ./tools/.github/scripts/release.py "$GITHUB_ORG" --core-repo-path=local_core --core-commit="$COMMIT_ID" --new-core-version="$VERSION_NUMBER"
           exit $?

--- a/manifest.yml
+++ b/manifest.yml
@@ -5,7 +5,7 @@ license: "MIT"
 
 dependencies:
   - name: "FreeRTOS-Kernel"
-    version: "5f3bab1"
+    version: "7e419c2"
     repository:
       type: "git"
       url: "https://github.com/FreeRTOS/FreeRTOS-Kernel.git"


### PR DESCRIPTION
<!--- Title -->

Description
-----------
This PR updates the hardcoded github organization in the release CI script to dynamically fetch it from the github context, enabling testing releases from forked branches.

Test Steps
-----------
https://github.com/tony-josi-aws/FreeRTOS/actions/runs/11907845141

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- ~[ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.~

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
