### PR TITLE
fix(logging): Add missing Windows.h include for WinSim build

### DIFF
--- a/FreeRTOS-Plus/Demo/Common/Logging/windows/Logging_WinSim.c
+++ b/FreeRTOS-Plus/Demo/Common/Logging/windows/Logging_WinSim.c
@@ -42,6 +42,9 @@
 #include <io.h>
 #include <ctype.h>
 
+/* Windows includes. */
+#include <windows.h>
+
 /* FreeRTOS includes. */
 #include "FreeRTOS.h"
 #include "task.h"


### PR DESCRIPTION


fix(logging): Add missing Windows.h include for WinSim build

Description
-----------
Logging_WinSim.c reference windows API and data structure.

In this PR:
- Added #include <Windows.h> to Logging_WinSim.c
- Resolves undefined identifier errors: WINAPI, HANDLE, TRUE, FALSE
- Fixes Windows API function declarations: CreateThread, SetEvent, etc.

Test Steps
-----------
Build FreeRTOS-Cellular-Interface should have no problem.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] ~~I have modified and/or added unit-tests to cover the code changes in this Pull Request.~~

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
