### PR TITLE
Fix build of & add CMake to LM3S Qemu Demo

### DIFF
--- a/FreeRTOS/Demo/CORTEX_LM3S6965_GCC_QEMU/.cproject
+++ b/FreeRTOS/Demo/CORTEX_LM3S6965_GCC_QEMU/.cproject
@@ -202,7 +202,7 @@
 						</tool>
 					</fileInfo>
 					<sourceEntries>
-						<entry excluding="FreeRTOS+Trace Recorder" flags="VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name=""/>
+						<entry excluding="FreeRTOS_Source/examples|FreeRTOS+Trace Recorder" flags="VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name=""/>
 					</sourceEntries>
 				</configuration>
 			</storageModule>

--- a/FreeRTOS/Demo/CORTEX_LM3S6965_GCC_QEMU/.cproject
+++ b/FreeRTOS/Demo/CORTEX_LM3S6965_GCC_QEMU/.cproject
@@ -202,7 +202,7 @@
 						</tool>
 					</fileInfo>
 					<sourceEntries>
-						<entry excluding="FreeRTOS_Source/examples|FreeRTOS+Trace Recorder" flags="VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name=""/>
+						<entry excluding="FreeRTOS_Source/examples|build|FreeRTOS+Trace Recorder" flags="VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name=""/>
 					</sourceEntries>
 				</configuration>
 			</storageModule>

