### PR TITLE
Update RV32 qemu Demo to support RVA23

### DIFF
--- a/FreeRTOS/Demo/RISC-V_RV32_QEMU_VIRT_GCC/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/RISC-V_RV32_QEMU_VIRT_GCC/FreeRTOSConfig.h
@@ -51,8 +51,13 @@
 #define configUSE_TICK_HOOK				1
 #define configCPU_CLOCK_HZ				( ( unsigned long ) 25000000 )
 #define configTICK_RATE_HZ				( ( TickType_t ) 1000 )
+#if __riscv_xlen == 64
+#define configMINIMAL_STACK_SIZE		( ( unsigned short ) 240 )
+#define configTOTAL_HEAP_SIZE			( ( size_t ) ( 220 * 1024 ) )
+#else
 #define configMINIMAL_STACK_SIZE		( ( unsigned short ) 120 )
 #define configTOTAL_HEAP_SIZE			( ( size_t ) ( 80 * 1024 ) )
+#endif
 #define configMAX_TASK_NAME_LEN			( 12 )
 #define configUSE_TRACE_FACILITY		1
 #define configUSE_16_BIT_TICKS			0

--- a/FreeRTOS/Demo/RISC-V_RV32_QEMU_VIRT_GCC/Readme.md
+++ b/FreeRTOS/Demo/RISC-V_RV32_QEMU_VIRT_GCC/Readme.md
@@ -2,11 +2,14 @@
 
 ## Requirements
 
-1. GNU RISC-V toolchains (tested on pre-built Sifive GNU Embedded Toolchain — v2020.12.8)
-  - https://www.sifive.com/software
-1. qemu-riscv32-system  (tested on pre-built Sifive QEMU — v2020.08.1)
-  - https://www.sifive.com/software
-1. Linux OS (tested on Ubuntu 20.04.3 LTS)
+1. GNU RISC-V toolchains (tested on 
+  * Pre-built Sifive GNU Embedded Toolchain — v3.0.4 - https://www.sifive.com/software
+  * Self built from https://github.com/riscv-collab/riscv-gnu-toolchain/tree/a33dac0251d17a7b74d99bd8fd401bfce87d2aed (tag: 2025.01.20)
+
+1. qemu-riscv64-system. Tested on
+  * pre-built Sifive QEMU — v3.0.4)- https://www.sifive.com/software
+  * qemu-system-riscv64 v 8.2.2
+1. Linux OS (tested on Ubuntu 24.04 LTS)
 
 
 ## How to build
@@ -35,16 +38,31 @@ To clean build artifacts:
 $ make -C build/gcc/ clean
 ```
 
+For any of the previous configurations, if you want to use the port on a RVA23 system instead of a RV32, you may append append `RVA23=1`
+
+```
+$ make -C build/gcc/ RVA23=1
+```
+
 If the build was successful, the RTOSDemo.elf executable will be located in the build/gcc/output directory.
 
 
 ## How to run
 
+For the RV32 build:
+
 ```
