### PR TITLE
Fix timeout type from BaseType_t to TickType_t

### DIFF
--- a/FreeRTOS-Plus/Demo/Common/Demo_IP_Protocols/Common/FreeRTOS_TCP_server.c
+++ b/FreeRTOS-Plus/Demo/Common/Demo_IP_Protocols/Common/FreeRTOS_TCP_server.c
@@ -76,7 +76,7 @@
             if( pxServer != NULL )
             {
                 struct freertos_sockaddr xAddress;
-                BaseType_t xNoTimeout = 0;
+                TickType_t xNoTimeout = 0;
                 BaseType_t xIndex;
 
                 memset( pxServer, '\0', xSize );
@@ -112,8 +112,8 @@
                             FreeRTOS_bind( xSocket, &xAddress, sizeof( xAddress ) );
                             FreeRTOS_listen( xSocket, pxConfigs[ xIndex ].xBackLog );
 
-                            FreeRTOS_setsockopt( xSocket, 0, FREERTOS_SO_RCVTIMEO, ( void * ) &xNoTimeout, sizeof( BaseType_t ) );
-                            FreeRTOS_setsockopt( xSocket, 0, FREERTOS_SO_SNDTIMEO, ( void * ) &xNoTimeout, sizeof( BaseType_t ) );
+                            FreeRTOS_setsockopt( xSocket, 0, FREERTOS_SO_RCVTIMEO, ( void * ) &xNoTimeout, sizeof( TickType_t ) );
+                            FreeRTOS_setsockopt( xSocket, 0, FREERTOS_SO_SNDTIMEO, ( void * ) &xNoTimeout, sizeof( TickType_t ) );
 
                             #if ( ipconfigHTTP_RX_BUFSIZE > 0 )
                             {


### PR DESCRIPTION
Fix timeout type from BaseType_t to TickType_t

Description
-----------
Fixed a bug where the timeout value was not reflected correctly in FreeRTOS_TCP_Server when TickType_t was set to 64-bit.

Test Steps
-----------
In portmacro.h, change TickType_t to uint64_t.
Set xNoTimeout to 1000.
Verify that the loop runs every second.

Checklist:
----------
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
