### PR TITLE
FreeRTOS_Plus_TCP_Echo_Qemu_mps2: fix compile with "gcc -flto"

### DIFF
--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Echo_Qemu_mps2/startup.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Echo_Qemu_mps2/startup.c
@@ -167,7 +167,7 @@ static void Default_Handler6( void )
     }
 }
 
-const uint32_t * const isr_vector[] __attribute__( ( section( ".isr_vector" ) ) ) =
+const uint32_t * const isr_vector[] __attribute__( ( section( ".isr_vector" ), used ) ) =
 {
     ( uint32_t * ) &_estack,
     ( uint32_t * ) &Reset_Handler,       /* Reset                -15  */

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Echo_Qemu_mps2/syscalls.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Echo_Qemu_mps2/syscalls.c
@@ -30,7 +30,7 @@ extern "C" {
 #include <sys/types.h>
 
 void uart_init( void );
-int _fstat( int file );
+__attribute__( ( used ) ) int _fstat( int file );
 int _read( int file,
            char * buf,
            int len );


### PR DESCRIPTION
FreeRTOS_Plus_TCP_Echo_Qemu_mps2: fix compile with "gcc -flto" by adding "__attribute__( used )" to isr_vector and _fstat().

<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
