### PR TITLE
Update FreeRTOS-Kernel to V11.3.1

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -5,7 +5,7 @@ license: "MIT"
 
 dependencies:
   - name: "FreeRTOS-Kernel"
-    version: "78069a7"
+    version: "592732b"
     repository:
       type: "git"
       url: "https://github.com/FreeRTOS/FreeRTOS-Kernel.git"

--- a/manifest.yml
+++ b/manifest.yml
@@ -5,7 +5,7 @@ license: "MIT"
 
 dependencies:
   - name: "FreeRTOS-Kernel"
-    version: "592732b"
+    version: "3a22924"
     repository:
       type: "git"
       url: "https://github.com/FreeRTOS/FreeRTOS-Kernel.git"


### PR DESCRIPTION
<!--- Title -->

Description
-----------
V11.3.1 has several security enhancements
and should be used over V11.3.0.

Test Steps
-----------
Not tested manually. Using CI/CD checks as a proxy.

Unit tests will fail as additional UTs are needed for the new periodic wait API, [xTaskPeriodicDelay](https://github.com/FreeRTOS/FreeRTOS-Kernel/commit/b178814998ceb08c007af5b009623de73835af9f).

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
