### PR TITLE
Update network_transport files based on MbedTLSv3.6.3

### DIFF
--- a/FreeRTOS-Plus/Source/Application-Protocols/network_transport/transport_mbedtls.c
+++ b/FreeRTOS-Plus/Source/Application-Protocols/network_transport/transport_mbedtls.c
@@ -462,13 +462,19 @@ static void setOptionalConfigurations( SSLContext_t * pSslContext,
     {
         mbedtlsError = mbedtls_ssl_set_hostname( &( pSslContext->context ),
                                                  pHostName );
+    }
+    /* MbedTLS-3.6.3 requires calling the mbedtls_ssl_set_hostname() before calling mbedtls_ssl_handshake(). */
+    else
+    {
+        mbedtlsError = mbedtls_ssl_set_hostname( &( pSslContext->context ),
+                                                 NULL );
+    }
 
-        if( mbedtlsError != 0 )
-        {
-            LogError( ( "Failed to set server name: mbedTLSError= %s : %s.",
-                        mbedtlsHighLevelCodeOrDefault( mbedtlsError ),
-                        mbedtlsLowLevelCodeOrDefault( mbedtlsError ) ) );
-        }
+    if( mbedtlsError != 0 )
+    {
+        LogError( ( "Failed to set server name: mbedTLSError= %s : %s.",
+                    mbedtlsHighLevelCodeOrDefault( mbedtlsError ),
+                    mbedtlsLowLevelCodeOrDefault( mbedtlsError ) ) );
     }
 
     /* Set Maximum Fragment Length if enabled. */

--- a/FreeRTOS-Plus/Source/Application-Protocols/network_transport/transport_mbedtls_pkcs11.c
+++ b/FreeRTOS-Plus/Source/Application-Protocols/network_transport/transport_mbedtls_pkcs11.c
@@ -463,15 +463,21 @@ static TlsTransportStatus_t tlsSetup( NetworkContext_t * pNetworkContext,
         {
             mbedtlsError = mbedtls_ssl_set_hostname( &( pTlsTransportParams->sslContext.context ),
                                                      pHostName );
+        }
+        /* MbedTLS-3.6.3 requires calling the mbedtls_ssl_set_hostname() before calling mbedtls_ssl_handshake(). */
+        else
+        {
+            mbedtlsError = mbedtls_ssl_set_hostname( &( pTlsTransportParams->sslContext.context ),
+                                                     NULL );
+        }
 
-            if( mbedtlsError != 0 )
-            {
-                LogError( ( "Failed to set server name: mbedTLSError= %s : %s.",
-                            mbedtlsHighLevelCodeOrDefault( mbedtlsError ),
-                            mbedtlsLowLevelCodeOrDefault( mbedtlsError ) ) );
+        if( mbedtlsError != 0 )
+        {
+            LogError( ( "Failed to set server name: mbedTLSError= %s : %s.",
+                        mbedtlsHighLevelCodeOrDefault( mbedtlsError ),
+                        mbedtlsLowLevelCodeOrDefault( mbedtlsError ) ) );
 
-                returnStatus = TLS_TRANSPORT_INTERNAL_ERROR;
-            }
+            returnStatus = TLS_TRANSPORT_INTERNAL_ERROR;
         }
     }
 


### PR DESCRIPTION
Description
-----------
For MBbedTLS-[v3.6.3](https://github.com/Mbed-TLS/mbedtls/releases/tag/mbedtls-3.6.3) , in TLS clients, if `mbedtls_ssl_set_hostname()` has not been called, `mbedtls_ssl_handshake()` now fails with
`MBEDTLS_ERR_SSL_CERTIFICATE_VERIFICATION_WITHOUT_HOSTNAME`.  As a result, the `mbedtls_ssl_handshake()` of MbedTLS function returns "False" when the `pNetworkCredentials->disableSni` is pdTRUE. 

This PR addresses that issue by calling `mbedtls_ssl_set_hostname()` with a NULL name when SNI is disabled, so the latest change of MbedTLS can be accomodated.

Test Steps
-----------
Ran the [MQTT_Basic_TLS demo](https://github.com/FreeRTOS/FreeRTOS/tree/main/FreeRTOS-Plus/Demo/coreMQTT_Windows_Simulator/MQTT_Basic_TLS)  with `democonfigDISABLE_SNI` set as `pdTRUE`
Here are the log results : 
[mqtt_basic_TLS_result_log.txt](https://github.com/user-attachments/files/19834451/mqtt_basic_TLS_result_log.txt)


Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
#1337 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
