### PR TITLE
Various Qemu Cortex M3 ports now support picolibc

### DIFF
--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Echo_Qemu_mps2/Makefile
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Echo_Qemu_mps2/Makefile
@@ -51,31 +51,38 @@ SOURCE_FILES += ${FREERTOS_TCP}/source/portable/BufferManagement/BufferAllocatio
 SOURCE_FILES += ${FREERTOS_TCP}/source/portable/NetworkInterface/MPS2_AN385/NetworkInterface.c
 SOURCE_FILES += ${FREERTOS_TCP}/source/portable/NetworkInterface/MPS2_AN385/ether_lan9118/smsc9220_eth_drv.c
 
-DEFINES := -DHEAP3
-CPPFLAGS += $(DEFINES)
+CPPFLAGS += -DHEAP3
 
+ifeq ($(PICOLIBC), 1)
+    CFLAGS += --specs=picolibc.specs -DPICOLIBC_INTEGER_PRINTF_SCANF --oslib=semihost
+endif
 CFLAGS += -mthumb -mcpu=cortex-m3
 ifeq ($(DEBUG), 1)
     CFLAGS += -g3 -Og -ffunction-sections -fdata-sections
 else
     CFLAGS += -Os -ffunction-sections -fdata-sections
 endif
-CFLAGS += -MMD
+#CFLAGS += -flto
 CFLAGS += -Wall -Wextra -Wshadow
 #CFLAGS += -Wpedantic -fanalyzer
-#CFLAGS += -flto
+CFLAGS += -MMD
 CFLAGS += $(INCLUDE_DIRS)
 
 LDFLAGS = -T mps2_m3.ld
 LDFLAGS += -Xlinker -Map=${BUILD_DIR}/output.map
 LDFLAGS += -Xlinker --gc-sections
-LDFLAGS += -nostartfiles -specs=nano.specs -specs=nosys.specs -specs=rdimon.specs
+#LDFLAGS += -Xlinker --print-gc-sections
+ifeq ($(PICOLIBC), 1)
+    LDFLAGS += -nostartfiles
+else
+    LDFLAGS += -nostartfiles -specs=nano.specs -specs=nosys.specs -specs=rdimon.specs
+endif
 
 OBJ_FILES := $(SOURCE_FILES:%.c=$(BUILD_DIR)/%.o)
 
 .PHONY: clean
 
-$(BUILD_DIR)/$(BIN) : $(OBJ_FILES)
+$(BUILD_DIR)/$(BIN): $(OBJ_FILES)
 	$(CC) $(CFLAGS) $(LDFLAGS) $+ -o $(@)
 	$(SIZE) $(@)
 
@@ -88,7 +95,7 @@ $(BUILD_DIR)/$(BIN) : $(OBJ_FILES)
 INCLUDES := $(SOURCE_FILES:%.c=$(BUILD_DIR)/%.d)
 -include $(INCLUDES)
 
-${BUILD_DIR}/%.o : %.c Makefile
+${BUILD_DIR}/%.o: %.c Makefile
 	-mkdir -p $(@D)
 	$(CC) $(CFLAGS) $(CPPFLAGS) -c $< -o $@
 

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Echo_Qemu_mps2/main_networking.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Echo_Qemu_mps2/main_networking.c
@@ -142,9 +142,10 @@ static UBaseType_t ulNextRand;
 void main_tcp_echo_client_tasks( void )
 {
     BaseType_t xReturn;
-#ifndef __PICOLIBC__
-    const uint32_t ulLongTime_ms = pdMS_TO_TICKS( 1000UL );
-#endif
+
+    #ifndef __PICOLIBC__
+        const uint32_t ulLongTime_ms = pdMS_TO_TICKS( 1000UL );
+    #endif
 
     /*
      * Instructions for using this project are provided on:
@@ -205,9 +206,9 @@ void main_tcp_echo_client_tasks( void )
      * really applicable to the Linux simulator port). */
     for( ; ; )
     {
-#ifndef __PICOLIBC__
-        usleep( ulLongTime_ms * 1000 );
-#endif
+        #ifndef __PICOLIBC__
+            usleep( ulLongTime_ms * 1000 );
+        #endif
     }
 }
 /*-----------------------------------------------------------*/

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Echo_Qemu_mps2/main_networking.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Echo_Qemu_mps2/main_networking.c
@@ -142,7 +142,9 @@ static UBaseType_t ulNextRand;
 void main_tcp_echo_client_tasks( void )
 {
     BaseType_t xReturn;
+#ifndef __PICOLIBC__
     const uint32_t ulLongTime_ms = pdMS_TO_TICKS( 1000UL );
+#endif
 
     /*
      * Instructions for using this project are provided on:
@@ -203,7 +205,9 @@ void main_tcp_echo_client_tasks( void )
      * really applicable to the Linux simulator port). */
     for( ; ; )
     {
+#ifndef __PICOLIBC__
         usleep( ulLongTime_ms * 1000 );
+#endif
     }
 }
 /*-----------------------------------------------------------*/

