### PR TITLE
Add tests to cover xQueueCreateSetStatic

### DIFF
--- a/FreeRTOS/Test/CMock/queue/sets/queue_set_utest.c
+++ b/FreeRTOS/Test/CMock/queue/sets/queue_set_utest.c
@@ -39,6 +39,7 @@
 #include "mock_fake_port.h"
 
 /* ============================  GLOBAL VARIABLES =========================== */
+#define EVENT_QUEUE_LENGTH 5
 
 /* ==========================  CALLBACK FUNCTIONS =========================== */
 
@@ -122,6 +123,19 @@ void test_xQueueCreateSet_oneLength( void )
     TEST_ASSERT_EQUAL( 0, uxQueueMessagesWaiting( xQueueSet ) );
 
     vQueueDelete( xQueueSet );
+}
+
+void test_xQueueCreateSetStatic_HappyPath( void )
+{
+    StaticQueue_t xQueueSetBuffer;
+    QueueHandle_t xQueueSetStorage[ EVENT_QUEUE_LENGTH ];
+    QueueSetHandle_t xQueueSet = NULL;
+
+    xQueueSet = xQueueCreateSetStatic( EVENT_QUEUE_LENGTH,
+                                       ( uint8_t * ) &( xQueueSetStorage[ 0 ] ),
+                                       &( xQueueSetBuffer ) );
+
+    TEST_ASSERT_NOT_NULL( xQueueSet );
 }
 
 /**


### PR DESCRIPTION


<!--- Title -->

Description
-----------
This API was recently added in the following PR: https://github.com/FreeRTOS/FreeRTOS-Kernel/pull/1228.

Test Steps
-----------
Run tests locally:
```
/home/ubuntu/workplace/development/FreeRTOS/FreeRTOS/Test/CMock/queue/sets/queue_set_utest.c:76:test_xQueueCreateSet_malloc_fail:PASS
/home/ubuntu/workplace/development/FreeRTOS/FreeRTOS/Test/CMock/queue/sets/queue_set_utest.c:91:test_xQueueCreateSet_zeroLength:PASS
/home/ubuntu/workplace/development/FreeRTOS/FreeRTOS/Test/CMock/queue/sets/queue_set_utest.c:110:test_xQueueCreateSet_oneLength:PASS
/home/ubuntu/workplace/development/FreeRTOS/FreeRTOS/Test/CMock/queue/sets/queue_set_utest.c:128:test_xQueueCreateSetStatic_HappyPath:PASS
/home/ubuntu/workplace/development/FreeRTOS/FreeRTOS/Test/CMock/queue/sets/queue_set_utest.c:145:test_xQueueAddToSet_AlreadyInSameSet:PASS
/home/ubuntu/workplace/development/FreeRTOS/FreeRTOS/Test/CMock/queue/sets/queue_set_utest.c:164:test_xQueueAddToSet_AlreadyInDifferentSet:PASS
/home/ubuntu/workplace/development/FreeRTOS/FreeRTOS/Test/CMock/queue/sets/queue_set_utest.c:186:test_xQueueAddToSet_PreviouslyInDifferentSet:PASS
/home/ubuntu/workplace/development/FreeRTOS/FreeRTOS/Test/CMock/queue/sets/queue_set_utest.c:209:test_xQueueAddToSet_QueueNotEmpty:PASS
/home/ubuntu/workplace/development/FreeRTOS/FreeRTOS/Test/CMock/queue/sets/queue_set_utest.c:228:test_xQueueSelectFromSet:PASS
/home/ubuntu/workplace/development/FreeRTOS/FreeRTOS/Test/CMock/queue/sets/queue_set_utest.c:292:test_xQueueSelectFromSetFromISR:PASS
/home/ubuntu/workplace/development/FreeRTOS/FreeRTOS/Test/CMock/queue/sets/queue_set_utest.c:363:test_xQueueRemoveFromSet_QueueNotEmpty:PASS
/home/ubuntu/workplace/development/FreeRTOS/FreeRTOS/Test/CMock/queue/sets/queue_set_utest.c:384:test_xQueueRemoveFromSet_QueueNotInSet:PASS
/home/ubuntu/workplace/development/FreeRTOS/FreeRTOS/Test/CMock/queue/sets/queue_set_utest.c:409:test_xQueueRemoveFromSet_QueueInSet:PASS

-----------------------
13 Tests 0 Failures 0 Ignored 
OK
```

Checklist:
----------
- [x] I have tested my changes. No regression in existing tests.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
CodeCov coverage flags it in the following PR - https://github.com/FreeRTOS/FreeRTOS-Kernel/pull/1233.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
