### PR TITLE
Update unit test for TASK and ISR lock macros

### DIFF
--- a/FreeRTOS/Test/CMock/config/fake_port.h
+++ b/FreeRTOS/Test/CMock/config/fake_port.h
@@ -50,10 +50,10 @@ void vPortSuppressTicksAndSleep( TickType_t xExpectedIdleTime );
 
 void portSetupTCB_CB( void * tcb );
 
-void vFakePortGetISRLock( void );
-void vFakePortReleaseISRLock( void );
-void vFakePortGetTaskLock( void );
-void vFakePortReleaseTaskLock( void );
+void vFakePortGetISRLock( BaseType_t xCoreID );
+void vFakePortReleaseISRLock( BaseType_t xCoreID );
+void vFakePortGetTaskLock( BaseType_t xCoreID );
+void vFakePortReleaseTaskLock( BaseType_t xCoreID );
 
 void vFakePortAssertIfISR();
 BaseType_t vFakePortCheckIfInISR( void );

--- a/FreeRTOS/Test/CMock/config/portmacro.h
+++ b/FreeRTOS/Test/CMock/config/portmacro.h
@@ -125,37 +125,37 @@ typedef unsigned long    UBaseType_t;
 /*-----------------------------------------------------------*/
 
 #define portSAVE_CONTEXT()
-#define portYIELD()                      vFakePortYield()
-#define portYIELD_WITHIN_API()           vFakePortYieldWithinAPI()
-#define portYIELD_FROM_ISR()             vFakePortYieldFromISR()
+#define portYIELD()                         vFakePortYield()
+#define portYIELD_WITHIN_API()              vFakePortYieldWithinAPI()
+#define portYIELD_FROM_ISR()                vFakePortYieldFromISR()
 
 /* Critical section handling. */
-#define portDISABLE_INTERRUPTS()         vFakePortDisableInterrupts()
-#define portENABLE_INTERRUPTS()          vFakePortEnableInterrupts()
+#define portDISABLE_INTERRUPTS()            vFakePortDisableInterrupts()
+#define portENABLE_INTERRUPTS()             vFakePortEnableInterrupts()
 #define portCLEAR_INTERRUPT_MASK_FROM_ISR( x ) \
     vFakePortClearInterruptMaskFromISR( x )
 #define portSET_INTERRUPT_MASK_FROM_ISR() \
     ulFakePortSetInterruptMaskFromISR()
-#define portSET_INTERRUPT_MASK()         ulFakePortSetInterruptMask()
-#define portCLEAR_INTERRUPT_MASK( x )    vFakePortClearInterruptMask( x )
+#define portSET_INTERRUPT_MASK()            ulFakePortSetInterruptMask()
+#define portCLEAR_INTERRUPT_MASK( x )       vFakePortClearInterruptMask( x )
 #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID() \
     vFakePortAssertIfInterruptPriorityInvalid()
-#define portENTER_CRITICAL()             vFakePortEnterCriticalSection()
-#define portEXIT_CRITICAL()              vFakePortExitCriticalSection()
-#define portGET_ISR_LOCK()               vFakePortGetISRLock()
-#define portRELEASE_ISR_LOCK()           vFakePortReleaseISRLock()
-#define portGET_TASK_LOCK()              vFakePortGetTaskLock()
-#define portRELEASE_TASK_LOCK()          vFakePortReleaseTaskLock()
+#define portENTER_CRITICAL()                vFakePortEnterCriticalSection()
+#define portEXIT_CRITICAL()                 vFakePortExitCriticalSection()
+#define portGET_ISR_LOCK( xCoreID )         vFakePortGetISRLock( xCoreID )
+#define portRELEASE_ISR_LOCK( xCoreID )     vFakePortReleaseISRLock( xCoreID )
+#define portGET_TASK_LOCK( xCoreID )        vFakePortGetTaskLock( xCoreID )
+#define portRELEASE_TASK_LOCK( xCoreID )    vFakePortReleaseTaskLock( xCoreID )
 
-#define portCHECK_IF_IN_ISR()            vFakePortCheckIfInISR()
-#define portRESTORE_INTERRUPTS( x )      vFakePortRestoreInterrupts( x )
+#define portCHECK_IF_IN_ISR()               vFakePortCheckIfInISR()
+#define portRESTORE_INTERRUPTS( x )         vFakePortRestoreInterrupts( x )
 #define portPRE_TASK_DELETE_HOOK( pvTaskToDelete, pxPendYield ) \
     vPortCurrentTaskDying( ( pvTaskToDelete ), ( pxPendYield ) )
-#define portSETUP_TCB( pxTCB )           portSetupTCB_CB( pxTCB );
-#define  portASSERT_IF_IN_ISR()          vFakePortAssertIfISR();
+#define portSETUP_TCB( pxTCB )              portSetupTCB_CB( pxTCB );
+#define  portASSERT_IF_IN_ISR()             vFakePortAssertIfISR();
 
-#define portGET_CORE_ID()                vFakePortGetCoreID()
-#define portYIELD_CORE( x )              vFakePortYieldCore( x )
+#define portGET_CORE_ID()                   vFakePortGetCoreID()
+#define portYIELD_CORE( x )                 vFakePortYieldCore( x )
 
 #define portENTER_CRITICAL_FROM_ISR    vFakePortEnterCriticalFromISR
 #define portEXIT_CRITICAL_FROM_ISR     vFakePortExitCriticalFromISR

--- a/FreeRTOS/Test/CMock/smp/config_assert/config_assert_utest.c
+++ b/FreeRTOS/Test/CMock/smp/config_assert/config_assert_utest.c
@@ -311,8 +311,8 @@ void test_prvSelectHighestPriorityTask_assert_scheduler_running_false( void )
     xSchedulerRunning = pdFALSE; /* causes the assert */
     uxSchedulerSuspended = pdFALSE;
 
-    vFakePortGetTaskLock_Expect();
-    vFakePortGetISRLock_Expect();
+    vFakePortGetTaskLock_Expect( 1 );
+    vFakePortGetISRLock_Expect( 1 );
 
     EXPECT_ASSERT_BREAK( vTaskSwitchContext( 1 ) );
     validate_and_clear_assertions();
@@ -344,8 +344,8 @@ void test_prvSelectHighestPriorityTask_assert_coreid_ne_runstate( void )
     xSchedulerRunning = pdTRUE;
     uxSchedulerSuspended = pdFALSE;
 
-    vFakePortGetTaskLock_Expect();
-    vFakePortGetISRLock_Expect();
+    vFakePortGetTaskLock_Expect( 0 );
+    vFakePortGetISRLock_Expect( 0 );
 
     listIS_CONTAINED_WITHIN_ExpectAnyArgsAndReturn( pdFALSE );
     listLIST_IS_EMPTY_ExpectAnyArgsAndReturn( pdFALSE );
@@ -467,8 +467,8 @@ void test_vTaskSwitchContext_assert_nexting_count_ne_zero( void )
 
     pxCurrentTCBs[ 1 ] = &currentTCB;
 
-    vFakePortGetTaskLock_Expect();
-    vFakePortGetISRLock_Expect();
+    vFakePortGetTaskLock_Expect( 1 );
+    vFakePortGetISRLock_Expect( 1 );
 
     EXPECT_ASSERT_BREAK( vTaskSwitchContext( 1 ) );
 
@@ -576,9 +576,9 @@ void test_prvGetExpectedIdleTime_assert_nextUnblock_lt_xTickCount( void )
     vFakePortAssertIfISR_Expect();
     ulFakePortSetInterruptMask_ExpectAndReturn( 0 );
     vFakePortGetCoreID_ExpectAndReturn( 0 );