-$ qemu-system-riscv32 -nographic -machine virt -net none \
-  -chardev stdio,id=con,mux=on -serial chardev:con \
-  -mon chardev=con,mode=readline -bios none \
-  -smp 4 -kernel ./build/gcc/output/RTOSDemo.elf
+$ qemu-system-riscv32 -nographic -machine virt -net none -chardev stdio,id=con,mux=on \
+    -serial chardev:con -mon chardev=con,mode=readline -bios none -smp 4 \
+    -s --kernel build/gcc/output/RTOSDemo.elf
+```
+
+For the RVA23 build:
+
+```
+$ qemu-system-riscv64 -nographic -machine virt -net none -chardev stdio,id=con,mux=on \
+    -serial chardev:con -mon chardev=con,mode=readline -bios none -smp 4 \
+    -s --kernel build/gcc/output/RTOSDemo.elf
 ```
 
 

--- a/FreeRTOS/Demo/RISC-V_RV32_QEMU_VIRT_GCC/Readme.md
+++ b/FreeRTOS/Demo/RISC-V_RV32_QEMU_VIRT_GCC/Readme.md
@@ -2,14 +2,15 @@
 
 ## Requirements
 
-1. GNU RISC-V toolchains (tested on 
+1. GNU RISC-V toolchains Tested on:
   * Pre-built Sifive GNU Embedded Toolchain — v3.0.4 - https://www.sifive.com/software
   * Self built from https://github.com/riscv-collab/riscv-gnu-toolchain/tree/a33dac0251d17a7b74d99bd8fd401bfce87d2aed (tag: 2025.01.20)
 
-1. qemu-riscv64-system. Tested on
-  * pre-built Sifive QEMU — v3.0.4)- https://www.sifive.com/software
+1. qemu-riscv64-system. Tested on:
+  * pre-built Sifive QEMU — v3.0.4 - https://www.sifive.com/software
   * qemu-system-riscv64 v 8.2.2
-1. Linux OS (tested on Ubuntu 24.04 LTS)
+1. Linux OS. Tested on:
+  * Ubuntu 24.04 LTS
 
 
 ## How to build

--- a/FreeRTOS/Demo/RISC-V_RV32_QEMU_VIRT_GCC/build/gcc/Makefile
+++ b/FreeRTOS/Demo/RISC-V_RV32_QEMU_VIRT_GCC/build/gcc/Makefile
@@ -14,10 +14,7 @@ GCC_VERSION = $(shell $(CC) --version | grep ^$(CC) | sed 's/^.* //g' | awk -F. 
 GCC_VERSION_NEED_ZICSR = "110100"
 
 ifeq ($(RVA23),1)
-  # The following ISA string should be used, however since autovectorization may be enabled in libc, 
-  # there may be issues if the Vector registers are not stored when we do task switching. So for the
-  # time being, we don't include the vector extensions.
-  #MARCH = rv64imafdcv_zicsr_zicntr_zihpm_ziccif_ziccrse_ziccamoa_zicclsm_za64rs_zihintpause_zic64b_zicbom_zicbop_zicboz_zfhmin_zkt_zvfhmin_zvbb_zvkt_zihintntl_zawrs
+  # For the time being, we don't include the vector extensions.
   MARCH = rv64imafdc_zicsr_zicntr_zihpm_ziccif_ziccrse_ziccamoa_zicclsm_za64rs_zihintpause_zic64b_zicbom_zicbop_zicboz_zfhmin_zkt_zihintntl_zawrs
   MABI = lp64d
   MCMODEL = medany

--- a/FreeRTOS/Demo/RISC-V_RV32_QEMU_VIRT_GCC/build/gcc/Makefile
+++ b/FreeRTOS/Demo/RISC-V_RV32_QEMU_VIRT_GCC/build/gcc/Makefile
@@ -13,16 +13,34 @@ MAKE = make
 GCC_VERSION = $(shell $(CC) --version | grep ^$(CC) | sed 's/^.* //g' | awk -F. '{ printf("%d%02d%02d"), $$1, $$2, $$3 }')
 GCC_VERSION_NEED_ZICSR = "110100"
 
+ifeq ($(RVA23),1)
+  # The following ISA string should be used, however since autovectorization may be enabled in libc, 
+  # there may be issues if the Vector registers are not stored when we do task switching. So for the
+  # time being, we don't include the vector extensions.
+  #MARCH = rv64imafdcv_zicsr_zicntr_zihpm_ziccif_ziccrse_ziccamoa_zicclsm_za64rs_zihintpause_zic64b_zicbom_zicbop_zicboz_zfhmin_zkt_zvfhmin_zvbb_zvkt_zihintntl_zawrs
+  MARCH = rv64imafdc_zicsr_zicntr_zihpm_ziccif_ziccrse_ziccamoa_zicclsm_za64rs_zihintpause_zic64b_zicbom_zicbop_zicboz_zfhmin_zkt_zihintntl_zawrs
+  MABI = lp64d
+  MCMODEL = medany
+  INCLUDE_DIRS += -I$(KERNEL_PORT_DIR)/chip_specific_extensions/RV32IF_CLINT
+  $(info  Using RVA23 build)
+else
+  ifeq ($(shell test $(GCC_VERSION) -ge $(GCC_VERSION_NEED_ZICSR) && echo true),true)
+    MARCH=rv32imac_zicsr
+  else
+    MARCH=rv32imac
+  endif
+  MABI=ilp32
+  MCMODEL=medlow
+  INCLUDE_DIRS += -I$(KERNEL_PORT_DIR)/chip_specific_extensions/RV32I_CLINT_no_extensions
+  $(info  Using RV32 build)
+endif
+
+
 CFLAGS += $(INCLUDE_DIRS) -fmessage-length=0 \
-          -mabi=ilp32 -mcmodel=medlow -ffunction-sections -fdata-sections \
+          -march=$(MARCH) -mabi=$(MABI) -mcmodel=$(MCMODEL) -ffunction-sections -fdata-sections \
           -Wno-unused-parameter -nostartfiles -g3 -Os
 
-ifeq ($(shell test $(GCC_VERSION) -ge $(GCC_VERSION_NEED_ZICSR) && echo true),true)
-    CFLAGS += -march=rv32imac_zicsr
-else
-    CFLAGS += -march=rv32imac
-endif
-          
+
 ifeq ($(PICOLIBC),1)
 CFLAGS += --specs=picolibc.specs -DPICOLIBC_INTEGER_PRINTF_SCANF 
 else
@@ -30,7 +48,7 @@ CFLAGS += --specs=nano.specs -fno-builtin-printf
 endif
 
 LDFLAGS += -nostartfiles -Xlinker --gc-sections -Wl,-Map,$(OUTPUT_DIR)/RTOSDemo.map \
-           -T./fake_rom.ld -march=rv32imac -mabi=ilp32 -mcmodel=medlow -Xlinker \
+           -T./fake_rom.ld -march=$(MARCH) -mabi=$(MABI) -mcmodel=$(MCMODEL) -Xlinker \
            --defsym=__stack_size=350 -Wl,--start-group -Wl,--end-group
 
 ifeq ($(PICOLIBC),1)
@@ -54,8 +72,7 @@ endif
 KERNEL_DIR = $(FREERTOS_ROOT)/Source
 KERNEL_PORT_DIR += $(KERNEL_DIR)/portable/GCC/RISC-V
 INCLUDE_DIRS += -I$(KERNEL_DIR)/include \
-				-I$(KERNEL_PORT_DIR) \
-				-I$(KERNEL_PORT_DIR)/chip_specific_extensions/RV32I_CLINT_no_extensions
+				-I$(KERNEL_PORT_DIR)
 VPATH += $(KERNEL_DIR) $(KERNEL_PORT_DIR) $(KERNEL_DIR)/portable/MemMang
 SOURCE_FILES += $(KERNEL_DIR)/tasks.c
 SOURCE_FILES += $(KERNEL_DIR)/list.c

--- a/FreeRTOS/Demo/RISC-V_RV32_QEMU_VIRT_GCC/build/gcc/Makefile
+++ b/FreeRTOS/Demo/RISC-V_RV32_QEMU_VIRT_GCC/build/gcc/Makefile
@@ -18,7 +18,7 @@ ifeq ($(RVA23),1)
   MARCH = rv64imafdc_zicsr_zicntr_zihpm_ziccif_ziccrse_ziccamoa_zicclsm_za64rs_zihintpause_zic64b_zicbom_zicbop_zicboz_zfhmin_zkt_zihintntl_zawrs
   MABI = lp64d
   MCMODEL = medany
-  INCLUDE_DIRS += -I$(KERNEL_PORT_DIR)/chip_specific_extensions/RV32IF_CLINT
+  CFLAGS+=-DconfigENABLE_FPU=1
   $(info  Using RVA23 build)
 else
   ifeq ($(shell test $(GCC_VERSION) -ge $(GCC_VERSION_NEED_ZICSR) && echo true),true)
@@ -28,10 +28,10 @@ else
   endif
   MABI=ilp32
   MCMODEL=medlow
-  INCLUDE_DIRS += -I$(KERNEL_PORT_DIR)/chip_specific_extensions/RV32I_CLINT_no_extensions
   $(info  Using RV32 build)
 endif
 
+INCLUDE_DIRS += -I$(KERNEL_PORT_DIR)/chip_specific_extensions/RV32I_CLINT_no_extensions
 
 CFLAGS += $(INCLUDE_DIRS) -fmessage-length=0 \
           -march=$(MARCH) -mabi=$(MABI) -mcmodel=$(MCMODEL) -ffunction-sections -fdata-sections \
@@ -39,7 +39,7 @@ CFLAGS += $(INCLUDE_DIRS) -fmessage-length=0 \
 
 
 ifeq ($(PICOLIBC),1)
-CFLAGS += --specs=picolibc.specs -DPICOLIBC_INTEGER_PRINTF_SCANF 
+CFLAGS += --specs=picolibc.specs -DPICOLIBC_INTEGER_PRINTF_SCANF
 else
 CFLAGS += --specs=nano.specs -fno-builtin-printf
 endif

--- a/FreeRTOS/Demo/RISC-V_RV32_QEMU_VIRT_GCC/build/gcc/RegTest.S
+++ b/FreeRTOS/Demo/RISC-V_RV32_QEMU_VIRT_GCC/build/gcc/RegTest.S
@@ -1,6 +1,6 @@
 /*
  * FreeRTOS V202212.00
- * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/FreeRTOS/Demo/RISC-V_RV32_QEMU_VIRT_GCC/build/gcc/RegTest.S
+++ b/FreeRTOS/Demo/RISC-V_RV32_QEMU_VIRT_GCC/build/gcc/RegTest.S
@@ -37,7 +37,7 @@
  * main_full.c.
  */
 
-.align( 4 )
+.align( 8 )
 vRegTest1Implementation:
 
     /* Fill the core registers with known values. */
@@ -68,6 +68,70 @@ vRegTest1Implementation:
     li x29, 0x1d
     li x30, 0x1e
     li x31, 0x1f
+#endif
+#if __riscv_flen == 64
+    li x15, 0xC030000000000000 // -16
+    fmv.d.x f0, x15
+    li x15, 0xC02E000000000000 // -15
+    fmv.d.x f1, x15
+    li x15, 0xC02C000000000000 // -14
+    fmv.d.x f2, x15
+    li x15, 0xc02a000000000000 // -13
+    fmv.d.x f3, x15
+    li x15, 0xC028000000000000 // -12
+    fmv.d.x f4, x15
+    li x15, 0xC026000000000000 // -11
+    fmv.d.x f5, x15
+    li x15, 0xc024000000000000 // -10
+    fmv.d.x f6, x15
+    li x15, 0xc022000000000000 // -9
+    fmv.d.x f7, x15
+    li x15, 0xc020000000000000 // -8
+    fmv.d.x f8, x15
+    li x15, 0xc01c000000000000 // -7
+    fmv.d.x f9, x15
+    li x15, 0xc018000000000000 // -6
+    fmv.d.x f10, x15
+    li x15, 0xc014000000000000 // -5
+    fmv.d.x f11, x15
+    li x15, 0xc010000000000000 // -4
+    fmv.d.x f12, x15
+    li x15, 0xc008000000000000 // -3
+    fmv.d.x f13, x15
+    li x15, 0xc000000000000000 // -2
+    fmv.d.x f14, x15
+    li x15, 0xbff0000000000000 // -1
+    fmv.d.x f15, x15
+    li x15, 0                  // 0
+    fmv.d.x f16, x15
+    li x15, 0x3ff0000000000000 // 1
+    fmv.d.x f17, x15
+    li x15, 0x4000000000000000 // 2
+    fmv.d.x f18, x15
+    li x15, 0x4008000000000000 // 3
+    fmv.d.x f19, x15
+    li x15, 0x4010000000000000 // 4
+    fmv.d.x f20, x15
+    li x15, 0x4014000000000000 // 5
+    fmv.d.x f21, x15
+    li x15, 0x4018000000000000 // 6
+    fmv.d.x f22, x15
+    li x15, 0x401c000000000000 // 7
+    fmv.d.x f23, x15
+    li x15, 0x4020000000000000 // 8
+    fmv.d.x f24, x15
+    li x15, 0x4022000000000000 // 9
+    fmv.d.x f25, x15
+    li x15, 0x4024000000000000 // 10
+    fmv.d.x f26, x15
+    li x15, 0x4026000000000000 // 11
+    fmv.d.x f27, x15
+    li x15, 0x4028000000000000 // 12
+    fmv.d.x f28, x15
+    li x15, 0x402a000000000000 // 13
+    fmv.d.x f29, x15
+    li x15, 0x402C000000000000 // 14
+    fmv.d.x f30, x15
 #endif
 
 reg1_loop:
@@ -129,12 +193,145 @@ reg1_loop:
     li x15, 0x1f
     bne x15, x31, reg1_error_loop
 #endif
+#if __riscv_flen == 64
+    li x15, 0xC030000000000000 // -16
+    fmv.d.x f31, x15
+    feq.d x15, f0, f31
+    beqz x15, reg1_error_loop
+    li x15, 0xC02E000000000000 // -15
+    fmv.d.x f31, x15
+    feq.d x15, f1, f31
+    beqz x15, reg1_error_loop
+    li x15, 0xC02C000000000000 // -14
+    fmv.d.x f31, x15
+    feq.d x15, f2, f31
+    beqz x15, reg1_error_loop
+    li x15, 0xc02a000000000000 // -13
+    fmv.d.x f31, x15
+    feq.d x15, f3, f31
+    beqz x15, reg1_error_loop
+    li x15, 0xC028000000000000 // -12
+    fmv.d.x f31, x15
+    feq.d x15, f4, f31
+    beqz x15, reg1_error_loop
+    li x15, 0xC026000000000000 // -11
+    fmv.d.x f31, x15
+    feq.d x15, f5, f31
+    beqz x15, reg1_error_loop
+    li x15, 0xc024000000000000 // -10
+    fmv.d.x f31, x15
+    feq.d x15, f6, f31
+    beqz x15, reg1_error_loop
+    li x15, 0xc022000000000000 // -9
+    fmv.d.x f31, x15
+    feq.d x15, f7, f31
+    beqz x15, reg1_error_loop
+    li x15, 0xc020000000000000 // -8
+    fmv.d.x f31, x15
+    feq.d x15, f8, f31
+    beqz x15, reg1_error_loop
+    li x15, 0xc01c000000000000 // -7
+    fmv.d.x f31, x15
+    feq.d x15, f9, f31
+    beqz x15, reg1_error_loop
+    li x15, 0xc018000000000000 // -6
+    fmv.d.x f31, x15
+    feq.d x15, f10, f31
+    beqz x15, reg1_error_loop
+    li x15, 0xc014000000000000 // -5
+    fmv.d.x f31, x15
+    feq.d x15, f11, f31
+    beqz x15, reg1_error_loop
+    li x15, 0xc010000000000000 // -4
+    fmv.d.x f31, x15
+    feq.d x15, f12, f31
+    beqz x15, reg1_error_loop
+    li x15, 0xc008000000000000 // -3
+    fmv.d.x f31, x15
+    feq.d x15, f13, f31
+    beqz x15, reg1_error_loop
+    li x15, 0xc000000000000000 // -2
+    fmv.d.x f31, x15
+    feq.d x15, f14, f31
+    beqz x15, reg1_error_loop
+    li x15, 0xbff0000000000000 // -1
+    fmv.d.x f31, x15
+    feq.d x15, f15, f31
+    beqz x15, reg1_error_loop
+    li x15, 0                  // 0
+    fmv.d.x f31, x15
+    feq.d x15, f16, f31
+    beqz x15, reg1_error_loop
+    li x15, 0x3ff0000000000000 // 1
+    fmv.d.x f31, x15
+    feq.d x15, f17, f31
+    beqz x15, reg1_error_loop
+    li x15, 0x4000000000000000 // 2
+    fmv.d.x f31, x15
+    feq.d x15, f18, f31
+    beqz x15, reg1_error_loop
+    li x15, 0x4008000000000000 // 3
+    fmv.d.x f31, x15
+    feq.d x15, f19, f31
+    beqz x15, reg1_error_loop
+    li x15, 0x4010000000000000 // 4
+    fmv.d.x f31, x15
+    feq.d x15, f20, f31
+    beqz x15, reg1_error_loop
+    li x15, 0x4014000000000000 // 5
+    fmv.d.x f31, x15
+    feq.d x15, f21, f31
+    beqz x15, reg1_error_loop
+    li x15, 0x4018000000000000 // 6
+    fmv.d.x f31, x15
+    feq.d x15, f22, f31
+    beqz x15, reg1_error_loop
+    li x15, 0x401c000000000000 // 7
+    fmv.d.x f31, x15
+    feq.d x15, f23, f31
+    beqz x15, reg1_error_loop
+    li x15, 0x4020000000000000 // 8
+    fmv.d.x f31, x15
+    feq.d x15, f24, f31
+    beqz x15, reg1_error_loop
+    li x15, 0x4022000000000000 // 9
+    fmv.d.x f31, x15
+    feq.d x15, f25, f31
+    beqz x15, reg1_error_loop
+    li x15, 0x4024000000000000 // 10
+    fmv.d.x f31, x15
+    feq.d x15, f26, f31
+    beqz x15, reg1_error_loop
+    li x15, 0x4026000000000000 // 11
+    fmv.d.x f31, x15
+    feq.d x15, f27, f31
+    beqz x15, reg1_error_loop
+    li x15, 0x4028000000000000 // 12
+    fmv.d.x f31, x15
+    feq.d x15, f28, f31
+    beqz x15, reg1_error_loop
+    li x15, 0x402a000000000000 // 13
+    fmv.d.x f31, x15
+    feq.d x15, f29, f31
+    beqz x15, reg1_error_loop
+    li x15, 0x402C000000000000 // 14
+    fmv.d.x f31, x15
+    feq.d x15, f30, f31
+    beqz x15, reg1_error_loop
+#endif
 
     /* Everything passed, increment the loop counter. */
+#if __riscv_xlen == 64
+    ld x15, ulRegTest1LoopCounterConst
+    ld x14, 0(x15)
+    addi x14, x14, 1
+    sd x14, 0(x15)
+#else
     lw x15, ulRegTest1LoopCounterConst
     lw x14, 0(x15)
     addi x14, x14, 1
     sw x14, 0(x15)
+#endif
 
     /* Restore clobbered register reading for next loop. */
     li x14, 0xe
@@ -149,12 +346,12 @@ reg1_error_loop:
     /* Busy loop which holds the task. */
     jal reg1_error_loop
 
-.align( 4 )
-ulRegTest1LoopCounterConst: .word ulRegTest1LoopCounter
+.align( 8 )
+ulRegTest1LoopCounterConst: .dword ulRegTest1LoopCounter
 
 /*-----------------------------------------------------------*/
 
-.align( 4 )
+.align( 8 )
 vRegTest2Implementation:
 
     /* Fill the core registers with known values. */
@@ -185,6 +382,70 @@ vRegTest2Implementation:
     li x29, 0x2d
     li x30, 0x2e
     li x31, 0x2f
+#endif
+#if __riscv_flen == 64
+    li x5, 0x402E000000000000 // 15
+    fmv.d.x f1, x5
+    li x5, 0x402C000000000000 // 14
+    fmv.d.x f2, x5
+    li x5, 0x402a000000000000 // 13
+    fmv.d.x f3, x5
+    li x5, 0x4028000000000000 // 12
+    fmv.d.x f4, x5
+    li x5, 0x4026000000000000 // 11
+    fmv.d.x f5, x5
+    li x5, 0x4024000000000000 // 10
+    fmv.d.x f6, x5
+    li x5, 0x4022000000000000 // 9
+    fmv.d.x f7, x5
+    li x5, 0x4020000000000000 // 8
+    fmv.d.x f8, x5
+    li x5, 0x401c000000000000 // 7
+    fmv.d.x f9, x5
+    li x5, 0x4018000000000000 // 6
+    fmv.d.x f10, x5
+    li x5, 0x4014000000000000 // 5
+    fmv.d.x f11, x5
+    li x5, 0x4010000000000000 // 4
+    fmv.d.x f12, x5
+    li x5, 0x4008000000000000 // 3
+    fmv.d.x f13, x5
+    li x5, 0x4000000000000000 // 2
+    fmv.d.x f14, x5
+    li x5, 0x3ff0000000000000 // 1
+    fmv.d.x f15, x5
+    li x5, 0                  // 0
+    fmv.d.x f16, x5
+    li x5, 0xbff0000000000000 // -1
+    fmv.d.x f17, x5
+    li x5, 0xc000000000000000 // -2
+    fmv.d.x f18, x5
+    li x5, 0xc008000000000000 // -3
+    fmv.d.x f19, x5
+    li x5, 0xc010000000000000 // -4
+    fmv.d.x f20, x5
+    li x5, 0xc014000000000000 // -5
+    fmv.d.x f21, x5
+    li x5, 0xc018000000000000 // -6
+    fmv.d.x f22, x5
+    li x5, 0xc01c000000000000 // -7
+    fmv.d.x f23, x5
+    li x5, 0xc020000000000000 // -8
+    fmv.d.x f24, x5
+    li x5, 0xc022000000000000 // -9
+    fmv.d.x f25, x5
+    li x5, 0xc024000000000000 // -10
+    fmv.d.x f26, x5
+    li x5, 0xC026000000000000 // -11
+    fmv.d.x f27, x5
+    li x5, 0xC028000000000000 // -12
+    fmv.d.x f28, x5
+    li x5, 0xC02A000000000000 // -13
+    fmv.d.x f29, x5
+    li x5, 0xC02C000000000000 // -14
+    fmv.d.x f30, x5
+    li x5, 0xC02E000000000000 // -15
+    fmv.d.x f31, x5
 #endif
 
 Reg2_loop:
@@ -246,12 +507,145 @@ Reg2_loop:
     li x5, 0x2f
     bne x5, x31, reg2_error_loop
 #endif
+#if __riscv_flen == 64
+    li x5, 0x402E000000000000 // 15
+    fmv.d.x f0, x5
+    feq.d x5, f1, f0
+    beqz x5, reg2_error_loop
+    li x5, 0x402C000000000000 // 14
+    fmv.d.x f0, x5
+    feq.d x5, f2, f0
+    beqz x5, reg2_error_loop
+    li x5, 0x402a000000000000 // 13
+    fmv.d.x f0, x5
+    feq.d x5, f3, f0
+    beqz x5, reg2_error_loop
+    li x5, 0x4028000000000000 // 12
+    fmv.d.x f0, x5
+    feq.d x5, f4, f0
+    beqz x5, reg2_error_loop
+    li x5, 0x4026000000000000 // 11
+    fmv.d.x f0, x5
+    feq.d x5, f5, f0
+    beqz x5, reg2_error_loop
+    li x5, 0x4024000000000000 // 10
+    fmv.d.x f0, x5
+    feq.d x5, f6, f0
+    beqz x5, reg2_error_loop
+    li x5, 0x4022000000000000 // 9
+    fmv.d.x f0, x5
+    feq.d x5, f7, f0
+    beqz x5, reg2_error_loop
+    li x5, 0x4020000000000000 // 8
+    fmv.d.x f0, x5
+    feq.d x5, f8, f0
+    beqz x5, reg2_error_loop
+    li x5, 0x401c000000000000 // 7
+    fmv.d.x f0, x5
+    feq.d x5, f9, f0
+    beqz x5, reg2_error_loop
+    li x5, 0x4018000000000000 // 6
+    fmv.d.x f0, x5
+    feq.d x5, f10, f0
+    beqz x5, reg2_error_loop
+    li x5, 0x4014000000000000 // 5
+    fmv.d.x f0, x5
+    feq.d x5, f11, f0
+    beqz x5, reg2_error_loop
+    li x5, 0x4010000000000000 // 4
+    fmv.d.x f0, x5
+    feq.d x5, f12, f0
+    beqz x5, reg2_error_loop
+    li x5, 0x4008000000000000 // 3
+    fmv.d.x f0, x5
+    feq.d x5, f13, f0
+    beqz x5, reg2_error_loop
+    li x5, 0x4000000000000000 // 2
+    fmv.d.x f0, x5
+    feq.d x5, f14, f0
+    beqz x5, reg2_error_loop
+    li x5, 0x3ff0000000000000 // 1
+    fmv.d.x f0, x5
+    feq.d x5, f15, f0
+    beqz x5, reg2_error_loop
+    li x5, 0                  // 0
+    fmv.d.x f0, x5
+    feq.d x5, f16, f0
+    beqz x5, reg2_error_loop
+    li x5, 0xbff0000000000000 // -1
+    fmv.d.x f0, x5
+    feq.d x5, f17, f0
+    beqz x5, reg2_error_loop
+    li x5, 0xc000000000000000 // -2
+    fmv.d.x f0, x5
+    feq.d x5, f18, f0
+    beqz x5, reg2_error_loop
+    li x5, 0xc008000000000000 // -3
+    fmv.d.x f0, x5
+    feq.d x5, f19, f0
+    beqz x5, reg2_error_loop
+    li x5, 0xc010000000000000 // -4
+    fmv.d.x f0, x5
+    feq.d x5, f20, f0
+    beqz x5, reg2_error_loop
+    li x5, 0xc014000000000000 // -5
+    fmv.d.x f0, x5
+    feq.d x5, f21, f0
+    beqz x5, reg2_error_loop
+    li x5, 0xc018000000000000 // -6
+    fmv.d.x f0, x5
+    feq.d x5, f22, f0
+    beqz x5, reg2_error_loop
+    li x5, 0xc01c000000000000 // -7
+    fmv.d.x f0, x5
+    feq.d x5, f23, f0
+    beqz x5, reg2_error_loop
+    li x5, 0xc020000000000000 // -8
+    fmv.d.x f0, x5
+    feq.d x5, f24, f0
+    beqz x5, reg2_error_loop
+    li x5, 0xc022000000000000 // -9
+    fmv.d.x f0, x5
+    feq.d x5, f25, f0
+    beqz x5, reg2_error_loop
+    li x5, 0xc024000000000000 // -10
+    fmv.d.x f0, x5
+    feq.d x5, f26, f0
+    beqz x5, reg2_error_loop
+    li x5, 0xC026000000000000 // -11
+    fmv.d.x f0, x5
+    feq.d x5, f27, f0
+    beqz x5, reg2_error_loop
+    li x5, 0xC028000000000000 // -12
+    fmv.d.x f0, x5
+    feq.d x5, f28, f0
+    beqz x5, reg2_error_loop
+    li x5, 0xC02A000000000000 // -13
+    fmv.d.x f0, x5
+    feq.d x5, f29, f0
+    beqz x5, reg2_error_loop
+    li x5, 0xC02C000000000000 // -14
+    fmv.d.x f0, x5
+    feq.d x5, f30, f0
+    beqz x5, reg2_error_loop
+    li x5, 0xC02E000000000000 // -15
+    fmv.d.x f0, x5
+    feq.d x5, f31, f0
+    beqz x5, reg2_error_loop
+#endif
 
     /* Everything passed, increment the loop counter. */
+#if __riscv_xlen == 64
+    ld x5, ulRegTest2LoopCounterConst
+    ld x6, 0(x5)
+    addi x6, x6, 1
+    sd x6, 0(x5)
+#else
     lw x5, ulRegTest2LoopCounterConst
     lw x6, 0(x5)
     addi x6, x6, 1
     sw x6, 0(x5)
+#endif
 
     /* Restore clobbered register reading for next loop. */
     li x6, 0x61
@@ -263,5 +657,5 @@ reg2_error_loop:
     /* Busy loop which holds the task. */
     jal reg2_error_loop
 
-.align( 4 )
-ulRegTest2LoopCounterConst: .word ulRegTest2LoopCounter
+.align( 8 )
+ulRegTest2LoopCounterConst: .dword ulRegTest2LoopCounter

--- a/FreeRTOS/Demo/RISC-V_RV32_QEMU_VIRT_GCC/build/gcc/fake_rom.ld
+++ b/FreeRTOS/Demo/RISC-V_RV32_QEMU_VIRT_GCC/build/gcc/fake_rom.ld
@@ -5,7 +5,7 @@ MEMORY
 {
 	/* Fake ROM area */
 	rom (rxa) : ORIGIN = 0x80000000, LENGTH = 512K
-	ram (wxa) : ORIGIN = 0x80080000, LENGTH = 512K
+	ram (wxa) : ORIGIN = 0x80080000, LENGTH = 1024K
 }
 
 SECTIONS

--- a/FreeRTOS/Demo/RISC-V_RV32_QEMU_VIRT_GCC/build/gcc/printf-stdarg.c
+++ b/FreeRTOS/Demo/RISC-V_RV32_QEMU_VIRT_GCC/build/gcc/printf-stdarg.c
@@ -168,29 +168,29 @@ static int tiny_print( char **out, const char *format, va_list args, unsigned in
 				width += *format - '0';
 			}
 			if( *format == 's' ) {
-				register char *s = (char *)va_arg( args, int );
+				register char *s = (char *)va_arg( args, long );
 				pc += prints (out, s?s:"(null)", width, pad, buflimit);
 				continue;
 			}
 			if( *format == 'd' ) {
-				pc += printi (out, va_arg( args, int ), 10, 1, width, pad, 'a', buflimit);
+				pc += printi (out, va_arg( args, long ), 10, 1, width, pad, 'a', buflimit);
 				continue;
 			}
 			if( *format == 'x' ) {
-				pc += printi (out, va_arg( args, int ), 16, 0, width, pad, 'a', buflimit);
+				pc += printi (out, va_arg( args, long ), 16, 0, width, pad, 'a', buflimit);
 				continue;
 			}
 			if( *format == 'X' ) {
-				pc += printi (out, va_arg( args, int ), 16, 0, width, pad, 'A', buflimit);
+				pc += printi (out, va_arg( args, long ), 16, 0, width, pad, 'A', buflimit);
 				continue;
 			}
 			if( *format == 'u' ) {
-				pc += printi (out, va_arg( args, int ), 10, 0, width, pad, 'a', buflimit);
+				pc += printi (out, va_arg( args, long ), 10, 0, width, pad, 'a', buflimit);
 				continue;
 			}
 			if( *format == 'c' ) {
 				/* char are converted to int then pushed on the stack */
-				scr[0] = (char)va_arg( args, int );
+				scr[0] = (char)va_arg( args, long );
 				scr[1] = '\0';
 				pc += prints (out, scr, width, pad, buflimit);
 				continue;

--- a/FreeRTOS/Demo/RISC-V_RV32_QEMU_VIRT_GCC/build/gcc/start.S
+++ b/FreeRTOS/Demo/RISC-V_RV32_QEMU_VIRT_GCC/build/gcc/start.S
@@ -1,6 +1,6 @@
 /*
  * FreeRTOS V202212.00
- * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/FreeRTOS/Demo/RISC-V_RV32_QEMU_VIRT_GCC/build/gcc/start.S
+++ b/FreeRTOS/Demo/RISC-V_RV32_QEMU_VIRT_GCC/build/gcc/start.S
@@ -68,6 +68,12 @@ _start:
 	addi a0, a0, REGSIZE
 	bltu a0, a1, 1b
 2:
+#ifdef __riscv_fdiv
+	// Enable FPU
+	li          t0, (1 << 13)
+	csrs        mstatus, t0
+	fscsr       x0
+#endif
 
 	// argc, argv, envp is 0
 	li  a0, 0

--- a/FreeRTOS/Demo/RISC-V_RV32_QEMU_VIRT_GCC/main.c
+++ b/FreeRTOS/Demo/RISC-V_RV32_QEMU_VIRT_GCC/main.c
@@ -252,7 +252,7 @@ void vAssertCalled( const char * pcFileName,
  * used by the Idle task. */
 void vApplicationGetIdleTaskMemory( StaticTask_t ** ppxIdleTaskTCBBuffer,
                                     StackType_t ** ppxIdleTaskStackBuffer,
-                                    uint32_t * pulIdleTaskStackSize )
+                                    StackType_t * pulIdleTaskStackSize )
 {
 /* If the buffers to be provided to the Idle task are declared inside this
  * function then they must be declared static - otherwise they will be allocated on

--- a/FreeRTOS/Demo/RISC-V_RV32_QEMU_VIRT_GCC/main_full.c
+++ b/FreeRTOS/Demo/RISC-V_RV32_QEMU_VIRT_GCC/main_full.c
@@ -249,7 +249,11 @@ static void prvCheckTask( void * pvParameters )
     ( void ) pvParameters;
 
     /* Demo start marker. */
+#if __riscv_flen == 64
+    printf( "FreeRTOS Demo Start (With FPU)\r\n" );
+#else
     printf( "FreeRTOS Demo Start\r\n" );
+#endif
 
     xPreviousWakeTime = xTaskGetTickCount();
 

--- a/manifest.yml
+++ b/manifest.yml
@@ -5,7 +5,7 @@ license: "MIT"
 
 dependencies:
   - name: "FreeRTOS-Kernel"
-    version: "1b8f596"
+    version: "5c824e5"
     repository:
       type: "git"
       url: "https://github.com/FreeRTOS/FreeRTOS-Kernel.git"

--- a/manifest.yml
+++ b/manifest.yml
@@ -5,7 +5,7 @@ license: "MIT"
 
 dependencies:
   - name: "FreeRTOS-Kernel"
-    version: "5c824e5"
+    version: "4d9cd90"
     repository:
       type: "git"
       url: "https://github.com/FreeRTOS/FreeRTOS-Kernel.git"


### PR DESCRIPTION
Update RV32 qemu Demo to support RVA23

Description
-----------
This PR modifies the already existing `RISC-V_RV32_QEMU_VIRT_GCC` demo, so at compilation time it can be configured as an RV32 system or (what will be) a [RISC-V RVA23](https://github.com/riscv/riscv-profiles/blob/main/src/rva23-profile.adoc) QEMU system which includes RV64, FPU and (later) vector support.

FPU context switch relies on [another PR](https://github.com/FreeRTOS/FreeRTOS-Kernel/pull/1250) in the FreeRTOS-Kernel Repo.

This PR:
* Modifies the `Makefile` so the `RVA23` is used as an option to build either the `RV32` or `RVA23` version of the test
* Modifies the sizes of memory (in the `ld` file and `FreeRTOSConfig.h`) to accomodate the larger contexts
* Update the `RegTest.S` file to include the FPU registers in the checks
* A few extra updates elsewhere to accommodate the 64-bit platforms

Finally I made the `Sources` submodule point to the branch with the FPU context switch support

Test Steps
-----------
To compile the demo:
* Put the toolchain in your path. Please note that the toolchain should be able to build for `rv32imac-ilp32` and `rv64ima-lp64fdv`.
* For RV32
    ```sh
     $ (cd FreeRTOS/Demo/RISC-V_RV32_QEMU_VIRT_GCC/ && make -C build/gcc DEBUG=1 all)
    ```
* For RVA23
    ```sh
     $ (cd FreeRTOS/Demo/RISC-V_RV32_QEMU_VIRT_GCC/ && make -C build/gcc DEBUG=1 RVA23=1 all)
    ```

To run the demo
* For RV32
    ```sh
     $ qemu-system-riscv32 -nographic -machine virt -net none -chardev stdio,id=con,mux=on -serial chardev:con -mon chardev=con,mode=readline -bios none -smp 4 -s --kernel build/gcc/output/RTOSDemo.elf)
Running qemu /home/jonathan.cubides/sifive/FRTOS_s5/FreeRTOS/FreeRTOS/Demo/RISC-V_RV32_QEMU_VIRT_GCC/build/gcc/output/RTOSDemo.elf 
FreeRTOS Demo Start
FreeRTOS Demo SUCCESS: : 5033
FreeRTOS Demo SUCCESS: : 10033
FreeRTOS Demo SUCCESS: : 15032
    ```
* For RVA23
    ```sh
     $ qemu-system-riscv64 -nographic -machine virt -net none -chardev stdio,id=con,mux=on -serial chardev:con -mon chardev=con,mode=readline -bios none -smp 4  -s --kernel build/gcc/output/RTOSDemo.elf
Running qemu /home/jonathan.cubides/sifive/FRTOS_s5/FreeRTOS/FreeRTOS/Demo/RISC-V_RV32_QEMU_VIRT_GCC/build/gcc/output/RTOSDemo.elf 
FreeRTOS Demo Start (With FPU)
FreeRTOS Demo SUCCESS: : 5033
FreeRTOS Demo SUCCESS: : 10033
FreeRTOS Demo SUCCESS: : 15033
    ```

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ X ] I have tested my changes. No regression in existing tests.
- [ X ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
