### PR TITLE
fix: replace bare except with except Exception in mpfs_configuration_generator.py

### DIFF
--- a/FreeRTOS/Demo/RISC-V_RV64_PolarFire_SoftConsole/polarfire_hal/platform/soc_config_generator/mpfs_configuration_generator.py
+++ b/FreeRTOS/Demo/RISC-V_RV64_PolarFire_SoftConsole/polarfire_hal/platform/soc_config_generator/mpfs_configuration_generator.py
@@ -167,7 +167,7 @@ def safe_make_folder(i):
     '''Makes a folder (and its parents) if not present'''
     try:
         os.makedirs(i)
-    except:
+    except Exception:
         pass
 
 


### PR DESCRIPTION
## Description

The safe_make_folder() function in the PolarFire RISC-V demo uses a bare except clause which catches SystemExit, KeyboardInterrupt, and GeneratorExit — almost never intended.

## Fix

Replace bare except with except Exception per Python best practices (PEP 8).

## Changes

- 1 file, 1 line changed
- FreeRTOS/Demo/RISC-V_RV64_PolarFire_SoftConsole/polarfire_hal/platform/soc_config_generator/mpfs_configuration_generator.py

Replaces #1407 (closed per reviewer feedback to remove unrelated changes).