--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Echo_Qemu_mps2/mps2_m3.ld
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Echo_Qemu_mps2/mps2_m3.ld
@@ -124,8 +124,10 @@ SECTIONS
         PROVIDE ( end = . );
         PROVIDE ( _end = . );
         _heap_bottom = .;
+        __heap_start = .;
         . = . + _Min_Heap_Size;
         _heap_top = .;
+        __heap_end = .;
         . = . + _Min_Stack_Size;
         . = ALIGN(8);
     } >RAM

--- a/FreeRTOS/Demo/CORTEX_MPS2_QEMU_IAR_GCC/build/gcc/Makefile
+++ b/FreeRTOS/Demo/CORTEX_MPS2_QEMU_IAR_GCC/build/gcc/Makefile
@@ -9,20 +9,23 @@ LD = arm-none-eabi-gcc
 SIZE = arm-none-eabi-size
 MAKE = make
 
-CFLAGS += -ffreestanding -mthumb -mcpu=cortex-m3
-CFLAGS += -Wall -Wextra -Wshadow -Wno-unused-value
+ifeq ($(PICOLIBC), 1)
+    CFLAGS += --specs=picolibc.specs -DPICOLIBC_INTEGER_PRINTF_SCANF
+endif
+CFLAGS += -mthumb -mcpu=cortex-m3
 CFLAGS += -g3 -Os -ffunction-sections -fdata-sections
-CFLAGS += -MMD -MP -MF"$(@:%.o=%.d)" -MT $@
-#CFLAGS += -std=c99
-#CFLAGS += -Wpedantic -fanalyzer
 #CFLAGS += -flto
+CFLAGS += -Wall -Wextra -Wshadow -Wno-unused-value
+CFLAGS += -MMD -MP -MF"$(@:%.o=%.d)" -MT $@
 CFLAGS += $(INCLUDE_DIRS)
 
 LDFLAGS = -T ./mps2_m3.ld
 LDFLAGS += -Xlinker -Map=$(OUTPUT_DIR)/RTOSDemo.map
 LDFLAGS += -Xlinker --gc-sections
-LDFLAGS += -nostartfiles
-LDFLAGS += -specs=nano.specs -specs=nosys.specs # -specs=rdimon.specs
+#LDFLAGS += -Xlinker --print-gc-sections
+ifneq ($(PICOLIBC), 1)
+    LDFLAGS += -nostartfiles -specs=nano.specs -specs=nosys.specs # -specs=rdimon.specs
+endif
 
 #
 # Kernel build.

--- a/FreeRTOS/Demo/CORTEX_MPS2_QEMU_IAR_GCC/build/gcc/Makefile
+++ b/FreeRTOS/Demo/CORTEX_MPS2_QEMU_IAR_GCC/build/gcc/Makefile
@@ -12,7 +12,7 @@ MAKE = make
 ifeq ($(PICOLIBC), 1)
     CFLAGS += --specs=picolibc.specs -DPICOLIBC_INTEGER_PRINTF_SCANF
 endif
