### PR TITLE
Downgrade return-mismatch error to warning

### DIFF
--- a/FreeRTOS/Demo/WIN32-MingW/Makefile
+++ b/FreeRTOS/Demo/WIN32-MingW/Makefile
@@ -3,7 +3,7 @@ BUILD_DIR := ./build
 
 # Compiler - Note this expects you are using MinGW version of GCC
 CC := gcc
-CFLAGS := -O0 -g3 -Wall -Wextra -c -fmessage-length=0 -Wcast-qual -D_WIN32_WINNT=0x0601
+CFLAGS := -O0 -g3 -Wall -Wextra -c -fmessage-length=0 -Wcast-qual -Wno-error=return-mismatch -D_WIN32_WINNT=0x0601
 
 ifeq ($(COVERAGE_TEST),1)
   CFLAGS += -DprojCOVERAGE_TEST=1


### PR DESCRIPTION
Description
-----------
`portYIELD_FROM_ISR(x)` is defined as `return x` in the Windows port which causes compilation failures in the WIN32-MinGW demo when using GCC 14.

Test Steps
-----------
Successful build - https://github.com/aggarg/FreeRTOS/actions/runs/18273477974/job/52020218185.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
https://github.com/FreeRTOS/FreeRTOS-Kernel/actions/runs/18272553628/job/52017559140?pr=1317

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
