### PR TITLE
POSIX Demo: clang warnings cleanup

### DIFF
--- a/FreeRTOS/Demo/Posix_GCC/console.c
+++ b/FreeRTOS/Demo/Posix_GCC/console.c
@@ -34,8 +34,10 @@
 #include <FreeRTOS.h>
 #include <semphr.h>
 
-SemaphoreHandle_t xStdioMutex;
-StaticSemaphore_t xStdioMutexBuffer;
+#include "console.h"
+
+static SemaphoreHandle_t xStdioMutex;
+static StaticSemaphore_t xStdioMutexBuffer;
 
 void console_init( void )
 {

--- a/FreeRTOS/Demo/Posix_GCC/main.c
+++ b/FreeRTOS/Demo/Posix_GCC/main.c
@@ -67,6 +67,7 @@
 
 /* Local includes. */
 #include "console.h"
+#include "timers.h"
 
 #if ( projENABLE_TRACING == 1 )
     #include <trcRecorder.h>
@@ -460,6 +461,8 @@ void handle_sigint( int signal )
 
 /*-----------------------------------------------------------*/
 
+#if ( projENABLE_TRACING == 1 )
+
 static uint32_t ulEntryTime = 0;
 
 void vTraceTimerReset( void )
@@ -480,5 +483,7 @@ uint32_t uiTraceTimerGetValue( void )
 {
     return( xTaskGetTickCount() - ulEntryTime );
 }
+
+#endif /* if ( projENABLE_TRACING == 1 ) */
 
 /*-----------------------------------------------------------*/

--- a/FreeRTOS/Demo/Posix_GCC/main_full.c
+++ b/FreeRTOS/Demo/Posix_GCC/main_full.c
@@ -114,7 +114,6 @@
 #define mainSEM_TEST_PRIORITY           ( tskIDLE_PRIORITY + 1 )
 #define mainBLOCK_Q_PRIORITY            ( tskIDLE_PRIORITY + 2 )
 #define mainCREATOR_TASK_PRIORITY       ( tskIDLE_PRIORITY + 3 )
-#define mainFLASH_TASK_PRIORITY         ( tskIDLE_PRIORITY + 1 )
 #define mainINTEGER_TASK_PRIORITY       ( tskIDLE_PRIORITY )
 #define mainGEN_QUEUE_TASK_PRIORITY     ( tskIDLE_PRIORITY )
 #define mainFLOP_TASK_PRIORITY          ( tskIDLE_PRIORITY )


### PR DESCRIPTION
Cleanup for clang compiler warnings:
- add "#include" to proper header files
- add "static" modifier to some vars
- if tracing is disabled, do not compile helper functions
- remove unused macro "mainFLASH_TASK_PRIORITY"

<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
