### PR TITLE
fix optimization bug and cleanup

### DIFF
--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Echo_Qemu_mps2/main_networking.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Echo_Qemu_mps2/main_networking.c
@@ -259,8 +259,10 @@ BaseType_t xTasksAlreadyCreated = pdFALSE;
         #else
             FreeRTOS_GetAddressConfiguration( &ulIPAddress, &ulNetMask, &ulGatewayAddress, &ulDNSServerAddress );
         #endif /* defined( ipconfigIPv4_BACKWARD_COMPATIBLE ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE == 0 ) */
+        FreeRTOS_printf( ( "Network Configuration:\r\n\r\n" ) );
+
         FreeRTOS_inet_ntoa( ulIPAddress, cBuffer );
-        FreeRTOS_printf( ( "\r\n\r\nIP Address: %s\r\n", cBuffer ) );
+        FreeRTOS_printf( ( "IP Address: %s\r\n", cBuffer ) );
 
         FreeRTOS_inet_ntoa( ulNetMask, cBuffer );
         FreeRTOS_printf( ( "Subnet Mask: %s\r\n", cBuffer ) );

--- a/FreeRTOS/Demo/Common/Minimal/MessageBufferDemo.c
+++ b/FreeRTOS/Demo/Common/Minimal/MessageBufferDemo.c
@@ -849,7 +849,7 @@ static void prvEchoServer( void * pvParameters )
 
     static void prvSpaceAvailableCoherenceActor( void * pvParameters )
     {
-        static char * cTxString = "12345";
+        static const char * cTxString = "12345";
         char cRxString[ mbCOHERENCE_TEST_BYTES_WRITTEN + 1 ]; /* +1 for NULL terminator. */
 
         ( void ) pvParameters;

--- a/FreeRTOS/Demo/Common/Minimal/TimerDemo.c
+++ b/FreeRTOS/Demo/Common/Minimal/TimerDemo.c
@@ -108,7 +108,7 @@ static uint8_t ucIsStopNeededInTimerZeroCallback = ( uint8_t ) pdFALSE;
 /* The one-shot timer is configured to use a callback function that increments
  * ucOneShotTimerCounter each time it gets called. */
 static TimerHandle_t xOneShotTimer = NULL;
-static uint8_t ucOneShotTimerCounter = ( uint8_t ) 0;
+static volatile uint8_t ucOneShotTimerCounter = ( uint8_t ) 0;
 
 /* The ISR reload timer is controlled from the tick hook to exercise the timer
  * API functions that can be used from an ISR.  It is configured to increment

--- a/FreeRTOS/Demo/Posix_GCC/main_full.c
+++ b/FreeRTOS/Demo/Posix_GCC/main_full.c
@@ -183,7 +183,7 @@ static void prvReloadModeTestTimerCallback( TimerHandle_t xTimer );
 /*-----------------------------------------------------------*/
 
 /* The variable into which error messages are latched. */
-static char * pcStatusMessage = "OK: No errors";
+static const char * pcStatusMessage = "OK: No errors";
 int xErrorCount = 0;
 
 /* This semaphore is created purely to test using the vSemaphoreDelete() and


### PR DESCRIPTION
- Compiling Demo/Common/Minimal/TimerDemo.c with "gcc -flto" breaks the tests, so add "volatile" modifier to "ucOneShotTimerCounter" to fix this.
- In Demo/FreeRTOS_Plus_TCP_Echo_Qemu_mps2/main_networking.c print the network configuration even more visible.
- In MessageBufferDemo.c and Demo/Posix_GCC/main_full.c fix compiler warnings from "gcc -Wwrite-strings" by adding a const modifier.

<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
