### PR TITLE
Fix: Validate first copyright is FreeRTOS

### DIFF
--- a/.github/scripts/common/header_checker.py
+++ b/.github/scripts/common/header_checker.py
@@ -131,10 +131,8 @@ class HeaderChecker:
         """Validate a given section based on file extentions and section name"""
         valid = False
         if self.copyright_regex and section_name == "copyright":
-            valid = True
-            for line in section:
-                if not self.copyright_regex.match(line):
-                    valid = False
+            if not self.copyright_regex.match(section[0]):
+                valid = False
         elif file_ext in self.pyExtList:
             valid = self.headers_py[section_name] == section
         elif file_ext in self.asmExtList:


### PR DESCRIPTION
Description
-----------
Switch to validating that the first copyright is FreeRTOS. This allows partners (example: Arm) to add their own copyrights on contributions.

This will ensure multiple copyright statements do not break header checks.

Test Steps
-----------
Work in progress

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [N/A] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
[Example of a PR](https://github.com/FreeRTOS/FreeRTOS-Kernel/pull/1314) failing header checks due to multiple copyright lines.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
