### PR TITLE
Fix IPv4 parsing in TCP echo client demo

### DIFF
--- a/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_IPv6_Demo/IPv6_Multi_WinSim_demo/TCPEchoClient_SingleTasks.c
+++ b/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_IPv6_Demo/IPv6_Multi_WinSim_demo/TCPEchoClient_SingleTasks.c
@@ -273,7 +273,7 @@
             }
             else
             {
-                rc = FreeRTOS_inet_pton( FREERTOS_AF_INET4, configECHO_SERVER_ADDR_STRING, ( void * ) xEchoServerAddress.sin_address.xIP_IPv6.ucBytes );
+                rc = FreeRTOS_inet_pton( FREERTOS_AF_INET4, configECHO_SERVER_ADDR_STRING, ( void * ) &( xEchoServerAddress.sin_address.ulIP_IPv4 ) );
                 configASSERT( rc == pdPASS );
                 xFamily = FREERTOS_AF_INET4;
             }


### PR DESCRIPTION
Description
-----------
Fix the IPv4 fallback path in `TCPEchoClient_SingleTasks.c` for the FreeRTOS+TCP IPv6 Windows simulator demo.

The code first tries to parse `configECHO_SERVER_ADDR_STRING` as IPv6. When that fails, it falls back to `FREERTOS_AF_INET4`, sets `sin_family` to `FREERTOS_AF_INET4`, and later connects using `xEchoServerAddress`. That IPv4 parse was still writing into `xEchoServerAddress.sin_address.xIP_IPv6.ucBytes`, leaving the IPv4 field inconsistent with the selected address family.

This changes the IPv4 fallback to write into `xEchoServerAddress.sin_address.ulIP_IPv4`, matching the UDP echo client in the same demo directory.

Test Steps
-----------
- `git diff --check origin/main..HEAD`
- `rg -n "FreeRTOS_inet_pton\(\s*FREERTOS_AF_INET4[^\n]*xIP_IPv6\.ucBytes" FreeRTOS-Plus/Demo FreeRTOS-Plus/Source -g "*.c" -g "*.h"`
- Verified the diff is limited to `TCPEchoClient_SingleTasks.c` and is a one-line field correction.

Local Windows simulator build was not run because this environment does not have `msbuild` or MSVC `cl` available.

Checklist:
----------
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
None.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.