### PR TITLE
Fix SMP coverage tests for kernel PR 1206

### DIFF
--- a/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c
+++ b/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c
@@ -1741,11 +1741,7 @@ void test_coverage_xTaskRemoveFromEventList_remove_eq_priority_task( void )
     uxCurrentNumberOfTasks = uxCurrentNumberOfTasks + 1;
 
     /* Expectations. */
-    vFakePortGetCoreID_StubWithCallback( NULL );
-    vFakePortGetCoreID_ExpectAndReturn( 0 ); /* Get portGET_CRITICAL_NESTING_COUNT. */
-    vFakePortGetCoreID_ExpectAndReturn( 0 ); /* Get prvYieldCore. */
-    vFakePortGetCoreID_ExpectAndReturn( 0 ); /* Get portGET_CRITICAL_NESTING_COUNT. */
-    vFakePortGetCoreID_ExpectAndReturn( 0 ); /* Get xYieldPendings. */
+    vFakePortGetCoreID_ExpectAndReturn( 0 );
     vFakePortGetCoreID_ExpectAndReturn( 0 ); /* portTASK_SWITCH_HOOK(). */
 
     /* API call. */
@@ -1942,9 +1938,7 @@ void test_coverage_vTaskRemoveFromUnorderedEventList_remove_higher_priority_task
     uxCurrentNumberOfTasks = uxCurrentNumberOfTasks + 1;
 
     /* Expectations. */
-    vFakePortGetCoreID_StubWithCallback( NULL );
-    vFakePortGetCoreID_ExpectAndReturn( 0 ); /* Get portGET_CRITICAL_NESTING_COUNT. */
-    vFakePortGetCoreID_ExpectAndReturn( 0 ); /* Get prvYieldCore. */
+    vFakePortGetCoreID_ExpectAndReturn( 0 );
 
     /* API call. */
     vTaskRemoveFromUnorderedEventList( &xTaskTCB.xEventListItem, 500 | 0x80000000UL );
@@ -1990,9 +1984,7 @@ void test_coverage_vTaskEnterCritical_task_in_critical_already( void )
 
     /* Expectations. */
     vFakePortDisableInterrupts_ExpectAndReturn( 0 );
-    vFakePortGetCoreID_ExpectAndReturn( 0 ); /* Get both locks. */
-    vFakePortGetCoreID_ExpectAndReturn( 0 ); /* Increment the critical nesting count. */
-    vFakePortGetCoreID_ExpectAndReturn( 0 ); /* Check first time enter critical section. */
+    vFakePortGetCoreID_ExpectAndReturn( 0 );
 
     /* API call. */
     vTaskEnterCritical();
@@ -2030,9 +2022,8 @@ void test_coverage_vTaskEnterCriticalFromISR_isr_in_critical_already( void )
     vFakePortGetCoreID_StubWithCallback( NULL );
 
     /* Expectations. */
+    vFakePortGetCoreID_ExpectAndReturn( 0 );
     ulFakePortSetInterruptMaskFromISR_ExpectAndReturn( 0x5a5a ); /* The value to be verified. */
-    vFakePortGetCoreID_ExpectAndReturn( 0 );                     /* Get ISR locks. */
-    vFakePortGetCoreID_ExpectAndReturn( 0 );                     /* Increment the critical nesting count. */
 
     /* API call. */
     xSavedInterruptStatus = vTaskEnterCriticalFromISR();
@@ -2073,10 +2064,7 @@ void test_coverage_vTaskExitCritical_task_enter_critical_mt_1( void )
     vFakePortGetCoreID_StubWithCallback( NULL );
 
     /* Expectations. */
-    vFakePortGetCoreID_ExpectAndReturn( 0 ); /* configASSERT. */
-    vFakePortGetCoreID_ExpectAndReturn( 0 ); /* Check critical nesting count. */
-    vFakePortGetCoreID_ExpectAndReturn( 0 ); /* Decrease the critical nesting count. */
-    vFakePortGetCoreID_ExpectAndReturn( 0 ); /* Check exit critical section. */
+    vFakePortGetCoreID_ExpectAndReturn( 0 );
 
     /* API call. */
     vTaskExitCritical();
@@ -2114,8 +2102,7 @@ void test_coverage_vTaskExitCritical_task_not_in_critical( void )
     vFakePortGetCoreID_StubWithCallback( NULL );
 
     /* Expectations. */
-    vFakePortGetCoreID_ExpectAndReturn( 0 ); /* configASSERT. */
-    vFakePortGetCoreID_ExpectAndReturn( 0 ); /* Check critical nesting count. */
+    vFakePortGetCoreID_ExpectAndReturn( 0 );
 
     /* API call. */
     vTaskExitCritical();
@@ -2172,10 +2159,7 @@ void test_coverage_vTaskExitCriticalFromISR_isr_enter_critical_mt_1( void )
     vFakePortGetCoreID_StubWithCallback( NULL );
 
     /* Expectations. */
-    vFakePortGetCoreID_ExpectAndReturn( 0 ); /* configASSERT. */
-    vFakePortGetCoreID_ExpectAndReturn( 0 ); /* Check critical nesting count. */
-    vFakePortGetCoreID_ExpectAndReturn( 0 ); /* Decrement critical nesting count. */
-    vFakePortGetCoreID_ExpectAndReturn( 0 ); /* Check critical nesting count. */
+    vFakePortGetCoreID_ExpectAndReturn( 0 );
 
     /* API call. */
     /* The mask value has not effect since ISR enters critical section more than 1 time. */
@@ -2215,8 +2199,7 @@ void test_coverage_vTaskExitCriticalFromISR_isr_not_in_critical( void )
     vFakePortGetCoreID_StubWithCallback( NULL );
 
     /* Expectations. */
-    vFakePortGetCoreID_ExpectAndReturn( 0 ); /* configASSERT. */
-    vFakePortGetCoreID_ExpectAndReturn( 0 ); /* Check critical nesting count. */
+    vFakePortGetCoreID_ExpectAndReturn( 0 );
 
     /* API call. */
     /* The mask value has not effect since ISR is not in critical section. */


### PR DESCRIPTION
Description
-----------
Fix SMP coverage tests for kernel PR 1206 - https://github.com/FreeRTOS/FreeRTOS-Kernel/pull/1206.

Test Steps
-----------
Run coverage tests.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
https://github.com/FreeRTOS/FreeRTOS-Kernel/pull/1206

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
