### PR TITLE
Update RISC-V Demo for Spike simulator

### DIFF
--- a/FreeRTOS/Demo/RISC-V-spike-htif_GCC/Makefile
+++ b/FreeRTOS/Demo/RISC-V-spike-htif_GCC/Makefile
@@ -8,11 +8,11 @@ DEBUG ?= 0
 BASE_ADDRESS ?= 0x80000000
 
 ifeq ($(XLEN), 64)
-    MARCH = rv64ima
+    MARCH = rv64ima_zicsr
     MABI = lp64
 	STACK_SIZE = 600
 else
-    MARCH = rv32ima
+    MARCH = rv32ima_zicsr
     MABI = ilp32
 	STACK_SIZE = 300
 endif

--- a/FreeRTOS/Demo/RISC-V-spike-htif_GCC/spike-1.cfg
+++ b/FreeRTOS/Demo/RISC-V-spike-htif_GCC/spike-1.cfg
@@ -1,11 +1,10 @@
-adapter_khz     10000
 
-interface remote_bitbang
-remote_bitbang_host localhost
-remote_bitbang_port 9824
+adapter driver remote_bitbang
+remote_bitbang host localhost
+remote_bitbang port 9824
 
 set _CHIPNAME riscv
-jtag newtap $_CHIPNAME cpu -irlen 5 -expected-id 0x10e31913
+jtag newtap $_CHIPNAME cpu -irlen 5 -expected-id 0xdeadbeef
 
 set _TARGETNAME $_CHIPNAME.cpu
 target create $_TARGETNAME riscv -chain-position $_TARGETNAME -rtos auto
@@ -13,8 +12,8 @@ target create $_TARGETNAME riscv -chain-position $_TARGETNAME -rtos auto
 $_TARGETNAME configure -work-area-phys 0x80000000 -work-area-size 8096 -work-area-backup 1
 
 
-gdb_report_data_abort enable
-gdb_report_register_access_error enable
+gdb report_data_abort enable
+gdb report_register_access_error enable
 
 # Expose an unimplemented CSR so we can test non-existent register access
 # behavior.
@@ -24,10 +23,8 @@ riscv expose_custom 1,12345-12348
 init
 
 set challenge [riscv authdata_read]
-riscv authdata_write [expr $challenge + 1]
+riscv authdata_write [expr {$challenge + 1}]
 
 halt
-
-reg mstatus 0
 
 arm semihosting enable


### PR DESCRIPTION


Description
-----------
Some commands in the Makefile and OpenOCD config file had to be updated to work with the current OpenOCD and RISC-V toolchain.

Makefile:

- Zicsr is now a standalone extension, so update the value of the -march argument, passed to GCC.

spike-1.cfg for OpenOCD:

- Update commands that changed their syntax - avoid deprecation warnings.
- Remove "adapter_khz" command - the virtual jtag_vpi adapter does not have any concept of clock frequency.
- Update -expected-id to match the JTAG IDCODE used by the Spike simulator.
- Fix the syntax of the "expr" command.
- Remove the command that zeroes mstatus register upon startup, as this would break the program operation. It is unclear why the command was there in the first place.

Test Steps
-----------
- Build Spike RISC-V ISA simulator from source (https://github.com/riscv-software-src/riscv-isa-sim).
- Build OpenOCD from source (https://github.com/openocd-org/openocd).
- Download RISC-V bare-metal toolchain from https://xpack-dev-tools.github.io/riscv-none-elf-gcc-xpack/blog/2025/10/23/riscv-none-elf-gcc-v15-2-0-1-released/.
- Build the demo:
  -  `cd FreeRTOS/Demo/RISC-V-spike-htif_GCC`
  -  `PATH=/path/to/your/xpack-riscv-none-elf-gcc-15.2.0-1/bin:$PATH make CROSS=riscv-none-elf- DEBUG=1`
- Launch the Spike simulator:
  -  `/path/to/your/bin/spike -p1 --isa rv32ima_zicsr -m0x80000000:0x10000000 --rbb-port 9824 build/RTOSDemo32.axf`
- In another terminal, launch OpenOCD:
  - `/path/to/your/bin/openocd -f spike-1.cfg`
- Check for successful target examination in the OpenOCD log:
```
...
Info : [riscv.cpu] Examined RISC-V core
Info : [riscv.cpu]  XLEN=32, misa=0x40141101
Info : [riscv.cpu] Examination succeed
Info : [riscv.cpu] starting gdb server on 3333
Info : Listening on port 3333 for gdb connections
...
```

  
  
  

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
