### PR TITLE
Demo/CORTEX_MPS2_QEMU_IAR_GCC: increase min stack size from 80 to 88

### DIFF
--- a/FreeRTOS/Demo/CORTEX_MPS2_QEMU_IAR_GCC/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_MPS2_QEMU_IAR_GCC/FreeRTOSConfig.h
@@ -46,7 +46,7 @@
 #define configUSE_TICK_HOOK                      1
 #define configCPU_CLOCK_HZ                       ( ( unsigned long ) 25000000 )
 #define configTICK_RATE_HZ                       ( ( TickType_t ) 1000 )
-#define configMINIMAL_STACK_SIZE                 ( ( unsigned short ) 80 )
+#define configMINIMAL_STACK_SIZE                 ( ( unsigned short ) 88 )
 #define configTOTAL_HEAP_SIZE                    ( ( size_t ) ( 60 * 1024 ) )
 #define configMAX_TASK_NAME_LEN                  ( 12 )
 


### PR DESCRIPTION
Description
-----------

Compiling this demo with picolibc 1.8.9 (as packaged with Debian trixie) results in a stack overflow. Increasing the minimal stack size from 80 to 88 bytes resolves this. (Debian trixie arm crosscompiler defaults to compile/link against picolibc and not newlib anymore.)

<!--- Describe your changes in detail. -->

Test Steps
-----------
stack overflow happens directly on test start.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
