### PR TITLE
Expand tests to account for queue use assertion

### DIFF
--- a/FreeRTOS/Test/CMock/queue/generic/queue_delete_dynamic_utest.c
+++ b/FreeRTOS/Test/CMock/queue/generic/queue_delete_dynamic_utest.c
@@ -129,3 +129,74 @@ void test_vQueueDelete_full( void )
     vQueueDelete( xQueue );
     TEST_ASSERT_EQUAL_PTR( ( void * ) xQueue, getLastFreedAddress() );
 }
+
+/**
+ * @brief Test vQueueDelete asserts when tasks are waiting to send and waiting to receive
+ * @details Verify that vQueueDelete triggers a configASSERT when both the
+ * xTasksWaitingToSend and xTasksWaitingToReceive lists are non-empty.
+ * @coverage vQueueDelete
+ */
+void test_vQueueDelete_assert_tasks_waiting_to_send_and_receive( void )
+{
+    QueueHandle_t xQueue = xQueueCreate( 1, sizeof( uint32_t ) );
+
+    /* Add a fake task to the WaitingToSend list */
+    td_task_addFakeTaskWaitingToSendToQueue( xQueue );
+
+    /* Expect the assert to fire due to non-empty WaitingToSend list */
+    EXPECT_ASSERT_BREAK( vQueueDelete( xQueue ) );
+
+    /* Clean up the fake task from the list */
+    td_task_removeFakeTaskFromList();
+
+    /* Now add a fake task to WaitingToReceive and verify that assert fires too */
+    td_task_addFakeTaskWaitingToReceiveFromQueue( xQueue );
+
+    EXPECT_ASSERT_BREAK( vQueueDelete( xQueue ) );
+
+    /* Clean up and delete */
+    td_task_removeFakeTaskFromList();
+    vQueueDelete( xQueue );
+}
+
+/**
+ * @brief Test vQueueDelete asserts when tasks are waiting to send only
+ * @details Verify that vQueueDelete triggers a configASSERT when the
+ * xTasksWaitingToSend list is non-empty.
+ * @coverage vQueueDelete
+ */
+void test_vQueueDelete_assert_tasks_waiting_to_send( void )
+{
+    QueueHandle_t xQueue = xQueueCreate( 1, sizeof( uint32_t ) );
+
+    /* Add a fake task to the WaitingToSend list */
+    td_task_addFakeTaskWaitingToSendToQueue( xQueue );
+
+    /* Expect the assert to fire due to non-empty WaitingToSend list */
+    EXPECT_ASSERT_BREAK( vQueueDelete( xQueue ) );
+
+    /* Clean up and delete */
+    td_task_removeFakeTaskFromList();
+    vQueueDelete( xQueue );
+}
+
+/**
+ * @brief Test vQueueDelete asserts when tasks are waiting to receive only
+ * @details Verify that vQueueDelete triggers a configASSERT when the
+ * xTasksWaitingToReceive list is non-empty.
+ * @coverage vQueueDelete
+ */
+void test_vQueueDelete_assert_tasks_waiting_to_receive( void )
+{
+    QueueHandle_t xQueue = xQueueCreate( 1, sizeof( uint32_t ) );
+
+    /* Add a fake task to the WaitingToReceive list */
+    td_task_addFakeTaskWaitingToReceiveFromQueue( xQueue );
+
+    /* Expect the assert to fire due to non-empty WaitingToReceive list */
+    EXPECT_ASSERT_BREAK( vQueueDelete( xQueue ) );
+
+    /* Clean up and delete */
+    td_task_removeFakeTaskFromList();
+    vQueueDelete( xQueue );
+}

--- a/FreeRTOS/Test/CMock/queue/queue_utest_common.h
+++ b/FreeRTOS/Test/CMock/queue/queue_utest_common.h
@@ -327,6 +327,13 @@ void td_task_addFakeTaskWaitingToSendToQueue( QueueHandle_t xQueue );
 void td_task_addFakeTaskWaitingToReceiveFromQueue( QueueHandle_t xQueue );
 
 /**
+ * @brief Remove the fake task from whatever waiting list it is currently in.
+ * @details This should be called before deleting a queue that has a fake task
+ * in one of its waiting lists (xTasksWaitingToSend or xTasksWaitingToReceive).
+ */
+void td_task_removeFakeTaskFromList( void );
+
+/**
  * @brief Test double for xTaskCheckForTimeOut
  */
 BaseType_t td_task_xTaskCheckForTimeOutStub( TimeOut_t * const pxTimeOut,

--- a/FreeRTOS/Test/CMock/queue/semaphore/mutex_utest.c
+++ b/FreeRTOS/Test/CMock/queue/semaphore/mutex_utest.c
@@ -540,6 +540,9 @@ void test_macro_xSemaphoreTake_blocking_mutex_inherit_timeout_high_prio_waiting(
 
     TEST_ASSERT_EQUAL( TICKS_TO_WAIT + 1, td_task_getCount_YieldFromTaskResumeAll() );
 
+    /* Remove the fake task from the waiting list before deleting the semaphore */
+    td_task_removeFakeTaskFromList();
+
     vSemaphoreDelete( xSemaphore );
 }
 

--- a/FreeRTOS/Test/CMock/queue/td_task.c
+++ b/FreeRTOS/Test/CMock/queue/td_task.c
@@ -290,6 +290,14 @@ void td_task_addFakeTaskWaitingToReceiveFromQueue( QueueHandle_t xQueue )
     vListInsert( pxTasksWaitingToReceive, &fakeTaskListItem );
 }
 
+void td_task_removeFakeTaskFromList( void )
+{
+    if( listLIST_ITEM_CONTAINER( &fakeTaskListItem ) != NULL )
+    {
+        uxListRemove( &fakeTaskListItem );
+    }
+}
+
 TickType_t td_task_getFakeTaskPriority( void )
 {
     return( configMAX_PRIORITIES - fakeTaskListItem.xItemValue );

--- a/manifest.yml
+++ b/manifest.yml
@@ -5,7 +5,7 @@ license: "MIT"
 
 dependencies:
   - name: "FreeRTOS-Kernel"
-    version: "fcc6653"
+    version: "78069a7"
     repository:
       type: "git"
       url: "https://github.com/FreeRTOS/FreeRTOS-Kernel.git"


### PR DESCRIPTION
<!--- Title -->

Description
-----------
Unit tests need to update now that the queue
asserts if in use during a deletion call.
Updated existing mutex test which left a queue
with a user during cleanup.
Added new queue unit tests

Test Steps
-----------
Tested through unit tests

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------

Requires https://github.com/FreeRTOS/FreeRTOS-Kernel/pull/1449 to be merged first


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
