### PR TITLE
Fix: Replace size_t with uint32_t in TaskNotifyArray.c for 16-bit dev…

### DIFF
--- a/FreeRTOS/Demo/Common/Minimal/TaskNotify.c
+++ b/FreeRTOS/Demo/Common/Minimal/TaskNotify.c
@@ -105,7 +105,7 @@ static uint32_t ulTimerNotificationsReceived = 0UL, ulTimerNotificationsSent = 0
 static TimerHandle_t xTimer = NULL;
 
 /* Used by the pseudo random number generating function. */
-static size_t uxNextRand = 0;
+static uint32_t uxNextRand = 0;
 
 /*-----------------------------------------------------------*/
 
@@ -121,7 +121,7 @@ void vStartTaskNotifyTask( void )
                  &xTaskToNotify );               /* Used to pass a handle to the task out is needed, otherwise set to NULL. */
 
     /* Pseudo seed the random number generator. */
-    uxNextRand = ( size_t ) prvRand;
+    uxNextRand = ( uint32_t ) prvRand;
 }
 /*-----------------------------------------------------------*/
 
@@ -712,10 +712,10 @@ BaseType_t xAreTaskNotificationTasksStillRunning( void )
 
 static UBaseType_t prvRand( void )
 {
-    const size_t uxMultiplier = ( size_t ) 0x015a4e35, uxIncrement = ( size_t ) 1;
+    const uint32_t uxMultiplier = ( uint32_t ) 0x015a4e35, uxIncrement = ( uint32_t ) 1;
 
     /* Utility function to generate a pseudo random number. */
     uxNextRand = ( uxMultiplier * uxNextRand ) + uxIncrement;
-    return( ( uxNextRand >> 16 ) & ( ( size_t ) 0x7fff ) );
+    return( ( uxNextRand >> 16 ) & ( ( uint32_t ) 0x7fff ) );
 }
 /*-----------------------------------------------------------*/

--- a/FreeRTOS/Demo/Common/Minimal/TaskNotifyArray.c
+++ b/FreeRTOS/Demo/Common/Minimal/TaskNotifyArray.c
@@ -137,7 +137,7 @@ static TimerHandle_t xIncrementingIndexTimer = NULL;
 static TimerHandle_t xNotifyWhileSuspendedTimer = NULL;
 
 /* Used by the pseudo random number generating function. */
-static size_t uxNextRand = 0;
+static uint32_t uxNextRand = 0;
 
 /* Used to communicate when to send a task notification to the tick hook tests. */
 static volatile BaseType_t xSendNotificationFromISR = pdFALSE;
@@ -166,7 +166,7 @@ void vStartTaskNotifyArrayTask( void )
                  &xTaskToNotify );                   /* Used to pass a handle to the task out if needed, otherwise set to NULL. */
 
     /* Pseudo seed the random number generator. */
-    uxNextRand = ( size_t ) prvRand;
+    uxNextRand = ( uint32_t ) prvRand;
 }
 /*-----------------------------------------------------------*/
 
@@ -1209,10 +1209,10 @@ BaseType_t xAreTaskNotificationArrayTasksStillRunning( void )
 
 static UBaseType_t prvRand( void )
 {
-    const size_t uxMultiplier = ( size_t ) 0x015a4e35, uxIncrement = ( size_t ) 1;
+    const uint32_t uxMultiplier = ( uint32_t ) 0x015a4e35, uxIncrement = ( uint32_t ) 1;
 
     /* Utility function to generate a pseudo random number. */
     uxNextRand = ( uxMultiplier * uxNextRand ) + uxIncrement;
-    return( ( uxNextRand >> 16 ) & ( ( size_t ) 0x7fff ) );
+    return( ( uxNextRand >> 16 ) & ( ( uint32_t ) 0x7fff ) );
 }
 /*-----------------------------------------------------------*/


### PR DESCRIPTION
Description
-----------
Replace `size_t` with `uint32_t` in the `prvRand()` pseudo-random number
generator function and related variables in both `TaskNotifyArray.c` and
`TaskNotify.c` demo/test files.

The `prvRand()` implementation assumes `size_t` is at least 32 bits
(e.g., it uses the constant `0x015a4e35` as a multiplier and shifts right
by 16 bits). This assumption breaks on 16-bit and 8-bit architectures
where `size_t` is only 16 bits, causing incorrect PRNG behavior and
preventing these test files from being used on such devices.

**Changes made:**
- `TaskNotifyArray.c`: Changed `static size_t uxNextRand` to
  `static uint32_t uxNextRand` and updated the seed cast from
  `(size_t)` to `(uint32_t)`.
- `TaskNotify.c`: Changed `static size_t uxNextRand` to
  `static uint32_t uxNextRand`, updated the seed cast from `(size_t)`
  to `(uint32_t)`, and replaced all `size_t` casts inside `prvRand()`
  (`uxMultiplier`, `uxIncrement`, and the bitmask) with `uint32_t`.

Test Steps
-----------
1. Build the FreeRTOS demo project that includes `TaskNotifyArray.c`
   and/or `TaskNotify.c` for a 32-bit target (e.g., Posix_GCC or any
   Cortex-M demo). Verify all notification tests still pass with no
   regressions.
2. Build the demo for a 16-bit target (e.g., MSP430 or PIC24) and
   confirm that the files now compile without warnings or truncation
   issues related to `size_t` being 16 bits.
3. Run the `xAreTaskNotificationArrayTasksStillRunning()` and
   `xAreTaskNotificationTasksStillRunning()` checks and confirm they
   report no errors.

Checklist:
----------
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
Fixes https://github.com/FreeRTOS/FreeRTOS/issues/550

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.