### PR TITLE
fix: replace bare except with except Exception in release.py

### DIFF
--- a/.github/scripts/release.py
+++ b/.github/scripts/release.py
@@ -179,7 +179,7 @@ class BaseRelease:
             self.repo.get_release(self.tag).delete_release()
         except UnknownObjectException:
             info('A release endpoint does not exist for "%s". No need to erase.' % self.tag)
-        except:
+        except Exception:
             assert False, 'Encountered error while trying to delete git release endpoint'
 
     def rollbackAutoCommits(self, n_autocommits=2, n_search=25):


### PR DESCRIPTION
## Summary

Replace bare `except:` clause with `except Exception:` in `deleteGitRelease()` to comply with PEP 8 (E722) and avoid accidentally catching `BaseException` subclasses like `SystemExit` and `KeyboardInterrupt`.

This is a follow-up to the same fix applied to `mpfs_configuration_generator.py` in PR #1412 (merged).

## Changes

```diff
-        except:
+        except Exception:
             assert False, 'Encountered error while trying to delete git release endpoint'
```

## Context

A bare `except:` catches everything including `SystemExit`, `KeyboardInterrupt`, and `GeneratorExit`, which should normally propagate. Using `except Exception:` catches all "expected" errors while letting critical signals through.