-CFLAGS += -mthumb -mcpu=cortex-m3
+CFLAGS += -mthumb -mcpu=cortex-m3 -ffreestanding
 CFLAGS += -g3 -Os -ffunction-sections -fdata-sections
 #CFLAGS += -flto
 CFLAGS += -Wall -Wextra -Wshadow -Wno-unused-value
@@ -102,7 +102,7 @@ VPATH += $(TRACERECORDER_DIR)
 VPATH += $(TRACERECORDER_DIR)/kernelports/FreeRTOS
 VPATH += $(TRACERECORDER_DIR)/streamports/RingBuffer
 INCLUDE_DIRS += -I$(TRACERECORDER_CFG_DIR)
-INCLUDE_DIRS += -I$(TRACERECORDER_DIR)/include 
+INCLUDE_DIRS += -I$(TRACERECORDER_DIR)/include
 INCLUDE_DIRS += -I$(TRACERECORDER_DIR)/kernelports/FreeRTOS/include
 INCLUDE_DIRS += -I$(TRACERECORDER_DIR)/streamports/RingBuffer/include
 SOURCE_FILES +=	(TRACERECORDER_DIR)/kernelports/FreeRTOS/trcKernelPort.c

--- a/FreeRTOS/Demo/CORTEX_MPS2_QEMU_IAR_GCC/build/gcc/startup_gcc.c
+++ b/FreeRTOS/Demo/CORTEX_MPS2_QEMU_IAR_GCC/build/gcc/startup_gcc.c
@@ -79,7 +79,7 @@ const uint32_t* isr_vector[] __attribute__((section(".isr_vector"), used)) =
 
 void Reset_Handler( void )
 {
-    main();
+    (void) main();
 }
 
 /* Variables used to store the value of registers at the time a hardfault

--- a/FreeRTOS/Demo/CORTEX_MPS2_QEMU_IAR_GCC/main.c
+++ b/FreeRTOS/Demo/CORTEX_MPS2_QEMU_IAR_GCC/main.c
@@ -103,7 +103,7 @@ static void prvUARTInit( void );
 
 /*-----------------------------------------------------------*/
 
-void main( void )
+int main( void )
 {
     /* See https://www.freertos.org/freertos-on-qemu-mps2-an385-model.html for
      * instructions. */
@@ -141,6 +141,7 @@ void main( void )
         main_full();
     }
     #endif
+    return 0;
 }
 /*-----------------------------------------------------------*/
 
@@ -313,6 +314,25 @@ static void prvUARTInit( void )
 }
 /*-----------------------------------------------------------*/
 
+#ifdef __PICOLIBC__
+int
+_uart_putc(char c, FILE *file)
+{
+    ( void ) file;
+
+    while( ( UART0_STATE & TX_BUFFER_MASK ) != 0 )
+    {
+    }
+
+    UART0_DATA = c;
+    return (unsigned char) c;
+}
+
+static FILE __stdio = FDEV_SETUP_STREAM(_uart_putc, NULL, NULL, _FDEV_SETUP_WRITE);
+__attribute__( ( used ) ) FILE *const stdout = &__stdio;
+#else
+/*-----------------------------------------------------------*/
+
 int __write( int iFile,
              char * pcString,
              int iStringLength )
@@ -351,3 +371,4 @@ void * malloc( size_t size )
     {
     }
 }
+#endif

--- a/FreeRTOS/Demo/CORTEX_MPU_M3_MPS2_QEMU_GCC/Makefile
+++ b/FreeRTOS/Demo/CORTEX_MPU_M3_MPS2_QEMU_GCC/Makefile
@@ -35,29 +35,29 @@ INCLUDE_DIRS          +=    -I$(FREERTOS_DIR)/Demo/CORTEX_MPU_M3_MPS2_QEMU_GCC/C
 INCLUDE_DIRS          +=    -I$(KERNEL_DIR)/include
 INCLUDE_DIRS          +=    -I$(KERNEL_DIR)/portable/GCC/ARM_CM3_MPU
 