--- a/FreeRTOS/Demo/CORTEX_LM3S6965_GCC_QEMU/CMakeLists.txt
+++ b/FreeRTOS/Demo/CORTEX_LM3S6965_GCC_QEMU/CMakeLists.txt
@@ -45,6 +45,11 @@ target_link_libraries(RTOSDemo PUBLIC
 add_custom_target(run
     COMMAND qemu-system-arm
         -machine lm3s6965evb
+        -monitor null
+        -semihosting
+        --semihosting-config enable=on,target=native
+        -serial stdio
+        -nographic
         -s # gdb tcp::1234
         -S
         -kernel $<TARGET_FILE:RTOSDemo>

--- a/FreeRTOS/Demo/CORTEX_LM3S6965_GCC_QEMU/CMakeLists.txt
+++ b/FreeRTOS/Demo/CORTEX_LM3S6965_GCC_QEMU/CMakeLists.txt
@@ -1,0 +1,53 @@
+cmake_minimum_required(VERSION 3.21)
+
+project(RTOSDemo LANGUAGES C ASM)
+
+set(FREERTOS_BASE "${CMAKE_CURRENT_LIST_DIR}/../../")
+set(FREERTOS_PORT GCC_ARM_CM3)
+set(FREERTOS_HEAP 4)
+add_library(freertos_config INTERFACE)
+target_include_directories(freertos_config INTERFACE .)
+add_subdirectory("${FREERTOS_BASE}/Source" FreeRTOS_kernel)
+
+add_executable(RTOSDemo
+    startup.c
+    main.c
+    LocalDemoFiles/IntQueueTimer.c
+    LocalDemoFiles/osram128x64x4.c
+    LocalDemoFiles/printf-stdarg.c
+    LocalDemoFiles/timertest.c
+
+    ../Common/Minimal/blocktim.c
+    ../Common/Minimal/death.c
+    ../Common/Minimal/EventGroupsDemo.c
+    ../Common/Minimal/IntQueue.c
+    ../Common/Minimal/MessageBufferDemo.c
+    ../Common/Minimal/QPeek.c
+    ../Common/Minimal/QueueSet.c
+    ../Common/Minimal/recmutex.c
+    ../Common/Minimal/semtest.c
+    ../Common/Minimal/StreamBufferDemo.c
+
+    ../Common/drivers/LuminaryMicro/ustdlib.c
+)
+target_include_directories(RTOSDemo PUBLIC
+    .
+    LocalDemoFiles
+    ../Common/include
+    ../Common/drivers/LuminaryMicro
+)
+target_link_libraries(RTOSDemo PUBLIC
+    freertos_kernel
+    "${CMAKE_CURRENT_LIST_DIR}/../Common/drivers/LuminaryMicro/arm-none-eabi-gcc/libdriver.a"
+    "${CMAKE_CURRENT_LIST_DIR}/../Common/drivers/LuminaryMicro/arm-none-eabi-gcc/libgr.a"
+)
+
+add_custom_target(run
+    COMMAND qemu-system-arm
+        -machine lm3s6965evb
+        -s # gdb tcp::1234
+        -S
+        -kernel $<TARGET_FILE:RTOSDemo>
+    VERBATIM COMMAND_EXPAND_LISTS
+    COMMENT "You can now attach GDB to localhost:1234"
+)

--- a/FreeRTOS/Demo/CORTEX_LM3S6965_GCC_QEMU/CMakePresets.json
+++ b/FreeRTOS/Demo/CORTEX_LM3S6965_GCC_QEMU/CMakePresets.json
@@ -1,0 +1,36 @@
+{
+  "version": 6,
+  "configurePresets": [
+    {
+      "name": "debug",
+      "toolchainFile": "gcc-arm-embedded.cmake",
+      "binaryDir": "build",
+      "generator": "Ninja",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "debug",
+        "CMAKE_EXPORT_COMPILE_COMMANDS": true
+      }
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "debug",
+      "configurePreset": "debug"
+    }
+  ],
+  "workflowPresets": [
+    {
+      "name": "debug",
+      "steps": [
+        {
+          "type": "configure",
+          "name": "debug"
+        },
+        {
+          "type": "build",
+          "name": "debug"
+        }
+      ]
+    }
+  ]
+}

--- a/FreeRTOS/Demo/CORTEX_LM3S6965_GCC_QEMU/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/CORTEX_LM3S6965_GCC_QEMU/FreeRTOSConfig.h
@@ -95,7 +95,7 @@ FreeRTOS/Source/tasks.c for limitations. */
 #define configKERNEL_INTERRUPT_PRIORITY 		( 255 )	/* All eight bits as QEMU doesn't model the priority bits. */
 /* !!!! configMAX_SYSCALL_INTERRUPT_PRIORITY must not be set to zero !!!!
 See http://www.FreeRTOS.org/RTOS-Cortex-M3-M4.html. */
-#define configMAX_SYSCALL_INTERRUPT_PRIORITY 	( 4 )
+#define configMAX_SYSCALL_INTERRUPT_PRIORITY 	( 0x40 )
 
 /* Use the Cortex-M3 optimised task selection rather than the generic C code
 version. */

--- a/FreeRTOS/Demo/CORTEX_LM3S6965_GCC_QEMU/StartQEMU.bat
+++ b/FreeRTOS/Demo/CORTEX_LM3S6965_GCC_QEMU/StartQEMU.bat
@@ -1,2 +1,1 @@
 qemu-system-arm -machine lm3s6965evb -s -S -kernel ./debug/RTOSDemo.elf
-

--- a/FreeRTOS/Demo/CORTEX_LM3S6965_GCC_QEMU/gcc-arm-embedded.cmake
+++ b/FreeRTOS/Demo/CORTEX_LM3S6965_GCC_QEMU/gcc-arm-embedded.cmake
@@ -1,0 +1,52 @@
+set(CMAKE_SYSTEM_NAME      Generic)
+set(CMAKE_SYSTEM_PROCESSOR arm)
+
+set(CMAKE_TOOLCHAIN_PREFIX arm-none-eabi-)
+
+set(CMAKE_C_COMPILER   ${CMAKE_TOOLCHAIN_PREFIX}gcc)
+set(CMAKE_ASM_COMPILER ${CMAKE_C_COMPILER})
+set(CMAKE_CXX_COMPILER ${CMAKE_TOOLCHAIN_PREFIX}g++)
+set(CMAKE_LINKER       ${CMAKE_TOOLCHAIN_PREFIX}gcc)
+set(CMAKE_OBJCOPY      ${CMAKE_TOOLCHAIN_PREFIX}objcopy)
+set(CMAKE_SIZE         ${CMAKE_TOOLCHAIN_PREFIX}size)
+
+set(CMAKE_EXECUTABLE_SUFFIX_ASM ".elf")
+set(CMAKE_EXECUTABLE_SUFFIX_C   ".elf")
+set(CMAKE_EXECUTABLE_SUFFIX_CXX ".elf")
+
+# Adjust the default behavior of the FIND_XXX() commands:
+# - Search programs in the host environment
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+# - Search headers and libraries in the target environment
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+
+# Don't try to execute linked programs
+set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
+
+set(CMAKE_C_FLAGS_INIT "-mcpu=cortex-m3 -mthumb")
+set(CMAKE_C_FLAGS_INIT "${CMAKE_C_FLAGS_INIT} --specs=nano.specs")
+
+# Always build debug information (stripped out for executable)
+# Add `-g3` to put macro values into debug information
+if(CMAKE_BUILD_TYPE MATCHES Debug)
+    set(CMAKE_C_FLAGS_INIT "${CMAKE_C_FLAGS_INIT} -O0 -g3")
+endif()
+if(CMAKE_BUILD_TYPE MATCHES Release)
+    set(CMAKE_C_FLAGS_INIT "${CMAKE_C_FLAGS_INIT} -O3 -g3")
+endif()
+if(CMAKE_BUILD_TYPE MATCHES MinSizeRel)
+    set(CMAKE_C_FLAGS_INIT "${CMAKE_C_FLAGS_INIT} -Os -g3")
+endif()
+
+set(CMAKE_ASM_FLAGS_INIT "${CMAKE_C_FLAGS_INIT} -x assembler-with-cpp")
+set(CMAKE_CXX_FLAGS_INIT "${CMAKE_C_FLAGS_INIT} -fno-rtti -fno-exceptions")
+
+set(CMAKE_ASM_LINK_FLAGS "-T ${CMAKE_CURRENT_LIST_DIR}/standalone.ld -nostartfiles")
+set(CMAKE_ASM_LINK_FLAGS "${CMAKE_ASM_LINK_FLAGS} -Wl,-Map=${CMAKE_PROJECT_NAME}.map")
+set(CMAKE_ASM_LINK_FLAGS "${CMAKE_ASM_LINK_FLAGS} -Wl,--print-memory-usage")
+
+set(CMAKE_C_LINK_FLAGS "${CMAKE_ASM_LINK_FLAGS} -Wl,--start-group -lc -lm -Wl,--end-group")
+set(CMAKE_C_LINK_FLAGS "${CMAKE_C_LINK_FLAGS} -ffunction-sections -fdata-sections -Wl,--gc-sections")
+
+set(CMAKE_CXX_LINK_FLAGS "${CMAKE_C_LINK_FLAGS} -Wl,--start-group -lstdc++ -lsupc++ -Wl,--end-group")

--- a/FreeRTOS/Demo/CORTEX_LM3S6965_GCC_QEMU/standalone.ld
+++ b/FreeRTOS/Demo/CORTEX_LM3S6965_GCC_QEMU/standalone.ld
@@ -4,24 +4,24 @@
  *                 DriverLib.
  *
  * Copyright (c) 2005-2007 Luminary Micro, Inc.  All rights reserved.
- * 
+ *
  * Software License Agreement
- * 
+ *
  * Luminary Micro, Inc. (LMI) is supplying this software for use solely and
  * exclusively on LMI's microcontroller products.
- * 
+ *
  * The software is owned by LMI and/or its suppliers, and is protected under
  * applicable copyright laws.  All rights are reserved.  Any use in violation
  * of the foregoing restrictions may subject the user to criminal sanctions
  * under applicable laws, as well as to civil liability for the breach of the
  * terms and conditions of this license.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED "AS IS".  NO WARRANTIES, WHETHER EXPRESS, IMPLIED
  * OR STATUTORY, INCLUDING, BUT NOT LIMITED TO, IMPLIED WARRANTIES OF
  * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE APPLY TO THIS SOFTWARE.
  * LMI SHALL NOT, IN ANY CIRCUMSTANCES, BE LIABLE FOR SPECIAL, INCIDENTAL, OR
  * CONSEQUENTIAL DAMAGES, FOR ANY REASON WHATSOEVER.
- * 
+ *
  * This is part of revision 1392 of the Stellaris Peripheral Driver Library.
  *
  *****************************************************************************/

--- a/FreeRTOS/Demo/CORTEX_LM3S6965_GCC_QEMU/standalone.ld
+++ b/FreeRTOS/Demo/CORTEX_LM3S6965_GCC_QEMU/standalone.ld
@@ -57,4 +57,9 @@ SECTIONS
         *(COMMON)
         _ebss = .;
     } > SRAM
