### PR TITLE
fix(freertos/tasks): Updated the xTaskGetIdleTaskHandle Test

### DIFF
--- a/FreeRTOS/Test/CMock/tasks/tasks_1_utest.c
+++ b/FreeRTOS/Test/CMock/tasks/tasks_1_utest.c
@@ -3607,12 +3607,22 @@ void test_xTaskGetIdleTaskHandle_success( void )
 {
     TaskHandle_t ret_idle_handle;
     int ret;
+    BaseType_t xIdleNameLen;
+    BaseType_t xCopyLen;
 
     start_scheduler();
+
+    /* The length of the idle task name is limited to the minimum of the length
+     * of configIDLE_TASK_NAME and configMAX_TASK_NAME_LEN - 2, keeping space
+     * for the core ID suffix and the null-terminator. */
+    xIdleNameLen = sizeof( configIDLE_TASK_NAME ) - 1;
+    xCopyLen = ( xIdleNameLen < configMAX_TASK_NAME_LEN - 2 ) ? xIdleNameLen : configMAX_TASK_NAME_LEN - 2;
+
     /* Api Call */
     ret_idle_handle = xTaskGetIdleTaskHandle();
     ptcb = ret_idle_handle;
-    ret = strncmp( ptcb->pcTaskName, configIDLE_TASK_NAME, configMAX_TASK_NAME_LEN - 1 );
+    /* Verify the base name of the idle task. */
+    ret = strncmp( ptcb->pcTaskName, configIDLE_TASK_NAME, xCopyLen );
     TEST_ASSERT_EQUAL( 0, ret );
 }
 


### PR DESCRIPTION
Description
-----------
- This commit updates the xTaskGetIdleTaskHandle unit test as per the idle task naming logic.
- The test update is necessitated by the idle task naming process update done in [Kernel PR #1203](https://github.com/FreeRTOS/FreeRTOS-Kernel/pull/1203).
- The test updates the `strncmp` length as per the new updates done in the kernel PR.

Test Steps
-----------
- Run CI tests with the updates done in [Kernel PR #1203](https://github.com/FreeRTOS/FreeRTOS-Kernel/pull/1203).

Checklist:
----------
- [x] I have tested my changes. No regression in existing tests.

Related Issue
-----------
- [Kernel PR #1203](https://github.com/FreeRTOS/FreeRTOS-Kernel/pull/1203)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