-    vFakePortGetTaskLock_Expect();
-    vFakePortGetISRLock_Expect();
-    vFakePortReleaseISRLock_Expect();
+    vFakePortGetTaskLock_Expect( 0 );
+    vFakePortGetISRLock_Expect( 0 );
+    vFakePortReleaseISRLock_Expect( 0 );
     vFakePortClearInterruptMask_Expect( 0 );
 
     /* API Call */

--- a/FreeRTOS/Test/CMock/smp/config_assert/config_assert_utest.c
+++ b/FreeRTOS/Test/CMock/smp/config_assert/config_assert_utest.c
@@ -577,6 +577,7 @@ void test_prvGetExpectedIdleTime_assert_nextUnblock_lt_xTickCount( void )
     ulFakePortSetInterruptMask_ExpectAndReturn( 0 );
     vFakePortGetCoreID_ExpectAndReturn( 0 );
     vFakePortGetTaskLock_Expect( 0 );
+    vFakePortGetCoreID_ExpectAndReturn( 0 );
     vFakePortGetISRLock_Expect( 0 );
     vFakePortReleaseISRLock_Expect( 0 );
     vFakePortClearInterruptMask_Expect( 0 );

--- a/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c
+++ b/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c
@@ -3328,7 +3328,7 @@ void test_coverage_xTaskResumeAll_task_in_pending_ready_list( void )
     vFakePortExitCriticalSection_StubWithCallback( NULL );
 
     /* Expectations. */
-    vFakePortReleaseTaskLock_Expect();
+    vFakePortReleaseTaskLock_Expect( 0 );
     vFakePortExitCriticalSection_Expect();
 
     /* API call. */
@@ -3398,7 +3398,7 @@ void test_coverage_xTaskResumeAll_task_in_pending_ready_list_uxpriority_lesser( 
     vFakePortExitCriticalSection_StubWithCallback( NULL );
 
     /* Expectations. */
-    vFakePortReleaseTaskLock_Expect();
+    vFakePortReleaseTaskLock_Expect( 0 );
     vFakePortExitCriticalSection_Expect();
 
     /* API call. */

--- a/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice_mock/covg_multiple_priorities_no_timeslice_mock_utest.c
+++ b/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice_mock/covg_multiple_priorities_no_timeslice_mock_utest.c
@@ -802,13 +802,13 @@ void test_coverage_prvGetExpectedIdleTime_ready_list_eq_1( void )
     vFakePortAssertIfISR_Expect();
     ulFakePortSetInterruptMask_ExpectAndReturn( 0 );
     vFakePortGetCoreID_ExpectAndReturn( 0 );
-    vFakePortGetTaskLock_Expect();
+    vFakePortGetTaskLock_Expect( 0 );
     /* prvCheckForRunStateChange */
     vFakePortGetCoreID_ExpectAndReturn( 0 );
     vFakePortAssertIfISR_Expect();
     /* End of prvCheckForRunStateChange */
-    vFakePortGetISRLock_Expect();
-    vFakePortReleaseISRLock_Expect();
+    vFakePortGetISRLock_Expect( 0 );
+    vFakePortReleaseISRLock_Expect( 0 );
     vFakePortClearInterruptMask_Expect( 0 );
     /* End of vTaskSuspendAll */
 
@@ -826,7 +826,7 @@ void test_coverage_prvGetExpectedIdleTime_ready_list_eq_1( void )
 
     vFakePortEnterCriticalSection_Expect();
     vFakePortGetCoreID_ExpectAndReturn( 0 );
-    vFakePortReleaseTaskLock_Expect();
+    vFakePortReleaseTaskLock_Expect( 0 );
     vFakePortExitCriticalSection_Expect();
 
     listCURRENT_LIST_LENGTH_ExpectAndThrow( &( pxReadyTasksLists[ tskIDLE_PRIORITY ] ),
@@ -908,12 +908,12 @@ void test_coverage_prvGetExpectedIdleTime_ready_list_eq_2( void )
     vFakePortAssertIfISR_Stub( port_assert_if_isr_cb );
     ulFakePortSetInterruptMask_ExpectAndReturn( 0 );
     vFakePortGetCoreID_ExpectAndReturn( 0 );
-    vFakePortGetTaskLock_Expect();
+    vFakePortGetTaskLock_Expect( 0 );
     /* prvCheckForRunStateChange */
     vFakePortGetCoreID_ExpectAndReturn( 0 );
     /* End of prvCheckForRunStateChange */
-    vFakePortGetISRLock_Expect();
-    vFakePortReleaseISRLock_Expect();
+    vFakePortGetISRLock_Expect( 0 );
+    vFakePortReleaseISRLock_Expect( 0 );
     vFakePortClearInterruptMask_Expect( 0 );
     /* End of vTaskSuspendAll */
 
@@ -926,7 +926,7 @@ void test_coverage_prvGetExpectedIdleTime_ready_list_eq_2( void )
 
     vFakePortEnterCriticalSection_Expect();
     vFakePortGetCoreID_ExpectAndReturn( 0 );
-    vFakePortReleaseTaskLock_Expect();
+    vFakePortReleaseTaskLock_Expect( 0 );
     vFakePortExitCriticalSection_Expect();
 
     listCURRENT_LIST_LENGTH_ExpectAndThrow( &( pxReadyTasksLists[ tskIDLE_PRIORITY ] ),

--- a/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice_mock/covg_multiple_priorities_no_timeslice_mock_utest.c
+++ b/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice_mock/covg_multiple_priorities_no_timeslice_mock_utest.c
@@ -807,6 +807,7 @@ void test_coverage_prvGetExpectedIdleTime_ready_list_eq_1( void )
     vFakePortGetCoreID_ExpectAndReturn( 0 );
     vFakePortAssertIfISR_Expect();
     /* End of prvCheckForRunStateChange */
+    vFakePortGetCoreID_ExpectAndReturn( 0 );
     vFakePortGetISRLock_Expect( 0 );
     vFakePortReleaseISRLock_Expect( 0 );
     vFakePortClearInterruptMask_Expect( 0 );
@@ -912,6 +913,7 @@ void test_coverage_prvGetExpectedIdleTime_ready_list_eq_2( void )
     /* prvCheckForRunStateChange */
     vFakePortGetCoreID_ExpectAndReturn( 0 );
     /* End of prvCheckForRunStateChange */
+    vFakePortGetCoreID_ExpectAndReturn( 0 );
     vFakePortGetISRLock_Expect( 0 );
     vFakePortReleaseISRLock_Expect( 0 );
     vFakePortClearInterruptMask_Expect( 0 );

--- a/FreeRTOS/Test/CMock/smp/single_priority_no_timeslice/covg_single_priority_no_timeslice_utest.c
+++ b/FreeRTOS/Test/CMock/smp/single_priority_no_timeslice/covg_single_priority_no_timeslice_utest.c
@@ -143,10 +143,10 @@ void test_coverage_prvCheckForRunStateChange_first_time_critical_section( void )
     /* Expection. */
     vFakePortEnableInterrupts_StubWithCallback( prvPortEnableInterruptsCb );
 
-    vFakePortReleaseISRLock_Expect();
-    vFakePortReleaseTaskLock_Expect();
-    vFakePortGetTaskLock_Expect();
-    vFakePortGetISRLock_Expect();
+    vFakePortReleaseISRLock_Expect( 0 );
+    vFakePortReleaseTaskLock_Expect( 0 );
+    vFakePortGetTaskLock_Expect( 0 );
+    vFakePortGetISRLock_Expect( 0 );
 
     /* API Call. */
     prvCheckForRunStateChange();
@@ -192,10 +192,10 @@ void test_coverage_prvCheckForRunStateChange_first_time_suspend_scheduler( void 
     /* Expection. */
     vFakePortEnableInterrupts_StubWithCallback( prvPortEnableInterruptsCb );
 
-    vFakePortReleaseTaskLock_Expect();
-    vFakePortGetTaskLock_Expect();
-    vFakePortGetISRLock_Expect();
-    vFakePortReleaseISRLock_Expect();
+    vFakePortReleaseTaskLock_Expect( 0 );
+    vFakePortGetTaskLock_Expect( 0 );
+    vFakePortGetISRLock_Expect( 0 );
+    vFakePortReleaseISRLock_Expect( 0 );
 
     /* API Call. */
     prvCheckForRunStateChange();
@@ -234,6 +234,7 @@ void test_task_get_system_state( void )
 
     /*Get System states */
     int no_of_tasks = uxTaskGetSystemState( tsk_status_array, MAX_TASKS, NULL );
+
     TEST_ASSERT( ( no_of_tasks > 0 ) && ( no_of_tasks <= MAX_TASKS ) );
 }
 
@@ -257,6 +258,7 @@ void test_task_get_system_state_custom_time( void )
 
     /*Get System states */
     int no_of_tasks = uxTaskGetSystemState( tsk_status_array, MAX_TASKS, &ulTotalRunTime );
+
     TEST_ASSERT( ( no_of_tasks > 0 ) && ( no_of_tasks <= MAX_TASKS ) );
 }
 
@@ -279,6 +281,7 @@ void test_task_get_system_state_unavilable_task_space( void )
 
     /*Get System states */
     int no_of_tasks = uxTaskGetSystemState( tsk_status_array, MAX_TASKS - 1, NULL );
+
     TEST_ASSERT( ( no_of_tasks == 0 ) && ( no_of_tasks <= MAX_TASKS ) );
 }
 

--- a/FreeRTOS/Test/CMock/smp/smp_utest_common.c
+++ b/FreeRTOS/Test/CMock/smp/smp_utest_common.c
@@ -241,7 +241,8 @@ unsigned int vFakePortGetCoreIDCallback( int cmock_num_calls )
     return ( unsigned int ) xCurrentCoreId;
 }
 