+
+    /DISCARD/ :
+    {
+        *(.ARM.exidx)
+    }
 }

--- a/FreeRTOS/Demo/CORTEX_LM3S6965_GCC_QEMU/startup.c
+++ b/FreeRTOS/Demo/CORTEX_LM3S6965_GCC_QEMU/startup.c
@@ -252,4 +252,3 @@ uipprintf(const char *fmt, ...)
 	( void ) fmt;
     return(0);
 }
-

--- a/FreeRTOS/Demo/CORTEX_LM3S6965_GCC_QEMU/trcConfig.h
+++ b/FreeRTOS/Demo/CORTEX_LM3S6965_GCC_QEMU/trcConfig.h
@@ -123,7 +123,7 @@ __attribute__( ( always_inline ) ) static inline void __set_PRIMASK(uint32_t pri
  * trace recorder library with an older version of FreeRTOS).
  *
  * TRC_FREERTOS_VERSION_7_3_X          If using FreeRTOS v7.3.X
- * TRC_FREERTOS_VERSION_7_4_X          If using FreeRTOS v7.4.X 
+ * TRC_FREERTOS_VERSION_7_4_X          If using FreeRTOS v7.4.X
  * TRC_FREERTOS_VERSION_7_5_X          If using FreeRTOS v7.5.X
  * TRC_FREERTOS_VERSION_7_6_X          If using FreeRTOS v7.6.X
  * TRC_FREERTOS_VERSION_8_X_X          If using FreeRTOS v8.X.X


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->
I wanted to build the Qemu demo to play around with it, and also build it without Eclipse if possible (just personal preference). I currently haven't added the FreeRTOS+Trace bits to the CMake, as they aren't used by default.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->
Now I can build & run using `cmake --preset=debug && cmake --build --preset=debug --target run`.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
