### PR TITLE
Fix: strncpy() may leave pcWriteBuffer non-null-terminated in FreeRTOS_CLI.c

### DIFF
--- a/FreeRTOS-Plus/Source/FreeRTOS-Plus-CLI/FreeRTOS_CLI.c
+++ b/FreeRTOS-Plus/Source/FreeRTOS-Plus-CLI/FreeRTOS_CLI.c
@@ -201,6 +201,7 @@ BaseType_t FreeRTOS_CLIProcessCommand( const char * const pcCommandInput,
         /* The command was found, but the number of parameters with the command
          * was incorrect. */
         strncpy( pcWriteBuffer, "Incorrect command parameter(s).  Enter \"help\" to view a list of available commands.\r\n\r\n", xWriteBufferLen );
+        pcWriteBuffer[ xWriteBufferLen - 1 ] = '\0';
         pxCommand = NULL;
     }
     else if( pxCommand != NULL )
@@ -220,6 +221,7 @@ BaseType_t FreeRTOS_CLIProcessCommand( const char * const pcCommandInput,
     {
         /* pxCommand was NULL, the command was not found. */
         strncpy( pcWriteBuffer, "Command not recognised.  Enter 'help' to view a list of available commands.\r\n\r\n", xWriteBufferLen );
+        pcWriteBuffer[ xWriteBufferLen - 1 ] = '\0';
         xReturn = pdFALSE;
     }
 
@@ -340,6 +342,7 @@ static BaseType_t prvHelpCommand( char * pcWriteBuffer,
     /* Return the next command help string, before moving the pointer on to
      * the next command in the list. */
     strncpy( pcWriteBuffer, pxCommand->pxCommandLineDefinition->pcHelpString, xWriteBufferLen );
+    pcWriteBuffer[ xWriteBufferLen - 1 ] = '\0';
     pxCommand = pxCommand->pxNext;
 
     if( pxCommand == NULL )


### PR DESCRIPTION
## How I Found This

While working as a firmware developer intern on ADAS/sensor fusion, ourteam used FreeRTOS+CLI as a debug console for runtime diagnostics over UART. While reviewing our CLI command handlers for safety, I traced howcommand output is written back to pcWriteBuffer and noticed the same non-null-termination pattern in the upstream FreeRTOS_CLI.c source itself. Since this library is used across many embedded/safety-relevant projects, I wanted to report and fix it upstream rather than just patch around it locally. This is my first contribution to FreeRTOS - happy to give back to a project our stack relies on daily.

## Problem

strncpy() does not guarantee null-termination of the destination buffer when the source string length is >= the specified length (xWriteBufferLen) If this happens, pcWriteBuffer ends up unterminated, and any later use ofstrlen(), printf("%s", ...), strcat(), etc. on that buffer can read past its allocated bounds.

This affects three call sites in FreeRTOS_CLI.c:

- Line 204: FreeRTOS_CLIProcessCommand(): "Incorrect command parameter(s)..." message
- Line 224: FreeRTOS_CLIProcessCommand(): "Command not recognised..." message
- Line 345: prvHelpCommand(): copying pcHelpString from a registered command

## Fix

Added explicit null-termination immediately after each strncpy() call:

strncpy( pcWriteBuffer, message, xWriteBufferLen );
pcWriteBuffer[ xWriteBufferLen - 1 ] = '\0';

This guarantees pcWriteBuffer is always null-terminated after these calls,
regardless of the source string's length relative to xWriteBufferLen.

## Notes

- `xWriteBufferLen` is assumed to be >= 1 at all current call sites (backed
  by fixed-size buffers such as `cOutputBuffer`), so no additional
  zero-length guard was added, to keep the diff minimal and focused.
- No known live crash/exploit report is attached to this - this is a
  defensive/correctness fix for a latent buffer over-read risk.
- All three call sites use the same fix pattern for consistency.