-void vFakePortGetISRLockCallback( int cmock_num_calls )
+void vFakePortGetISRLockCallback( BaseType_t xCoreID,
+                                  int cmock_num_calls )
 {
     int i;
 
@@ -250,25 +251,27 @@ void vFakePortGetISRLockCallback( int cmock_num_calls )
     /* Ensure that no other core is in the critical section. */
     for( i = 0; i < configNUMBER_OF_CORES; i++ )
     {
-        if( i != xCurrentCoreId )
+        if( i != xCoreID )
         {
             TEST_ASSERT_MESSAGE( xIsrLockCount[ i ] == 0, "vFakePortGetISRLock xIsrLockCount[ i ] > 0" );
             TEST_ASSERT_MESSAGE( xTaskLockCount[ i ] == 0, "vFakePortGetISRLock xTaskLockCount[ i ] > 0" );
         }
     }
 
-    xIsrLockCount[ xCurrentCoreId ]++;
+    xIsrLockCount[ xCoreID ]++;
 }
 
-void vFakePortReleaseISRLockCallback( int cmock_num_calls )
+void vFakePortReleaseISRLockCallback( BaseType_t xCoreID,
+                                      int cmock_num_calls )
 {
     ( void ) cmock_num_calls;
 
-    TEST_ASSERT_MESSAGE( xIsrLockCount[ xCurrentCoreId ] > 0, "xIsrLockCount[ xCurrentCoreId ] <= 0" );
-    xIsrLockCount[ xCurrentCoreId ]--;
+    TEST_ASSERT_MESSAGE( xIsrLockCount[ xCoreID ] > 0, "xIsrLockCount[ xCoreID ] <= 0" );
+    xIsrLockCount[ xCoreID ]--;
 }
 
-void vFakePortGetTaskLockCallback( int cmock_num_calls )
+void vFakePortGetTaskLockCallback( BaseType_t xCoreID,
+                                   int cmock_num_calls )
 {
     int i;
 
@@ -277,36 +280,38 @@ void vFakePortGetTaskLockCallback( int cmock_num_calls )
     /* Ensure that no other core is in the critical section. */
     for( i = 0; i < configNUMBER_OF_CORES; i++ )
     {
-        if( i != xCurrentCoreId )
+        if( i != xCoreID )
         {
             TEST_ASSERT_MESSAGE( xIsrLockCount[ i ] == 0, "vFakePortGetTaskLock xIsrLockCount[ i ] > 0" );
             TEST_ASSERT_MESSAGE( xTaskLockCount[ i ] == 0, "vFakePortGetTaskLock xTaskLockCount[ i ] > 0" );
         }
     }
 
-    xTaskLockCount[ xCurrentCoreId ]++;
+    xTaskLockCount[ xCoreID ]++;
 }
 
-void vFakePortReleaseTaskLockCallback( int cmock_num_calls )
+void vFakePortReleaseTaskLockCallback( BaseType_t xCoreID,
+                                       int cmock_num_calls )
 {
     ( void ) cmock_num_calls;
 
-    TEST_ASSERT_MESSAGE( xTaskLockCount[ xCurrentCoreId ] > 0, "xTaskLockCount[ xCurrentCoreId ] <= 0" );
-    xTaskLockCount[ xCurrentCoreId ]--;
+    TEST_ASSERT_MESSAGE( xTaskLockCount[ xCoreID ] > 0, "xTaskLockCount[ xCoreID ] <= 0" );
+    xTaskLockCount[ xCoreID ]--;
 
     /* When releasing the ISR lock, check if any core is waiting to yield. */
-    if( xTaskLockCount[ xCurrentCoreId ] == 0 )
+    if( xTaskLockCount[ xCoreID ] == 0 )
     {
         vYieldCores();
     }
 }
 
-void vFakePortReleaseTaskLockAsyncCallback( int cmock_num_calls )
+void vFakePortReleaseTaskLockAsyncCallback( BaseType_t xCoreID,
+                                            int cmock_num_calls )
 {
     ( void ) cmock_num_calls;
 
-    TEST_ASSERT_MESSAGE( xTaskLockCount[ xCurrentCoreId ] > 0, "xTaskLockCount[ xCurrentCoreId ] <= 0" );
-    xTaskLockCount[ xCurrentCoreId ]--;
+    TEST_ASSERT_MESSAGE( xTaskLockCount[ xCoreID ] > 0, "xTaskLockCount[ xCoreID ] <= 0" );
+    xTaskLockCount[ xCoreID ]--;
 }
 
 portBASE_TYPE vFakePortEnterCriticalFromISRCallback( int cmock_num_calls )

--- a/FreeRTOS/Test/CMock/tasks/tasks_1_utest.c
+++ b/FreeRTOS/Test/CMock/tasks/tasks_1_utest.c
@@ -349,22 +349,22 @@ unsigned int vFakePortGetCoreID( void )
     return 0;
 }
 
-void vFakePortReleaseTaskLock( void )
+void vFakePortReleaseTaskLock( BaseType_t xCoreID )
 {
     HOOK_DIAG();
 }
 
-void vFakePortGetTaskLock( void )
+void vFakePortGetTaskLock( BaseType_t xCoreID )
 {
     HOOK_DIAG();
 }
 
-void vFakePortGetISRLock( void )
+void vFakePortGetISRLock( BaseType_t xCoreID )
 {
     HOOK_DIAG();
 }
 
-void vFakePortReleaseISRLock( void )
+void vFakePortReleaseISRLock( BaseType_t xCoreID )
 {
     HOOK_DIAG();
 }
@@ -671,6 +671,7 @@ void test_xTaskCreateStatic_success( void )
                                ulStackDepth * sizeof( StackType_t ) ) );
 
     StackType_t * pxTopOfStack = &( ptcb->pxStack[ ulStackDepth - ( uint32_t ) 1 ] );
+
     pxTopOfStack = ( StackType_t * ) ( ( ( portPOINTER_SIZE_TYPE ) pxTopOfStack )
                                        & ( ~( ( portPOINTER_SIZE_TYPE ) portBYTE_ALIGNMENT_MASK ) ) );
 
