### PR TITLE
Fix Fleet Provisioning demo flow issues

### DIFF
--- a/FreeRTOS-Plus/Demo/AWS/Fleet_Provisioning_Windows_Simulator/CSR_Demo/FleetProvisioningDemoExample.c
+++ b/FreeRTOS-Plus/Demo/AWS/Fleet_Provisioning_Windows_Simulator/CSR_Demo/FleetProvisioningDemoExample.c
@@ -823,7 +823,7 @@ int prvFleetProvisioningTask( void * pvParameters )
 
         /**** Retry in case of failure ****************************************/
 
-        xPkcs11CloseSession(xP11Session);
+        xPkcs11CloseSession( xP11Session );
 
         /* Increment the demo run count. */
         ulDemoRunCount++;

--- a/FreeRTOS-Plus/Demo/AWS/Fleet_Provisioning_Windows_Simulator/CSR_Demo/pkcs11_operations.c
+++ b/FreeRTOS-Plus/Demo/AWS/Fleet_Provisioning_Windows_Simulator/CSR_Demo/pkcs11_operations.c
@@ -392,7 +392,6 @@ bool xPkcs11CloseSession( CK_SESSION_HANDLE xP11Session )
         xResult = xFunctionList->C_CloseSession( xP11Session );
     }
 
-
     return( xResult == CKR_OK );
 }
 


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->

- Updated the flow of Fleet Provisioning demo reference code to avoid closing PKCS11 session prematurely.
- Updated the function `xPkcs11CloseSession` to avoid deinitializing PKCS#11 library prematurely.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->
Run the Fleet Provisioning demo reference code and observe the result.
_(Note: This issue was detected in a custom Fleet Provisioning application.)_ 

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->
Issue reported in FreeRTOS forum: [First connection to MQTT broker after Fleet Provisioning Demo always fails](https://forums.freertos.org/t/first-connection-to-mqtt-broker-after-fleet-provisioning-demo-always-fails/24810)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
