### PR TITLE
Demo/Common/Minimal/StreamBufferInterrupt.c: more strict result checking

### DIFF
--- a/FreeRTOS/Demo/Common/Minimal/StreamBufferInterrupt.c
+++ b/FreeRTOS/Demo/Common/Minimal/StreamBufferInterrupt.c
@@ -213,7 +213,7 @@ void vBasicStreamBufferSendFromISR( void )
 
 BaseType_t xIsInterruptStreamBufferDemoStillRunning( void )
 {
-    uint32_t ulLastCycleCount = 0;
+    static uint32_t ulLastCycleCount = 0;
 
     /* Check the demo is still running. */
     if( ulLastCycleCount == ulCycleCount )


### PR DESCRIPTION
From looking at the code, I think this more strict error checking was intended in xIsInterruptStreamBufferDemoStillRunning(). If not, then the else part and var could be completely removed as dead code.

<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