@@ -1869,6 +1870,7 @@ void test_vTaskDelay_success_gt_0_yield_called( void )
     task_handle = create_task();
     ptcb = ( TCB_t * ) task_handle;
     TickType_t delay = 34;
+
     /* Expectations */
     /* prvAddCurrentTaskToDelayedList */
     uxListRemove_ExpectAndReturn( &ptcb->xStateListItem, 1 );
@@ -1891,6 +1893,7 @@ void test_vTaskDelay_success_gt_0_yield_not_called( void )
     task_handle = create_task();
     ptcb = ( TCB_t * ) task_handle;
     TickType_t delay = 34;
+
     /* Expectations */
     /* prvAddCurrentTaskToDelayedList */
     uxListRemove_ExpectAndReturn( &ptcb->xStateListItem, pdTRUE );
@@ -1937,6 +1940,7 @@ void test_vTaskDelay_success_gt_0_already_yielded( void )
     pxCurrentTCB = task_handle;
     ptcb = ( TCB_t * ) task_handle;
     TickType_t delay = 34;
+
     /* Expectations */
     /* prvAddCurrentTaskToDelayedList */
     uxListRemove_ExpectAndReturn( &ptcb->xStateListItem, pdTRUE );
@@ -1981,6 +1985,7 @@ void test_eTaskGetState_success_current_tcb( void )
     task_handle = create_task();
     ptcb = ( TCB_t * ) task_handle;
     eTaskState ret_task_state;
+
     /* no Expectations */
 
     /* API Call */
@@ -2000,6 +2005,7 @@ void test_eTaskGetState_success_not_current_tcb_pending_ready( void )
     ptcb = ( TCB_t * ) task_handle;
     TEST_ASSERT_NOT_EQUAL( pxCurrentTCB, ptcb );
     eTaskState ret_task_state;
+
     /* Expectations */
     listLIST_ITEM_CONTAINER_ExpectAndReturn( &ptcb->xStateListItem,
                                              NULL );
@@ -2023,6 +2029,7 @@ void test_eTaskGetState_success_not_current_tcb_blocked_delayed( void )
     ptcb = ( TCB_t * ) task_handle;
     TEST_ASSERT_NOT_EQUAL( pxCurrentTCB, ptcb );
     eTaskState ret_task_state;
+
     /* Expectations */
     listLIST_ITEM_CONTAINER_ExpectAndReturn( &ptcb->xStateListItem,
                                              pxDelayedTaskList );
@@ -2046,6 +2053,7 @@ void test_eTaskGetState_success_not_current_tcb_blocked_overflow( void )
     ptcb = ( TCB_t * ) task_handle;
     TEST_ASSERT_NOT_EQUAL( pxCurrentTCB, ptcb );
     eTaskState ret_task_state;
+
     /* Expectations */
     listLIST_ITEM_CONTAINER_ExpectAndReturn( &ptcb->xStateListItem,
                                              pxOverflowDelayedTaskList );
@@ -2069,6 +2077,7 @@ void test_eTaskGetState_success_not_current_tcb_ready( void )
     ptcb = ( TCB_t * ) task_handle;
     TEST_ASSERT_NOT_EQUAL( pxCurrentTCB, ptcb );
     eTaskState ret_task_state;
+
     /* Expectations */
     listLIST_ITEM_CONTAINER_ExpectAndReturn( &ptcb->xStateListItem,
                                              &pxReadyTasksLists[ 0 ] );
@@ -2092,6 +2101,7 @@ void test_eTaskGetState_success_not_current_tcb_suspended( void )
     ptcb = ( TCB_t * ) task_handle;
     TEST_ASSERT_NOT_EQUAL( pxCurrentTCB, ptcb );
     eTaskState ret_task_state;
+
     /* Expectations */
     listLIST_ITEM_CONTAINER_ExpectAndReturn( &ptcb->xStateListItem,
                                              &xSuspendedTaskList );
@@ -2117,6 +2127,7 @@ void test_eTaskGetState_success_not_current_tcb_deleted( void )
     ptcb = ( TCB_t * ) task_handle;
     TEST_ASSERT_NOT_EQUAL( pxCurrentTCB, ptcb );
     eTaskState ret_task_state;
+
     /* Expectations */
     listLIST_ITEM_CONTAINER_ExpectAndReturn( &ptcb->xStateListItem,
                                              &xTasksWaitingTermination );
@@ -2140,6 +2151,7 @@ void test_eTaskGetState_success_not_current_tcb_deleted_not_found( void )
     ptcb = ( TCB_t * ) task_handle;
     TEST_ASSERT_NOT_EQUAL( pxCurrentTCB, ptcb );
     eTaskState ret_task_state;
+
     /* Expectations */
     listLIST_ITEM_CONTAINER_ExpectAndReturn( &ptcb->xStateListItem,
                                              NULL );
@@ -2169,6 +2181,7 @@ void test_eTaskGetState_success_not_current_tcb_wait_notif( void )
     ptcb->ucNotifyState[ 0 ] = 1; /* taskWAITING_NOTIFICATION */
     TEST_ASSERT_NOT_EQUAL( pxCurrentTCB, ptcb );
     eTaskState ret_task_state;
+
     /* Expectations */
     listLIST_ITEM_CONTAINER_ExpectAndReturn( &ptcb->xStateListItem,
                                              &xSuspendedTaskList );
@@ -2194,6 +2207,7 @@ void test_eTaskGetState_success_not_current_tcb_blocked( void )
     ptcb = ( TCB_t * ) task_handle;
     TEST_ASSERT_NOT_EQUAL( pxCurrentTCB, ptcb );
     eTaskState ret_task_state;
+
     /* Expectations */
     listLIST_ITEM_CONTAINER_ExpectAndReturn( &ptcb->xStateListItem,
                                              &xSuspendedTaskList );
@@ -3655,6 +3669,7 @@ void test_xTaskGetApplicationTaskTag_null_tcb_current( void )
     vTaskSetApplicationTaskTag( task_handle, pxHookFunction );
 
     TaskHookFunction_t hook_function;
+
     hook_function = xTaskGetApplicationTaskTag( NULL );
 
     TEST_ASSERT_EQUAL( &pxHookFunction, hook_function );
@@ -3668,6 +3683,7 @@ void test_xTaskGetApplicationTaskTag_tcb( void )
     vTaskSetApplicationTaskTag( task_handle, pxHookFunction );
 
     TaskHookFunction_t hook_function;
+
     hook_function = xTaskGetApplicationTaskTag( task_handle );
 
     TEST_ASSERT_EQUAL( &pxHookFunction, hook_function );
@@ -3693,6 +3709,7 @@ void test_xTaskGetApplicationTaskTagFromISR_success( void )
     vTaskSetApplicationTaskTag( task_handle, pxHookFunction );
 
     TaskHookFunction_t hook_function;
+
     hook_function = xTaskGetApplicationTaskTagFromISR( task_handle );
 
     TEST_ASSERT_EQUAL( &pxHookFunction, hook_function );
@@ -3708,6 +3725,7 @@ void test_xTaskGetApplicationTaskTagFromISR_null_handle( void )
     vTaskSetApplicationTaskTag( task_handle, pxHookFunction );
 
     TaskHookFunction_t hook_function;
+
     hook_function = xTaskGetApplicationTaskTagFromISR( NULL );
 
     TEST_ASSERT_EQUAL( &pxHookFunction, hook_function );
@@ -4177,6 +4195,7 @@ void test_xTaskCheckForTimeOut_timeout( void )
     time_out.xOverflowCount = xNumOfOverflows;
     time_out.xTimeOnEntering = 3;
     uint32_t expected = ( 1000 - ( xTickCount - time_out.xTimeOnEntering ) );
