### PR TITLE
CBMC: Escape Python regex strings

### DIFF
--- a/FreeRTOS/Test/CBMC/proofs/make_common_makefile.py
+++ b/FreeRTOS/Test/CBMC/proofs/make_common_makefile.py
@@ -30,7 +30,7 @@ import os
 import argparse
 
 def cleanup_whitespace(string):
-    return re.sub('\s+', ' ', string.strip())
+    return re.sub(r'\s+', ' ', string.strip())
 
 ################################################################
 # Operating system specific values
@@ -83,9 +83,9 @@ def patch_compile_output(opsys, line, key, value):
 
     if key in ["COMPILE_ONLY", "COMPILE_LINK"] and value is not None:
         if value[-1] == '/Fo':
-            return re.sub('/Fo\s+', '/Fo', line)
+            return re.sub(r'/Fo\s+', '/Fo', line)
         if value[-1] == '/Fe':
-            return re.sub('/Fe\s+', '/Fe', line)
+            return re.sub(r'/Fe\s+', '/Fe', line)
     return line
 
 ################################################################
@@ -181,7 +181,7 @@ def write_makefile(opsys, template, defines, makefile):
     with open(template) as _template:
         for line in _template:
             line = patch_path_separator(opsys, line)
-            keys = re.findall('@(\w+)@', line)
+            keys = re.findall(r'@(\w+)@', line)
             values = [find_definition(key, defines) for key in keys]
             for key, value in zip(keys, values):
                 if value is not None:

--- a/FreeRTOS/Test/CBMC/proofs/make_proof_makefiles.py
+++ b/FreeRTOS/Test/CBMC/proofs/make_proof_makefiles.py
@@ -121,7 +121,7 @@ def prolog():
 
                 On Windows ->
 
-                H_INC = /Imy\cool\directory
+                H_INC = /Imy\\cool\\directory
                 H_DEF = /DHALF=/2
 
         When invoked, this script walks the directory tree looking for files


### PR DESCRIPTION
## Summary
- use raw regex strings in the FreeRTOS CBMC Makefile helper
- escape the Windows path example in the CBMC proof Makefile generator help text
- keep the parsed Python AST unchanged while removing Python invalid escape warnings

## Verification
- SyntaxWarning scan for the two changed files reports `TOTAL 0`
- AST comparison against `origin/main` reports `AST_EQUAL True` for both changed files
- `git diff --check`
- `git ls-files --eol FreeRTOS/Test/CBMC/proofs/make_common_makefile.py FreeRTOS/Test/CBMC/proofs/make_proof_makefiles.py`

I also checked for open duplicate PRs/issues mentioning `make_common_makefile.py`, `make_proof_makefiles.py`, `invalid escape`, `SyntaxWarning`, and `CBMC`, and found no matches.

I intentionally limited this PR to files tracked by the FreeRTOS repository. A similarly named FreeRTOS-Plus-TCP script lives outside the tracked files in this repository and is not changed here.
