### PR TITLE
Add xTimerDelete strippable pattern to event_groups and smp CMock configs

### DIFF
--- a/FreeRTOS/Test/CMock/event_groups/event_groups.yml
+++ b/FreeRTOS/Test/CMock/event_groups/event_groups.yml
@@ -29,4 +29,5 @@
   :strippables:
     - PRIVILEGED_FUNCTION
     - portDONT_DISCARD
+    - '(?:BaseType_t\s+xTimerDelete\s*\([\s\w,\n\t]*\)[\s\w,\n\t]*\s*;\s*)'
   :treat_externs: :include

--- a/FreeRTOS/Test/CMock/smp/smp.yml
+++ b/FreeRTOS/Test/CMock/smp/smp.yml
@@ -29,4 +29,4 @@
   :strippables:
     - PRIVILEGED_FUNCTION
     - portDONT_DISCARD
-
+    - '(?:BaseType_t\s+xTimerDelete\s*\([\s\w,\n\t]*\)[\s\w,\n\t]*\s*;\s*)'


### PR DESCRIPTION
This is in accordance to fix the failure at https://github.com/FreeRTOS/FreeRTOS-Kernel/pull/1412

<!--- Title -->

Description
-----------
Add xTimerDelete strippable pattern to event_groups and smp CMock configs

Test Steps
-----------
Ran the unit test locally

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