+
     /* API Call */
     ret_check_timeout = xTaskCheckForTimeOut( &time_out,
                                               &ticks_to_wait );

--- a/FreeRTOS/Test/CMock/tasks/tasks_2_utest.c
+++ b/FreeRTOS/Test/CMock/tasks/tasks_2_utest.c
@@ -410,22 +410,22 @@ unsigned int vFakePortGetCoreID( void )
     return 0;
 }
 
-void vFakePortReleaseTaskLock( void )
+void vFakePortReleaseTaskLock( BaseType_t xCoreID )
 {
     HOOK_DIAG();
 }
 
-void vFakePortGetTaskLock( void )
+void vFakePortGetTaskLock( BaseType_t xCoreID )
 {
     HOOK_DIAG();
 }
 
-void vFakePortGetISRLock( void )
+void vFakePortGetISRLock( BaseType_t xCoreID )
 {
     HOOK_DIAG();
 }
 
-void vFakePortReleaseISRLock( void )
+void vFakePortReleaseISRLock( BaseType_t xCoreID )
 {
     HOOK_DIAG();
 }

--- a/FreeRTOS/Test/CMock/tasks/tasks_assert_utest.c
+++ b/FreeRTOS/Test/CMock/tasks/tasks_assert_utest.c
@@ -425,22 +425,22 @@ unsigned int vFakePortGetCoreID( void )
     return 0;
 }
 
-void vFakePortReleaseTaskLock( void )
+void vFakePortReleaseTaskLock( BaseType_t xCoreID )
 {
     HOOK_DIAG();
 }
 
-void vFakePortGetTaskLock( void )
+void vFakePortGetTaskLock( BaseType_t xCoreID )
 {
     HOOK_DIAG();
 }
 
-void vFakePortGetISRLock( void )
+void vFakePortGetISRLock( BaseType_t xCoreID )
 {
     HOOK_DIAG();
 }
 
-void vFakePortReleaseISRLock( void )
+void vFakePortReleaseISRLock( BaseType_t xCoreID )
 {
     HOOK_DIAG();
 }

--- a/FreeRTOS/Test/CMock/tasks/tasks_freertos/tasks_utest.c
+++ b/FreeRTOS/Test/CMock/tasks/tasks_freertos/tasks_utest.c
@@ -290,22 +290,22 @@ unsigned int vFakePortGetCoreID( void )
     return 0;
 }
 
-void vFakePortReleaseTaskLock( void )
+void vFakePortReleaseTaskLock( BaseType_t xCoreID )
 {
     HOOK_DIAG();
 }
 
-void vFakePortGetTaskLock( void )
+void vFakePortGetTaskLock( BaseType_t xCoreID )
 {
     HOOK_DIAG();
 }
 
-void vFakePortGetISRLock( void )
+void vFakePortGetISRLock( BaseType_t xCoreID )
 {
     HOOK_DIAG();
 }
 
-void vFakePortReleaseISRLock( void )
+void vFakePortReleaseISRLock( BaseType_t xCoreID )
 {
     HOOK_DIAG();
 }


### PR DESCRIPTION

Update unit test for TASK and ISR lock macros

Description
-----------
* Adding xCoreID parameter to TASK and ISR lock port macros

