### PR TITLE
Fixed a bug in the HTTP server sample where the browser would not respond when a 404 error occurred.

### DIFF
--- a/FreeRTOS-Plus/Demo/Common/Demo_IP_Protocols/HTTP_Server/FreeRTOS_HTTP_server.c
+++ b/FreeRTOS-Plus/Demo/Common/Demo_IP_Protocols/HTTP_Server/FreeRTOS_HTTP_server.c
@@ -297,6 +297,9 @@
 
         if( pxClient->pxFileHandle == NULL )
         {
+            snprintf( pxClient->pxParent->pcExtraContents, sizeof( pxClient->pxParent->pcExtraContents ),
+                      "Content-Length: 0\r\n" );
+
             /* "404 File not found". */
             xRc = prvSendReply( pxClient, WEB_NOT_FOUND );
         }


### PR DESCRIPTION
Fixed a bug in the HTTP server sample where the browser would not respond when a 404 error occurred.

Description
-----------
Fixed a bug that caused the browser to keep waiting for a response when a file was not found on the HTTP server.
The Content-Length header is missing only in the 404 case, so I added it, like this line:
https://github.com/FreeRTOS/FreeRTOS/blob/ff5a96c5017f8bee8399a4a04a360273fdc8cbad/FreeRTOS-Plus/Demo/Common/Demo_IP_Protocols/HTTP_Server/FreeRTOS_HTTP_server.c#L183-L187

Test Steps
-----------
Open your browser's debugging tools and open the Network tab.
Open a pathname that doesn't exist.
You'll see a 404 Not Found header, but the browser is still waiting for a response.

With this fix, your browser will respond immediately.
(However, it won't provide a richer experience.)

Tested on: Chrome Version 144.0.7559.110 (Official Build) (64-bit)

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
