### PR TITLE
Fix: Add missing xSemaphoreGive in TCP Echo Posix console.c

### DIFF
--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Echo_Posix/console.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Echo_Posix/console.c
@@ -34,12 +34,22 @@
 #include <FreeRTOS.h>
 #include <semphr.h>
 
-SemaphoreHandle_t xStdioMutex;
-StaticSemaphore_t xStdioMutexBuffer;
+#include "console.h"
+
+static SemaphoreHandle_t xStdioMutex;
+static StaticSemaphore_t xStdioMutexBuffer;
 
 void console_init( void )
 {
-    xStdioMutex = xSemaphoreCreateMutexStatic( &xStdioMutexBuffer );
+    #if ( configSUPPORT_STATIC_ALLOCATION == 1 )
+    {
+        xStdioMutex = xSemaphoreCreateMutexStatic( &xStdioMutexBuffer );
+    }
+    #else /* if( configSUPPORT_STATIC_ALLOCATION == 1 ) */
+    {
+        xStdioMutex = xSemaphoreCreateMutex();
+    }
+    #endif /* if( configSUPPORT_STATIC_ALLOCATION == 1 ) */
 }
 
 void console_print( const char * fmt,
@@ -53,6 +63,7 @@ void console_print( const char * fmt,
 
     vprintf( fmt, vargs );
 
+    xSemaphoreGive( xStdioMutex );
 
     va_end( vargs );
 }


### PR DESCRIPTION
The console_print() function in the FreeRTOS_Plus_TCP_Echo_Posix demo takes the stdio mutex but never releases it, causing a deadlock after the first call to console_print().

This commit syncs the file with Posix_GCC/console.c by:

Adding missing xSemaphoreGive() call

Adding missing #include console.h

Making variables static

Adding configSUPPORT_STATIC_ALLOCATION conditional

Fixes https://github.com/FreeRTOS/FreeRTOS/issues/1394

Description
-----------
<!--- Describe your changes in detail. -->

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