-DEFINES               :=    -DHEAP4
-CPPFLAGS              +=    $(DEFINES)
+CPPFLAGS              +=    -DHEAP4
 
+ifeq ($(PICOLIBC), 1)
+    CFLAGS            +=     --specs=picolibc.specs -DPICOLIBC_INTEGER_PRINTF_SCANF
+endif
 CFLAGS                +=    -mthumb -mcpu=cortex-m3
+ifeq ($(DEBUG), 1)
+    CFLAGS            +=     -g3 -Og -ffunction-sections -fdata-sections -save-temps=obj
+else
+    CFLAGS            +=     -Os -ffunction-sections -fdata-sections
+endif
+#CFLAGS                +=    -flto
 CFLAGS                +=    -Wall -Wextra -Wshadow -Wno-unused-parameter
-#CFLAGS                +=    -Wpedantic -fanalyzer
 CFLAGS                +=    $(INCLUDE_DIRS)
 
 LDFLAGS                =    -T ./scripts/mps2_m3.ld
 LDFLAGS               +=    -Xlinker -Map=${BUILD_DIR}/output.map
 LDFLAGS               +=    -Xlinker --gc-sections
-LDFLAGS               +=    -nostartfiles -nostdlib -nolibc -nodefaultlibs
+#LDFLAGS               +=    -Xlinker --print-gc-sections
+#LDFLAGS               +=    -nostartfiles -nostdlib -nolibc -nodefaultlibs
+LDFLAGS               +=    -nostdlib
 
-ifeq ($(DEBUG), 1)
-    CFLAGS                +=     -g3 -Og -ffunction-sections -fdata-sections -save-temps=obj
-else
-    CFLAGS                +=     -Os -ffunction-sections -fdata-sections
-endif
 
-ifeq ($(PICOLIBC), 1)
-    CFLAGS                +=     --specs=picolibc.specs -DPICOLIBC_INTEGER_PRINTF_SCANF
-   LDFLAGS                +=     --specs=picolibc.specs -DPICOLIBC_INTEGER_PRINTF_SCANF
-endif
 
 OBJ_FILES             :=    $(SOURCE_FILES:%.c=$(BUILD_DIR)/%.o)
 

--- a/FreeRTOS/Demo/CORTEX_MPU_M3_MPS2_QEMU_GCC/scripts/mps2_m3.ld
+++ b/FreeRTOS/Demo/CORTEX_MPU_M3_MPS2_QEMU_GCC/scripts/mps2_m3.ld
@@ -66,7 +66,8 @@ SECTIONS
         *(privileged_functions)
         . = ALIGN(4);
         FILL(0xDEAD);
-        /* Ensure that un-privileged code is placed after the region reserved                                                                                                                                         4          * for privileged kernel code. */
+        /* Ensure that un-privileged code is placed after the region reserved
+	    * for privileged kernel code. */
         /* Note that dot (.) actually refers to the byte offset from the start
             * of the current section (.privileged_functions in this case). As a
             * result, setting dot (.) to a value sets the size of the section. */

--- a/FreeRTOS/Demo/CORTEX_MPU_M3_MPS2_QEMU_GCC/syscall.c
+++ b/FreeRTOS/Demo/CORTEX_MPU_M3_MPS2_QEMU_GCC/syscall.c
@@ -76,7 +76,7 @@ _uart_putc(char c, FILE *file)
 
 static FILE __stdio = FDEV_SETUP_STREAM(_uart_putc, NULL, NULL, _FDEV_SETUP_WRITE);
 
-FILE *const stdout = &__stdio;
+__attribute__( ( used ) ) FILE *const stdout = &__stdio;
 
 #else
 


### PR DESCRIPTION
Allow various Qemu Cortex M3 ports to compile against picolibc. Also support "-flto" to work correctly.
Tested with picolibc in current Debian 13.
Just use "PICOLIBC=1 make" to switch over from default newlib.

<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
