### PR TITLE
Update coreSNTP demo for change in Sntp_ConvertToUnixTime API

### DIFF
--- a/FreeRTOS-Plus/Demo/coreSNTP_Windows_Simulator/SNTPClientTask.c
+++ b/FreeRTOS-Plus/Demo/coreSNTP_Windows_Simulator/SNTPClientTask.c
@@ -919,7 +919,7 @@ static void sntpClient_SetTime( const SntpServerInfo_t * pTimeServer,
 
     /* Always correct the system base time on receiving time from server.*/
     SntpStatus_t status;
-    uint32_t unixSecs;
+    UnixTime_t unixSecs;
     uint32_t unixMicroSecs;
 
     /* Convert server time from NTP timestamp to UNIX format. */
@@ -929,7 +929,7 @@ static void sntpClient_SetTime( const SntpServerInfo_t * pTimeServer,
     configASSERT( status == SntpSuccess );
 
     /* Always correct the base time of the system clock as the time received from the server. */
-    systemClock.baseTime.secs = unixSecs;
+    systemClock.baseTime.secs = ( uint32_t )unixSecs;
     systemClock.baseTime.msecs = unixMicroSecs / 1000;
 
     /* Set the clock adjustment "slew" rate of system clock if it wasn't set already and this is NOT

--- a/manifest.yml
+++ b/manifest.yml
@@ -124,7 +124,7 @@ dependencies:
       path: "FreeRTOS-Plus/Source/AWS/ota"
 
   - name: "coreSNTP"
-    version: "941ad2f"
+    version: "89fffaa"
     repository:
       type: "git"
       url: "https://github.com/FreeRTOS/coreSNTP"

--- a/manifest.yml
+++ b/manifest.yml
@@ -124,7 +124,7 @@ dependencies:
       path: "FreeRTOS-Plus/Source/AWS/ota"
 
   - name: "coreSNTP"
-    version: "89fffaa"
+    version: "941ad2f"
     repository:
       type: "git"
       url: "https://github.com/FreeRTOS/coreSNTP"

--- a/manifest.yml
+++ b/manifest.yml
@@ -124,7 +124,7 @@ dependencies:
       path: "FreeRTOS-Plus/Source/AWS/ota"
 
   - name: "coreSNTP"
-    version: "c5face5"
+    version: "941ad2f"
     repository:
       type: "git"
       url: "https://github.com/FreeRTOS/coreSNTP"


### PR DESCRIPTION
Description
-----------
The [PR](https://github.com/FreeRTOS/coreSNTP/pull/104) updates the SNTP to Unix time conversion logic to support 64-bit Unix time (Y2038 compliance) while maintaining backward compatibility with legacy 32-bit systems. This PR updates the coreSNTP WinSim demo to update the API.

Test Steps
-----------
Run the demo without any errors/warnings.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] <s>I have modified and/or added unit-tests to cover the code changes in this Pull Request.</s>

Related Issue
-----------
https://github.com/FreeRTOS/coreSNTP/pull/104


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