Test Steps
-----------
Build with https://github.com/FreeRTOS/FreeRTOS-Kernel/pull/1212 should has no compile error.
```
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/config_assert/config_assert_utest.c:198:test_prvYieldForTask_assert_critical_nesting_lteq_zero:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/config_assert/config_assert_utest.c:239:test_prvYieldForTask_assert_yieldpending_core_is_false:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/config_assert/config_assert_utest.c:303:test_prvSelectHighestPriorityTask_assert_scheduler_running_false:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/config_assert/config_assert_utest.c:335:test_prvSelectHighestPriorityTask_assert_coreid_ne_runstate:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/config_assert/config_assert_utest.c:373:test_vTaskDelete_assert_scheduler_suspended_eq_1:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/config_assert/config_assert_utest.c:423:test_vTaskSuspend_assert_schedulersuspended_ne_zero:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/config_assert/config_assert_utest.c:462:test_vTaskSwitchContext_assert_nexting_count_ne_zero:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/config_assert/config_assert_utest.c:492:test_vTaskExitCritical_assert_critical_nesting_eq_zero:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/config_assert/config_assert_utest.c:521:test_vTaskExitCriticalFromISR_assertcritical_nesting_eq_zero:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/config_assert/config_assert_utest.c:551:test_prvGetExpectedIdleTime_assert_nextUnblock_lt_xTickCount:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/config_assert/config_assert_utest.c:600:test_vTaskStepTick_assert_scheduler_not_suspended:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/config_assert/config_assert_utest.c:624:test_vTaskStepTick_assert_tick_to_jump_eq_0:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/config_assert/config_assert_utest.c:649:test_xTaskGetIdleTaskHandleForCore_assert_invalid_core_id_lt:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/config_assert/config_assert_utest.c:668:test_xTaskGetIdleTaskHandleForCore_assert_invalid_core_id_ge:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/config_assert/config_assert_utest.c:687:test_xTaskGetIdleTaskHandleForCore_assert_null_idle_task_handle:PASS

-----------------------
15 Tests 0 Failures 0 Ignored
OK
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c:224:test_coverage_vTaskPreemptionEnable_scheduler_not_running:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c:265:test_coverage_vTaskPreemptionEnable_scheduler_running:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c:301:test_coverage_vTaskPreemptionEnable_null_handle:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c:351:test_coverage_vTaskPreemptionEnable_task_not_running_gt_cores:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c:395:test_coverage_vTaskPreemptionEnable_task_running:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c:439:test_coverage_vTaskCoreAffinityGet:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c:479:test_coverage_vTaskCoreAffinityGet_null_handle:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c:522:test_coverage_uxTaskGetTaskNumber_task_handle:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c:556:test_coverage_uxTaskGetTaskNumber_null_task_handle:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c:582:test_coverage_vTaskSetTaskNumber_task_handle:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c:611:test_coverage_vTaskSetTaskNumber_null_task_handle:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c:634:test_coverage_uxTaskGetStackHighWaterMark:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c:669:test_coverage_uxTaskGetStackHighWaterMark_null_task_handle:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c:712:test_coverage_xTaskGetCurrentTaskHandleForCore_valid_core_id:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c:749:test_coverage_xTaskGetCurrentTaskHandleForCore_invalid_core_id_ge:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c:786:test_coverage_xTaskGetCurrentTaskHandleForCore_invalid_core_id_lt:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c:815:test_coverage_vTaskList_no_task_created:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c:847:test_coverage_vTaskList_task_eRunning:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c:913:test_coverage_vTaskList_task_eReady:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c:979:test_coverage_vTaskList_task_eBlocked:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c:1045:test_coverage_vTaskList_task_eSuspended:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c:1111:test_coverage_vTaskList_task_eDeleted:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c:1181:test_coverage_xTaskDelayUntil_current_task_should_delay:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c:1233:test_coverage_prvAddNewTaskToReadyList_create_more_idle_tasks_than_cores:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c:1306:test_coverage_vTaskCoreAffinitySet_null_task_handle:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c:1354:test_coverage_prvYieldForTask_task_is_running_eq:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c:1402:test_coverage_prvYieldForTask_task_yielding:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c:1450:test_coverage_prvYieldForTask_task_yield_pending:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c:1507:test_coverage_prvSelectHighestPriorityTask_affinity_preemption_disabled:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c:1600:test_coverage_prvSelectHighestPriorityTask_affinity_preemption_enabled:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c:1698:test_coverage_xTaskRemoveFromEventList_remove_eq_priority_task:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c:1786:test_coverage_xTaskRemoveFromEventList_remove_higher_priority_task:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c:1885:test_coverage_vTaskRemoveFromUnorderedEventList_remove_higher_priority_task:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c:1972:test_coverage_vTaskEnterCritical_task_in_critical_already:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c:2010:test_coverage_vTaskEnterCriticalFromISR_isr_in_critical_already:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c:2054:test_coverage_vTaskExitCritical_task_enter_critical_mt_1:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c:2092:test_coverage_vTaskExitCritical_task_not_in_critical:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c:2149:test_coverage_vTaskExitCriticalFromISR_isr_enter_critical_mt_1:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c:2189:test_coverage_vTaskExitCriticalFromISR_isr_not_in_critical:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c:2231:test_coverage_pvTaskGetThreadLocalStoragePointer_xIndex_is_zero:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c:2266:test_coverage_pvTaskGetThreadLocalStoragePointer_null_handle:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c:2308:test_coverage_pvTaskGetThreadLocalStoragePointer_fail:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c:2340:test_coverage_xTaskGenericNotifyFromISR_priority_le:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c:2439:test_coverage_xTaskGenericNotifyFromISR_priority_gt:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c:2550:test_coverage_xTaskGenericNotifyFromISR_priority_gt_null_param:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c:2658:test_coverage_vTaskGenericNotifyGiveFromISR_priority_le:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c:2751:test_coverage_vTaskGenericNotifyGiveFromISR_priority_gt:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c:2856:test_coverage_vTaskGenericNotifyGiveFromISR_priority_gt_null_param:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c:2952:test_coverage_prvCheckTasksWaitingTermination_multiple_idle_tasks:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c:2997:test_coverage_prvCheckTasksWaitingTermination_delete_not_running_task:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c:3052:test_coverage_prvCheckTasksWaitingTermination_delete_running_task:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c:3106:test_coverage_prvDeleteTCB_static_stack_only:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c:3143:test_coverage_xTaskResumeFromISR_task_suspended_uxpriority_greater:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c:3218:test_coverage_xTaskResumeFromISR_task_suspended_uxpriority_lesser:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c:3290:test_coverage_xTaskResumeAll_task_in_pending_ready_list:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c:3360:test_coverage_xTaskResumeAll_task_in_pending_ready_list_uxpriority_lesser:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c:3428:test_coverage_vTaskResume_null_task:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c:3448:test_coverage_xTaskGenericNotify_with_eAction_equalto_eNoAction_taskWAITING_NOTIFICATION_uxpriority_lesser:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c:3500:test_coverage_xTaskGenericNotify_with_eAction_equalto_eNoAction_taskWAITING_NOTIFICATION_uxpriority_greater:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c:3553:test_coverage_vTaskGetInfo_implicit_task:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c:3601:test_coverage_vTaskGetInfo_oob_xTaskRunState:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c:3639:test_coverage_vTaskGetInfo_blocked_task:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c:3684:test_coverage_vTaskGetInfo_get_free_stack_space:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c:3730:test_coverage_xTaskPriorityInherit_task_uxpriority_lesser:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c:3801:test_coverage_xTaskPriorityInherit_task_uxpriority_greater:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c:3869:test_coverage_xTaskPriorityInherit_task_is_running:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c:3918:test_coverage_xTaskPriorityInherit_task_invalid_state:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c:3968:test_coverage_xTaskPriorityDisinherit_task_uxpriority_lesser:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c:4038:test_coverage_xTaskPriorityDisinherit_task_uxpriority_greater:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c:4107:test_coverage_xTaskPriorityDisinherit_task_invalid_state:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c:4158:test_coverage_xTaskPriorityDisinheritAfterTimeout_task_uxpriority_lesser:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c:4225:test_coverage_xTaskPriorityDisinheritAfterTimeout_task_uxpriority_greater:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c:4291:test_coverage_vTaskPriorityDisinheritAfterTimeout_task_invalid_state:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c:4341:test_coverage_uxTaskGetSystemState_array_size_lt_current_num_tasks:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c:4371:test_coverage_uxTaskGetSystemState_valid_run_time_param:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c:4426:test_coverage_prvSearchForNameWithinSingleList_empty_list:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c:4459:test_coverage_prvSearchForNameWithinSingleList_task_found:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c:4500:test_coverage_prvSearchForNameWithinSingleList_task_not_found:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c:4540:test_coverage_prvSearchForNameWithinSingleList_long_task_name:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c:4591:test_coverage_prvCreateIdleTasks_get_static_memory:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c:4626:test_coverage_xTaskGetIdleTaskHandleForCore_success:PASS

-----------------------
81 Tests 0 Failures 0 Ignored
OK
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice_mock/covg_multiple_priorities_no_timeslice_mock_utest.c:225:test_coverage_vTaskSuspend_scheduler_running_false:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice_mock/covg_multiple_priorities_no_timeslice_mock_utest.c:263:test_coverage_vTaskSuspend_running_state_below_range:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice_mock/covg_multiple_priorities_no_timeslice_mock_utest.c:301:test_coverage_vTaskSuspend_running_state_above_range:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice_mock/covg_multiple_priorities_no_timeslice_mock_utest.c:337:test_coverage_vTaskPrioritySet_non_running_state:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice_mock/covg_multiple_priorities_no_timeslice_mock_utest.c:374:test_coverage_vTaskPrioritySet_running_state:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice_mock/covg_multiple_priorities_no_timeslice_mock_utest.c:418:test_coverage_prvYieldCore_core_id_ne_current_coreid:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice_mock/covg_multiple_priorities_no_timeslice_mock_utest.c:461:test_coverage_prvYieldCore_runstate_eq_yielding:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice_mock/covg_multiple_priorities_no_timeslice_mock_utest.c:511:test_coverage_vTaskDelete_task_not_running:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice_mock/covg_multiple_priorities_no_timeslice_mock_utest.c:561:test_coverage_eTaskGetState_task_not_running:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice_mock/covg_multiple_priorities_no_timeslice_mock_utest.c:602:test_coverage_vTaskPreemptionDisable_null_handle:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice_mock/covg_multiple_priorities_no_timeslice_mock_utest.c:639:test_coverage_prvGetExpectedIdleTime_top_priority_gt_idle_prio:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice_mock/covg_multiple_priorities_no_timeslice_mock_utest.c:709:test_coverage_prvGetExpectedIdleTime_ready_list_gt_one:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice_mock/covg_multiple_priorities_no_timeslice_mock_utest.c:777:test_coverage_prvGetExpectedIdleTime_ready_list_eq_1:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice_mock/covg_multiple_priorities_no_timeslice_mock_utest.c:881:test_coverage_prvGetExpectedIdleTime_ready_list_eq_2:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice_mock/covg_multiple_priorities_no_timeslice_mock_utest.c:978:test_coverage_prvGetExpectedIdleTime_top_ready_prio_gt_idle_prio_current_prio_lt_idle:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice_mock/covg_multiple_priorities_no_timeslice_mock_utest.c:1044:test_coverage_prvCreateIdleTasks_name_within_max_len:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice_mock/covg_multiple_priorities_no_timeslice_mock_utest.c:1124:test_coverage_prvCreateIdleTasks_name_too_long:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice_mock/covg_multiple_priorities_no_timeslice_mock_utest.c:1192:test_coverage_xTaskGetSchedulerState_scheduler_not_running_and_suspended:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice_mock/covg_multiple_priorities_no_timeslice_mock_utest.c:1226:test_coverage_eTaskConfirmSleepModeStatus_no_tasks_waiting_timeout:PASS

-----------------------
19 Tests 0 Failures 0 Ignored
OK
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/multiple_priorities_no_timeslice_utest.c:134:test_priority_verification_tasks_equal_priority:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/multiple_priorities_no_timeslice_utest.c:183:test_priority_verification_tasks_different_priorities:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/multiple_priorities_no_timeslice_utest.c:239:test_priority_change_tasks_equal_priority_lower:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/multiple_priorities_no_timeslice_utest.c:306:test_priority_change_tasks_equal_priority_raise:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/multiple_priorities_no_timeslice_utest.c:378:test_priority_change_tasks_different_priority_raise_to_equal:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/multiple_priorities_no_timeslice_utest.c:457:test_priority_change_tasks_different_priority_raise_to_higher:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/multiple_priorities_no_timeslice_utest.c:537:test_priority_change_tasks_different_priority_lower_to_equal:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/multiple_priorities_no_timeslice_utest.c:617:test_priority_change_tasks_different_priority_lower_to_lowest:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/multiple_priorities_no_timeslice_utest.c:694:test_priority_change_tasks_equal_priority_raise_additional_task:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/multiple_priorities_no_timeslice_utest.c:768:test_task_delete_tasks_different_priorities_delete_low:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/multiple_priorities_no_timeslice_utest.c:842:test_task_delete_tasks_different_priorities_delete_high:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/multiple_priorities_no_timeslice_utest.c:918:test_task_delete_select_high_priority_task:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/multiple_priorities_no_timeslice_utest.c:1002:test_task_create_tasks_equal_priority:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/multiple_priorities_no_timeslice_utest.c:1066:test_task_create_tasks_lower_priority:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/multiple_priorities_no_timeslice_utest.c:1130:test_task_create_tasks_higher_priority:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/multiple_priorities_no_timeslice_utest.c:1195:test_task_create_all_cores_equal_priority_equal:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/multiple_priorities_no_timeslice_utest.c:1260:test_task_create_all_cores_equal_priority_lower:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/multiple_priorities_no_timeslice_utest.c:1326:test_task_create_all_cores_equal_priority_higher:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/multiple_priorities_no_timeslice_utest.c:1395:test_task_create_all_cores_different_priority_high:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/multiple_priorities_no_timeslice_utest.c:1466:test_task_create_all_cores_different_priority_low:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/multiple_priorities_no_timeslice_utest.c:1540:test_task_suspend_all_cores_equal_priority:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/multiple_priorities_no_timeslice_utest.c:1618:test_task_suspend_select_high_priority_task:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/multiple_priorities_no_timeslice_utest.c:1703:test_task_suspend_all_cores_different_priority_suspend_high:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/multiple_priorities_no_timeslice_utest.c:1789:test_task_suspend_all_cores_different_priority_suspend_low:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/multiple_priorities_no_timeslice_utest.c:1875:test_task_blocked_all_cores_equal_priority:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/multiple_priorities_no_timeslice_utest.c:1959:test_task_blocked_all_cores_different_priority_block_high:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/multiple_priorities_no_timeslice_utest.c:2047:test_task_block_all_cores_high_priority_block:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/multiple_priorities_no_timeslice_utest.c:2134:test_task_blocked_select_high_priority_task:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/multiple_priorities_no_timeslice_utest.c:2211:test_task_affinity_verification_separate_cores:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/multiple_priorities_no_timeslice_utest.c:2269:test_task_affinity_verification_same_cores:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/multiple_priorities_no_timeslice_utest.c:2344:test_task_affinity_suspend_same_core_affinity:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/multiple_priorities_no_timeslice_utest.c:2422:test_task_affinity_out_of_range:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/multiple_priorities_no_timeslice_utest.c:2495:test_task_affinity_resume_suspended_task:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/multiple_priorities_no_timeslice_utest.c:2579:test_task_affinity_modify_affinity:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/multiple_priorities_no_timeslice_utest.c:2659:test_task_affinity_modify_priority:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/multiple_priorities_no_timeslice_utest.c:2738:test_task_preemption_verification:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/multiple_priorities_no_timeslice_utest.c:2828:test_task_preemption_new_task:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/multiple_priorities_no_timeslice_utest.c:2911:test_task_preemption_change_priority:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/multiple_priorities_no_timeslice_utest.c:3007:test_task_preemption_change_affinity:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/multiple_priorities_no_timeslice_utest.c:3095:test_task_yield_run_wait_longest:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/multiple_priorities_no_timeslice_utest.c:3264:test_task_yield_run_equal_priority_new_task:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/multiple_priorities_no_timeslice_utest.c:3326:test_task_priority_inherit_disinherit:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/multiple_priorities_no_timeslice_utest.c:3435:test_task_priority_inherit_disinherit_timeout:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/multiple_priorities_no_timeslice_utest.c:3553:test_task_create_task_set_affinity_async_yield:PASS

-----------------------
44 Tests 0 Failures 0 Ignored
OK
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_timeslice/covg_multiple_priorities_timeslice_utest.c:116:test_coverage_xTaskIncrementTick_no_eq_priority_task:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_timeslice/covg_multiple_priorities_timeslice_utest.c:193:test_coverage_xTaskIncrementTick_no_eq_priority_task_yield_pending:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_timeslice/covg_multiple_priorities_timeslice_utest.c:269:test_coverage_xTaskIncrementTick_preemption_disabled_task:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_timeslice/covg_multiple_priorities_timeslice_utest.c:348:test_coverage_xTaskIncrementTick_ready_higher_priority_delayed_task:PASS

-----------------------
4 Tests 0 Failures 0 Ignored
OK
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_timeslice/multiple_priorities_timeslice_utest.c:122:test_timeslice_verification_tasks_equal_priority:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_timeslice/multiple_priorities_timeslice_utest.c:194:test_timeslice_verification_idle_core:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_timeslice/multiple_priorities_timeslice_utest.c:260:test_timeslice_verification_different_priority_tasks:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_timeslice/multiple_priorities_timeslice_utest.c:329:test_timeslice_verification_low_priority_tasks_rotate:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_timeslice/multiple_priorities_timeslice_utest.c:416:test_priority_change_tasks_different_priority_raise_to_equal:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_timeslice/multiple_priorities_timeslice_utest.c:507:test_priority_change_tasks_equal_priority_raise_to_high:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_timeslice/multiple_priorities_timeslice_utest.c:596:test_priority_change_tasks_equal_priority_lower_ready_task:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_timeslice/multiple_priorities_timeslice_utest.c:681:test_priority_change_tasks_equal_priority_lower_running_task:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_timeslice/multiple_priorities_timeslice_utest.c:769:test_task_create_tasks_equal_priority:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_timeslice/multiple_priorities_timeslice_utest.c:849:test_task_create_tasks_lower_priority:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_timeslice/multiple_priorities_timeslice_utest.c:929:test_task_create_tasks_higher_priority:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_timeslice/multiple_priorities_timeslice_utest.c:1036:test_task_delete_tasks_equal_priorities_delete_running_task:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_timeslice/multiple_priorities_timeslice_utest.c:1134:test_task_suspend_running_task:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_timeslice/multiple_priorities_timeslice_utest.c:1248:test_task_block_running_task:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_timeslice/multiple_priorities_timeslice_utest.c:1364:test_task_affinity_verification:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/multiple_priorities_timeslice/multiple_priorities_timeslice_utest.c:1455:test_task_affinity_set_affinity_running_task:PASS

-----------------------
16 Tests 0 Failures 0 Ignored
OK
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/single_priority_no_timeslice/covg_single_priority_no_timeslice_utest.c:126:test_coverage_prvCheckForRunStateChange_first_time_critical_section:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/single_priority_no_timeslice/covg_single_priority_no_timeslice_utest.c:177:test_coverage_prvCheckForRunStateChange_first_time_suspend_scheduler:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/single_priority_no_timeslice/covg_single_priority_no_timeslice_utest.c:223:test_task_get_system_state:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/single_priority_no_timeslice/covg_single_priority_no_timeslice_utest.c:246:test_task_get_system_state_custom_time:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/single_priority_no_timeslice/covg_single_priority_no_timeslice_utest.c:270:test_task_get_system_state_unavilable_task_space:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/single_priority_no_timeslice/covg_single_priority_no_timeslice_utest.c:309:test_coverage_vTaskStepTick_eq_task_unblock_time:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/single_priority_no_timeslice/covg_single_priority_no_timeslice_utest.c:361:test_coverage_xTaskResumeFromISR_resume_higher_priority_suspended_task:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/single_priority_no_timeslice/covg_single_priority_no_timeslice_utest.c:420:test_coverage_xTaskResumeFromISR_resume_lower_priority_suspended_task:PASS

-----------------------
8 Tests 0 Failures 0 Ignored
OK
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/single_priority_no_timeslice/single_priority_no_timeslice_utest.c:105:test_priority_verification_tasks_equal_priority:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/single_priority_no_timeslice/single_priority_no_timeslice_utest.c:152:test_priority_verification_tasks_different_priorities:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/single_priority_no_timeslice/single_priority_no_timeslice_utest.c:212:test_priority_change_tasks_equal_priority_lower:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/single_priority_no_timeslice/single_priority_no_timeslice_utest.c:283:test_priority_change_tasks_equal_priority_raise:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/single_priority_no_timeslice/single_priority_no_timeslice_utest.c:353:test_priority_change_task_high_priority_raise:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/single_priority_no_timeslice/single_priority_no_timeslice_utest.c:423:test_priority_change_tasks_different_priority_raise:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/single_priority_no_timeslice/single_priority_no_timeslice_utest.c:500:test_priority_change_tasks_different_priority_lower:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/single_priority_no_timeslice/single_priority_no_timeslice_utest.c:590:test_task_create_tasks_equal_priority:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/single_priority_no_timeslice/single_priority_no_timeslice_utest.c:652:test_task_create_tasks_lower_priority:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/single_priority_no_timeslice/single_priority_no_timeslice_utest.c:714:test_task_create_tasks_higher_priority:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/single_priority_no_timeslice/single_priority_no_timeslice_utest.c:834:test_task_create_all_cores_equal_priority_equal:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/single_priority_no_timeslice/single_priority_no_timeslice_utest.c:897:test_task_create_all_cores_equal_priority_lower:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/single_priority_no_timeslice/single_priority_no_timeslice_utest.c:960:test_task_create_all_cores_equal_priority_higher:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/single_priority_no_timeslice/single_priority_no_timeslice_utest.c:1053:test_task_create_all_cores_different_priority_high:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/single_priority_no_timeslice/single_priority_no_timeslice_utest.c:1126:test_task_create_all_cores_different_priority_low:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/single_priority_no_timeslice/single_priority_no_timeslice_utest.c:1198:test_task_delete_tasks_equal_priority_delete_task:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/single_priority_no_timeslice/single_priority_no_timeslice_utest.c:1268:test_task_delete_tasks_different_priorities_delete_low:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/single_priority_no_timeslice/single_priority_no_timeslice_utest.c:1347:test_task_delete_tasks_different_priorities_delete_high:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/single_priority_no_timeslice/single_priority_no_timeslice_utest.c:1422:test_task_delete_tasks_equal_priority_delete_running:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/single_priority_no_timeslice/single_priority_no_timeslice_utest.c:1497:test_task_delete_all_cores_high_priority_delete_high_priority_task:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/single_priority_no_timeslice/single_priority_no_timeslice_utest.c:1583:test_task_suspend_all_cores_equal_priority:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/single_priority_no_timeslice/single_priority_no_timeslice_utest.c:1666:test_task_suspend_all_cores_different_priority_suspend_high:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/single_priority_no_timeslice/single_priority_no_timeslice_utest.c:1818:test_task_suspend_all_cores_different_priority_suspend_low:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/single_priority_no_timeslice/single_priority_no_timeslice_utest.c:1909:test_task_suspend_all_cores_high_priority_suspend:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/single_priority_no_timeslice/single_priority_no_timeslice_utest.c:1998:test_task_suspend_all_cores_equal_priority_suspend_running:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/single_priority_no_timeslice/single_priority_no_timeslice_utest.c:2070:test_task_blocked_all_cores_equal_priority:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/single_priority_no_timeslice/single_priority_no_timeslice_utest.c:2153:test_task_blocked_all_cores_different_priority_block_high:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/single_priority_no_timeslice/single_priority_no_timeslice_utest.c:2274:test_task_block_all_cores_high_priority_block:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/single_priority_no_timeslice/single_priority_no_timeslice_utest.c:2363:test_task_block_all_cores_equal_priority_block_running:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/single_priority_no_timeslice/single_priority_no_timeslice_utest.c:2437:test_task_priority_inherit_disinherit:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/single_priority_no_timeslice/single_priority_no_timeslice_utest.c:2546:test_task_priority_inherit_disinherit_timeout:PASS

-----------------------
31 Tests 0 Failures 0 Ignored
OK
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/single_priority_timeslice/covg_single_priority_timeslice_utest.c:116:test_coverage_prvIdleTask_no_other_idle_priority_task:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/single_priority_timeslice/covg_single_priority_timeslice_utest.c:167:test_coverage_prvIdleTask_yield_for_idle_priority_task:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/single_priority_timeslice/covg_single_priority_timeslice_utest.c:228:test_coverage_prvPassiveIdleTask_no_other_idle_priority_task:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/single_priority_timeslice/covg_single_priority_timeslice_utest.c:279:test_coverage_prvPassiveIdleTask_yield_for_idle_priority_task:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/single_priority_timeslice/covg_single_priority_timeslice_utest.c:339:test_coverage_prvSelectHighestPriorityTask_not_schedule_none_idle_task:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/single_priority_timeslice/covg_single_priority_timeslice_utest.c:424:test_coverage_prvSelectHighestPriorityTask_affinity_task_yielding:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/single_priority_timeslice/covg_single_priority_timeslice_utest.c:516:test_coverage_prvSelectHighestPriorityTask_affinity_task_state_invalid:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/single_priority_timeslice/covg_single_priority_timeslice_utest.c:606:test_coverage_prvSelectHighestPriorityTask_affinity_task_yield_pending:PASS

-----------------------
8 Tests 0 Failures 0 Ignored
OK
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/single_priority_timeslice/single_priority_timeslice_utest.c:122:test_timeslice_verification_tasks_equal_priority:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/single_priority_timeslice/single_priority_timeslice_utest.c:194:test_timeslice_verification_idle_core:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/single_priority_timeslice/single_priority_timeslice_utest.c:260:test_timeslice_verification_different_priority_tasks:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/single_priority_timeslice/single_priority_timeslice_utest.c:344:test_priority_change_tasks_different_priority_raise_to_equal:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/single_priority_timeslice/single_priority_timeslice_utest.c:441:test_priority_change_tasks_equal_priority_lower_ready_task:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/single_priority_timeslice/single_priority_timeslice_utest.c:538:test_task_create_tasks_equal_priority:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/single_priority_timeslice/single_priority_timeslice_utest.c:618:test_task_create_tasks_lower_priority:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/single_priority_timeslice/single_priority_timeslice_utest.c:701:test_task_delete_tasks_equal_priorities_delete_running_task:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/single_priority_timeslice/single_priority_timeslice_utest.c:799:test_task_suspend_running_task:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/single_priority_timeslice/single_priority_timeslice_utest.c:913:test_task_block_running_task:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/single_priority_timeslice/single_priority_timeslice_utest.c:1029:test_task_affinity_verification:PASS
/mnt/c/msys64/home/chinglee/kernel/FreeRTOS-coreID-utest/FreeRTOS/Test/CMock/smp/single_priority_timeslice/single_priority_timeslice_utest.c:1120:test_task_affinity_set_affinity_running_task:PASS

-----------------------
12 Tests 0 Failures 0 Ignored
OK
```

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
https://github.com/FreeRTOS/FreeRTOS-Kernel/pull/1212


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
