### PR TITLE
Align stack size to 16-byte boundary by changing `__stack_size` from …

### DIFF
--- a/FreeRTOS/Demo/RISC-V_RV32_QEMU_VIRT_GCC/build/gcc/Makefile
+++ b/FreeRTOS/Demo/RISC-V_RV32_QEMU_VIRT_GCC/build/gcc/Makefile
@@ -45,7 +45,7 @@ endif
 
 LDFLAGS += -nostartfiles -Xlinker --gc-sections -Wl,-Map,$(OUTPUT_DIR)/RTOSDemo.map \
            -T./fake_rom.ld -march=$(MARCH) -mabi=$(MABI) -mcmodel=$(MCMODEL) -Xlinker \
-           --defsym=__stack_size=350 -Wl,--start-group -Wl,--end-group
+           --defsym=__stack_size=352 -Wl,--start-group -Wl,--end-group
 
 ifeq ($(PICOLIBC),1)
 LDFLAGS += --specs=picolibc.specs --oslib=semihost --crt0=minimal -DPICOLIBC_INTEGER_PRINTF_SCANF


### PR DESCRIPTION
…350 to 352​

# Align stack size to 16-byte boundary by changing __stack_size from 350 to 352​

## Description
-----------
This pull request updates the `__stack_size` definition in the linker flags, changing its value from 350 to 352. This change ensures that the stack size is a multiple of 16, aligning the stack pointer (sp) to a 16-byte boundary as required by the system architecture.​

### Background

Previously, __stack_size was set to 350 bytes, which is not a multiple of 16. Although the linker script aligns the start of the stack section to a 16-byte boundary, adding a non-multiple of 16 to this aligned address resulted in a stack top (_stack_top) that was not 16-byte aligned. This misalignment caused exceptions due to misaligned memory accesses, as the stack pointer was not properly aligned.​

### Changes

    Updated the linker flags to set __stack_size to 352 bytes.​

### Impact

This change ensures that the stack pointer remains 16-byte aligned, preventing misaligned memory access exceptions and improving system stability.​

### Testing

After making this change, the system no longer encounters misaligned memory access exceptions related to stack operations. All functionalities have been tested and are working as expected.

## Test Steps
-----------
After executing this project on QEMU, I tried to execute it on gem5.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
