### PR TITLE
Demo/CORTEX_MPU_M3_MPS2_QEMU_GCC: support "gcc -flto" and fixes

### DIFF
--- a/FreeRTOS/Demo/CORTEX_MPU_M3_MPS2_QEMU_GCC/init/startup.c
+++ b/FreeRTOS/Demo/CORTEX_MPU_M3_MPS2_QEMU_GCC/init/startup.c
@@ -66,7 +66,7 @@ void Reset_Handler( void )
     _start();
 }
 
-void prvGetRegistersFromStack( uint32_t * pulFaultStackAddress )
+__attribute__( ( used ) ) static void prvGetRegistersFromStack( uint32_t * pulFaultStackAddress )
 {
 /* These are volatile to try and prevent the compiler/linker optimizing them
  * away as the variables never actually get used.  If the debugger won't show the
@@ -196,7 +196,7 @@ void Debug_Handler( void )
     );
 }
 
-const uint32_t * const isr_vector[] __attribute__( ( section( ".isr_vector" ) ) ) =
+const uint32_t * const isr_vector[] __attribute__( ( section( ".isr_vector" ), used ) ) =
 {
     ( uint32_t * ) &_estack,
     ( uint32_t * ) &Reset_Handler,       /* Reset                     -15 */
@@ -244,12 +244,12 @@ void exit( int status )
     __asm volatile (
         "mov r1, r0\n"
         "cmp r1, #0\n"
-        "bne .notclean\n"
+        "bne .notclean2\n"
         "ldr r1, =0x20026\n" /* ADP_Stopped_ApplicationExit, a clean exit */
-        ".notclean:\n"
+        ".notclean2:\n"
         "movs r0, #0x18\n"   /* SYS_EXIT */
         "bkpt 0xab\n"
-        "end: b end\n"
+        "end2: b end2\n"
         ".ltorg\n"
         );
 

--- a/FreeRTOS/Demo/CORTEX_MPU_M3_MPS2_QEMU_GCC/main.c
+++ b/FreeRTOS/Demo/CORTEX_MPU_M3_MPS2_QEMU_GCC/main.c
@@ -34,9 +34,6 @@
 #include <stdarg.h>
 #include <stdio.h>
 
-void vApplicationIdleHook( void );
-void vApplicationTickHook( void );
-
 int main( void )
 {
     app_main();

--- a/FreeRTOS/Demo/CORTEX_MPU_M3_MPS2_QEMU_GCC/syscall.c
+++ b/FreeRTOS/Demo/CORTEX_MPU_M3_MPS2_QEMU_GCC/syscall.c
@@ -90,7 +90,7 @@ static char * heap_end = ( char * ) &_heap_bottom;
  * @todo  implement if necessary
  *
  */
-int _fstat( int file )
+__attribute__( ( used ) ) int _fstat( int file )
 {
     ( void ) file;
     return 0;
@@ -101,7 +101,7 @@ int _fstat( int file )
  * @todo  implement if necessary
  *
  */
-int _read( int file,
+__attribute__( ( used ) ) int _read( int file,
            char * buf,
            int len )
 {
@@ -119,7 +119,7 @@ int _read( int file,
  * @param [in] len   length of the buffer
  * @returns the number of bytes written
  */
-int _write( int file,
+__attribute__( ( used ) ) int _write( int file,
             char * buf,
             int len )
 {
@@ -141,7 +141,7 @@ int _write( int file,
  * @returns the previous top of the heap
  * @note uses a global variable <b>heap_end</b> to keep track of the previous top
  */
-void * _sbrk( int incr )
+__attribute__( ( used ) ) void * _sbrk( int incr )
 {
     void * prev_heap_end = heap_end;
 
@@ -155,12 +155,12 @@ void * _sbrk( int incr )
     return prev_heap_end;
 }
 
-void _close( int fd )
+__attribute__( ( used ) ) void _close( int fd )
 {
     ( void ) fd;
 }
 
-int _lseek( int filedes,
+__attribute__( ( used ) ) int _lseek( int filedes,
             int offset,
             int whence )
 {
@@ -171,7 +171,7 @@ int _lseek( int filedes,
     return 0;
 }
 
-int _isatty()
+__attribute__( ( used ) ) int _isatty( void )
 {
     return 0;
 }


### PR DESCRIPTION
* Fix compiler warning "gcc -Wmissing-prototypes" in startup.c.
* For "gcc -flto" fix duplicate labels in asm (startup.c) and mark some functions as "used" in startup.c and syscalls.c.
* Fix "gcc -Wredundant-decls" in main.c.

<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
