### PR TITLE
Demo: allow overriding toolchain prefix in RISC-V QEMU virt GCC demo

### DIFF
--- a/FreeRTOS/Demo/RISC-V-Qemu-virt_GCC/Makefile
+++ b/FreeRTOS/Demo/RISC-V-Qemu-virt_GCC/Makefile
@@ -1,4 +1,6 @@
-CROSS   = riscv64-unknown-elf-
+# Toolchain prefix can be overridden, e.g.:
+#   make CROSS=riscv-none-elf-
+CROSS ?= riscv64-unknown-elf-
 CC      = $(CROSS)gcc
 OBJCOPY = $(CROSS)objcopy
 ARCH    = $(CROSS)ar


### PR DESCRIPTION
Description
-----------
This change makes the RISC-V QEMU virt GCC demo Makefile more portable by allowing
the toolchain prefix to be overridden via `make CROSS=...`.

The default behavior remains unchanged (`riscv64-unknown-elf-` is still used when
no override is provided), but this allows users to build the demo with alternative
toolchain prefixes such as `riscv-none-elf-` (e.g. xPack toolchains on macOS).

Test Steps
-----------
1. Build with an overridden toolchain prefix:
   - `make clean CROSS=riscv-none-elf-`
   - `make DEBUG=1 CROSS=riscv-none-elf-`
   - Verified that `build/RTOSDemo.axf` is generated successfully.

2. Verified that the default toolchain prefix remains unchanged when `CROSS` is not provided.

Checklist:
----------
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
N/A