### PR TITLE
Demo/Common: fix divide by zero possibility and non-used return values

### DIFF
--- a/FreeRTOS/Demo/Common/Minimal/StreamBufferDemo.c
+++ b/FreeRTOS/Demo/Common/Minimal/StreamBufferDemo.c
@@ -560,7 +560,7 @@ static void prvSingleTaskTests( StreamBufferHandle_t xStreamBuffer )
     /* Ensure data was written as expected even when there was an attempt to
      * write more than was available.  This also tries to read more bytes than are
      * available. */
-    xReturned = xStreamBufferReceive( xStreamBuffer, ( void * ) pucFullBuffer, xFullBufferSize, xMinimalBlockTime );
+    xStreamBufferReceive( xStreamBuffer, ( void * ) pucFullBuffer, xFullBufferSize, xMinimalBlockTime );
     prvCheckExpectedState( memcmp( ( const void * ) pucFullBuffer, ( const void * ) pc54ByteString, sbSTREAM_BUFFER_LENGTH_BYTES ) == 0 );
     prvCheckExpectedState( xStreamBufferIsFull( xStreamBuffer ) == pdFALSE );
     prvCheckExpectedState( xStreamBufferIsEmpty( xStreamBuffer ) == pdTRUE );

--- a/FreeRTOS/Demo/Common/Minimal/TaskNotify.c
+++ b/FreeRTOS/Demo/Common/Minimal/TaskNotify.c
@@ -242,6 +242,7 @@ static void prvSingleTaskTests( void )
     configASSERT( xReturned == pdPASS );
     ( void ) xReturned; /* In case configASSERT() is not defined. */
     xReturned = xTaskNotifyWait( notifyUINT32_MAX, 0, &ulNotifiedValue, 0 );
+    configASSERT( xReturned == pdPASS );
     configASSERT( ulNotifiedValue == ulSecondNotifiedValueConst );
     ( void ) ulNotifiedValue; /* In case configASSERT() is not defined. */
 

--- a/FreeRTOS/Demo/Common/Minimal/TimerDemo.c
+++ b/FreeRTOS/Demo/Common/Minimal/TimerDemo.c
@@ -230,8 +230,8 @@ static void prvTimerTestTask( void * pvParameters )
 BaseType_t xAreTimerDemoTasksStillRunning( TickType_t xCycleFrequency )
 {
     static uint32_t ulLastLoopCounter = 0UL;
-    TickType_t xMaxBlockTimeUsedByTheseTests, xLoopCounterIncrementTimeMax;
     static TickType_t xIterationsWithoutCounterIncrement = ( TickType_t ) 0, xLastCycleFrequency;
+    TickType_t xMaxBlockTimeUsedByTheseTests, xLoopCounterIncrementTimeMax;
 
     if( xLastCycleFrequency != xCycleFrequency )
     {
@@ -241,17 +241,22 @@ BaseType_t xAreTimerDemoTasksStillRunning( TickType_t xCycleFrequency )
         xLastCycleFrequency = xCycleFrequency;
     }
 
-    /* Calculate the maximum number of times that it is permissible for this
-     * function to be called without ulLoopCounter being incremented.  This is
-     * necessary because the tests in this file block for extended periods, and the
-     * block period might be longer than the time between calls to this function. */
-    xMaxBlockTimeUsedByTheseTests = ( ( TickType_t ) configTIMER_QUEUE_LENGTH ) * xBasePeriod;
-    xLoopCounterIncrementTimeMax = ( xMaxBlockTimeUsedByTheseTests / xCycleFrequency ) + 1;
-
     /* If the demo task is still running then the loop counter is expected to
      * have incremented every xLoopCounterIncrementTimeMax calls. */
     if( ulLastLoopCounter == ulLoopCounter )
     {
+        /* Calculate the maximum number of times that it is permissible for this
+         * function to be called without ulLoopCounter being incremented.  This is
+         * necessary because the tests in this file block for extended periods, and the
+         * block period might be longer than the time between calls to this function. */
+        xMaxBlockTimeUsedByTheseTests = ( ( TickType_t ) configTIMER_QUEUE_LENGTH ) * xBasePeriod;
+        if( xCycleFrequency != ( TickType_t ) 0 )
+        {
+            xLoopCounterIncrementTimeMax = ( xMaxBlockTimeUsedByTheseTests / xCycleFrequency ) + 1;
+        } else {
+            xLoopCounterIncrementTimeMax = ( TickType_t ) 0;
+        }
+
         xIterationsWithoutCounterIncrement++;
 
         if( xIterationsWithoutCounterIncrement > xLoopCounterIncrementTimeMax )

--- a/FreeRTOS/Demo/Common/Minimal/TimerDemo.c
+++ b/FreeRTOS/Demo/Common/Minimal/TimerDemo.c
@@ -233,6 +233,8 @@ BaseType_t xAreTimerDemoTasksStillRunning( TickType_t xCycleFrequency )
     static TickType_t xIterationsWithoutCounterIncrement = ( TickType_t ) 0, xLastCycleFrequency;
     TickType_t xMaxBlockTimeUsedByTheseTests, xLoopCounterIncrementTimeMax;
 
+    configASSERT( xCycleFrequency != 0UL );
+
     if( xLastCycleFrequency != xCycleFrequency )
     {
         /* The cycle frequency has probably become much faster due to an error
@@ -250,12 +252,7 @@ BaseType_t xAreTimerDemoTasksStillRunning( TickType_t xCycleFrequency )
          * necessary because the tests in this file block for extended periods, and the
          * block period might be longer than the time between calls to this function. */
         xMaxBlockTimeUsedByTheseTests = ( ( TickType_t ) configTIMER_QUEUE_LENGTH ) * xBasePeriod;
-        if( xCycleFrequency != ( TickType_t ) 0 )
-        {
-            xLoopCounterIncrementTimeMax = ( xMaxBlockTimeUsedByTheseTests / xCycleFrequency ) + 1;
-        } else {
-            xLoopCounterIncrementTimeMax = ( TickType_t ) 0;
-        }
+        xLoopCounterIncrementTimeMax = ( xMaxBlockTimeUsedByTheseTests / xCycleFrequency ) + 1;
 
         xIterationsWithoutCounterIncrement++;
 


### PR DESCRIPTION
- In TimerDemo.c fix possible divide by zero in "xMaxBlockTimeUsedByTheseTests / xCycleFrequency".
- Move this code in TimerDemo.c into if-clause where it is actually used.
- In Minimal/StreamBufferDemo.c and Minimal/TaskNotify.c avoid unused return values.

<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
