### PR TITLE
fix .d Makefile rule

### DIFF
--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Echo_Qemu_mps2/Makefile
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Echo_Qemu_mps2/Makefile
@@ -86,9 +86,10 @@ $(BUILD_DIR)/$(BIN): $(OBJ_FILES)
 	$(CC) $(CFLAGS) $(LDFLAGS) $+ -o $(@)
 	$(SIZE) $(@)
 
-%.d: %.c
-	@set -e; rm -f $@; \
-	$(CC) -M $(CPPFLAGS) $< > $@.$$$$; \
+$(BUILD_DIR)/%.d: %.c
+	mkdir -p $(@D)
+	set -e; rm -f $@; \
+	$(CC) -M $(INCLUDE_DIRS) $(CPPFLAGS) $< > $@.$$$$; \
 	sed 's,\($*\)\.o[ :]*,\1.o $@ : ,g' < $@.$$$$ > $@; \
 	rm -f $@.$$$$
 


### PR DESCRIPTION
Change-Id: Ie1d0f9260303d598052ca94305424e2828134229

fix .d make rules

Description
-----------
the following make rule not exec when make,
and if this rule exec,  has compile error,
this commit will fix these issue.

-%.d: %.c
-       @set -e; rm -f $@; \
-       $(CC) -M $(CPPFLAGS) $< > $@.$$$$; \



Test Steps
-----------

cd FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Echo_Qemu_mps2/
make
cat build/startup.d
you will see this output
startup.o build/startup.d : startup.c \
 /.../toolchain/arm-gnu-toolchain-12.2.rel1-x86_64-arm-none-eabi/lib/gcc/arm-none-eabi/12.2.1/include/stdint.h \
 /.../toolchain/arm-gnu-toolchain-12.2.rel1-x86_64-arm-none-eabi/arm-none-eabi/include/stdint.h \

Checklist:
----------
1. elf success to generate
2. .d rule exec correctly

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
