### PR TITLE
CI: fix Windows Simulator demos by locating VS via vswhere (not hardcoded Enterprise path)

### DIFF
--- a/.github/workflows/freertos_plus_demos.yml
+++ b/.github/workflows/freertos_plus_demos.yml
@@ -321,7 +321,8 @@ jobs:
           echo "::group::${{ env.stepName }}"
           Push-Location
           Get-Location
-          & "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\Launch-VsDevShell.ps1"
+          $vsPath = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -property installationPath
+          & "$vsPath\Common7\Tools\Launch-VsDevShell.ps1"
           Get-Location
           Pop-Location
 
@@ -425,7 +426,8 @@ jobs:
           echo "::group::${{ env.stepName }}"
           Push-Location
           Get-Location
-          & "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\Launch-VsDevShell.ps1"
+          $vsPath = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -property installationPath
+          & "$vsPath\Common7\Tools\Launch-VsDevShell.ps1"
           Get-Location
           Pop-Location
 
@@ -1221,7 +1223,8 @@ jobs:
           echo "::group::${{ env.stepName }}"
           Push-Location
           Get-Location
-          & "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\Launch-VsDevShell.ps1"
+          $vsPath = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -property installationPath
+          & "$vsPath\Common7\Tools\Launch-VsDevShell.ps1"
           Get-Location
           Pop-Location
 


### PR DESCRIPTION
## Problem

The three Windows Simulator demo jobs in `.github/workflows/freertos_plus_demos.yml` (`corePKCS11 WinSim Demos`, `core Library Windows Simulator Demos`, `FreeRTOS+TCP Windows Simulator Demos`) are currently failing on `main` at the **Install Glib** step with:

```
The term 'C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\Launch-VsDevShell.ps1'
is not recognized as a name of a cmdlet, function, script file, or executable program.
```

The step hardcodes the **Enterprise** edition path to `Launch-VsDevShell.ps1`. The GitHub-hosted `windows-latest` runner image no longer provides Visual Studio at that edition path, so the script is missing and the dev-shell setup (and therefore the Glib build) fails.

## Fix

Discover the Visual Studio installation path at runtime with `vswhere.exe`, which lives at a fixed, edition-independent location (`%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe`), then invoke the located `Launch-VsDevShell.ps1`:

```powershell
$vsPath = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -property installationPath
& "$vsPath\Common7\Tools\Launch-VsDevShell.ps1"
```

Applied to all three `Install Glib` blocks in the workflow.

## Notes

This is a CI-infrastructure fix and is **independent of any product/source change**. It unblocks open PRs (e.g. #1412) that are red purely due to this runner-image regression.