### PR TITLE
Fix 64b misalignment in RISC-V-spike-htif_GCC linker

### DIFF
--- a/FreeRTOS/Demo/RISC-V-spike-htif_GCC/fake_rom.lds
+++ b/FreeRTOS/Demo/RISC-V-spike-htif_GCC/fake_rom.lds
@@ -31,7 +31,7 @@ SECTIONS
 		_etext = .;
 	} >rom AT>rom
 
-	.rodata.align ALIGN(4):
+	.rodata.align ALIGN(8):
 	{
 		_rodata = .;
 	} >rom AT>rom
@@ -47,13 +47,13 @@ SECTIONS
 		*(.rodata .rodata.*)
 		*(.gnu.linkonce.r.*)
 
-		. = ALIGN(4);
+		. = ALIGN(8);
 		_erodata = .;
 	} >rom AT>rom
 
 	.data.align :
 	{
-		. = ALIGN(4);
+		. = ALIGN(8);
 		_data = .;
 	} >ram AT>rom
 
@@ -78,13 +78,13 @@ SECTIONS
 		*(.srodata.cst2)
 		*(.srodata .srodata.*)
 
-		. = ALIGN(4);
+		. = ALIGN(8);
 		_edata = .;
 	} >ram AT>rom
 
 	.bss.align :
 	{
-		. = ALIGN(4);
+		. = ALIGN(8);
 		_bss = .;
 	} >ram AT>rom
 
@@ -101,7 +101,7 @@ SECTIONS
 		*(.gnu.linkonce.b.*)
 		*(COMMON)
 
-		. = ALIGN(4);
+		. = ALIGN(8);
 		_ebss = .;
 	} >ram AT>rom
 


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->

This PR updates the alignment in RISC-V-spike-htif_GCC to handle 32/64b cases. Before, even if XLEN=64, sections could be 32b aligned which causes an error on systems that don't support misaligned load / store. With 64b alignment, both cases should work. We could parameterize it to have XLEN alignment for a slight overhead reduction but I would suggest simply keeping 64b alignment for both.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

make -C FreeRTOS/Demo/RISC-V-spike-htif_GCC

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

This specific example works, but not sure how to run regression or if necessary. Happy to add a 64b test if it doesn't exist already!

Related Issue
-----------
<!-- If any, please provide issue ID. -->

I am not aware of a current related issue.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
