### PR TITLE
Demo/Posix_GCC: fix compiler flags and compiler warnings

### DIFF
--- a/FreeRTOS/Demo/Posix_GCC/CMakeLists.txt
+++ b/FreeRTOS/Demo/Posix_GCC/CMakeLists.txt
@@ -35,8 +35,8 @@ else()
     set( CMAKE_BUILD_TYPE "debug" )
 endif()
 
-set(CMAKE_CXX_FLAGS_RELEASE "-O3")
-set(CMAKE_CXX_FLAGS_DEBUG "-O0 -g3")
+set(CMAKE_C_FLAGS_RELEASE "-O3")
+set(CMAKE_C_FLAGS_DEBUG "-O0 -g3")
 
 if( SANITIZE_ADDRESS )
     add_compile_options( -fsanitize=address -fsanitize=alignment )

--- a/FreeRTOS/Demo/Posix_GCC/main_full.c
+++ b/FreeRTOS/Demo/Posix_GCC/main_full.c
@@ -510,7 +510,7 @@ void vFullDemoIdleFunction( void )
 
     /* Exercise heap_5 a bit.  The malloc failed hook will trap failed
      * allocations so there is no need to test here. */
-    pvAllocated = pvPortMalloc( ( rand() % 500 ) + 1 );
+    pvAllocated = pvPortMalloc( ( size_t ) ( ( rand() % 500 ) + 1 ) );
     vPortFree( pvAllocated );
 
     /* Exit after a fixed time so code coverage results are written to the
@@ -656,7 +656,8 @@ static void prvDemonstrateTimerQueryFunctions( void )
 
 static void prvDemonstratePendingFunctionCall( void )
 {
-    static intptr_t ulParameter1 = 1000UL, ulParameter2 = 0UL;
+    static intptr_t ulParameter1 = 1000L;
+    static uint32_t ulParameter2 = 0UL;
     const TickType_t xDontBlock = 0; /* This is called from the idle task so must *not* attempt to block. */
 
     /* prvPendedFunction() just expects the parameters to be incremented by one


### PR DESCRIPTION
- Change CMakeLists.txt to set the C compiler flags instead of the C++ compiler flags.
- Change to compiler warnings from "gcc -Wconversion" in main_full.c.

Description
-----------
<!--- Describe your changes in detail. -->

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
